### PR TITLE
fix: Restrict metrics and observability service exposure

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -98,9 +98,10 @@ isnad-graph.noorinalabs.com {
         reverse_proxy api:8000
     }
 
-    # Metrics (Prometheus scrape endpoint)
+    # Metrics — not publicly proxied; Prometheus scrapes api:8000
+    # directly via the Docker backend network (see prometheus.yml).
     handle /metrics {
-        reverse_proxy api:8000
+        respond 403
     }
 
     # ── Other services ───────────────────────────────────────────────

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -12,8 +12,8 @@ services:
       dockerfile: Dockerfile
     image: noorinalabs-isnad-graph-neo4j:5-community
     ports:
-      - "7474:7474"
-      - "7687:7687"
+      - "127.0.0.1:7474:7474"
+      - "127.0.0.1:7687:7687"
     environment:
       NEO4J_AUTH: "neo4j/${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set}"
       NEO4J_PLUGINS: '["apoc", "graph-data-science"]'
@@ -444,7 +444,7 @@ services:
       - "--storage.tsdb.retention.time=30d"
       - "--web.enable-lifecycle"
     ports:
-      - "9090:9090"
+      - "127.0.0.1:9090:9090"
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:9090/-/healthy || exit 1"]
       interval: 10s
@@ -467,7 +467,7 @@ services:
       - "--config.file=/etc/alertmanager/alertmanager.yml"
       - "--storage.path=/alertmanager"
     ports:
-      - "9093:9093"
+      - "127.0.0.1:9093:9093"
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:9093/-/healthy || exit 1"]
       interval: 10s
@@ -530,7 +530,7 @@ services:
     command:
       - "-config.file=/etc/loki/local-config.yaml"
     ports:
-      - "3100:3100"
+      - "127.0.0.1:3100:3100"
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:3100/ready || exit 1"]
       interval: 10s
@@ -590,7 +590,7 @@ services:
   node-exporter:
     image: prom/node-exporter:v1.9.1
     ports:
-      - "9100:9100"
+      - "127.0.0.1:9100:9100"
     volumes:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
@@ -619,7 +619,7 @@ services:
     environment:
       DATA_SOURCE_NAME: "postgresql://${POSTGRES_USER:?POSTGRES_USER must be set}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/${POSTGRES_DB:?POSTGRES_DB must be set}?sslmode=disable"
     ports:
-      - "9187:9187"
+      - "127.0.0.1:9187:9187"
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:9187/metrics || exit 1"]
       interval: 10s


### PR DESCRIPTION
## Summary
- Block public `/metrics` proxy in Caddyfile — returns 403 instead of forwarding to the API. Prometheus scrapes `api:8000` directly via the Docker `backend` network so the Caddy route was unnecessary and exposed internal metrics publicly (#68)
- Bind all observability services (Prometheus, Alertmanager, Loki, node-exporter, postgres-exporter) and Neo4j to `127.0.0.1` instead of `0.0.0.0`, restricting access to the host only. Only Caddy remains publicly exposed on ports 80/443 (#69)

## Related Issues
Closes #68
Closes #69

## Review Checklist
- [ ] Reviewed by another team member
- [ ] Must-fix items resolved

Co-Authored-By: Santiago Ferreira <parametrization+Santiago.Ferreira@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>