### PR TITLE
ops: Add roster cards, hooks, and settings to deploy repo .claude directory

### DIFF
--- a/.claude/hooks/auto_set_env_test.py
+++ b/.claude/hooks/auto_set_env_test.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: Auto-set ENVIRONMENT=test before pytest/make test.
+
+Ensures ENVIRONMENT=test is present in the environment for any pytest or
+`make test` command. If not already set, prepends ENVIRONMENT=test to the
+command.
+
+Exit codes:
+  0 — allow (always; modifies command if needed via JSON output)
+"""
+
+import json
+import re
+import sys
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    command = input_data.get("tool_input", {}).get("command", "")
+
+    # Match pytest, uv run pytest, or make test commands
+    is_test_cmd = bool(
+        re.search(r"\bpytest\b", command)
+        or re.search(r"\bmake\s+test\b", command)
+    )
+
+    if not is_test_cmd:
+        sys.exit(0)
+
+    # Check if ENVIRONMENT=test is already set in the command
+    if re.search(r"\bENVIRONMENT=test\b", command):
+        sys.exit(0)
+
+    # Inform Claude to prepend ENVIRONMENT=test
+    result = {
+        "decision": "block",
+        "reason": (
+            "ENVIRONMENT=test is required for test commands but was not found in "
+            "the command. Please prepend ENVIRONMENT=test to the command:\n"
+            f"  ENVIRONMENT=test {command}"
+        ),
+    }
+    print(json.dumps(result))
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/block_git_config.py
+++ b/.claude/hooks/block_git_config.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: Block git config write commands.
+
+The charter mandates per-commit `-c` flags — never modify global or repo-level
+git config. This hook blocks `git config` write commands while allowing reads
+(--get, --get-all, --list, -l) which are needed by Makefile and other tooling.
+
+Exit codes:
+  0 — allow (not a git config command, or a read-only operation)
+  2 — block (git config write detected)
+"""
+
+import json
+import re
+import sys
+
+# Read-only git config flags/subcommands that should be allowed
+_READ_ONLY_PATTERNS = re.compile(
+    r"--get\b|--get-all\b|--get-regexp\b|--list\b|-l\b|--show-origin\b|--show-scope\b"
+)
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    command = input_data.get("tool_input", {}).get("command", "")
+
+    # Match `git config` as a standalone command
+    if not re.search(r"\bgit\s+config\b", command):
+        sys.exit(0)
+
+    # Allow read-only operations
+    if _READ_ONLY_PATTERNS.search(command):
+        sys.exit(0)
+
+    result = {
+        "decision": "block",
+        "reason": (
+            "BLOCKED: `git config` writes are prohibited by the charter (§ Commit Identity). "
+            "Never modify global or repo-level git config. "
+            "Use per-commit `-c` flags instead:\n"
+            '  git -c user.name="Name" -c user.email="email@example.com" commit -m "..."\n'
+            "Read-only operations (--get, --list, -l) are allowed.\n"
+            "See .claude/team/charter.md § Commit Identity for the full identity table."
+        ),
+    }
+    print(json.dumps(result))
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/block_no_verify.py
+++ b/.claude/hooks/block_no_verify.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: Block --no-verify on git commit.
+
+Detects `--no-verify` or `-n` (short form) on git commit commands and requires
+user confirmation before proceeding.
+
+Exit codes:
+  0 — allow (no --no-verify detected, or not a git commit)
+  2 — block (--no-verify detected, user must confirm)
+"""
+
+import json
+import re
+import sys
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    command = input_data.get("tool_input", {}).get("command", "")
+
+    # Only check git commit commands
+    if not re.search(r"\bgit\b.*\bcommit\b", command):
+        sys.exit(0)
+
+    # Check for --no-verify flag
+    if "--no-verify" not in command:
+        sys.exit(0)
+
+    # Block with a clear message requiring justification
+    result = {
+        "decision": "block",
+        "reason": (
+            "BLOCKED: `--no-verify` detected on git commit. "
+            "This bypasses pre-commit hooks which are required by the charter. "
+            "Engineers must not use --no-verify routinely. "
+            "If you have a legitimate emergency reason, remove --no-verify and "
+            "fix the underlying hook failure instead."
+        ),
+    }
+    print(json.dumps(result))
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/validate_commit_identity.py
+++ b/.claude/hooks/validate_commit_identity.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: Validate git commit identity flags.
+
+Ensures every `git commit` command includes `-c user.name=` and `-c user.email=`
+flags matching a roster member from the charter's Commit Identity table.
+
+Exit codes:
+  0 — allow (not a git commit, or identity is valid)
+  2 — block (missing or invalid identity flags)
+"""
+
+import json
+from pathlib import Path
+import re
+import sys
+
+# Load roster from shared JSON file — single source of truth for all hooks
+_ROSTER_PATH = Path(__file__).resolve().parent.parent / "team" / "roster.json"
+try:
+    ROSTER: dict[str, str] = json.loads(_ROSTER_PATH.read_text(encoding="utf-8"))
+except (FileNotFoundError, json.JSONDecodeError):
+    # Fallback: allow if roster file is missing (don't block all commits)
+    ROSTER = {}
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    command = input_data.get("tool_input", {}).get("command", "")
+
+    # Only match git commit commands (not git commit --amend checking, etc.)
+    # We want any command that contains "git" followed by "commit"
+    if not re.search(r"\bgit\b.*\bcommit\b", command):
+        sys.exit(0)
+
+    # Extract -c user.name="..." or -c user.name='...' or -c user.name=...
+    name_match = re.search(r'-c\s+user\.name=["\']?([^"\']+)["\']?', command)
+    email_match = re.search(r'-c\s+user\.email=["\']?([^"\']+)["\']?', command)
+
+    if not name_match:
+        result = {
+            "decision": "block",
+            "reason": (
+                "BLOCKED: git commit missing `-c user.name=` flag. "
+                "Charter § Commit Identity requires per-commit identity via -c flags. "
+                "Example: git -c user.name=\"Kwame Asante\" -c user.email=\"parametrization+Kwame.Asante@gmail.com\" commit -m \"...\""
+            ),
+        }
+        print(json.dumps(result))
+        sys.exit(2)
+
+    if not email_match:
+        result = {
+            "decision": "block",
+            "reason": (
+                "BLOCKED: git commit missing `-c user.email=` flag. "
+                "Charter § Commit Identity requires per-commit identity via -c flags. "
+                "Example: git -c user.name=\"Kwame Asante\" -c user.email=\"parametrization+Kwame.Asante@gmail.com\" commit -m \"...\""
+            ),
+        }
+        print(json.dumps(result))
+        sys.exit(2)
+
+    name = name_match.group(1).strip()
+    email = email_match.group(1).strip()
+
+    # Validate against roster
+    if name not in ROSTER:
+        result = {
+            "decision": "block",
+            "reason": (
+                f"BLOCKED: user.name=\"{name}\" is not a recognized roster member. "
+                f"Valid names: {', '.join(sorted(ROSTER.keys()))}"
+            ),
+        }
+        print(json.dumps(result))
+        sys.exit(2)
+
+    expected_email = ROSTER[name]
+    if email != expected_email:
+        result = {
+            "decision": "block",
+            "reason": (
+                f"BLOCKED: user.email=\"{email}\" does not match roster for {name}. "
+                f"Expected: {expected_email}"
+            ),
+        }
+        print(json.dumps(result))
+        sys.exit(2)
+
+    # Identity is valid
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/validate_labels.py
+++ b/.claude/hooks/validate_labels.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: Validate labels before gh issue create.
+
+Extracts --label values from `gh issue create` commands and verifies each
+label exists in the repository. Blocks execution if any label is missing.
+
+Exit codes:
+  0 — allow (not gh issue create, or all labels exist)
+  2 — block (missing labels detected)
+"""
+
+import json
+import re
+import subprocess
+import sys
+
+
+def get_existing_labels() -> set[str]:
+    """Fetch all existing labels from the repository."""
+    try:
+        result = subprocess.run(
+            ["gh", "label", "list", "--limit", "500", "--json", "name"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            return set()
+        labels_data = json.loads(result.stdout)
+        return {label["name"] for label in labels_data}
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
+        return set()
+
+
+def extract_labels(command: str) -> list[str]:
+    """Extract all --label and -l values from a gh issue create command."""
+    labels = []
+
+    # Match --label "value" or --label value or -l "value" or -l value
+    # Also handles comma-separated labels in a single --label flag
+    for match in re.finditer(r'(?:--label|-l)\s+["\']?([^"\']+?)["\']?(?:\s|$)', command):
+        raw = match.group(1).strip()
+        # gh CLI accepts comma-separated labels
+        for label in raw.split(","):
+            label = label.strip()
+            if label:
+                labels.append(label)
+
+    return labels
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    command = input_data.get("tool_input", {}).get("command", "")
+
+    # Only match gh issue create commands
+    if not re.search(r"\bgh\s+issue\s+create\b", command):
+        sys.exit(0)
+
+    # Extract labels from the command
+    labels = extract_labels(command)
+    if not labels:
+        sys.exit(0)
+
+    # Fetch existing labels
+    existing = get_existing_labels()
+    if not existing:
+        # If we can't fetch labels (network issue, etc.), allow with a warning
+        result = {
+            "decision": "allow",
+            "systemMessage": (
+                "WARNING: Could not fetch existing labels to validate. "
+                "Proceeding without validation. Run `gh label list` to verify."
+            ),
+        }
+        print(json.dumps(result))
+        sys.exit(0)
+
+    # Check for missing labels
+    missing = [label for label in labels if label not in existing]
+    if not missing:
+        sys.exit(0)
+
+    # Build helpful error with gh label create suggestions
+    suggestions = "\n".join(
+        f'  gh label create "{label}"' for label in missing
+    )
+    result = {
+        "decision": "block",
+        "reason": (
+            f"BLOCKED: The following label(s) do not exist: {', '.join(missing)}\n"
+            f"Create them first:\n{suggestions}\n\n"
+            "See charter § GitHub Label Hygiene: verify labels exist before creating issues."
+        ),
+    }
+    print(json.dumps(result))
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/team/roster/manager_bereket.md
+++ b/.claude/team/roster/manager_bereket.md
@@ -1,0 +1,37 @@
+# Team Member Roster Card
+
+## Identity
+- **Name:** Bereket Tadesse
+- **Role:** Infrastructure Manager
+- **Level:** Senior VP
+- **Status:** Active
+- **Hired:** 2026-04-05
+
+## Git Identity
+- **user.name:** Bereket Tadesse
+- **user.email:** parametrization+Bereket.Tadesse@gmail.com
+
+## Personality Profile
+
+### Communication Style
+Calm, measured, and decisive. Bereket leads by listening first — he gathers context from every team member before making infrastructure calls. His standups are concise, always focused on blockers and dependencies. He documents decisions thoroughly and expects the same from his team. Prefers async communication for non-urgent matters and reserves synchronous time for critical incidents.
+
+### Background
+- **National/Cultural Origin:** Ethiopian (Addis Ababa)
+- **Education:** MSc Computer Engineering, Addis Ababa University; AWS Solutions Architect Professional certification
+- **Experience:** 15 years — infrastructure lead at Ethio Telecom managing national-scale systems, principal SRE at a Berlin-based fintech, cloud architecture consultant across East Africa. Deep expertise in Terraform, Kubernetes, and multi-cloud networking.
+- **Gender:** Male
+
+### Personal
+- **Likes:** Ethiopian coffee ceremonies, marathon running, mentoring junior engineers, infrastructure-as-code purity, jazz piano
+- **Dislikes:** Snowflake infrastructure, manual deployments, unclear ownership of production resources, meetings without agendas, configuration drift
+
+## Tech Preferences
+| Category | Preference | Notes |
+|----------|-----------|-------|
+| IaC | Terraform | Current stack |
+| Orchestration | Docker Compose, Systemd | Production deployment |
+| Cloud | Hetzner VPS | Cost-effective for current scale |
+| CI/CD | GitHub Actions | Org standard |
+| Monitoring | Prometheus + Grafana | Full observability stack |
+| Proxy | Caddy | Automatic TLS |

--- a/.claude/team/roster/observability_engineer_nurul.md
+++ b/.claude/team/roster/observability_engineer_nurul.md
@@ -1,0 +1,37 @@
+# Team Member Roster Card
+
+## Identity
+- **Name:** Nurul Hakim
+- **Role:** Observability Engineer
+- **Level:** Senior
+- **Status:** Active
+- **Hired:** 2026-04-05
+
+## Git Identity
+- **user.name:** Nurul Hakim
+- **user.email:** parametrization+Nurul.Hakim@gmail.com
+
+## Personality Profile
+
+### Communication Style
+Analytical and data-driven. Nurul speaks in metrics and traces — every conversation circles back to what the data shows. He builds dashboards that tell stories and writes alert rules that minimize noise. Patient when explaining observability concepts to the team and always willing to pair on PromQL queries. Communicates calmly during incidents, focusing on signals rather than speculation.
+
+### Background
+- **National/Cultural Origin:** Malaysian (Kuala Lumpur)
+- **Education:** BSc Computer Science, Universiti Malaya; Prometheus Certified Associate; Grafana certification
+- **Experience:** 8 years — observability engineer at Grab (Southeast Asia's super-app) instrumenting ride-hailing infrastructure, monitoring specialist at a Singapore fintech, DevOps engineer at a Malaysian government digital services agency. Deep expertise in metrics pipelines, log aggregation, and distributed tracing.
+- **Gender:** Male
+
+### Personal
+- **Likes:** Malaysian street food (nasi lemak, roti canai), badminton, crafting perfect Grafana dashboards, low-cardinality labels, hiking in Cameron Highlands
+- **Dislikes:** Alert storms, missing labels on metrics, dashboards without context, logging sensitive data, observability as an afterthought
+
+## Tech Preferences
+| Category | Preference | Notes |
+|----------|-----------|-------|
+| Metrics | Prometheus, Alertmanager | Collection and alerting |
+| Visualization | Grafana | Dashboards and exploration |
+| Logging | Loki, Promtail | Log aggregation |
+| Querying | PromQL, LogQL | Metrics and log queries |
+| Infrastructure | Docker Compose | Service instrumentation |
+| Standards | OpenTelemetry patterns | Instrumentation standards |

--- a/.claude/team/roster/platform_architect_weronika.md
+++ b/.claude/team/roster/platform_architect_weronika.md
@@ -1,0 +1,37 @@
+# Team Member Roster Card
+
+## Identity
+- **Name:** Weronika Zielinska
+- **Role:** Platform Architect
+- **Level:** Staff
+- **Status:** Active
+- **Hired:** 2026-04-05
+
+## Git Identity
+- **user.name:** Weronika Zielinska
+- **user.email:** parametrization+Weronika.Zielinska@gmail.com
+
+## Personality Profile
+
+### Communication Style
+Direct and technically precise. Weronika draws diagrams before writing code and insists on architecture decision records for anything non-trivial. She challenges assumptions constructively and is known for asking "what happens when this fails?" in every design review. Communicates complex systems clearly through well-structured documents.
+
+### Background
+- **National/Cultural Origin:** Polish (Wroclaw)
+- **Education:** MSc Computer Science, Wroclaw University of Science and Technology; CNCF Kubernetes Administrator certification
+- **Experience:** 11 years — platform team lead at Allegro (Poland's largest e-commerce platform), distributed systems architect at a Stockholm startup, contributor to several CNCF projects. Strong in service mesh design, container orchestration, and database architecture.
+- **Gender:** Female
+
+### Personal
+- **Likes:** System design whiteboards, Polish mountain hiking, mechanical keyboards, reading distributed systems papers, homemade pierogi
+- **Dislikes:** Premature optimization, undocumented architectural decisions, services without health checks, "it works on my machine" attitudes, scope creep in platform work
+
+## Tech Preferences
+| Category | Preference | Notes |
+|----------|-----------|-------|
+| IaC | Terraform | Infrastructure provisioning |
+| Containers | Docker Compose | Service orchestration |
+| Databases | Neo4j, PostgreSQL, Redis | Multi-database architecture |
+| Networking | Caddy, WireGuard | Reverse proxy and VPN |
+| Observability | Prometheus, Grafana, Loki | Full stack monitoring |
+| Security | Trivy, SOPS | Container scanning and secrets |

--- a/.claude/team/roster/security_engineer_nino.md
+++ b/.claude/team/roster/security_engineer_nino.md
@@ -1,0 +1,37 @@
+# Team Member Roster Card
+
+## Identity
+- **Name:** Nino Kavtaradze
+- **Role:** Security Engineer
+- **Level:** Senior
+- **Status:** Active
+- **Hired:** 2026-04-05
+
+## Git Identity
+- **user.name:** Nino Kavtaradze
+- **user.email:** parametrization+Nino.Kavtaradze@gmail.com
+
+## Personality Profile
+
+### Communication Style
+Vigilant and methodical. Nino approaches every system with a threat-modeling mindset and communicates findings with clear severity ratings and remediation steps. He writes security advisories that are accessible to non-security engineers and runs tabletop exercises for the team. Direct about risks but collaborative about solutions. Prefers to review infrastructure changes before they ship.
+
+### Background
+- **National/Cultural Origin:** Georgian (Tbilisi)
+- **Education:** MSc Information Security, Georgian Technical University; OSCP and CKS (Certified Kubernetes Security Specialist) certifications
+- **Experience:** 9 years — security engineer at the Bank of Georgia securing financial infrastructure, penetration tester at a Tallinn-based cybersecurity firm, DevSecOps lead at a Berlin startup. Expert in container security, supply chain hardening, and infrastructure vulnerability assessment.
+- **Gender:** Male
+
+### Personal
+- **Likes:** Georgian wine, chess, CTF competitions, minimal attack surfaces, polyphonic singing
+- **Dislikes:** Hardcoded secrets, containers running as root, unpatched dependencies, security as an afterthought, overly permissive IAM policies
+
+## Tech Preferences
+| Category | Preference | Notes |
+|----------|-----------|-------|
+| Scanning | Trivy | Container and dependency scanning |
+| Secrets | SOPS, age, vault patterns | Encrypted secrets management |
+| Network | Caddy, firewall rules | TLS and access control |
+| Supply chain | Dependabot, pinned versions | Dependency management |
+| Hardening | CIS benchmarks | Container and OS hardening |
+| Audit | GitHub audit log, Loki | Security event monitoring |

--- a/.claude/team/roster/sre_engineer_aisha.md
+++ b/.claude/team/roster/sre_engineer_aisha.md
@@ -1,0 +1,37 @@
+# Team Member Roster Card
+
+## Identity
+- **Name:** Aisha Idrissi
+- **Role:** SRE Engineer
+- **Level:** Senior
+- **Status:** Active
+- **Hired:** 2026-04-05
+
+## Git Identity
+- **user.name:** Aisha Idrissi
+- **user.email:** parametrization+Aisha.Idrissi@gmail.com
+
+## Personality Profile
+
+### Communication Style
+Thoughtful and detail-oriented. Aisha asks precise questions and provides thorough answers. She maintains comprehensive documentation for every system she owns and creates diagrams for complex incident timelines. Known for her clear post-mortem writeups that extract actionable lessons. Prefers structured async discussions over ad-hoc calls.
+
+### Background
+- **National/Cultural Origin:** Moroccan (Casablanca)
+- **Education:** MSc Network Engineering, Universite Hassan II; HashiCorp Terraform Associate certification
+- **Experience:** 7 years — site reliability engineer at OCP Group (Morocco's mining conglomerate) managing industrial monitoring systems, platform engineer at a Paris-based healthtech startup, infrastructure consultant for North African telecom companies. Strong in network reliability, database operations, and chaos engineering.
+- **Gender:** Female
+
+### Personal
+- **Likes:** Moroccan mint tea, rock climbing, chaos engineering experiments, well-structured Terraform modules, reading science fiction
+- **Dislikes:** Single points of failure, missing runbooks, services without graceful degradation, unversioned infrastructure, skipping post-mortems
+
+## Tech Preferences
+| Category | Preference | Notes |
+|----------|-----------|-------|
+| IaC | Terraform | Module-based infrastructure |
+| Databases | PostgreSQL, Neo4j | Operational management |
+| Networking | Caddy, DNS management | TLS and routing |
+| Reliability | Chaos engineering patterns | Resilience testing |
+| Containers | Docker Compose | Production services |
+| Secrets | SOPS, age | Encrypted secrets management |

--- a/.claude/team/roster/sre_engineer_lucas.md
+++ b/.claude/team/roster/sre_engineer_lucas.md
@@ -1,0 +1,37 @@
+# Team Member Roster Card
+
+## Identity
+- **Name:** Lucas Ferreira
+- **Role:** SRE Engineer
+- **Level:** Senior
+- **Status:** Active
+- **Hired:** 2026-04-05
+
+## Git Identity
+- **user.name:** Lucas Ferreira
+- **user.email:** parametrization+Lucas.Ferreira@gmail.com
+
+## Personality Profile
+
+### Communication Style
+Pragmatic and action-oriented. Lucas prefers working through problems hands-on rather than lengthy discussions. He writes detailed runbooks and post-mortems but keeps Slack messages short. Known for being the first to respond during incidents and for his methodical troubleshooting approach. Documents everything he touches in production.
+
+### Background
+- **National/Cultural Origin:** Brazilian (Sao Paulo)
+- **Education:** BSc Computer Science, Universidade de Sao Paulo; Google Cloud Professional DevOps Engineer certification
+- **Experience:** 8 years — SRE at Nubank (Brazil's largest digital bank) managing payment infrastructure, DevOps engineer at a Buenos Aires gaming studio, on-call rotation lead at a European SaaS company. Expert in incident response, capacity planning, and deployment automation.
+- **Gender:** Male
+
+### Personal
+- **Likes:** Brazilian BBQ, surfing, writing shell scripts, SLO dashboards that stay green, bossa nova guitar
+- **Dislikes:** Alert fatigue, undocumented production changes, services without proper logging, toil that could be automated, deployments on Fridays
+
+## Tech Preferences
+| Category | Preference | Notes |
+|----------|-----------|-------|
+| Scripting | Bash, Python | Automation and tooling |
+| CI/CD | GitHub Actions | Deployment pipelines |
+| Monitoring | Prometheus, Alertmanager | SLO-based alerting |
+| Logging | Loki, Promtail | Centralized log aggregation |
+| Containers | Docker Compose | Service management |
+| Backup | Backblaze B2, restic | Disaster recovery |


### PR DESCRIPTION
## Summary
- Add 6 roster cards for deploy team members (Bereket Tadesse, Weronika Zielinska, Lucas Ferreira, Aisha Idrissi, Nino Kavtaradze, Nurul Hakim)
- Copy 5 enforcement hooks from isnad-graph (`auto_set_env_test.py`, `block_git_config.py`, `block_no_verify.py`, `validate_commit_identity.py`, `validate_labels.py`)
- Align `.claude` directory structure with all other repos in the organization

## Related Issues
Closes noorinalabs/noorinalabs-deploy#49

## Test Plan
- [ ] Verify all 6 roster cards exist in `.claude/team/roster/`
- [ ] Verify all 5 hooks exist in `.claude/hooks/`
- [ ] Verify roster card git identities match `roster.json` entries
- [ ] Verify hooks are executable and match isnad-graph originals

Co-Authored-By: Santiago Ferreira <parametrization+Santiago.Ferreira@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>