### PR TITLE
fix: CORS_ORIGINS must be JSON array for Pydantic Settings

### DIFF
--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -308,7 +308,7 @@ services:
       - REDIS_URL=redis://:${USER_REDIS_PASSWORD:?USER_REDIS_PASSWORD must be set}@user-redis:6379/0
       - JWT_PRIVATE_KEY=${JWT_PRIVATE_KEY:?JWT_PRIVATE_KEY must be set}
       - JWT_PUBLIC_KEY=${JWT_PUBLIC_KEY:?JWT_PUBLIC_KEY must be set}
-      - CORS_ORIGINS=${CORS_ORIGINS:-https://isnad-graph.noorinalabs.com}
+      - CORS_ORIGINS=["https://isnad-graph.noorinalabs.com"]
       - AUTH_GOOGLE_CLIENT_ID=${AUTH_GOOGLE_CLIENT_ID:-}
       - AUTH_GOOGLE_CLIENT_SECRET=${AUTH_GOOGLE_CLIENT_SECRET:-}
       - AUTH_GITHUB_CLIENT_ID=${AUTH_GITHUB_CLIENT_ID:-}


### PR DESCRIPTION
## Summary
- Change CORS_ORIGINS from plain string to JSON array format

## Root Cause
User-service crashed on startup with `SettingsError: error parsing value for field "CORS_ORIGINS"` / `JSONDecodeError`. Pydantic Settings expects `list[str]` fields as JSON arrays, not plain strings.

## Related Issues
Part of noorinalabs/noorinalabs-main#48

Co-Authored-By: Santiago Ferreira <parametrization+Santiago.Ferreira@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>