### PR TITLE
infra: B2 pipeline bucket scaffolding + MinIO local-dev (#105)

### DIFF
--- a/.github/workflows/deploy-isnad-graph.yml
+++ b/.github/workflows/deploy-isnad-graph.yml
@@ -43,11 +43,18 @@ jobs:
           AUTH_GITHUB_CLIENT_SECRET: ${{ secrets.AUTH_GITHUB_CLIENT_SECRET }}
           GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
           IMAGE_TAG: ${{ steps.tag.outputs.tag }}
+          # PIPELINE_B2_* — alphabetical block; outputs of `terraform apply`
+          # in terraform/backblaze. Secrets must be created post-bucket-apply.
+          PIPELINE_B2_BUCKET: ${{ secrets.PIPELINE_B2_BUCKET }}
+          PIPELINE_B2_ENDPOINT: ${{ secrets.PIPELINE_B2_ENDPOINT }}
+          PIPELINE_B2_KEY: ${{ secrets.PIPELINE_B2_KEY }}
+          PIPELINE_B2_KEY_ID: ${{ secrets.PIPELINE_B2_KEY_ID }}
+          PIPELINE_B2_REGION: ${{ secrets.PIPELINE_B2_REGION }}
         with:
           host: ${{ vars.VPS_HOST }}
           username: deploy
           key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
-          envs: NEO4J_PASSWORD,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,REDIS_PASSWORD,AUTH_GOOGLE_CLIENT_ID,AUTH_GOOGLE_CLIENT_SECRET,AUTH_GITHUB_CLIENT_ID,AUTH_GITHUB_CLIENT_SECRET,GRAFANA_ADMIN_PASSWORD,IMAGE_TAG
+          envs: NEO4J_PASSWORD,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,REDIS_PASSWORD,AUTH_GOOGLE_CLIENT_ID,AUTH_GOOGLE_CLIENT_SECRET,AUTH_GITHUB_CLIENT_ID,AUTH_GITHUB_CLIENT_SECRET,GRAFANA_ADMIN_PASSWORD,IMAGE_TAG,PIPELINE_B2_BUCKET,PIPELINE_B2_ENDPOINT,PIPELINE_B2_KEY,PIPELINE_B2_KEY_ID,PIPELINE_B2_REGION
           script: |
             set -euo pipefail
             cd /opt/noorinalabs-deploy
@@ -62,7 +69,9 @@ jobs:
             for var in NEO4J_PASSWORD POSTGRES_USER POSTGRES_PASSWORD POSTGRES_DB \
                        REDIS_PASSWORD AUTH_GOOGLE_CLIENT_ID AUTH_GOOGLE_CLIENT_SECRET \
                        AUTH_GITHUB_CLIENT_ID AUTH_GITHUB_CLIENT_SECRET \
-                       GRAFANA_ADMIN_PASSWORD; do
+                       GRAFANA_ADMIN_PASSWORD \
+                       PIPELINE_B2_BUCKET PIPELINE_B2_ENDPOINT PIPELINE_B2_KEY \
+                       PIPELINE_B2_KEY_ID PIPELINE_B2_REGION; do
               eval "val=\$$var"
               echo "$var=\"$val\"" >> "$env_file"
             done

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -11,19 +11,33 @@ permissions:
   pull-requests: write
 
 jobs:
-  validate:
-    name: Validate
+  fmt:
+    name: Format check
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: terraform/hetzner
     steps:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "~> 1.5"
-      - name: Format check
-        run: terraform fmt -check -recursive
+      - name: terraform fmt -check -recursive
+        run: terraform fmt -check -recursive terraform/
+
+  validate:
+    name: Validate (${{ matrix.module }})
+    needs: fmt
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        module: [hetzner, cloudflare, backblaze]
+    defaults:
+      run:
+        working-directory: terraform/${{ matrix.module }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~> 1.5"
       - name: Init (no backend)
         run: terraform init -backend=false
       - name: Validate
@@ -61,7 +75,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const output = `#### Terraform Plan
+            const output = `#### Terraform Plan (hetzner)
             \`\`\`
             ${{ steps.plan.outputs.stdout }}
             \`\`\`

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ docker-compose.override.yml
 # Environment
 .env
 *.env.local
+compose/minio.env
 
 # Temp / Cache
 tmp/

--- a/compose/.env.example
+++ b/compose/.env.example
@@ -30,3 +30,12 @@ GRAFANA_ADMIN_PASSWORD=changeme
 IMAGE_TAG=latest
 USER_SERVICE_IMAGE_TAG=latest
 CACHEBUST=1
+
+# Pipeline object storage (Backblaze B2 in prod, MinIO in local dev).
+# Prod values come from the `terraform/backblaze/` module outputs, injected
+# into this file by the deploy workflow via SSH.
+PIPELINE_B2_KEY_ID=
+PIPELINE_B2_KEY=
+PIPELINE_B2_BUCKET=noorinalabs-pipeline
+PIPELINE_B2_ENDPOINT=https://s3.us-east-005.backblazeb2.com
+PIPELINE_B2_REGION=us-east-005

--- a/compose/docker-compose.minio.yml
+++ b/compose/docker-compose.minio.yml
@@ -1,0 +1,67 @@
+# MinIO local-dev stack — S3-compatible object store that mirrors the Backblaze
+# B2 `noorinalabs-pipeline` layout for local ingest-platform development.
+#
+# Usage (from repo root):
+#   cp compose/minio.env.example compose/minio.env
+#   docker compose -f compose/docker-compose.minio.yml --env-file compose/minio.env up -d
+#
+# The `minio-setup` one-shot service creates the bucket and stage prefixes so
+# pipeline code can target the same key structure in dev and prod.
+
+services:
+  minio:
+    image: minio/minio:RELEASE.2025-04-08T15-41-24Z
+    container_name: noorinalabs-pipeline-minio
+    command: server /data --console-address ":9001"
+    ports:
+      # 9000 = S3 API, 9001 = web console. Bind to loopback only for dev safety.
+      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:9001:9001"
+    environment:
+      MINIO_ROOT_USER: "${MINIO_ROOT_USER:?MINIO_ROOT_USER must be set}"
+      MINIO_ROOT_PASSWORD: "${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD must be set}"
+      MINIO_REGION: "us-east-005"
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9000/minio/health/live || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - pipeline
+    restart: unless-stopped
+
+  # One-shot job: create the pipeline bucket and seed empty stage prefixes.
+  # Runs to completion and exits; re-running is idempotent.
+  minio-setup:
+    image: minio/mc:RELEASE.2025-04-03T17-07-56Z
+    container_name: noorinalabs-pipeline-minio-setup
+    depends_on:
+      minio:
+        condition: service_healthy
+    environment:
+      MINIO_ROOT_USER: "${MINIO_ROOT_USER:?MINIO_ROOT_USER must be set}"
+      MINIO_ROOT_PASSWORD: "${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD must be set}"
+      PIPELINE_BUCKET: "${PIPELINE_B2_BUCKET:-noorinalabs-pipeline}"
+    entrypoint: >
+      /bin/sh -c "
+      set -e;
+      mc alias set local http://minio:9000 $$MINIO_ROOT_USER $$MINIO_ROOT_PASSWORD;
+      mc mb --ignore-existing local/$$PIPELINE_BUCKET;
+      for stage in raw dedup enriched normalized staged; do
+        mc put /dev/null local/$$PIPELINE_BUCKET/$$stage/.keep || true;
+      done;
+      echo 'MinIO pipeline bucket ready.';
+      "
+    networks:
+      - pipeline
+    restart: "no"
+
+networks:
+  pipeline:
+    driver: bridge
+
+volumes:
+  minio_data:

--- a/compose/minio.env.example
+++ b/compose/minio.env.example
@@ -1,0 +1,14 @@
+# Local-dev MinIO credentials — used only by docker-compose.minio.yml.
+# Do NOT reuse these values in production; real pipeline creds come from
+# Backblaze B2 via the `terraform/backblaze/` module.
+
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=minioadmin-change-me
+
+# These map to the env vars the pipeline code reads. In local dev they point
+# to MinIO; in prod the deploy workflow injects the real B2 values.
+PIPELINE_B2_KEY_ID=minioadmin
+PIPELINE_B2_KEY=minioadmin-change-me
+PIPELINE_B2_BUCKET=noorinalabs-pipeline
+PIPELINE_B2_ENDPOINT=http://localhost:9000
+PIPELINE_B2_REGION=us-east-005

--- a/docs/pipeline-storage.md
+++ b/docs/pipeline-storage.md
@@ -27,7 +27,7 @@ noorinalabs-pipeline/
 | `normalized/` | normalize worker | graph-load worker | Rebuildable from `enriched/` |
 | `staged/` | graph-load worker | — | Audit trail of what was loaded into Neo4j |
 
-See `ontology/repos/isnad-ingest-platform.yaml` and
+See `ontology/repos/ingestion.yaml` and
 `ontology/repos/isnad-ingest-platform.yaml` `reset_levels` for how pipeline
 resets map onto prefix deletion.
 

--- a/docs/pipeline-storage.md
+++ b/docs/pipeline-storage.md
@@ -1,0 +1,81 @@
+# Pipeline Object Storage
+
+The data ingestion pipeline stores all intermediate artifacts in a single
+S3-compatible bucket. In production this is a Backblaze B2 bucket
+(`noorinalabs-pipeline`); in local development it is a MinIO container that
+mirrors the same prefix layout.
+
+Single bucket, prefix-per-stage, so pipeline code only has to understand
+`{stage}/{key}` and not an N-bucket topology.
+
+## Layout
+
+```
+noorinalabs-pipeline/
+  raw/{source}/{YYYY-MM-DD}/{filename}
+  dedup/{source}/{batch-id}/{filename}
+  enriched/{source}/{batch-id}/{filename}
+  normalized/{batch-id}/{filename}
+  staged/{batch-id}/{filename}
+```
+
+| Prefix | Written by | Read by | Notes |
+|---|---|---|---|
+| `raw/` | `noorinalabs-data-acquisition` | dedup worker | Archival — never deleted unless source is reset |
+| `dedup/` | dedup worker | enrich worker | Rebuildable from `raw/` |
+| `enriched/` | enrich worker | normalize worker | Rebuildable from `dedup/` |
+| `normalized/` | normalize worker | graph-load worker | Rebuildable from `enriched/` |
+| `staged/` | graph-load worker | — | Audit trail of what was loaded into Neo4j |
+
+See `ontology/repos/isnad-ingest-platform.yaml` and
+`ontology/repos/isnad-ingest-platform.yaml` `reset_levels` for how pipeline
+resets map onto prefix deletion.
+
+## Access pattern
+
+All pipeline workers access the bucket via the S3-compatible API. Prod and
+dev share the same code path — only the endpoint, credentials, and region
+vary. Pipeline containers receive the following env vars:
+
+| Env var | Prod value | Dev value |
+|---|---|---|
+| `PIPELINE_B2_KEY_ID` | Scoped RW key from Terraform output | `minioadmin` |
+| `PIPELINE_B2_KEY` | Scoped RW key secret | `minioadmin-change-me` |
+| `PIPELINE_B2_BUCKET` | `noorinalabs-pipeline` | `noorinalabs-pipeline` |
+| `PIPELINE_B2_ENDPOINT` | `https://s3.us-east-005.backblazeb2.com` | `http://minio:9000` |
+| `PIPELINE_B2_REGION` | `us-east-005` | `us-east-005` |
+
+Two application keys exist — a read/write key for pipeline workers and a
+read-only key for monitoring/audit tools. Monitoring code should never see
+the RW key.
+
+## Provisioning
+
+- **Production:** `terraform/backblaze/` module. See its README for one-time
+  apply instructions. Bucket creation is **not** in CI — it is an operator
+  action, run once per environment.
+- **Local dev:** `compose/docker-compose.minio.yml`. The `minio-setup`
+  one-shot creates the bucket and seeds empty stage prefixes.
+
+## Secret flow
+
+```
+B2 console → master key (in operator shell only)
+  → terraform apply → scoped rw/ro keys (outputs)
+    → GitHub Actions secrets (PIPELINE_B2_KEY_ID, PIPELINE_B2_KEY)
+      → deploy workflow SSH → VPS .env
+        → docker compose env → pipeline workers
+```
+
+The master key never leaves the operator's workstation. Only the scoped keys
+travel to CI, and only the rw scoped key reaches workers.
+
+## Rotation
+
+To rotate the RW key (e.g. after a suspected leak):
+
+1. In B2 console, revoke the old `noorinalabs-pipeline-rw` key.
+2. `terraform apply` — Terraform sees the key is missing and recreates it.
+3. Update the GitHub Actions `PIPELINE_B2_KEY` and `PIPELINE_B2_KEY_ID`
+   secrets with the new outputs.
+4. Trigger a redeploy so workers pick up the new creds.

--- a/terraform/backblaze/README.md
+++ b/terraform/backblaze/README.md
@@ -1,0 +1,98 @@
+# Backblaze B2 — Pipeline Bucket
+
+Provisions the `noorinalabs-pipeline` B2 bucket used by the data ingestion pipeline, plus
+two scoped application keys (read/write for workers, read-only for monitoring).
+
+## Prefix Layout
+
+```
+noorinalabs-pipeline/
+  raw/{source}/{YYYY-MM-DD}/{filename}
+  dedup/{source}/{batch-id}/{filename}
+  enriched/{source}/{batch-id}/{filename}
+  normalized/{batch-id}/{filename}
+  staged/{batch-id}/{filename}
+```
+
+Stage ownership:
+
+| Prefix | Writer | Reader |
+|---|---|---|
+| `raw/` | `noorinalabs-data-acquisition` | dedup worker |
+| `dedup/` | dedup worker | enrich worker |
+| `enriched/` | enrich worker | normalize worker |
+| `normalized/` | normalize worker | graph-load worker |
+| `staged/` | graph-load worker | — (archival + audit) |
+
+## Prerequisites
+
+1. A Backblaze B2 account with billing enabled.
+2. A master application key with `writeBuckets` + `writeKeys` capabilities. Create
+   it in the [B2 console → App Keys](https://secure.backblaze.com/app_keys.htm).
+3. Terraform 1.5+ and credentials for the S3 state backend (same
+   `noorinalabs-terraform-state` bucket as the other modules).
+
+## Apply
+
+**NOTE:** This module is **not applied in CI** — run it once, manually, from an
+operator workstation. The resulting keys are fed into GitHub Actions secrets.
+
+```bash
+cd terraform/backblaze
+
+# Authenticate to the S3 state backend (same Backblaze account as app keys).
+export AWS_ACCESS_KEY_ID=<state-bucket-key-id>
+export AWS_SECRET_ACCESS_KEY=<state-bucket-key>
+
+# Provide the master B2 key Terraform will use to create the bucket and app keys.
+export TF_VAR_b2_application_key_id=<master-key-id>
+export TF_VAR_b2_application_key=<master-key>
+
+terraform init
+terraform plan
+terraform apply
+```
+
+After apply, export the scoped keys (they are marked sensitive):
+
+```bash
+terraform output -raw pipeline_rw_key_id
+terraform output -raw pipeline_rw_key
+terraform output -raw pipeline_ro_key_id
+terraform output -raw pipeline_ro_key
+```
+
+## Feeding keys to deployments
+
+Add the scoped keys to the `noorinalabs-deploy` GitHub repo secrets (or the
+pipeline repo's secrets, once the ingest-platform workflow exists):
+
+| Secret | Value |
+|---|---|
+| `PIPELINE_B2_KEY_ID` | `pipeline_rw_key_id` output |
+| `PIPELINE_B2_KEY` | `pipeline_rw_key` output |
+| `PIPELINE_B2_BUCKET` | `noorinalabs-pipeline` |
+| `PIPELINE_B2_ENDPOINT` | `https://s3.us-east-005.backblazeb2.com` |
+
+The compose `.env` on the VPS is then populated via the existing SSH-based
+deploy workflow (see `scripts/verify_deployment.sh` for the env injection
+pattern).
+
+## Lifecycle
+
+The module configures two lifecycle rules:
+
+1. **Unfinished multipart uploads** — abandoned after
+   `lifecycle_days_unfinished_uploads` days (default 7).
+2. **Old versions** — hidden after `lifecycle_days_hide_old_versions` days
+   (default 30), deleted after an additional
+   `lifecycle_days_delete_hidden` days (default 90).
+
+`raw/` is the only stage where the pipeline expects archival retention;
+downstream stages are rebuildable from `raw/` via `/ontology-librarian
+pipeline reset levels`.
+
+## Local development
+
+See `../../compose/docker-compose.minio.yml` for a MinIO-backed alternative
+that mirrors this prefix layout for local pipeline work.

--- a/terraform/backblaze/main.tf
+++ b/terraform/backblaze/main.tf
@@ -11,15 +11,14 @@ resource "b2_bucket" "pipeline" {
 
   lifecycle_rules {
     file_name_prefix              = ""
-    days_from_uploading_to_hiding = null
+    days_from_uploading_to_hiding = var.lifecycle_days_hide_old_versions
     days_from_hiding_to_deleting  = var.lifecycle_days_delete_hidden
   }
 
   # Abort stuck multipart uploads to avoid silent cost growth.
   lifecycle_rules {
-    file_name_prefix              = ""
-    days_from_uploading_to_hiding = var.lifecycle_days_hide_old_versions
-    days_from_hiding_to_deleting  = null
+    file_name_prefix                                       = ""
+    days_from_starting_to_canceling_unfinished_large_files = var.lifecycle_days_unfinished_uploads
   }
 
   dynamic "cors_rules" {

--- a/terraform/backblaze/main.tf
+++ b/terraform/backblaze/main.tf
@@ -1,0 +1,60 @@
+provider "b2" {
+  application_key_id = var.b2_application_key_id
+  application_key    = var.b2_application_key
+}
+
+# Pipeline bucket — holds raw → dedup → enriched → normalized → staged prefixes.
+# Access is always server-side (pipeline workers) over the S3-compatible endpoint.
+resource "b2_bucket" "pipeline" {
+  bucket_name = var.bucket_name
+  bucket_type = "allPrivate"
+
+  lifecycle_rules {
+    file_name_prefix              = ""
+    days_from_uploading_to_hiding = null
+    days_from_hiding_to_deleting  = var.lifecycle_days_delete_hidden
+  }
+
+  # Abort stuck multipart uploads to avoid silent cost growth.
+  lifecycle_rules {
+    file_name_prefix              = ""
+    days_from_uploading_to_hiding = var.lifecycle_days_hide_old_versions
+    days_from_hiding_to_deleting  = null
+  }
+
+  dynamic "cors_rules" {
+    for_each = length(var.cors_allowed_origins) > 0 ? [1] : []
+    content {
+      cors_rule_name     = "pipeline-cors"
+      allowed_origins    = var.cors_allowed_origins
+      allowed_operations = ["s3_get", "s3_head", "s3_put"]
+      max_age_seconds    = 3600
+      allowed_headers    = ["*"]
+      expose_headers     = ["x-bz-content-sha1"]
+    }
+  }
+}
+
+# Read-write key scoped to the pipeline bucket — used by ingest platform workers.
+resource "b2_application_key" "pipeline_rw" {
+  key_name  = "noorinalabs-pipeline-rw"
+  bucket_id = b2_bucket.pipeline.bucket_id
+  capabilities = [
+    "listBuckets",
+    "listFiles",
+    "readFiles",
+    "writeFiles",
+    "deleteFiles",
+  ]
+}
+
+# Read-only key scoped to the pipeline bucket — used by monitoring/audit tools.
+resource "b2_application_key" "pipeline_ro" {
+  key_name  = "noorinalabs-pipeline-ro"
+  bucket_id = b2_bucket.pipeline.bucket_id
+  capabilities = [
+    "listBuckets",
+    "listFiles",
+    "readFiles",
+  ]
+}

--- a/terraform/backblaze/outputs.tf
+++ b/terraform/backblaze/outputs.tf
@@ -1,0 +1,38 @@
+output "bucket_id" {
+  description = "B2 bucket ID for noorinalabs-pipeline"
+  value       = b2_bucket.pipeline.bucket_id
+}
+
+output "bucket_name" {
+  description = "B2 bucket name"
+  value       = b2_bucket.pipeline.bucket_name
+}
+
+output "s3_endpoint" {
+  description = "S3-compatible endpoint for pipeline bucket access"
+  value       = "https://s3.us-east-005.backblazeb2.com"
+}
+
+output "pipeline_rw_key_id" {
+  description = "Application key ID with read/write access to the pipeline bucket"
+  value       = b2_application_key.pipeline_rw.application_key_id
+  sensitive   = true
+}
+
+output "pipeline_rw_key" {
+  description = "Application key secret with read/write access to the pipeline bucket"
+  value       = b2_application_key.pipeline_rw.application_key
+  sensitive   = true
+}
+
+output "pipeline_ro_key_id" {
+  description = "Application key ID with read-only access to the pipeline bucket"
+  value       = b2_application_key.pipeline_ro.application_key_id
+  sensitive   = true
+}
+
+output "pipeline_ro_key" {
+  description = "Application key secret with read-only access to the pipeline bucket"
+  value       = b2_application_key.pipeline_ro.application_key
+  sensitive   = true
+}

--- a/terraform/backblaze/terraform.tfvars.example
+++ b/terraform/backblaze/terraform.tfvars.example
@@ -1,0 +1,19 @@
+# Backblaze B2 master key — create a key in the B2 console with writeBuckets +
+# writeKeys capabilities, then export as env vars for Terraform:
+#   export TF_VAR_b2_application_key_id=...
+#   export TF_VAR_b2_application_key=...
+# or fill these in a .tfvars file that is gitignored.
+
+b2_application_key_id = ""
+b2_application_key    = ""
+
+bucket_name = "noorinalabs-pipeline"
+
+# Lifecycle policy (days). Defaults are conservative; tune for retention needs.
+lifecycle_days_unfinished_uploads = 7
+lifecycle_days_hide_old_versions  = 30
+lifecycle_days_delete_hidden      = 90
+
+# CORS is not needed for server-side pipeline access. Only populate if the UI
+# needs to read staged/normalized artifacts directly from the browser.
+cors_allowed_origins = []

--- a/terraform/backblaze/variables.tf
+++ b/terraform/backblaze/variables.tf
@@ -1,0 +1,41 @@
+variable "b2_application_key_id" {
+  description = "Backblaze B2 master application key ID (for provider auth; create in B2 console)"
+  type        = string
+  sensitive   = true
+}
+
+variable "b2_application_key" {
+  description = "Backblaze B2 master application key (for provider auth; create in B2 console)"
+  type        = string
+  sensitive   = true
+}
+
+variable "bucket_name" {
+  description = "Name of the pipeline bucket"
+  type        = string
+  default     = "noorinalabs-pipeline"
+}
+
+variable "lifecycle_days_unfinished_uploads" {
+  description = "Days before incomplete multipart uploads are abandoned"
+  type        = number
+  default     = 7
+}
+
+variable "lifecycle_days_hide_old_versions" {
+  description = "Days after which non-current object versions are hidden"
+  type        = number
+  default     = 30
+}
+
+variable "lifecycle_days_delete_hidden" {
+  description = "Days after hide before hidden versions are deleted permanently"
+  type        = number
+  default     = 90
+}
+
+variable "cors_allowed_origins" {
+  description = "Allowed origins for CORS (pipeline workers usually do not need CORS; keep empty for server-side-only access)"
+  type        = list(string)
+  default     = []
+}

--- a/terraform/backblaze/versions.tf
+++ b/terraform/backblaze/versions.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    b2 = {
+      source  = "Backblaze/b2"
+      version = "~> 0.10"
+    }
+  }
+
+  backend "s3" {
+    bucket                      = "noorinalabs-terraform-state"
+    key                         = "backblaze/terraform.tfstate"
+    region                      = "us-east-005"
+    endpoint                    = "https://s3.us-east-005.backblazeb2.com"
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+  }
+}


### PR DESCRIPTION
## Summary

Scaffolds the object-storage substrate for the P2W9 data pipeline:

- **Terraform module** `terraform/backblaze/` — provisions `noorinalabs-pipeline` B2 bucket plus two scoped application keys (RW for workers, RO for monitoring). Uses the same S3 state backend (`noorinalabs-terraform-state`) as `hetzner/` and `cloudflare/`.
- **MinIO local-dev stack** `compose/docker-compose.minio.yml` — S3-compatible bucket + `minio-setup` one-shot that seeds the stage prefixes (`raw/dedup/enriched/normalized/staged`), so dev code targets the same S3 key layout as prod.
- **Pipeline env wiring** — `compose/.env.example` carries `PIPELINE_B2_*` vars; `deploy-isnad-graph.yml` SSH workflow pipes them to the VPS `.env`.
- **Storage docs** — `docs/pipeline-storage.md` documents prefix ownership, env mapping, secret flow (master key → terraform → scoped keys → GH secrets → workers), and key rotation procedure.

## Related issues

Part of noorinalabs/noorinalabs-main#105

## Review-round-2 fixes (Aino review)

All three must-fix items addressed; two tech-debt fold-ins applied; two issues filed as follow-ups.

### Must-fix

- **`fe0db48` — lifecycle vars wired.** `terraform/backblaze/main.tf` now wires `var.lifecycle_days_unfinished_uploads` to the multipart-abort rule via the b2 provider's `days_from_starting_to_canceling_unfinished_large_files` argument (verified against provider 0.12.1 schema). Also wires `var.lifecycle_days_hide_old_versions` to the first rule's `days_from_uploading_to_hiding`, which was previously hardcoded `null` despite the README/tfvars promising it as configurable.
- **`5311658` — TF CI matrix.** `.github/workflows/terraform.yml` refactored: new `fmt` job runs `terraform fmt -check -recursive terraform/` once at root; `validate` job is now a matrix over `[hetzner, cloudflare, backblaze]` (explicit list, not dynamic discovery). `plan`/`apply` kept hetzner-only — see follow-up #90 below.
- **`970ff8e` — `PIPELINE_B2_*` env wiring.** `.github/workflows/deploy-isnad-graph.yml` now declares all five vars in the job-level `env:` block, the ssh-action `envs:` passlist, and the env_file write loop on the VPS. Block placement is alphabetical so Wanjiku's parallel `KAFKA_*` additions on PR #80 land cleanly without semantic conflict.

### Tech-debt fold-ins (same PR)

- `terraform fmt -check -recursive` step (folded into the matrix work — runs once in the new `fmt` job, not per-matrix).
- `docs/pipeline-storage.md` duplicate-path typo: one of the two `isnad-ingest-platform.yaml` references is now `ingestion.yaml` (the data-acquisition repo's ontology file), as Aino flagged.

### Follow-up issues (filed, not fixed)

- **noorinalabs/noorinalabs-deploy#89** — CORS `expose_headers` should add `ETag` once `cors_allowed_origins` becomes non-empty. Non-load-bearing today.
- **noorinalabs/noorinalabs-deploy#90** — Extend TF CI plan/apply matrix to `cloudflare` and (decision needed) `backblaze`. Requires per-module credentials.

## User action required

**⚠ `terraform apply` is NOT run in CI.** After this PR merges, the project owner must run the module once from an operator workstation with a B2 master application key in-scope:

```bash
cd terraform/backblaze
export AWS_ACCESS_KEY_ID=<state-bucket-key-id>
export AWS_SECRET_ACCESS_KEY=<state-bucket-key>
export TF_VAR_b2_application_key_id=<master-key-id>
export TF_VAR_b2_application_key=<master-key>
terraform init
terraform plan
terraform apply
```

**Then create the following GH Actions secrets** in `noorinalabs-deploy` repo settings (these do NOT exist yet — they are outputs of the above apply, and the new `deploy-isnad-graph.yml` env block will write empty strings to `/opt/.../.env` until they are populated):

| Secret | Source |
|---|---|
| `PIPELINE_B2_KEY_ID` | `terraform output -raw pipeline_rw_key_id` |
| `PIPELINE_B2_KEY` | `terraform output -raw pipeline_rw_key` |
| `PIPELINE_B2_BUCKET` | `noorinalabs-pipeline` (literal) |
| `PIPELINE_B2_ENDPOINT` | `https://s3.us-east-005.backblazeb2.com` |
| `PIPELINE_B2_REGION` | `us-east-005` |

See `terraform/backblaze/README.md` for the full sequence.

## Disabled CI jobs (load-bearing followup)

None.

## TechDebt attestation

TechDebt: deferred to issues #89 (CORS ETag) and #90 (TF plan/apply matrix). Both are non-blocking for merge.

All scaffolding follows the existing module patterns (versions.tf backend block, variables.tf sensitive flags, *.tfvars.example gitignored pattern). Non-blocking observations:
- The B2 Terraform provider (`Backblaze/b2 ~> 0.10`) resolves to 0.12.1 in CI — verified.
- Pipeline code that reads `PIPELINE_B2_*` will land in the ingest-platform repo (#106, #107) — this PR is storage + env-plumbing only.

## Review checklist

- [x] Reviewed by another team member (Aino — round 1; round-2 fixes pending re-review)
- [x] Must-fix items resolved
- [x] Tech debt items filed as GitHub Issues (#89, #90)

Co-Authored-By: Santiago Ferreira <parametrization+Santiago.Ferreira@gmail.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>