### PR TITLE
fix: Use REDISCLI_AUTH env var for Redis health checks

### DIFF
--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -89,7 +89,7 @@ services:
     tmpfs:
       - /tmp:size=64M
     healthcheck:
-      test: ["CMD-SHELL", "redis-cli -a \"${REDIS_PASSWORD}\" ping | grep -q PONG"]
+      test: ["CMD-SHELL", "REDISCLI_AUTH=${REDIS_PASSWORD} redis-cli ping | grep -q PONG"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -388,7 +388,7 @@ services:
     volumes:
       - user_redis_data:/data
     healthcheck:
-      test: ["CMD-SHELL", "redis-cli -a \"${USER_REDIS_PASSWORD}\" ping | grep -q PONG"]
+      test: ["CMD-SHELL", "REDISCLI_AUTH=${USER_REDIS_PASSWORD} redis-cli ping | grep -q PONG"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
- Replace `redis-cli -a "${REDIS_PASSWORD}"` with `REDISCLI_AUTH=${REDIS_PASSWORD} redis-cli` in both `redis` and `user-redis` health checks
- The `-a` flag exposes the password in process listings (`/proc/*/cmdline`); `REDISCLI_AUTH` passes it via environment instead
- Both services updated for consistency

## Related Issues
Closes #41

## Review Checklist
- [ ] Reviewed by another team member
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Nadia Khoury <parametrization+Nadia.Khoury@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>