### PR TITLE
Fix brand name NoorinALabs → Noorina Labs

### DIFF
--- a/.claude/team/charter.md
+++ b/.claude/team/charter.md
@@ -1,8 +1,8 @@
-# Team Charter — NoorinALabs (Organization)
+# Team Charter — Noorina Labs (Organization)
 
 ## Purpose
 
-All work across all NoorinALabs repositories is executed through a simulated team of specialized agents. Every problem-solving session MUST instantiate this team structure. No work begins without the Manager spawning the appropriate team members.
+All work across all Noorina Labs repositories is executed through a simulated team of specialized agents. Every problem-solving session MUST instantiate this team structure. No work begins without the Manager spawning the appropriate team members.
 
 ## Execution Model
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code when working in the deployment orches
 
 ## Project Overview
 
-**noorinalabs-deploy** is the deployment orchestration repo for all NoorinALabs services. It owns everything that runs on the production server: Docker Compose configs, Terraform provisioning, reverse proxy, observability stack, and deployment workflows.
+**noorinalabs-deploy** is the deployment orchestration repo for all Noorina Labs services. It owns everything that runs on the production server: Docker Compose configs, Terraform provisioning, reverse proxy, observability stack, and deployment workflows.
 
 ## Guiding Principle
 

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -1,4 +1,4 @@
-# Production Docker Compose — NoorinALabs deployment
+# Production Docker Compose — Noorina Labs deployment
 # Location: noorinalabs-deploy/compose/docker-compose.prod.yml
 # Usage: docker compose -f compose/docker-compose.prod.yml --env-file .env up -d
 #

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-This document is the definitive reference for how the NoorinALabs deployment system works.
+This document is the definitive reference for how the Noorina Labs deployment system works.
 
 ## Table of Contents
 
@@ -19,7 +19,7 @@ This document is the definitive reference for how the NoorinALabs deployment sys
 
 ## Overview
 
-`noorinalabs-deploy` orchestrates deployments for the NoorinALabs platform. It owns everything running on the production VPS: Docker Compose services, infrastructure provisioning, reverse proxy configuration, and observability.
+`noorinalabs-deploy` orchestrates deployments for the Noorina Labs platform. It owns everything running on the production VPS: Docker Compose services, infrastructure provisioning, reverse proxy configuration, and observability.
 
 **Core principle:** Service repos own what they build; this repo owns what runs on the server.
 

--- a/scripts/bootstrap-vps.sh
+++ b/scripts/bootstrap-vps.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # =============================================================================
-# bootstrap-vps.sh — First-time VPS setup for NoorinALabs
+# bootstrap-vps.sh — First-time VPS setup for Noorina Labs
 #
 # Run as root on a fresh Hetzner VPS:
 #   ssh -i ~/.ssh/isnad_deploy root@isnad-graph.noorinalabs.com
@@ -16,7 +16,7 @@ INSTALL_DIR="/opt/noorinalabs-deploy"
 DEPLOY_USER="deploy"
 
 echo "============================================="
-echo "  NoorinALabs VPS bootstrap"
+echo "  Noorina Labs VPS bootstrap"
 echo "============================================="
 echo ""
 


### PR DESCRIPTION
## Summary
- Replaces "NoorinALabs" with "Noorina Labs" in documentation prose, docker-compose comment, bootstrap script echo, architecture docs, CLAUDE.md, and team charter
- No code identifiers, URLs, Docker image names, or repo references were changed

Closes #13