### PR TITLE
fix(deploy): wire GHCR auth + force GHCR-only for landing-page (#104)

### DIFF
--- a/.github/workflows/deploy-isnad-graph.yml
+++ b/.github/workflows/deploy-isnad-graph.yml
@@ -17,6 +17,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: production
+    # `packages: read` lets the auto-provisioned GITHUB_TOKEN pull from GHCR.
+    # `contents: read` is the default once any explicit permissions are listed; restating
+    # for clarity since `actions/checkout` needs it. Least-privilege scope: no writes.
+    permissions:
+      packages: read
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -48,6 +54,11 @@ jobs:
           KAFKA_UI_PASSWORD: ${{ secrets.KAFKA_UI_PASSWORD }}
           KAFKA_UI_USER: ${{ secrets.KAFKA_UI_USER }}
           IMAGE_TAG: ${{ steps.tag.outputs.tag }}
+          # GHCR auth — auto-provisioned, runtime-only. NEVER add to the env_file
+          # write loop below; these are session credentials and must not persist on
+          # the VPS in `.env`. The trap in the script logs out at end-of-run.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.repository_owner }}
           # PIPELINE_B2_* — alphabetical block; outputs of `terraform apply`
           # in terraform/backblaze. Secrets must be created post-bucket-apply.
           PIPELINE_B2_BUCKET: ${{ secrets.PIPELINE_B2_BUCKET }}
@@ -63,7 +74,7 @@ jobs:
           host: ${{ vars.VPS_HOST }}
           username: deploy
           key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
-          envs: NEO4J_PASSWORD,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,REDIS_PASSWORD,AUTH_GOOGLE_CLIENT_ID,AUTH_GOOGLE_CLIENT_SECRET,AUTH_GITHUB_CLIENT_ID,AUTH_GITHUB_CLIENT_SECRET,GRAFANA_ADMIN_PASSWORD,JWT_PRIVATE_KEY,JWT_PUBLIC_KEY,KAFKA_CLUSTER_ID,KAFKA_UI_PASSWORD,KAFKA_UI_USER,IMAGE_TAG,PIPELINE_B2_BUCKET,PIPELINE_B2_ENDPOINT,PIPELINE_B2_KEY,PIPELINE_B2_KEY_ID,PIPELINE_B2_REGION,USER_POSTGRES_DB,USER_POSTGRES_PASSWORD,USER_POSTGRES_USER,USER_REDIS_PASSWORD
+          envs: NEO4J_PASSWORD,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,REDIS_PASSWORD,AUTH_GOOGLE_CLIENT_ID,AUTH_GOOGLE_CLIENT_SECRET,AUTH_GITHUB_CLIENT_ID,AUTH_GITHUB_CLIENT_SECRET,GRAFANA_ADMIN_PASSWORD,JWT_PRIVATE_KEY,JWT_PUBLIC_KEY,KAFKA_CLUSTER_ID,KAFKA_UI_PASSWORD,KAFKA_UI_USER,IMAGE_TAG,PIPELINE_B2_BUCKET,PIPELINE_B2_ENDPOINT,PIPELINE_B2_KEY,PIPELINE_B2_KEY_ID,PIPELINE_B2_REGION,USER_POSTGRES_DB,USER_POSTGRES_PASSWORD,USER_POSTGRES_USER,USER_REDIS_PASSWORD,GITHUB_TOKEN,GITHUB_ACTOR
           script: |
             set -euo pipefail
             cd /opt/noorinalabs-deploy
@@ -96,6 +107,12 @@ jobs:
             printf "%s='%s'\n" "IMAGE_TAG" "${IMAGE_TAG}" >> "$env_file"
             printf "%s='%s'\n" "CACHEBUST" "$(date +%s)" >> "$env_file"
             chmod 600 "$env_file"
+
+            echo "==> Authenticating to GHCR..."
+            # Register logout trap FIRST so it fires even if login fails — leaves no
+            # stored credentials in the deploy user's ~/.docker/config.json on exit.
+            trap 'docker logout ghcr.io >/dev/null 2>&1 || true' EXIT
+            echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
 
             echo "==> Pulling latest noorinalabs-isnad-graph source (for local builds)..."
             cd /opt/noorinalabs-isnad-graph

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -213,10 +213,13 @@ services:
     restart: unless-stopped
 
   landing:
+    # GHCR-only — no local-build fallback. The deploy workflow logs into ghcr.io
+    # using the auto-provisioned GITHUB_TOKEN (workflow `permissions: packages: read`
+    # required, see .github/workflows/deploy-isnad-graph.yml). A manual
+    # `docker compose up` on the VPS without prior `docker login ghcr.io` will fail
+    # at pull — that's intentional; deploys go through the workflow. The api/frontend
+    # services still have `build:` blocks pending the owner decision in #103.
     image: ghcr.io/noorinalabs/noorinalabs-landing-page:${LANDING_IMAGE_TAG:-latest}
-    build:
-      context: /opt/noorinalabs-landing-page
-      dockerfile: Dockerfile
     expose:
       - "80"
     read_only: true


### PR DESCRIPTION
## Summary

Fixes #104. Wires GHCR auth into the deploy workflow and drops the `build:` block from the `landing` service so it pulls from `ghcr.io/noorinalabs/noorinalabs-landing-page` only. Unblocks tonight's verification deploy.

## Repro

Deploy run [24613612894](https://github.com/noorinalabs/noorinalabs-deploy/actions/runs/24613612894) failed at `docker compose up`:

- `landing` couldn't pull from GHCR (no auth) and had a `build:` context pointing at `/opt/noorinalabs-landing-page`, a path that doesn't exist on the VPS post-extraction.
- `user-service` (image-only, no `build:`) hit the same GHCR auth failure — that's the same root cause but only landing-page gets the no-build-fallback fix in this PR (api/frontend deferred to #103).

## Changes

### `.github/workflows/deploy-isnad-graph.yml`

1. **Job-level `permissions:` block** — `packages: read` (so the auto-provisioned `GITHUB_TOKEN` can pull from GHCR) + `contents: read` (for `actions/checkout`). Least-privilege; no writes anywhere.
2. **Pass `GITHUB_TOKEN` and `GITHUB_ACTOR`** through the SSH `env:` block + `envs:` passlist. `GITHUB_ACTOR` sourced from `${{ github.repository_owner }}` (stable across `repository_dispatch` and `workflow_dispatch` triggers, unlike `${{ github.actor }}` which can vary). **Explicitly NOT added to the env_file write loop** — these are session credentials, must not persist on the VPS. An inline comment in the workflow documents this constraint so future maintainers don't add them to the loop "for symmetry."
3. **`docker login ghcr.io ... --password-stdin`** added after `.env` is written, before any `docker compose pull/up`. Uses stdin to keep the token out of process arg-vector / logs.
4. **`trap '... docker logout ghcr.io ...' EXIT`** registered BEFORE the login call, so logout fires even if login itself or any later step fails. Leaves no stored credentials in the deploy user's `~/.docker/config.json`.

### `compose/docker-compose.prod.yml`

5. **Drop `build:` block from `landing`** service. After: landing pulls exclusively from `ghcr.io/noorinalabs/noorinalabs-landing-page:${LANDING_IMAGE_TAG:-latest}`. Multi-line comment above the `image:` line documents the intentional one-way dependency on the workflow's GHCR login + cross-references #103 for the parallel api/frontend tech-debt.

## Security framing

- `GITHUB_TOKEN` is the auto-provisioned, per-run, repo-scoped token. No new long-lived repo secret created.
- Token never written to `.env`, never logged via stdout (`--password-stdin`), never persisted on the VPS post-deploy (trap-registered logout).
- `permissions:` block scoped to `packages: read` and `contents: read` — no writes, no other scopes. Workflow cannot push images, modify releases, or alter repo state.
- Trap registered BEFORE `docker login` so logout fires on early failures (e.g. wrong actor, expired token, network blip).

## Owner action required

**NONE.** Uses the auto-provisioned `secrets.GITHUB_TOKEN`. No new GH Actions secret to create.

## Explicitly NOT changed

- `api` and `frontend` `build:` blocks — owner-deferred. See **#103** for the parallel cleanup decision.
- `--build` flag on `docker compose up` — owner-deferred (same #103).
- `provectuslabs/kafka-ui` and other public images — no auth needed.

## Disabled CI jobs (load-bearing followup)

None.

## Tech debt

**TechDebt:** #103 — `api`/`frontend` services force-build locally despite having GHCR images; same fix pattern as landing-page in this PR but owner-deferred for explicit option (a)-vs-(b) decision.

## Test plan

- [ ] `compose-validate` workflow passes (this PR touches `compose/**`).
- [ ] Post-merge `workflow_dispatch` deploy: `docker login ghcr.io` succeeds in step output (step name "Authenticating to GHCR").
- [ ] `docker compose pull` succeeds for `landing` and `user-service`.
- [ ] `docker compose up` brings the full stack up healthy.
- [ ] `docker logout ghcr.io` runs on workflow EXIT (visible in step trailer).
- [ ] Post-deploy SSH check: `cat /home/deploy/.docker/config.json` does NOT contain a `ghcr.io` auth entry (trap fired correctly).
- [ ] Post-deploy SSH check: `cat /opt/noorinalabs-deploy/.env` does NOT contain `GITHUB_TOKEN` or `GITHUB_ACTOR` lines (security constraint held).

## Reviewers

Requestor: Wanjiku.Mwangi
Requestees: Aino.Virtanen (org-level standards), Nadia.Khoury (program director sign-off, since this gates tonight's verification deploy)
