### PR TITLE
fix: Add bare-path Caddy routes for user-service endpoints

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -30,31 +30,49 @@ isnad-graph.noorinalabs.com {
     }
 
     # User service — user management API
+    handle /api/v1/users {
+        reverse_proxy user-service:8000
+    }
     handle /api/v1/users/* {
         reverse_proxy user-service:8000
     }
 
     # User service — session management
+    handle /api/v1/sessions {
+        reverse_proxy user-service:8000
+    }
     handle /api/v1/sessions/* {
         reverse_proxy user-service:8000
     }
 
     # User service — subscription management
+    handle /api/v1/subscriptions {
+        reverse_proxy user-service:8000
+    }
     handle /api/v1/subscriptions/* {
         reverse_proxy user-service:8000
     }
 
     # User service — email verification
+    handle /api/v1/verification {
+        reverse_proxy user-service:8000
+    }
     handle /api/v1/verification/* {
         reverse_proxy user-service:8000
     }
 
     # User service — roles
+    handle /api/v1/roles {
+        reverse_proxy user-service:8000
+    }
     handle /api/v1/roles/* {
         reverse_proxy user-service:8000
     }
 
     # User service — 2FA (TOTP)
+    handle /api/v1/2fa {
+        reverse_proxy user-service:8000
+    }
     handle /api/v1/2fa/* {
         reverse_proxy user-service:8000
     }


### PR DESCRIPTION
## Summary
- Add non-wildcard `handle` blocks for all user-service routes
- Fixes: bare `/api/v1/sessions`, `/api/v1/subscriptions`, `/api/v1/verification`, `/api/v1/roles`, `/api/v1/2fa`, `/api/v1/users` falling through to isnad-graph catch-all

## Related Issues
Closes #53

Co-Authored-By: Santiago Ferreira <parametrization+Santiago.Ferreira@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>