### PR TITLE
infra(tf): add skip_requesting_account_id to all s3 backends (#91)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "~> 1.5"
+          terraform_version: "~> 1.6"
       - name: terraform fmt -check -recursive
         run: terraform fmt -check -recursive terraform/
 
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "~> 1.5"
+          terraform_version: "~> 1.6"
       - name: Init (no backend)
         run: terraform init -backend=false
       - name: Validate
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "~> 1.5"
+          terraform_version: "~> 1.6"
       - name: Generate CI SSH key
         run: |
           ssh-keygen -t ed25519 -f /tmp/ci_key -N ""
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "~> 1.5"
+          terraform_version: "~> 1.6"
       - name: Generate CI SSH key
         run: |
           ssh-keygen -t ed25519 -f /tmp/ci_key -N ""

--- a/terraform/backblaze/versions.tf
+++ b/terraform/backblaze/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0"
+  required_version = ">= 1.6.0"
 
   required_providers {
     b2 = {

--- a/terraform/backblaze/versions.tf
+++ b/terraform/backblaze/versions.tf
@@ -9,12 +9,15 @@ terraform {
   }
 
   backend "s3" {
-    bucket                      = "noorinalabs-terraform-state"
-    key                         = "backblaze/terraform.tfstate"
-    region                      = "us-east-005"
-    endpoint                    = "https://s3.us-east-005.backblazeb2.com"
+    bucket = "noorinalabs-terraform-state"
+    key    = "backblaze/terraform.tfstate"
+    region = "us-east-005"
+    endpoints = {
+      s3 = "https://s3.us-east-005.backblazeb2.com"
+    }
     skip_credentials_validation = true
     skip_metadata_api_check     = true
     skip_region_validation      = true
+    skip_requesting_account_id  = true
   }
 }

--- a/terraform/cloudflare/versions.tf
+++ b/terraform/cloudflare/versions.tf
@@ -9,12 +9,15 @@ terraform {
   }
 
   backend "s3" {
-    bucket                      = "noorinalabs-terraform-state"
-    key                         = "cloudflare/terraform.tfstate"
-    region                      = "us-east-005"
-    endpoint                    = "https://s3.us-east-005.backblazeb2.com"
+    bucket = "noorinalabs-terraform-state"
+    key    = "cloudflare/terraform.tfstate"
+    region = "us-east-005"
+    endpoints = {
+      s3 = "https://s3.us-east-005.backblazeb2.com"
+    }
     skip_credentials_validation = true
     skip_metadata_api_check     = true
     skip_region_validation      = true
+    skip_requesting_account_id  = true
   }
 }

--- a/terraform/cloudflare/versions.tf
+++ b/terraform/cloudflare/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0"
+  required_version = ">= 1.6.0"
 
   required_providers {
     cloudflare = {

--- a/terraform/hetzner/versions.tf
+++ b/terraform/hetzner/versions.tf
@@ -9,12 +9,15 @@ terraform {
   }
 
   backend "s3" {
-    bucket                      = "noorinalabs-terraform-state"
-    key                         = "hetzner/terraform.tfstate"
-    region                      = "us-east-005"
-    endpoint                    = "https://s3.us-east-005.backblazeb2.com"
+    bucket = "noorinalabs-terraform-state"
+    key    = "hetzner/terraform.tfstate"
+    region = "us-east-005"
+    endpoints = {
+      s3 = "https://s3.us-east-005.backblazeb2.com"
+    }
     skip_credentials_validation = true
     skip_metadata_api_check     = true
     skip_region_validation      = true
+    skip_requesting_account_id  = true
   }
 }

--- a/terraform/hetzner/versions.tf
+++ b/terraform/hetzner/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0"
+  required_version = ">= 1.6.0"
 
   required_providers {
     hcloud = {


### PR DESCRIPTION
## Summary

Fixes `terraform init` failure on fresh modules by adding `skip_requesting_account_id = true` to all three terraform backend blocks (`hetzner`, `cloudflare`, `backblaze`) and migrating the deprecated `endpoint = "..."` to the new `endpoints.s3 = {...}` form.

Closes #91. Surfaced post-merge of #79 when the owner ran `terraform init -reconfigure` against `terraform/backblaze/` for the first time.

## Root cause + repro

```
$ cd terraform/backblaze && terraform init
Error: Retrieving AWS account details: AWS account ID not previously found
       and failed retrieving via all available methods.
  * retrieving caller identity from STS: ... dial tcp:
      lookup sts.us-east-005.amazonaws.com: no such host
  * retrieving account information via iam:ListRoles: ... InvalidClientTokenId
```

The `s3` backend is implemented by the `hashicorp/aws` provider. Recent provider versions resolve the AWS account ID via `sts:GetCallerIdentity` and `iam:ListRoles` — both hit the configured endpoint (B2's S3-compatible service, which has no AWS metadata), and both fail. The existing `skip_credentials_validation` / `skip_metadata_api_check` / `skip_region_validation` flags do not cover the account-ID lookup; the missing flag is `skip_requesting_account_id = true`.

`hetzner` and `cloudflare` only avoid surfacing this today because their cached `.terraform/` was initialized under an older AWS provider that didn't enforce the account-ID lookup. The same failure occurs on the next `terraform init -reconfigure` for those modules.

Each backend block now uses the corrected shape:

```hcl
backend "s3" {
  bucket = "noorinalabs-terraform-state"
  key    = "<module>/terraform.tfstate"
  region = "us-east-005"
  endpoints = {
    s3 = "https://s3.us-east-005.backblazeb2.com"
  }
  skip_credentials_validation = true
  skip_metadata_api_check     = true
  skip_region_validation      = true
  skip_requesting_account_id  = true
}
```

## Required terraform version bump (1.5 → 1.6)

The new backend syntax (`endpoints = {...}` and `skip_requesting_account_id`) requires terraform >= 1.6 for the s3 backend. The first push of this PR initially failed the `Plan` job because CI was pinned to `~> 1.5`:

```
Error: Unsupported argument
  on versions.tf line 15: 'endpoints' is not expected here. Did you mean 'endpoint'?
Error: Unsupported argument
  on versions.tf line 21: 'skip_requesting_account_id' is not expected here.
```

(`Validate` jobs missed this because they run `terraform init -backend=false` and never parse the backend block.)

Second commit `29eb0f5` bumps:
- All four jobs in `.github/workflows/terraform.yml` to `terraform_version: "~> 1.6"`.
- `terraform/{hetzner,cloudflare,backblaze}/versions.tf` `required_version` from `>= 1.5.0` to `>= 1.6.0` so a downgrade fails fast with a clear error.

## Scope

4 files:
- `terraform/backblaze/versions.tf`
- `terraform/cloudflare/versions.tf`
- `terraform/hetzner/versions.tf`
- `.github/workflows/terraform.yml`

## Migration note (breaking for cached state)

**Operators with an existing `.terraform/` directory for `hetzner` or `cloudflare` must run `terraform init -reconfigure` after pulling.** The backend configuration changed (top-level `endpoint` → nested `endpoints.s3`, plus the new `skip_requesting_account_id` flag), and Terraform requires reinitialization when the backend block changes. State data is unaffected — only the local cached config in `.terraform/terraform.tfstate` and provider plugin selection.

**Operators with terraform < 1.6 must upgrade.** The `required_version` constraint will reject the configuration otherwise. Current owner workstation is 1.14.x; CI is now `~> 1.6`.

`backblaze` operators are unaffected since the module has not been initialized off-PR-79 yet.

## CI verification

Matrix CI introduced in #79: `Format check`, `Validate (hetzner)`, `Validate (cloudflare)`, `Validate (backblaze)`, plus `Plan` (hetzner). All five must pass. Local `terraform fmt -check -recursive terraform/` and `terraform -chdir=terraform/backblaze validate` both pass under terraform 1.14.8.

`terraform init` against the real backend was deliberately not run (would touch state).

## Disabled CI jobs (load-bearing followup)

None.

## TechDebt attestation

TechDebt: none. This PR **is** the tech-debt fix from #91; nothing new uncovered.

## Review checklist

- [ ] Reviewed by another team member
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Santiago Ferreira <parametrization+Santiago.Ferreira@gmail.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>