### PR TITLE
fix(deploy): drop build: blocks for api + frontend services — GHCR-only (#103)

### DIFF
--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -112,10 +112,14 @@ services:
     restart: unless-stopped
 
   api:
+    # GHCR-only — no local-build fallback. The deploy workflow logs into ghcr.io
+    # using the auto-provisioned GITHUB_TOKEN (workflow `permissions: packages: read`
+    # required, see .github/workflows/deploy-isnad-graph.yml). A manual
+    # `docker compose up` on the VPS without prior `docker login ghcr.io` will fail
+    # at pull — that's intentional; deploys go through the workflow. See the
+    # cutover meta (noorinalabs-main#145) and #103 for the rationale (VPS has no
+    # Node toolchain, so the previous local-build path was never viable).
     image: ghcr.io/noorinalabs/noorinalabs-isnad-graph:${IMAGE_TAG:-latest}
-    build:
-      context: /opt/noorinalabs-isnad-graph
-      dockerfile: Dockerfile
     expose:
       - "8000"
     # Security: read_only prevents runtime writes to the container filesystem.
@@ -173,12 +177,15 @@ services:
     restart: unless-stopped
 
   frontend:
+    # GHCR-only — no local-build fallback. The deploy workflow logs into ghcr.io
+    # using the auto-provisioned GITHUB_TOKEN (workflow `permissions: packages: read`
+    # required, see .github/workflows/deploy-isnad-graph.yml). A manual
+    # `docker compose up` on the VPS without prior `docker login ghcr.io` will fail
+    # at pull — that's intentional; deploys go through the workflow. See the
+    # cutover meta (noorinalabs-main#145) and #103 for the rationale: the VPS has
+    # no Node/npm toolchain, so the previous `npm pack`-based build path was
+    # never viable and the CACHEBUST arg (local-build cache buster) went with it.
     image: ghcr.io/noorinalabs/noorinalabs-isnad-graph-frontend:${IMAGE_TAG:-latest}
-    build:
-      context: /opt/noorinalabs-isnad-graph/frontend
-      dockerfile: Dockerfile
-      args:
-        CACHEBUST: ${CACHEBUST:-1}
     expose:
       - "80"
     read_only: true
@@ -217,8 +224,7 @@ services:
     # using the auto-provisioned GITHUB_TOKEN (workflow `permissions: packages: read`
     # required, see .github/workflows/deploy-isnad-graph.yml). A manual
     # `docker compose up` on the VPS without prior `docker login ghcr.io` will fail
-    # at pull — that's intentional; deploys go through the workflow. The api/frontend
-    # services still have `build:` blocks pending the owner decision in #103.
+    # at pull — that's intentional; deploys go through the workflow.
     image: ghcr.io/noorinalabs/noorinalabs-landing-page:${LANDING_IMAGE_TAG:-latest}
     expose:
       - "80"


### PR DESCRIPTION
Closes #103. Part of noorinalabs/noorinalabs-main#145.

## Summary

- Drops the `build:` blocks from the `api` and `frontend` services in `compose/docker-compose.prod.yml`. Both services are now GHCR-only, matching the pattern `landing` already uses (PR #105).
- Adds an explanatory GHCR-only comment block above each `image:` line, mirroring `landing`'s comment. Points: GHCR-only, no local-build fallback, deploy workflow handles `docker login ghcr.io` using the auto-provisioned `GITHUB_TOKEN` (`permissions: packages: read`), a manual `docker compose up` on the VPS without prior login will fail at pull — intentional, deploys go through the workflow.
- Deletes the stale trailing sentence in `landing`'s comment that referenced the pending owner decision in #103 — no longer pending.
- Drops the `CACHEBUST` build-arg from `frontend` along with the `build:` block (it was a local-build cache buster with no purpose for pulled images). The workflow still writes `CACHEBUST` into the `.env` file on the VPS — that's harmless (unused variable) and intentionally not touched here to keep this PR minimal.

## Why

The VPS has no Node/npm toolchain. The previous `npm pack`-based frontend build path (clone design-system, cp the 0.0.1 tarball into the build context, run `docker build`) could not execute and caused 14 consecutive deploy failures. Owner picked option (a) from #103: drop the `build:` blocks entirely and rely on GHCR-published images — same model `landing` has used successfully since #105.

## Ontology

Updated `image_fallback` in the parent-repo ontology (`noorinalabs-main/ontology/repos/deploy.yaml`) from `"GHCR pull with fallback to local build"` to reflect GHCR-only for all app services. This repo does not have its own `ontology/` directory. That edit will land via the parent's `/ontology-rebuild` cadence.

## Test plan

- [x] YAML parses cleanly (validated locally via `python3 -c "yaml.safe_load(...)"`). `api`, `frontend`, `landing` all have `image:` and no `build:`.
- [ ] `compose-validate.yml` CI workflow runs on this PR — will catch anything missed locally (Docker not available in the worktree environment).
- [ ] First deploy after merge requires the GHCR images to exist. The orchestrator sequences merge order so `noorinalabs-isnad-graph` publishes first GHCR images **before** this PR merges.

## Follow-ups (not in this PR)

- `deploy-isnad-graph.yml` still passes `--build` to `docker compose up` (line 146). Inert for services without `build:` blocks, so not blocking. Should be cleaned up along with the now-dead design-system tarball staging (lines 123-140) and `/opt/noorinalabs-isnad-graph` git clone (lines 117-121). Flagging as tech-debt; happy to open a follow-up issue.

## Charter notes

- Commit identity: Lucas Ferreira via per-commit `-c` flags (no global/repo config changes).
- Two reviewers requested below.