### PR TITLE
fix(bootstrap): suppress debconf prompts + preserve operator configs on apt upgrade (#110)

### DIFF
--- a/scripts/bootstrap-vps.sh
+++ b/scripts/bootstrap-vps.sh
@@ -11,6 +11,12 @@
 # =============================================================================
 set -euo pipefail
 
+# Suppress all interactive debconf prompts during apt operations. Without this,
+# any package whose postinst asks a question (docker.io "restart Docker?",
+# openssh-server, libc6, etc.) hangs the script indefinitely on the first
+# upgrade-with-prompt. See #110 for the incident this fixes.
+export DEBIAN_FRONTEND=noninteractive
+
 REPO_URL="https://github.com/noorinalabs/noorinalabs-deploy.git"
 INSTALL_DIR="/opt/noorinalabs-deploy"
 DEPLOY_USER="deploy"
@@ -29,7 +35,14 @@ fi
 # ── Step 1: System packages ─────────────────────────────────────────────────
 echo "==> [1/7] Installing system packages..."
 apt-get update -qq
-apt-get install -y -qq docker.io docker-compose-v2 docker-buildx git curl > /dev/null
+# --force-confold: keep operator-modified config files on upgrade (don't blow
+#   away changes under /etc/docker/, /etc/ssh/, etc.).
+# --force-confdef: use the package's default when there's no existing file to
+#   preserve. Standard idempotent-upgrade pair.
+apt-get install -y -qq \
+  -o Dpkg::Options::="--force-confdef" \
+  -o Dpkg::Options::="--force-confold" \
+  docker.io docker-compose-v2 docker-buildx git curl > /dev/null
 systemctl enable docker
 systemctl start docker
 echo "    Docker version: $(docker --version)"


### PR DESCRIPTION
## Summary

Fixes #110. Two surgical changes near the top of `scripts/bootstrap-vps.sh` so the script can run end-to-end without operator interaction even when an apt package upgrade hits a debconf prompt.

## Repro

PR #109 just merged Step 4.5 to the bootstrap script and instructed the owner to re-run it as documented in #109's owner-action note. The re-run hung at Step 1 on a `docker.io` postinst prompt:

```
Configuration file '/etc/init.d/docker'
 ==> Modified (by you or by a script) since installation.
 ==> Package distributor has shipped an updated version.
 ...
*** docker [Y/n]?
```

Owner's SSH session bounced before he could answer, leaving the bootstrap force-killed in an unrecoverable state. Same hang would fire on `openssh-server` ("restart services?"), `libc6`, or any package whose postinst runs `dpkg-reconfigure` interactively.

## Changes

`scripts/bootstrap-vps.sh` — single file, +14/-1, two hunks:

1. **`export DEBIAN_FRONTEND=noninteractive`** added immediately after `set -euo pipefail` (with a 4-line comment explaining the latent risk and pointing at #110). Affects every apt call in the script — both `apt-get update` (line 37) and `apt-get install` (line 42) inherit the env var.

2. **`-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"`** added to the `apt-get install` invocation. Standard idempotent-upgrade pair:
   - `--force-confold` — keep operator-modified config files (don't blow away changes under `/etc/docker/`, `/etc/ssh/`, etc.).
   - `--force-confdef` — use the package's default when there's no existing file to preserve.

   Layout reformatted from one line to multi-line with backslash continuations, with inline comments documenting each flag. The package list itself is unchanged.

## Audit

Only 2 apt-get calls in the script:

- Line 37: `apt-get update -qq` — no install/upgrade work, dpkg flags not needed; benefits from `DEBIAN_FRONTEND` env var.
- Line 42: `apt-get install -y -qq ...` — both fixes apply.

No other apt invocations anywhere else in `scripts/`. Verified via grep.

## Owner action required

**NONE** for already-merged PR #109. The owner is currently mid-bootstrap on the VPS using the manual workaround (answered the docker.io prompt by hand). This PR benefits the **next** bootstrap re-run — whenever a future PR adds a new aux-repo to `AUX_REPOS` or anything else triggers a re-run.

## Disabled CI jobs (load-bearing followup)

None.

## Tech debt

None — this PR IS the fix for #110.

## Test plan

- [ ] `bash -n scripts/bootstrap-vps.sh` — verified pre-commit, exit 0.
- [ ] No CI triggers on this PR (paths-filter doesn't watch `scripts/**` for compose-validate; same coverage gap as Aino's #96).
- [ ] Future bootstrap re-run on the VPS completes Step 1 without any debconf prompt, regardless of which packages have postinst questions pending. Verifiable on next aux-repo addition.
- [ ] Operator-modified configs under `/etc/docker/` (if any) are preserved across the re-run.

## Reviewers

Requestor: Wanjiku.Mwangi
Requestees: Aino.Virtanen (org-level standards), Nadia.Khoury (program director sign-off, since this is in the bootstrap path that gates every future deploy)
