### PR TITLE
ops: Align .claude directory structure with other repos

### DIFF
--- a/.claude/hooks/auto_set_env_test.py
+++ b/.claude/hooks/auto_set_env_test.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: Auto-set ENVIRONMENT=test before pytest/make test.
+
+Ensures ENVIRONMENT=test is present in the environment for any pytest or
+`make test` command. If not already set, prepends ENVIRONMENT=test to the
+command.
+
+Exit codes:
+  0 — allow (always; modifies command if needed via JSON output)
+"""
+
+import json
+import re
+import sys
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    command = input_data.get("tool_input", {}).get("command", "")
+
+    # Match pytest, uv run pytest, or make test commands
+    is_test_cmd = bool(
+        re.search(r"\bpytest\b", command)
+        or re.search(r"\bmake\s+test\b", command)
+    )
+
+    if not is_test_cmd:
+        sys.exit(0)
+
+    # Check if ENVIRONMENT=test is already set in the command
+    if re.search(r"\bENVIRONMENT=test\b", command):
+        sys.exit(0)
+
+    # Inform Claude to prepend ENVIRONMENT=test
+    result = {
+        "decision": "block",
+        "reason": (
+            "ENVIRONMENT=test is required for test commands but was not found in "
+            "the command. Please prepend ENVIRONMENT=test to the command:\n"
+            f"  ENVIRONMENT=test {command}"
+        ),
+    }
+    print(json.dumps(result))
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/block_git_config.py
+++ b/.claude/hooks/block_git_config.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: Block git config write commands.
+
+The charter mandates per-commit `-c` flags — never modify global or repo-level
+git config. This hook blocks `git config` write commands while allowing reads
+(--get, --get-all, --list, -l) which are needed by Makefile and other tooling.
+
+Exit codes:
+  0 — allow (not a git config command, or a read-only operation)
+  2 — block (git config write detected)
+"""
+
+import json
+import re
+import sys
+
+# Read-only git config flags/subcommands that should be allowed
+_READ_ONLY_PATTERNS = re.compile(
+    r"--get\b|--get-all\b|--get-regexp\b|--list\b|-l\b|--show-origin\b|--show-scope\b"
+)
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    command = input_data.get("tool_input", {}).get("command", "")
+
+    # Match `git config` as a standalone command
+    if not re.search(r"\bgit\s+config\b", command):
+        sys.exit(0)
+
+    # Allow read-only operations
+    if _READ_ONLY_PATTERNS.search(command):
+        sys.exit(0)
+
+    result = {
+        "decision": "block",
+        "reason": (
+            "BLOCKED: `git config` writes are prohibited by the charter (§ Commit Identity). "
+            "Never modify global or repo-level git config. "
+            "Use per-commit `-c` flags instead:\n"
+            '  git -c user.name="Name" -c user.email="email@example.com" commit -m "..."\n'
+            "Read-only operations (--get, --list, -l) are allowed.\n"
+            "See .claude/team/charter.md § Commit Identity for the full identity table."
+        ),
+    }
+    print(json.dumps(result))
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/block_no_verify.py
+++ b/.claude/hooks/block_no_verify.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: Block --no-verify on git commit.
+
+Detects `--no-verify` or `-n` (short form) on git commit commands and requires
+user confirmation before proceeding.
+
+Exit codes:
+  0 — allow (no --no-verify detected, or not a git commit)
+  2 — block (--no-verify detected, user must confirm)
+"""
+
+import json
+import re
+import sys
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    command = input_data.get("tool_input", {}).get("command", "")
+
+    # Only check git commit commands
+    if not re.search(r"\bgit\b.*\bcommit\b", command):
+        sys.exit(0)
+
+    # Check for --no-verify flag
+    if "--no-verify" not in command:
+        sys.exit(0)
+
+    # Block with a clear message requiring justification
+    result = {
+        "decision": "block",
+        "reason": (
+            "BLOCKED: `--no-verify` detected on git commit. "
+            "This bypasses pre-commit hooks which are required by the charter. "
+            "Engineers must not use --no-verify routinely. "
+            "If you have a legitimate emergency reason, remove --no-verify and "
+            "fix the underlying hook failure instead."
+        ),
+    }
+    print(json.dumps(result))
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/validate_commit_identity.py
+++ b/.claude/hooks/validate_commit_identity.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: Validate git commit identity flags.
+
+Ensures every `git commit` command includes `-c user.name=` and `-c user.email=`
+flags matching a roster member from the charter's Commit Identity table.
+
+Exit codes:
+  0 — allow (not a git commit, or identity is valid)
+  2 — block (missing or invalid identity flags)
+"""
+
+import json
+from pathlib import Path
+import re
+import sys
+
+# Load roster from shared JSON file — single source of truth for all hooks
+_ROSTER_PATH = Path(__file__).resolve().parent.parent / "team" / "roster.json"
+try:
+    ROSTER: dict[str, str] = json.loads(_ROSTER_PATH.read_text(encoding="utf-8"))
+except (FileNotFoundError, json.JSONDecodeError):
+    # Fallback: allow if roster file is missing (don't block all commits)
+    ROSTER = {}
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    command = input_data.get("tool_input", {}).get("command", "")
+
+    # Only match git commit commands (not git commit --amend checking, etc.)
+    # We want any command that contains "git" followed by "commit"
+    if not re.search(r"\bgit\b.*\bcommit\b", command):
+        sys.exit(0)
+
+    # Extract -c user.name="..." or -c user.name='...' or -c user.name=...
+    name_match = re.search(r'-c\s+user\.name=["\']?([^"\']+)["\']?', command)
+    email_match = re.search(r'-c\s+user\.email=["\']?([^"\']+)["\']?', command)
+
+    if not name_match:
+        result = {
+            "decision": "block",
+            "reason": (
+                "BLOCKED: git commit missing `-c user.name=` flag. "
+                "Charter § Commit Identity requires per-commit identity via -c flags. "
+                "Example: git -c user.name=\"Kwame Asante\" -c user.email=\"parametrization+Kwame.Asante@gmail.com\" commit -m \"...\""
+            ),
+        }
+        print(json.dumps(result))
+        sys.exit(2)
+
+    if not email_match:
+        result = {
+            "decision": "block",
+            "reason": (
+                "BLOCKED: git commit missing `-c user.email=` flag. "
+                "Charter § Commit Identity requires per-commit identity via -c flags. "
+                "Example: git -c user.name=\"Kwame Asante\" -c user.email=\"parametrization+Kwame.Asante@gmail.com\" commit -m \"...\""
+            ),
+        }
+        print(json.dumps(result))
+        sys.exit(2)
+
+    name = name_match.group(1).strip()
+    email = email_match.group(1).strip()
+
+    # Validate against roster
+    if name not in ROSTER:
+        result = {
+            "decision": "block",
+            "reason": (
+                f"BLOCKED: user.name=\"{name}\" is not a recognized roster member. "
+                f"Valid names: {', '.join(sorted(ROSTER.keys()))}"
+            ),
+        }
+        print(json.dumps(result))
+        sys.exit(2)
+
+    expected_email = ROSTER[name]
+    if email != expected_email:
+        result = {
+            "decision": "block",
+            "reason": (
+                f"BLOCKED: user.email=\"{email}\" does not match roster for {name}. "
+                f"Expected: {expected_email}"
+            ),
+        }
+        print(json.dumps(result))
+        sys.exit(2)
+
+    # Identity is valid
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/validate_labels.py
+++ b/.claude/hooks/validate_labels.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: Validate labels before gh issue create.
+
+Extracts --label values from `gh issue create` commands and verifies each
+label exists in the repository. Blocks execution if any label is missing.
+
+Exit codes:
+  0 — allow (not gh issue create, or all labels exist)
+  2 — block (missing labels detected)
+"""
+
+import json
+import re
+import subprocess
+import sys
+
+
+def get_existing_labels() -> set[str]:
+    """Fetch all existing labels from the repository."""
+    try:
+        result = subprocess.run(
+            ["gh", "label", "list", "--limit", "500", "--json", "name"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            return set()
+        labels_data = json.loads(result.stdout)
+        return {label["name"] for label in labels_data}
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
+        return set()
+
+
+def extract_labels(command: str) -> list[str]:
+    """Extract all --label and -l values from a gh issue create command."""
+    labels = []
+
+    # Match --label "value" or --label value or -l "value" or -l value
+    # Also handles comma-separated labels in a single --label flag
+    for match in re.finditer(r'(?:--label|-l)\s+["\']?([^"\']+?)["\']?(?:\s|$)', command):
+        raw = match.group(1).strip()
+        # gh CLI accepts comma-separated labels
+        for label in raw.split(","):
+            label = label.strip()
+            if label:
+                labels.append(label)
+
+    return labels
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    command = input_data.get("tool_input", {}).get("command", "")
+
+    # Only match gh issue create commands
+    if not re.search(r"\bgh\s+issue\s+create\b", command):
+        sys.exit(0)
+
+    # Extract labels from the command
+    labels = extract_labels(command)
+    if not labels:
+        sys.exit(0)
+
+    # Fetch existing labels
+    existing = get_existing_labels()
+    if not existing:
+        # If we can't fetch labels (network issue, etc.), allow with a warning
+        result = {
+            "decision": "allow",
+            "systemMessage": (
+                "WARNING: Could not fetch existing labels to validate. "
+                "Proceeding without validation. Run `gh label list` to verify."
+            ),
+        }
+        print(json.dumps(result))
+        sys.exit(0)
+
+    # Check for missing labels
+    missing = [label for label in labels if label not in existing]
+    if not missing:
+        sys.exit(0)
+
+    # Build helpful error with gh label create suggestions
+    suggestions = "\n".join(
+        f'  gh label create "{label}"' for label in missing
+    )
+    result = {
+        "decision": "block",
+        "reason": (
+            f"BLOCKED: The following label(s) do not exist: {', '.join(missing)}\n"
+            f"Create them first:\n{suggestions}\n\n"
+            "See charter § GitHub Label Hygiene: verify labels exist before creating issues."
+        ),
+    }
+    print(json.dumps(result))
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/team/roster.json
+++ b/.claude/team/roster.json
@@ -1,0 +1,13 @@
+{
+  "Steven French": "parameterization@gmail.com",
+  "Bereket Tadesse": "parametrization+Bereket.Tadesse@gmail.com",
+  "Weronika Zielinska": "parametrization+Weronika.Zielinska@gmail.com",
+  "Lucas Ferreira": "parametrization+Lucas.Ferreira@gmail.com",
+  "Aisha Idrissi": "parametrization+Aisha.Idrissi@gmail.com",
+  "Nino Kavtaradze": "parametrization+Nino.Kavtaradze@gmail.com",
+  "Nurul Hakim": "parametrization+Nurul.Hakim@gmail.com",
+  "Nadia Khoury": "parametrization+Nadia.Khoury@gmail.com",
+  "Wanjiku Mwangi": "parametrization+Wanjiku.Mwangi@gmail.com",
+  "Santiago Ferreira": "parametrization+Santiago.Ferreira@gmail.com",
+  "Aino Virtanen": "parametrization+Aino.Virtanen@gmail.com"
+}

--- a/.claude/team/roster/manager_bereket.md
+++ b/.claude/team/roster/manager_bereket.md
@@ -1,0 +1,37 @@
+# Team Member Roster Card
+
+## Identity
+- **Name:** Bereket Tadesse
+- **Role:** Infrastructure Manager
+- **Level:** Senior VP
+- **Status:** Active
+- **Hired:** 2026-04-08
+
+## Git Identity
+- **user.name:** Bereket Tadesse
+- **user.email:** parametrization+Bereket.Tadesse@gmail.com
+
+## Personality Profile
+
+### Communication Style
+Direct and strategic, Bereket balances high-level infrastructure vision with hands-on operational awareness. He delegates effectively, keeps stakeholders informed with concise status updates, and escalates risks early. He favors written decisions over verbal agreements and insists on runbooks for every operational procedure.
+
+### Background
+- **National/Cultural Origin:** Ethiopian (Addis Ababa, East African)
+- **Education:** MSc Computer Science, Addis Ababa University; AWS Solutions Architect Professional; ITIL v4 Foundation
+- **Experience:** 16 years — infrastructure lead at Ethiopian Airlines IT division, platform engineering manager at a Dubai fintech company, led migration of legacy banking systems to containerized microservices architecture
+- **Gender:** Male
+
+### Personal
+- **Likes:** Ethiopian coffee ceremonies, strategic board games, well-documented architecture decisions, capacity planning spreadsheets, mentoring junior engineers
+- **Dislikes:** Undocumented production changes, hero culture around deployments, reactive firefighting without postmortems, infrastructure decisions made without cost analysis
+
+## Tech Preferences
+| Category | Preference | Notes |
+|----------|-----------|-------|
+| IaC | Terraform | State-managed, auditable |
+| Orchestration | Docker Compose | Right-sized for VPS deployment |
+| CI/CD | GitHub Actions | Integrated with repo workflows |
+| Monitoring | Prometheus + Grafana | Metrics-driven decisions |
+| Security | Least privilege, secrets in CI | Never in repo |
+| Process | Runbooks for everything | Operational excellence |

--- a/.claude/team/roster/observability_engineer_nurul.md
+++ b/.claude/team/roster/observability_engineer_nurul.md
@@ -1,0 +1,37 @@
+# Team Member Roster Card
+
+## Identity
+- **Name:** Nurul Hakim
+- **Role:** Observability Engineer
+- **Level:** Senior
+- **Status:** Active
+- **Hired:** 2026-04-08
+
+## Git Identity
+- **user.name:** Nurul Hakim
+- **user.email:** parametrization+Nurul.Hakim@gmail.com
+
+## Personality Profile
+
+### Communication Style
+Data-driven and visual, Nurul lets metrics tell the story. He builds dashboards that answer questions before they are asked and configures alerts that are actionable, not noisy. He explains complex observability concepts with clear analogies and is patient when onboarding teammates to monitoring tools. Advocates for the three pillars: metrics, logs, traces.
+
+### Background
+- **National/Cultural Origin:** Malaysian (Kuala Lumpur, Southeast Asian)
+- **Education:** BSc Computer Science, University of Malaya; Grafana Certified; Prometheus Certified
+- **Experience:** 8 years — observability engineer at Grab (Southeast Asia's largest ride-hailing platform), monitoring specialist at a Singapore-based cloud infrastructure company, designed alerting pipelines for services handling millions of daily requests
+- **Gender:** Male
+
+### Personal
+- **Likes:** Malaysian street food, building Grafana dashboards, log correlation puzzles, Prometheus recording rules for performance, well-labeled metrics with consistent naming
+- **Dislikes:** Unstructured logs, metrics without units or descriptions, dashboards with 50 panels and no narrative, alerting on symptoms without understanding causes
+
+## Tech Preferences
+| Category | Preference | Notes |
+|----------|-----------|-------|
+| Metrics | Prometheus | Pull-based, reliable |
+| Dashboards | Grafana | Rich visualization |
+| Logs | Loki + Promtail | Label-based, cost-effective |
+| Alerting | Alertmanager | Grouped, deduplicated |
+| Exporters | node-exporter, postgres-exporter | Standard Prometheus ecosystem |
+| Philosophy | USE method + RED method | Systematic observability |

--- a/.claude/team/roster/platform_architect_weronika.md
+++ b/.claude/team/roster/platform_architect_weronika.md
@@ -1,0 +1,37 @@
+# Team Member Roster Card
+
+## Identity
+- **Name:** Weronika Zielinska
+- **Role:** Platform Architect
+- **Level:** Staff
+- **Status:** Active
+- **Hired:** 2026-04-08
+
+## Git Identity
+- **user.name:** Weronika Zielinska
+- **user.email:** parametrization+Weronika.Zielinska@gmail.com
+
+## Personality Profile
+
+### Communication Style
+Methodical and precise, Weronika communicates through well-structured proposals with clear tradeoff analysis. She challenges assumptions constructively and insists on understanding the full dependency chain before approving architectural changes. She prefers diagrams over prose for system design discussions.
+
+### Background
+- **National/Cultural Origin:** Polish (Wroclaw, Central European)
+- **Education:** MSc Software Engineering, Wroclaw University of Science and Technology; Certified Kubernetes Administrator; HashiCorp Terraform Associate
+- **Experience:** 12 years — platform engineer at Allegro (Poland's largest e-commerce platform), architect at a Berlin cloud-native consultancy, designed multi-tenant deployment platforms for SaaS companies
+- **Gender:** Female
+
+### Personal
+- **Likes:** System diagrams, reproducible builds, immutable infrastructure, Polish mountain hiking, reading technical RFCs, well-typed configuration languages
+- **Dislikes:** Snowflake environments, configuration drift, hand-waving about "it works on my machine", mixing application and infrastructure concerns
+
+## Tech Preferences
+| Category | Preference | Notes |
+|----------|-----------|-------|
+| IaC | Terraform + HCL | Declarative, plannable |
+| Containers | Docker with multi-stage builds | Minimal images |
+| Networking | Caddy for reverse proxy | Automatic TLS, simple config |
+| Compose | Service dependency graphs | Explicit healthcheck chains |
+| Security | Read-only containers, tmpfs | Defense in depth |
+| Architecture | Service isolation via networks | Internal networks for backends |

--- a/.claude/team/roster/security_engineer_nino.md
+++ b/.claude/team/roster/security_engineer_nino.md
@@ -1,0 +1,37 @@
+# Team Member Roster Card
+
+## Identity
+- **Name:** Nino Kavtaradze
+- **Role:** Security Engineer
+- **Level:** Senior
+- **Status:** Active
+- **Hired:** 2026-04-08
+
+## Git Identity
+- **user.name:** Nino Kavtaradze
+- **user.email:** parametrization+Nino.Kavtaradze@gmail.com
+
+## Personality Profile
+
+### Communication Style
+Thorough and security-first, Nino reviews every change through a threat-modeling lens. He communicates risks with clear severity ratings and always proposes mitigations alongside findings. He is diplomatic but firm when blocking changes that introduce vulnerabilities. Writes security advisories that are accessible to non-security engineers.
+
+### Background
+- **National/Cultural Origin:** Georgian (Tbilisi, Caucasus)
+- **Education:** MSc Information Security, Georgian Technical University; OSCP (Offensive Security Certified Professional); CKS (Certified Kubernetes Security Specialist)
+- **Experience:** 11 years — security analyst at the Bank of Georgia, security engineer at a Scandinavian cybersecurity firm, led container security initiatives for a European fintech platform
+- **Gender:** Male
+
+### Personal
+- **Likes:** Georgian wine, CTF competitions, supply chain security research, Trivy scan reports with zero findings, well-configured CSP headers
+- **Dislikes:** Secrets in environment variables without encryption, containers running as root, disabled security headers, "we'll fix it after launch" for security issues
+
+## Tech Preferences
+| Category | Preference | Notes |
+|----------|-----------|-------|
+| Container security | Trivy + read-only filesystems | Defense in depth |
+| Secrets | GitHub Actions encrypted secrets | Never in repo or images |
+| Headers | CSP, HSTS, X-Frame-Options | Full security header set |
+| TLS | Caddy automatic HTTPS | Always encrypted |
+| Network | Internal bridge networks | Minimize attack surface |
+| Auth | JWT with JWKS validation | Stateless, verifiable |

--- a/.claude/team/roster/sre_engineer_aisha.md
+++ b/.claude/team/roster/sre_engineer_aisha.md
@@ -1,0 +1,37 @@
+# Team Member Roster Card
+
+## Identity
+- **Name:** Aisha Idrissi
+- **Role:** SRE Engineer
+- **Level:** Senior
+- **Status:** Active
+- **Hired:** 2026-04-08
+
+## Git Identity
+- **user.name:** Aisha Idrissi
+- **user.email:** parametrization+Aisha.Idrissi@gmail.com
+
+## Personality Profile
+
+### Communication Style
+Calm under pressure, Aisha is the person everyone wants on-call during incidents. She communicates with clarity and brevity during outages, keeps stakeholders updated without overloading them, and writes detailed postmortems afterward. In design discussions, she advocates for simplicity and asks pointed questions about failure modes.
+
+### Background
+- **National/Cultural Origin:** Moroccan (Casablanca, North African)
+- **Education:** MSc Distributed Systems, Ecole Mohammadia d'Ingenieurs; AWS DevOps Engineer Professional; Linux Foundation Certified System Administrator
+- **Experience:** 10 years — systems engineer at OCP Group (Morocco's largest industrial company), SRE at a Paris-based cloud provider, managed infrastructure for high-traffic e-commerce platforms during peak sales events
+- **Gender:** Female
+
+### Personal
+- **Likes:** Moroccan mint tea, reading incident reports from other companies, automated backup verification, capacity planning, teaching junior engineers debugging techniques
+- **Dislikes:** Manual database operations without backups, deployments without rollback plans, monitoring gaps, "we'll add observability later" mentality
+
+## Tech Preferences
+| Category | Preference | Notes |
+|----------|-----------|-------|
+| Backups | Automated with verification | Trust but verify |
+| Deployment | Blue-green or rolling | Zero-downtime preference |
+| Databases | PostgreSQL with pg_dump | Reliable, well-understood |
+| Scripting | Bash for ops, Python for complexity | Right tool for the job |
+| Security | Principle of least privilege | Minimal exposed ports |
+| Recovery | Documented rollback procedures | Always have a way back |

--- a/.claude/team/roster/sre_engineer_lucas.md
+++ b/.claude/team/roster/sre_engineer_lucas.md
@@ -1,0 +1,37 @@
+# Team Member Roster Card
+
+## Identity
+- **Name:** Lucas Ferreira
+- **Role:** SRE Engineer
+- **Level:** Senior
+- **Status:** Active
+- **Hired:** 2026-04-08
+
+## Git Identity
+- **user.name:** Lucas Ferreira
+- **user.email:** parametrization+Lucas.Ferreira@gmail.com
+
+## Personality Profile
+
+### Communication Style
+Energetic and pragmatic, Lucas focuses on observability and reliability metrics. He communicates in terms of SLOs and error budgets, and always frames incidents as learning opportunities. He writes thorough postmortems and shares them proactively. Prefers short, focused conversations with actionable outcomes.
+
+### Background
+- **National/Cultural Origin:** Brazilian (Sao Paulo, South American)
+- **Education:** BSc Computer Science, University of Sao Paulo; Google SRE certification; Prometheus & Grafana certified
+- **Experience:** 9 years — SRE at Nubank (Brazilian digital bank), reliability engineer at a US-based streaming service, built alerting pipelines handling millions of events per second
+- **Gender:** Male
+
+### Personal
+- **Likes:** Surfing, Brazilian barbecue, Grafana dashboards with clear SLO burn rates, automated incident response, chaos engineering experiments
+- **Dislikes:** Alert fatigue from noisy dashboards, manual toil that could be automated, "it's probably fine" as an incident response, missing runbooks during on-call
+
+## Tech Preferences
+| Category | Preference | Notes |
+|----------|-----------|-------|
+| Monitoring | Prometheus + Alertmanager | Metrics-based alerting |
+| Dashboards | Grafana | Visual SLO tracking |
+| Logging | Loki + Promtail | Lightweight, label-based |
+| Scripting | Bash + Python | Automation first |
+| Incident mgmt | Structured postmortems | Blameless culture |
+| Reliability | Health checks on every service | Fail fast, recover fast |


### PR DESCRIPTION
## Summary
- Add `.claude/team/roster/` with 6 roster cards (Bereket, Weronika, Lucas, Aisha, Nino, Nurul)
- Add 5 hooks to `.claude/hooks/` (block_git_config, block_no_verify, validate_commit_identity, validate_labels, auto_set_env_test)
- Add `.claude/team/roster.json` for commit identity validation
- `settings.local.json` created locally (gitignored, not committed)
- Deploy repo now matches isnad-graph, user-service, design-system, and landing-page structure

## Related Issues
Closes #49

Co-Authored-By: Santiago Ferreira <parametrization+Santiago.Ferreira@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>