### PR TITLE
fix(deploy): clone+cp design-system 0.0.1.tgz for frontend build (#106)

### DIFF
--- a/.github/workflows/deploy-isnad-graph.yml
+++ b/.github/workflows/deploy-isnad-graph.yml
@@ -120,6 +120,25 @@ jobs:
             git reset --hard origin/main
             cd /opt/noorinalabs-deploy
 
+            echo "==> Staging design-system tarball into frontend build context..."
+            # frontend/package-lock.json resolves @noorinalabs/design-system from
+            # `file:/noorinalabs-design-system-0.0.1.tgz`. The Dockerfile (see
+            # noorinalabs-isnad-graph#818) COPYs that file from the build context.
+            # The design-system repo commits the pre-built 0.0.1.tgz at its root;
+            # we transport it verbatim. NO `npm pack` here — running pack on the
+            # current design-system source yields 0.0.2.tgz which fails the
+            # lockfile's integrity check. Long-term retired by isnad-graph#817
+            # (frontend → GHCR) and noorinalabs-design-system#57 (DS → npm registry).
+            if [ -d /opt/noorinalabs-design-system ]; then
+              cd /opt/noorinalabs-design-system
+              git fetch origin main
+              git reset --hard origin/main
+            else
+              git clone https://github.com/noorinalabs/noorinalabs-design-system.git /opt/noorinalabs-design-system
+            fi
+            cp /opt/noorinalabs-design-system/noorinalabs-design-system-0.0.1.tgz /opt/noorinalabs-isnad-graph/frontend/
+            cd /opt/noorinalabs-deploy
+
             echo "==> Attempting GHCR image pull..."
             docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env pull api frontend 2>/dev/null || echo "GHCR pull failed — will build locally"
 


### PR DESCRIPTION
## Summary

Fixes #106. Adds 3 functional lines to the SSH deploy script: clone (or pull) `noorinalabs-design-system`, copy its checked-in `noorinalabs-design-system-0.0.1.tgz` into `/opt/noorinalabs-isnad-graph/frontend/`, and `cd` back. Companion to noorinalabs/noorinalabs-isnad-graph#818 (Linh Pham, owner-routed). The two PRs can land in either order; deploy succeeds once both are on main.

## Repro

Deploy run [24613819108](https://github.com/noorinalabs/noorinalabs-deploy/actions/runs/24613819108) failed at frontend `docker build`:

```
target frontend: failed to solve: process "/bin/sh -c npm ci" did not complete successfully: exit code: 254
ENOENT: no such file or directory, open '/noorinalabs-design-system-0.0.1.tgz'
```

The Dockerfile companion (#818) adds `COPY noorinalabs-design-system-0.0.1.tgz /` before `npm ci`. That `COPY` only resolves if the tarball is present in the build context (`frontend/`). This PR makes that true.

## Why no `npm pack`

The design-system repo just bumped its `package.json` to `0.0.2` (commit `d61d96f`: "fix(DS#50): align package.json version to 0.0.2"). Running `npm pack` on current design-system would yield a `0.0.2.tgz` that fails the consuming `frontend/package-lock.json`'s integrity hash (`sha512-sLYwhCu1...`), even after rename. The literal `noorinalabs-design-system-0.0.1.tgz` file (matching the lockfile's expected hash) IS still committed at the design-system repo root — transporting it verbatim is the only zero-friction unblock.

This tarball-transport approach is intentionally minimal and gets retired by:
- noorinalabs/noorinalabs-isnad-graph#817 — frontend image to GHCR (after which the deploy pulls a pre-built image and never builds frontend on the VPS at all)
- noorinalabs/noorinalabs-design-system#57 — design-system to npm registry (after which `frontend/package-lock.json` resolves from a real registry, not a `file:` path)

**Don't bikeshed the version-pinning awkwardness — it's tracked.**

## Changes

`.github/workflows/deploy-isnad-graph.yml`:
- New step `==> Staging design-system tarball into frontend build context...`, placed AFTER the existing isnad-graph clone block, BEFORE `==> Attempting GHCR image pull...`. Three functional lines (clone-or-pull conditional, `cp`, `cd` back), plus a 12-line comment block documenting the why and the long-term retirement path.
- No node toolchain on the VPS. No `npm install`/`npm ci`/`npm pack`/`npm run build`.

## Owner action required

NONE. The clone uses HTTPS public-repo access (`git clone https://github.com/noorinalabs/noorinalabs-design-system.git`) — no auth needed for a public repo, and the `cp` is a local file move on the VPS.

## Disabled CI jobs (load-bearing followup)

None.

## Tech debt

**TechDebt:** noorinalabs/noorinalabs-deploy#103 (api/frontend force-build cleanup — orthogonal but adjacent), and the long-term retirement path through noorinalabs/noorinalabs-isnad-graph#817 + noorinalabs/noorinalabs-design-system#57 (both retire this entire transport).

## Test plan

- [ ] Eyeball + local YAML validation pass (verified: `python3 -c 'import yaml; yaml.safe_load(...)'`).
- [ ] No `compose-validate` CI trigger (paths don't touch `compose/**` — see #96 coverage gap).
- [ ] Post-merge (with #818 also on main): `workflow_dispatch` deploy succeeds. The `==> Staging design-system tarball...` step completes, and the subsequent `docker compose up --build` for `frontend` succeeds at `npm ci`.
- [ ] Post-deploy SSH check: `ls /opt/noorinalabs-isnad-graph/frontend/noorinalabs-design-system-0.0.1.tgz` exists.
- [ ] Re-running the deploy step is idempotent: the `if [ -d /opt/noorinalabs-design-system ]` branch hits on second run, fetches/resets, no re-clone.

## CI note

Same coverage gap as PR #95, #99, #105: `compose-validate.yml`'s paths-filter doesn't include `.github/workflows/deploy-isnad-graph.yml`. Aino's #96 tracks closing this gap.

## Reviewers

Requestor: Wanjiku.Mwangi
Requestees: Aino.Virtanen (org-level standards), Nadia.Khoury (program director sign-off, since this gates tonight's verification deploy)
