### PR TITLE
ops(terraform): Add CI/CD workflow for plan/apply

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,106 @@
+name: Terraform
+on:
+  pull_request:
+    paths: ['terraform/**']
+  push:
+    branches: [main]
+    paths: ['terraform/**']
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: terraform/hetzner
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~> 1.5"
+      - name: Format check
+        run: terraform fmt -check -recursive
+      - name: Init (no backend)
+        run: terraform init -backend=false
+      - name: Validate
+        run: terraform validate
+
+  plan:
+    name: Plan
+    needs: validate
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    environment: production
+    defaults:
+      run:
+        working-directory: terraform/hetzner
+    env:
+      TF_VAR_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~> 1.5"
+      - name: Generate CI SSH key
+        run: |
+          ssh-keygen -t ed25519 -f /tmp/ci_key -N ""
+          echo "TF_VAR_ssh_public_key_path=/tmp/ci_key.pub" >> "$GITHUB_ENV"
+      - name: Init
+        run: terraform init
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.B2_APPLICATION_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.B2_APPLICATION_KEY }}
+      - name: Plan
+        id: plan
+        run: terraform plan -no-color -out=tfplan
+        continue-on-error: true
+      - name: Comment PR with plan
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const output = `#### Terraform Plan
+            \`\`\`
+            ${{ steps.plan.outputs.stdout }}
+            \`\`\`
+            *Triggered by @${{ github.actor }}*`;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+      - name: Fail if plan failed
+        if: steps.plan.outcome == 'failure'
+        run: exit 1
+
+  apply:
+    name: Apply
+    needs: validate
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment: production
+    defaults:
+      run:
+        working-directory: terraform/hetzner
+    env:
+      TF_VAR_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~> 1.5"
+      - name: Generate CI SSH key
+        run: |
+          ssh-keygen -t ed25519 -f /tmp/ci_key -N ""
+          echo "TF_VAR_ssh_public_key_path=/tmp/ci_key.pub" >> "$GITHUB_ENV"
+      - name: Init
+        run: terraform init
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.B2_APPLICATION_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.B2_APPLICATION_KEY }}
+      - name: Apply
+        run: terraform apply -auto-approve


### PR DESCRIPTION
## Summary

- Add `.github/workflows/terraform.yml` with validate, plan, and apply jobs
- PRs touching `terraform/**` get format check, validation, and plan output posted as a PR comment
- Merges to main trigger auto-apply via the `production` environment (approval gate)
- B2 backend credentials passed to `terraform init` for state storage
- CI generates a temporary SSH key to satisfy the `ssh_public_key_path` variable during plan/apply

Closes #7

## Test plan

- [ ] Open a PR touching `terraform/` and verify the validate job runs (fmt + validate)
- [ ] Verify terraform plan output appears as a PR comment
- [ ] Merge to main and verify apply job triggers with production environment gate
- [ ] Confirm secrets `HCLOUD_TOKEN`, `B2_APPLICATION_KEY_ID`, `B2_APPLICATION_KEY` are configured in repo settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)