### PR TITLE
Add landing page deployment infrastructure

### DIFF
--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -6,6 +6,9 @@ on:
       isnad_image_tag:
         description: 'noorinalabs-isnad-graph image tag'
         default: 'latest'
+      landing_image_tag:
+        description: 'noorinalabs-landing-page image tag'
+        default: 'latest'
 
 concurrency:
   group: deploy-production
@@ -32,11 +35,12 @@ jobs:
           AUTH_GITHUB_CLIENT_SECRET: ${{ secrets.AUTH_GITHUB_CLIENT_SECRET }}
           GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
           IMAGE_TAG: ${{ inputs.isnad_image_tag }}
+          LANDING_IMAGE_TAG: ${{ inputs.landing_image_tag }}
         with:
           host: ${{ vars.VPS_HOST }}
           username: deploy
           key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
-          envs: NEO4J_PASSWORD,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,REDIS_PASSWORD,AUTH_GOOGLE_CLIENT_ID,AUTH_GOOGLE_CLIENT_SECRET,AUTH_GITHUB_CLIENT_ID,AUTH_GITHUB_CLIENT_SECRET,GRAFANA_ADMIN_PASSWORD,IMAGE_TAG
+          envs: NEO4J_PASSWORD,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,REDIS_PASSWORD,AUTH_GOOGLE_CLIENT_ID,AUTH_GOOGLE_CLIENT_SECRET,AUTH_GITHUB_CLIENT_ID,AUTH_GITHUB_CLIENT_SECRET,GRAFANA_ADMIN_PASSWORD,IMAGE_TAG,LANDING_IMAGE_TAG
           script: |
             set -euo pipefail
             cd /opt/noorinalabs-deploy
@@ -52,6 +56,7 @@ jobs:
               echo "$var=\"$val\"" >> "$env_file"
             done
             echo "IMAGE_TAG=\"${IMAGE_TAG}\"" >> "$env_file"
+            echo "LANDING_IMAGE_TAG=\"${LANDING_IMAGE_TAG}\"" >> "$env_file"
             echo "CACHEBUST=\"$(date +%s)\"" >> "$env_file"
             chmod 600 "$env_file"
 

--- a/.github/workflows/deploy-landing-page.yml
+++ b/.github/workflows/deploy-landing-page.yml
@@ -1,0 +1,57 @@
+name: Deploy noorinalabs-landing-page
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Image tag to deploy (default: latest)'
+        default: 'latest'
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy landing page to VPS
+        uses: appleboy/ssh-action@v1
+        env:
+          LANDING_IMAGE_TAG: ${{ inputs.image_tag }}
+        with:
+          host: ${{ vars.VPS_HOST }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          envs: LANDING_IMAGE_TAG
+          script: |
+            set -euo pipefail
+            cd /opt/noorinalabs-deploy
+            git fetch origin main && git reset --hard origin/main
+
+            docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env pull landing
+            docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env up -d landing
+
+            echo "==> Waiting for landing service to stabilize..."
+            for i in $(seq 1 12); do
+              health=$(docker inspect --format='{{.State.Health.Status}}' noorinalabs-landing-1 2>/dev/null || echo "not_found")
+              echo "Attempt $i/12: landing=$health"
+              if [ "$health" = "healthy" ]; then echo "Landing page healthy"; break; fi
+              if [ "$i" -eq 12 ]; then
+                echo "ERROR: Landing health check failed after 60 seconds"
+                docker compose -p noorinalabs -f compose/docker-compose.prod.yml logs --tail=50 landing
+                exit 1
+              fi
+              sleep 5
+            done
+
+      - name: Report deployment status
+        if: always()
+        run: |
+          echo "## Deploy noorinalabs-landing-page: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Image tag:** ${{ inputs.image_tag }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Triggered by:** ${{ github.actor }}" >> "$GITHUB_STEP_SUMMARY"

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,3 +1,20 @@
+www.noorinalabs.com {
+    redir https://noorinalabs.com{uri} permanent
+}
+
+noorinalabs.com {
+    reverse_proxy landing:80
+
+    header {
+        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+        X-Content-Type-Options "nosniff"
+        X-Frame-Options "DENY"
+        X-XSS-Protection "0"
+        Referrer-Policy "strict-origin-when-cross-origin"
+        -Server
+    }
+}
+
 isnad-graph.noorinalabs.com {
     # API routes (versioned)
     handle /api/* {

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -212,6 +212,41 @@ services:
       - frontend
     restart: unless-stopped
 
+  landing:
+    image: ghcr.io/noorinalabs/noorinalabs-landing-page:${LANDING_IMAGE_TAG:-latest}
+    build:
+      context: /opt/noorinalabs-landing-page
+      dockerfile: Dockerfile
+    expose:
+      - "80"
+    read_only: true
+    tmpfs:
+      - /tmp:size=64M
+      - /var/cache/nginx:size=128M
+      - /run:size=16M
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:80/ || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+          cpus: "0.5"
+        reservations:
+          memory: 64M
+          cpus: "0.1"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - frontend
+    restart: unless-stopped
+
   # --- Reverse Proxy ---
 
   caddy:
@@ -236,6 +271,8 @@ services:
       api:
         condition: service_healthy
       frontend:
+        condition: service_healthy
+      landing:
         condition: service_healthy
     deploy:
       resources:


### PR DESCRIPTION
## Summary
- Add `landing` service to `docker-compose.prod.yml` — nginx container serving the landing page from GHCR image
- Add `noorinalabs.com` and `www.noorinalabs.com` server blocks to `Caddyfile` with security headers and www-to-apex redirect
- Create `deploy-landing-page.yml` workflow for standalone landing page deploys via `workflow_dispatch`
- Update `deploy-all.yml` with `LANDING_IMAGE_TAG` input so full-stack deploys include the landing service

Closes #2, Closes #5, Closes #3

## Test plan
- [ ] Verify `docker compose config` parses the updated compose file without errors
- [ ] Deploy to staging/VPS and confirm `noorinalabs.com` serves the landing page
- [ ] Confirm `www.noorinalabs.com` redirects to `noorinalabs.com`
- [ ] Run `deploy-landing-page.yml` workflow manually and verify it completes
- [ ] Run `deploy-all.yml` workflow and verify landing service is included