### PR TITLE
fix(infra): swap bitnami/* image refs to bitnamilegacy/* (#101)

### DIFF
--- a/compose/.env.example
+++ b/compose/.env.example
@@ -28,7 +28,7 @@ GRAFANA_ADMIN_PASSWORD=changeme
 
 # Kafka (pipeline messaging, KRaft mode — see infra/kafka/init-topics.sh)
 # Generate KAFKA_CLUSTER_ID once and keep it stable across restarts:
-#   docker run --rm bitnami/kafka:3.8.0 kafka-storage.sh random-uuid
+#   docker run --rm bitnamilegacy/kafka:3.8.0 kafka-storage.sh random-uuid
 KAFKA_CLUSTER_ID=
 KAFKA_UI_USER=admin
 KAFKA_UI_PASSWORD=changeme

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -653,7 +653,10 @@ services:
   # remote access is only via SSH tunnel. Topic creation is handled by the
   # one-shot kafka-init service below.
   kafka:
-    image: bitnami/kafka:3.8.0
+    # bitnami/* namespace was sunset Aug 2025; images now live at bitnamilegacy/*.
+    # Same image, same internal paths (/bitnami/kafka, /opt/bitnami/kafka/...) — only
+    # the registry namespace changes. Long-term migration off Bitnami tracked in #100.
+    image: bitnamilegacy/kafka:3.8.0
     user: "1001:1001"
     environment:
       # Core KRaft identity
@@ -661,7 +664,7 @@ services:
       KAFKA_CFG_PROCESS_ROLES: "controller,broker"
       KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: "1@kafka:9093"
       # Cluster ID must be stable across restarts — supplied via env (see .env.example).
-      KAFKA_KRAFT_CLUSTER_ID: "${KAFKA_CLUSTER_ID:?KAFKA_CLUSTER_ID must be set (generate once: docker run --rm bitnami/kafka:3.8.0 kafka-storage.sh random-uuid)}"
+      KAFKA_KRAFT_CLUSTER_ID: "${KAFKA_CLUSTER_ID:?KAFKA_CLUSTER_ID must be set (generate once: docker run --rm bitnamilegacy/kafka:3.8.0 kafka-storage.sh random-uuid)}"
       # Listeners (plaintext, internal-only — backend network is docker-internal)
       KAFKA_CFG_LISTENERS: "INTERNAL://:9092,CONTROLLER://:9093"
       KAFKA_CFG_ADVERTISED_LISTENERS: "INTERNAL://kafka:9092"
@@ -713,7 +716,8 @@ services:
     # One-shot topic creation. Idempotent: uses --if-not-exists. Exits 0 on success.
     # The service stays in "exited" state after the first successful run and is
     # re-executed whenever compose is brought up — cheap and safe.
-    image: bitnami/kafka:3.8.0
+    # bitnamilegacy/* — see broker service comment + #100 for the long-term plan.
+    image: bitnamilegacy/kafka:3.8.0
     user: "1001:1001"
     volumes:
       - ../infra/kafka/init-topics.sh:/opt/bitnami/kafka/init-topics.sh:ro

--- a/docs/pipeline-kafka.md
+++ b/docs/pipeline-kafka.md
@@ -76,8 +76,10 @@ The broker listener is on the `backend` Docker network (internal). It is not rea
 `KAFKA_CLUSTER_ID` is required and must remain stable — changing it after the first boot will cause the broker to refuse to start against existing log directories. Generate once at VPS bootstrap time:
 
 ```
-docker run --rm bitnami/kafka:3.8.0 kafka-storage.sh random-uuid
+docker run --rm bitnamilegacy/kafka:3.8.0 kafka-storage.sh random-uuid
 ```
+
+(The `bitnami/*` namespace was sunset Aug 2025; `bitnamilegacy/*` is the same image rebadged. Long-term migration off Bitnami tracked in #100.)
 
 Store the output in the production `.env` file alongside the other secrets.
 


### PR DESCRIPTION
## Summary

Fixes #101. Surgical 3-file unblock: swap `bitnami/kafka:3.8.0` → `bitnamilegacy/kafka:3.8.0` in compose + operator-facing docs. The `bitnami/*` Docker Hub namespace was sunset by Broadcom in Aug 2025; deploy run [24613310696](https://github.com/noorinalabs/noorinalabs-deploy/actions/runs/24613310696) failed at `docker compose up` with `pull access denied for bitnami/kafka, repository does not exist`.

## What changed (3 files, +11/-5)

| File | Change |
|---|---|
| `compose/docker-compose.prod.yml` | `image:` lines for `kafka` and `kafka-init` services swapped; the operator-instruction string inside the `KAFKA_CLUSTER_ID:?` error message updated; added a 3-line comment block above the broker `image:` line documenting the swap and pointing at #100. |
| `compose/.env.example` | Cluster-ID generation comment updated. |
| `docs/pipeline-kafka.md` | § Cluster ID generation command updated; added a one-line note pointing operators at #100. |

## Existence verification

```
$ curl -s -o /dev/null -w "%{http_code}\n" https://hub.docker.com/v2/repositories/bitnamilegacy/kafka/tags/3.8.0/
200
```

`bitnamilegacy/kafka:3.8.0` is the same image rebadged — internal filesystem layout (`/bitnami/kafka` data dir, `/opt/bitnami/kafka/*.sh` script paths) and env-var schema (`KAFKA_CFG_*`, `KAFKA_KRAFT_*`) are identical. Existing KRaft log directories on the VPS will boot against the new image without re-bootstrap because the image internals are unchanged.

## Explicitly NOT changed

These are paths INSIDE the container, set by the image's own filesystem — preserved:
- `kafka_data:/bitnami/kafka` (volume mount target inside the broker)
- `../infra/kafka/init-topics.sh:/opt/bitnami/kafka/init-topics.sh:ro` (init script bind-mount inside `kafka-init`)
- `entrypoint: ["/bin/bash", "/opt/bitnami/kafka/init-topics.sh"]`

`provectuslabs/kafka-ui` is not Bitnami — not touched.

## Why not migrate to apache/kafka now?

`bitnamilegacy/*` is itself a stopgap; Bitnami has signaled the legacy namespace will eventually disappear too. The proper migration off Bitnami requires a decision between `apache/kafka`, `apache/kafka-native`, and `confluentinc/cp-kafka` — different env-var schemas, different KRaft cluster-ID delivery mechanisms, different volume mount paths, possibly different licensing implications. That decision is owner-gated and tracked separately in **#100** with a full pros/cons framework. **This PR is the interim unblock only.**

## Disabled CI jobs (load-bearing followup)

None.

## Tech debt

**TechDebt:** #100 — long-term migration off Bitnami (decision required from owner before implementation).

## Test plan

- [ ] `compose-validate` workflow passes (this PR DOES touch `compose/**`, so the workflow will trigger this time).
- [ ] Post-merge `workflow_dispatch` deploy succeeds without the `pull access denied for bitnami/kafka` error.
- [ ] `kafka` service reaches healthy state within `start_period` (40s) — KRaft cluster ID preserved across the swap because the image internals are identical.
- [ ] `kafka-init` re-runs and exits 0 (idempotent, no topic recreation).
- [ ] `kafka_data` volume contents survive the image change (verified by broker booting against existing KRaft log dir).

## Reviewers

Requestor: Wanjiku.Mwangi
Requestees: Aino.Virtanen (org-level standards), Nadia.Khoury (program director sign-off, since this gates the next deploy)
