### PR TITLE
infra(bootstrap): pre-provision /opt/<aux-repo> dirs for deploy clones (#108)

### DIFF
--- a/scripts/bootstrap-vps.sh
+++ b/scripts/bootstrap-vps.sh
@@ -70,6 +70,29 @@ else
 fi
 chown -R $DEPLOY_USER:$DEPLOY_USER "$INSTALL_DIR"
 
+# ── Step 4.5: Pre-provision auxiliary repo directories ─────────────────────
+# /opt/ is root-owned by default, so the deploy user can't `git clone` into it
+# without these dirs existing first with the right ownership. The deploy
+# workflow (.github/workflows/deploy-isnad-graph.yml) clone-or-pulls into each
+# of these. To add a new repo to the deploy pipeline: append it to AUX_REPOS,
+# re-run this bootstrap script (idempotent), done. See deploy#108 for context.
+echo "==> [4.5/7] Pre-provisioning auxiliary repo directories under /opt/..."
+AUX_REPOS=(
+  "noorinalabs-isnad-graph"
+  "noorinalabs-design-system"
+)
+for repo in "${AUX_REPOS[@]}"; do
+  dir="/opt/$repo"
+  if [ ! -d "$dir" ]; then
+    mkdir -p "$dir"
+    echo "    Created $dir"
+  else
+    echo "    Exists  $dir"
+  fi
+  chown $DEPLOY_USER:$DEPLOY_USER "$dir"
+done
+echo "    Auxiliary repo dirs ready."
+
 # ── Step 5: Create production .env ──────────────────────────────────────────
 echo "==> [5/7] Creating production .env..."
 ENV_FILE="$INSTALL_DIR/.env"


### PR DESCRIPTION
## Summary

Closes #108. Adds **Step 4.5** to `scripts/bootstrap-vps.sh` — a data-driven loop that pre-creates and chowns the `/opt/<repo>` directories the deploy workflow needs to clone into. Surfaced today by PR #107 (design-system clone failed with `Permission denied` because `/opt/` is root-owned and the deploy user can't `mkdir` there).

## Owner action required AFTER merge

> **The owner must SSH to the VPS as root and re-run the bootstrap script ONCE to apply Step 4.5.**
>
> ```
> ssh root@isnad-graph.noorinalabs.com
> sudo bash /opt/noorinalabs-deploy/scripts/bootstrap-vps.sh
> ```
>
> Bootstrap is fully idempotent — safe to re-run. Effects of re-running:
> - Step 1 (apt) — already installed, no-op.
> - Step 2 (deploy user) — already exists, no-op.
> - Step 3 (SSH keys) — re-copies from `/root`, idempotent.
> - Step 4 (deploy repo clone) — does `git fetch && git reset --hard origin/main`, picks up this PR's bootstrap change AND any other recent merges.
> - **Step 4.5 (NEW)** — creates `/opt/noorinalabs-design-system` if missing, chowns to deploy user. Also re-chowns `/opt/noorinalabs-isnad-graph` (no-op if already correct).
> - Step 5 (`.env`) — file exists, no-op.
> - Step 6 (rclone) — already installed, no-op.
> - Step 7 (backup timer) — already installed, no-op.
>
> Net effect: only the missing `/opt/noorinalabs-design-system` dir is created. Tonight's deploy then proceeds without the manual `sudo mkdir+chown` workaround the owner is currently doing.

## Repro

PR #107 (design-system clone+cp) merged and the next deploy run [24615354566](https://github.com/noorinalabs/noorinalabs-deploy/actions/runs/24615354566) failed at the new `==> Staging design-system tarball...` step:

```
fatal: could not create work tree dir '/opt/noorinalabs-design-system': Permission denied
```

`/opt/` is root-owned by Ubuntu default; deploy user can't `mkdir` in it. `/opt/noorinalabs-isnad-graph` works because someone hand-created it at original VPS provisioning — that hand-step was never codified, and now any new repo trips the same gap.

## Changes

`scripts/bootstrap-vps.sh` — single hunk, +23 lines, between existing Step 4 (clone deploy repo) and Step 5 (.env):

```bash
# ── Step 4.5: Pre-provision auxiliary repo directories ─────────────────────
echo "==> [4.5/7] Pre-provisioning auxiliary repo directories under /opt/..."
AUX_REPOS=(
  "noorinalabs-isnad-graph"
  "noorinalabs-design-system"
)
for repo in "${AUX_REPOS[@]}"; do
  dir="/opt/$repo"
  if [ ! -d "$dir" ]; then
    mkdir -p "$dir"
    echo "    Created $dir"
  else
    echo "    Exists  $dir"
  fi
  chown $DEPLOY_USER:$DEPLOY_USER "$dir"
done
echo "    Auxiliary repo dirs ready."
```

Plus a 5-line comment block above explaining the why and pointing at #108 for context.

## Properties

- **Idempotent.** `mkdir -p` no-ops when the dir exists. `chown` is unconditional and matches the existing line-71 pattern (same `$DEPLOY_USER` target, no quoting changes from established style). Distinguishes `Created` vs `Exists` in output so operators see at a glance what changed on a re-run.
- **Data-driven.** Adding a new repo to the deploy pipeline becomes a 1-line append to `AUX_REPOS` + a bootstrap re-run.
- **Deploy script unchanged.** Existing `if [ -d /opt/<repo> ]; then ... else git clone ...` logic in the deploy workflow handles "dir exists, just pull" vs "dir empty, clone fresh" — both cases work after this provisioning.

## Step numbering

Used `[4.5/7]` rather than renumbering all 7 echoes to `[N/8]`. Per spec this is the lower-churn option and preserves the existing step-7 anchors operators may have memorized. The `7` denominator is unchanged because no NEW top-level step was added — 4.5 is a sub-step under "VPS provisioning". A future cleanup could renumber to strict sequential, but that's its own trivial PR.

## Disabled CI jobs (load-bearing followup)

None.

## Tech debt

None — this PR IS the fix for #108.

## Test plan

- [ ] Local bash syntax check: `bash -n scripts/bootstrap-vps.sh` — verified pre-commit, exit 0.
- [ ] No CI triggers on this PR (paths-filter doesn't watch `scripts/**` for compose-validate; same coverage gap as Aino's #96).
- [ ] Post-merge: owner SSHes to VPS and runs `sudo bash /opt/noorinalabs-deploy/scripts/bootstrap-vps.sh`. Output shows `Created /opt/noorinalabs-design-system` and `Exists  /opt/noorinalabs-isnad-graph`.
- [ ] Subsequent deploy run completes the design-system clone+cp step without `Permission denied`.
- [ ] Re-running bootstrap a second time shows `Exists` for both dirs (idempotency confirmation).

## Reviewers

Requestor: Wanjiku.Mwangi
Requestees: Aino.Virtanen (org-level standards), Nadia.Khoury (program director sign-off, since this gates tonight's verification deploy)
