### PR TITLE
fix: Add JWT key env vars and pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,40 @@
+# Pre-commit hooks for noorinalabs-deploy
+# Install: pre-commit install
+# Docs: https://pre-commit.com/
+#
+# Hook execution order (fail-fast, cheapest first):
+#   1. Terraform format check
+#   2. Terraform validate
+#   3. gitleaks (secret detection)
+#
+# Prerequisites:
+#   - Terraform ~> 1.5
+
+repos:
+  # --- Terraform format ---
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.96.3
+    hooks:
+      - id: terraform_fmt
+        name: terraform-fmt
+
+      - id: terraform_validate
+        name: terraform-validate
+
+  # --- Secret detection ---
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.24.3
+    hooks:
+      - id: gitleaks
+        name: gitleaks
+
+  # --- Env file completeness check ---
+  - repo: local
+    hooks:
+      - id: env-example-check
+        name: env-example-check
+        entry: bash -c 'docker compose --env-file compose/.env.example -f compose/docker-compose.prod.yml config > /dev/null 2>&1 || echo "WARNING: .env.example may be incomplete (docker compose config failed)"'
+        language: system
+        pass_filenames: false
+        files: (\.env|docker-compose)
+        stages: [pre-commit]

--- a/compose/.env.example
+++ b/compose/.env.example
@@ -19,6 +19,8 @@ USER_REDIS_PASSWORD=changeme
 
 # User service auth
 JWT_SECRET=changeme
+JWT_PRIVATE_KEY=
+JWT_PUBLIC_KEY=
 CORS_ORIGINS=https://isnad-graph.noorinalabs.com
 
 # Observability


### PR DESCRIPTION
## Summary
- Add `JWT_PRIVATE_KEY` and `JWT_PUBLIC_KEY` placeholder entries to `compose/.env.example` so `docker compose config` validates
- Create `.pre-commit-config.yaml` with terraform fmt/validate, gitleaks, and env file completeness check

## Related Issues
Closes #60
Closes #61

## Review Checklist
- [ ] Reviewed by another team member
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Santiago Ferreira <parametrization+Santiago.Ferreira@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>