### PR TITLE
fix(deploy): single-quote env_file values to survive SSH transport (#94)

### DIFF
--- a/.github/workflows/deploy-isnad-graph.yml
+++ b/.github/workflows/deploy-isnad-graph.yml
@@ -69,6 +69,11 @@ jobs:
             echo "==> Writing .env for docker-compose..."
             env_file=".env"
             : > "$env_file"
+            # Single-quoted values: docker-compose env-file format treats single-quoted
+            # strings as literal (no escape processing), and single quotes survive the
+            # SSH transport without escape-eating that strips backslash-escaped double
+            # quotes. Limitation: values containing a literal "'" are not supported
+            # (none of our current secrets do — see #94).
             for var in NEO4J_PASSWORD POSTGRES_USER POSTGRES_PASSWORD POSTGRES_DB \
                        REDIS_PASSWORD AUTH_GOOGLE_CLIENT_ID AUTH_GOOGLE_CLIENT_SECRET \
                        AUTH_GITHUB_CLIENT_ID AUTH_GITHUB_CLIENT_SECRET \
@@ -77,10 +82,10 @@ jobs:
                        PIPELINE_B2_BUCKET PIPELINE_B2_ENDPOINT PIPELINE_B2_KEY \
                        PIPELINE_B2_KEY_ID PIPELINE_B2_REGION; do
               eval "val=\$$var"
-              echo "$var=\"$val\"" >> "$env_file"
+              printf "%s='%s'\n" "$var" "$val" >> "$env_file"
             done
-            echo "IMAGE_TAG=\"${IMAGE_TAG}\"" >> "$env_file"
-            echo "CACHEBUST=\"$(date +%s)\"" >> "$env_file"
+            printf "%s='%s'\n" "IMAGE_TAG" "${IMAGE_TAG}" >> "$env_file"
+            printf "%s='%s'\n" "CACHEBUST" "$(date +%s)" >> "$env_file"
             chmod 600 "$env_file"
 
             echo "==> Pulling latest noorinalabs-isnad-graph source (for local builds)..."


### PR DESCRIPTION
## Summary

Fixes #94. Single-line behavioral fix to the env_file write loop in `.github/workflows/deploy-isnad-graph.yml` so the on-VPS `.env` file is written with single-quoted values that survive both SSH transport and docker-compose env-file parsing.

## Repro

`workflow_dispatch` deploy on `eec873d` (post-#80 + #79 merge) — run [24612706763](https://github.com/noorinalabs/noorinalabs-deploy/actions/runs/24612706763) — failed at the `docker compose up` step:

```
failed to read /opt/noorinalabs-deploy/.env: line 16: unexpected character "/" in variable name ***\""
```

Line 16 = `PIPELINE_B2_KEY` per the `for var in ...` ordering. SSH inspection of the on-VPS `.env` confirmed the value was stored UNQUOTED, e.g. `PIPELINE_B2_KEY=K005abc/def`. docker-compose's env-file parser cannot handle a `/` in an unquoted value — it tries to extend the variable name past `=` and bails.

Latent for ~6 months — existing secrets (passwords, IDs, base-64 cluster IDs) didn't trip it. B2 access keys do.

## Root cause

The loop used:

```bash
echo "$var=\"$val\"" >> "$env_file"
```

Intended to emit `VAR="value"` on the VPS. But the appleboy/ssh-action transport interprets the backslashes during command transport, stripping the `\"` escapes before the script reaches the remote shell. What actually executes on the VPS is:

```bash
echo "$var=" "$val" ""
```

…producing `VAR=value` (unquoted) plus a trailing empty arg.

## Fix

Switched to single-quoted printf:

```bash
printf "%s='%s'\n" "$var" "$val" >> "$env_file"
```

Why single quotes:
- Survive SSH transport without escape interpretation (no backslashes for the transport to eat).
- docker-compose env-file format treats single-quoted strings as fully literal (no expansion of `\n`, `$`, etc. inside the quoted string), so `/`, `+`, `=`, `:` in values are all safe.

Same change applied to the `IMAGE_TAG` and `CACHEBUST` standalone lines that follow the loop.

A 5-line comment block above the loop documents the rationale and the known limitation, so the next person editing this loop doesn't revert it back to `\"...\"` thinking it's "cleaner."

## Known limitation

A value containing a literal `'` (single quote) would break this scheme. None of our current GH Actions secrets do. If a future secret needs one, switch to a Python-based env writer that quotes correctly per docker-compose grammar — that's a follow-up only if it actually happens (no issue filed pre-emptively).

## Disabled CI jobs (load-bearing followup)

None.

## Tech debt

None — this PR IS the fix for the previously-undiagnosed env-file quoting bug.

## Test plan

- [ ] `compose-validate` workflow passes (paths-filter watches `.github/workflows/compose-validate.yml` and the workflow itself, but not other workflow files — see check below).
- [ ] Post-merge: `workflow_dispatch` deploy on the new tip succeeds without the `unexpected character "/"` error.
- [ ] Post-merge: SSH to VPS, `cat /opt/noorinalabs-deploy/.env` shows every line in `VAR='value'` form.
- [ ] No regression: docker-compose successfully consumes the new env-file format and starts all services.

## Reviewers

Requestor: Wanjiku.Mwangi
Requestees: Aino.Virtanen (org-level standards), Nadia.Khoury (program director sign-off, since this gates the next deploy)
