### PR TITLE
fix(deploy): remove dead local-build scaffolding from deploy-isnad-graph.yml (#115)

### DIFF
--- a/.github/workflows/deploy-isnad-graph.yml
+++ b/.github/workflows/deploy-isnad-graph.yml
@@ -105,7 +105,6 @@ jobs:
               printf "%s='%s'\n" "$var" "$val" >> "$env_file"
             done
             printf "%s='%s'\n" "IMAGE_TAG" "${IMAGE_TAG}" >> "$env_file"
-            printf "%s='%s'\n" "CACHEBUST" "$(date +%s)" >> "$env_file"
             chmod 600 "$env_file"
 
             echo "==> Authenticating to GHCR..."
@@ -114,36 +113,11 @@ jobs:
             trap 'docker logout ghcr.io >/dev/null 2>&1 || true' EXIT
             echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
 
-            echo "==> Pulling latest noorinalabs-isnad-graph source (for local builds)..."
-            cd /opt/noorinalabs-isnad-graph
-            git fetch origin main
-            git reset --hard origin/main
-            cd /opt/noorinalabs-deploy
+            echo "==> Pulling images from GHCR..."
+            docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env pull api frontend landing user-service
 
-            echo "==> Staging design-system tarball into frontend build context..."
-            # frontend/package-lock.json resolves @noorinalabs/design-system from
-            # `file:/noorinalabs-design-system-0.0.1.tgz`. The Dockerfile (see
-            # noorinalabs-isnad-graph#818) COPYs that file from the build context.
-            # The design-system repo commits the pre-built 0.0.1.tgz at its root;
-            # we transport it verbatim. NO `npm pack` here — running pack on the
-            # current design-system source yields 0.0.2.tgz which fails the
-            # lockfile's integrity check. Long-term retired by isnad-graph#817
-            # (frontend → GHCR) and noorinalabs-design-system#57 (DS → npm registry).
-            if [ -d /opt/noorinalabs-design-system ]; then
-              cd /opt/noorinalabs-design-system
-              git fetch origin main
-              git reset --hard origin/main
-            else
-              git clone https://github.com/noorinalabs/noorinalabs-design-system.git /opt/noorinalabs-design-system
-            fi
-            cp /opt/noorinalabs-design-system/noorinalabs-design-system-0.0.1.tgz /opt/noorinalabs-isnad-graph/frontend/
-            cd /opt/noorinalabs-deploy
-
-            echo "==> Attempting GHCR image pull..."
-            docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env pull api frontend 2>/dev/null || echo "GHCR pull failed — will build locally"
-
-            echo "==> Starting services (builds locally if no GHCR image)..."
-            docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env up -d --build --force-recreate --remove-orphans
+            echo "==> Starting services..."
+            docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env up -d --force-recreate --remove-orphans
 
             echo "==> Waiting for services to stabilize..."
             sleep 15

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,11 +97,10 @@ The primary deployment workflow (`deploy-isnad-graph.yml`) follows this sequence
 1. **SSH to VPS** as `deploy` user via `appleboy/ssh-action@v1`
 2. **Pull latest deploy configs** — `git fetch origin main && git reset --hard origin/main` in `/opt/noorinalabs-deploy`
 3. **Write `.env`** — all secrets are injected as SSH environment variables and written to `.env` with `chmod 600`. The file is recreated fresh each deployment.
-4. **Pull latest isnad-graph source** — `git fetch && reset` in `/opt/noorinalabs-isnad-graph` (used as build context fallback)
-5. **Try GHCR images first** — `docker compose pull api frontend` attempts to pull pre-built images from `ghcr.io/noorinalabs/`
-6. **Fall back to local build** — if GHCR pull fails, `docker compose up --build` builds from the local source checkout
-7. **Start services** — `docker compose up -d --build --force-recreate --remove-orphans`
-8. **Health check loop** — polls the API container health status up to 24 times at 5-second intervals (120 seconds total). On failure, dumps the last 50 lines of API logs and exits non-zero.
+4. **Authenticate to GHCR** — `docker login ghcr.io` using the auto-provisioned `GITHUB_TOKEN`; a trap ensures logout on exit so no credentials persist on the VPS.
+5. **Pull images from GHCR** — `docker compose pull api frontend landing user-service` pulls pre-built images from `ghcr.io/noorinalabs/`. All application services are image-only; there is no local-build fallback.
+6. **Start services** — `docker compose up -d --force-recreate --remove-orphans`
+7. **Health check loop** — polls the API container health status up to 24 times at 5-second intervals (120 seconds total). On failure, dumps the last 50 lines of API logs and exits non-zero.
 
 ## Secrets Management
 
@@ -142,7 +141,6 @@ The `.env` file is ephemeral: recreated fresh on each deployment, written with `
 | Variable | Source |
 |----------|--------|
 | `IMAGE_TAG` | Workflow input or `latest` |
-| `CACHEBUST` | `date +%s` (forces frontend rebuild) |
 
 ## Infrastructure
 

--- a/docs/runbooks/deploy-isnad-graph.md
+++ b/docs/runbooks/deploy-isnad-graph.md
@@ -44,9 +44,9 @@ To deploy all 13 services (including infrastructure):
 1. SSH to VPS as `deploy` user
 2. Pull latest deploy config: `git fetch origin main && git reset --hard origin/main` in `/opt/noorinalabs-deploy`
 3. Write `.env` from GitHub secrets (recreated fresh each deploy, `chmod 600`)
-4. Pull latest `noorinalabs-isnad-graph` source to `/opt/noorinalabs-isnad-graph` (local build fallback)
-5. Attempt GHCR image pull for `api` and `frontend`
-6. Start services: `docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env up -d --build --force-recreate --remove-orphans`
+4. Authenticate to GHCR: `docker login ghcr.io` with auto-provisioned `GITHUB_TOKEN` (logout on exit via trap)
+5. Pull images from GHCR for `api`, `frontend`, `landing`, `user-service`
+6. Start services: `docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env up -d --force-recreate --remove-orphans`
 7. Health check loop: polls API container up to 24 times at 5-second intervals (120s total)
 
 ## Post-Deployment Verification

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -100,7 +100,7 @@ docker pull ghcr.io/noorinalabs/noorinalabs-isnad-graph:latest
     --jq '.[].metadata.container.tags[]' | head -20
   ```
 
-**Fallback behavior:** The deploy workflow is designed to fall back to local builds from `/opt/noorinalabs-isnad-graph` when GHCR pull fails. This is slower but functional.
+**No fallback:** As of the GHCR cutover (`noorinalabs-main#145`), application services are image-only — there is no local-build fallback. If `docker compose pull` fails, the deploy fails. Fix the GHCR auth/tag/image issue and re-run; do not attempt to `--build` on the VPS.
 
 ## VPS Disk Space / Resource Exhaustion
 


### PR DESCRIPTION
Closes #115. Expedites the follow-up Aisha filed in #114's review — it became blocking when today's deploy (run 24631768008) failed at the dead tarball-staging step despite the GHCR cutover (#145) being complete. Part of noorinalabs/noorinalabs-main#145.

## What changed in `.github/workflows/deploy-isnad-graph.yml`

Deleted all scaffolding that was only needed for local builds of `api` / `frontend`:

- `--build` flag on `docker compose up` — services have no `build:` blocks anymore, so this is inert/confusing.
- `/opt/noorinalabs-isnad-graph` source clone step — nothing reads from that checkout now.
- Design-system tarball staging block — the literal cause of the run-24631768008 failure (`cp: cannot stat '/opt/noorinalabs-design-system/noorinalabs-design-system-0.0.1.tgz'`).
- `CACHEBUST=$(date +%s)` `.env` write — only affected frontend build cache, irrelevant with pulled images.
- Misleading `|| echo "GHCR pull failed — will build locally"` echo — replaced with a plain "Pulling images from GHCR" line.

Also extended the `pull` step from `api frontend` to `api frontend landing user-service` so all GHCR-sourced app services are pre-pulled.

## Docs updated

- `docs/architecture.md` — rewrote the Deployment Flow section (steps 4-7) for image-only flow; removed `CACHEBUST` from the "Derived at deploy time" table.
- `docs/runbooks/deploy-isnad-graph.md` — same rewrite in "What Happens During Deploy".
- `docs/troubleshooting.md` — replaced the "Fallback behavior" paragraph with a "No fallback" note directing operators to fix GHCR auth/tag/image rather than `--build`.

## Test plan

After merge, the VPS flow becomes:

- [ ] `cd /opt/noorinalabs-deploy && git fetch origin main && git reset --hard origin/main`
- [ ] `docker login ghcr.io` using the auto-provisioned `GITHUB_TOKEN` (handled by the workflow trap)
- [ ] `docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env pull api frontend landing user-service`
- [ ] `docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env up -d --force-recreate --remove-orphans`
- [ ] Health-check loop in the workflow confirms `noorinalabs-api-1` reaches `healthy` within 120s
- [ ] `docker compose ps` shows all 22 services Up/healthy

Post-merge, trigger `deploy-isnad-graph.yml` via `workflow_dispatch` with `image_tag=latest` to confirm the 16th attempt goes green end-to-end.
