### PR TITLE
fix(kafka): run container with GID 0 (root group) to match image default (#124)

### DIFF
--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -666,7 +666,12 @@ services:
     # Same image, same internal paths (/bitnami/kafka, /opt/bitnami/kafka/...) — only
     # the registry namespace changes. Long-term migration off Bitnami tracked in #100.
     image: bitnamilegacy/kafka:3.8.0
-    user: "1001:1001"
+    # Must run with GID 0 (root group) — matches the image's default USER directive.
+    # /opt/bitnami/kafka/config is root:root 775; the entrypoint cp's default configs
+    # there on first run and requires group-write via gid=0. Explicit user: 1001:1001
+    # loses that group membership and fails with "Permission denied" on server.properties
+    # — see #124. Long-term migration off Bitnami tracked in #100.
+    user: "1001:0"
     environment:
       # Core KRaft identity
       KAFKA_CFG_NODE_ID: "1"
@@ -727,7 +732,12 @@ services:
     # re-executed whenever compose is brought up — cheap and safe.
     # bitnamilegacy/* — see broker service comment + #100 for the long-term plan.
     image: bitnamilegacy/kafka:3.8.0
-    user: "1001:1001"
+    # Must run with GID 0 (root group) — matches the image's default USER directive.
+    # /opt/bitnami/kafka/config is root:root 775; the entrypoint cp's default configs
+    # there on first run and requires group-write via gid=0. Explicit user: 1001:1001
+    # loses that group membership and fails with "Permission denied" on server.properties
+    # — see #124. Long-term migration off Bitnami tracked in #100.
+    user: "1001:0"
     volumes:
       - ../infra/kafka/init-topics.sh:/opt/bitnami/kafka/init-topics.sh:ro
     entrypoint: ["/bin/bash", "/opt/bitnami/kafka/init-topics.sh"]


### PR DESCRIPTION
Closes #124. Promoted out of #123 triage. Part of #145 cutover follow-through.

## Summary

One-line compose fix: `user: "1001:1001"` → `user: "1001:0"` on both `kafka` and `kafka-init` services. Matches the `bitnamilegacy/kafka:3.8.0` image's default USER directive (uid=1001, gid=0).

## Root cause (from diagnostic on VPS 2026-04-19)

- Image's config dir `/opt/bitnami/kafka/config/` is owned by root:root with 775 perms — group write requires gid=0.
- Image default USER: `uid=1001 gid=0(root)` (confirmed via `docker run --rm --entrypoint /bin/bash bitnamilegacy/kafka:3.8.0 -c id`).
- Compose override `user: "1001:1001"` moved gid to 1001, losing root-group membership.
- First-run cp of server.properties into config dir failed with "Permission denied", causing restart loop.

## Why we never saw this before today

Kafka was added in #80 on 2026-04-18. No deploy since then has successfully reached the kafka bring-up — all earlier failures happened in the frontend build stage (VPS missing Node, fixed by #145 cutover). Today's first green deploy (run 24632616582) exposed kafka as the first real failure point post-cutover.

## Test plan

1. Merge this PR.
2. Retrigger deploy via `workflow_dispatch` in noorinalabs-deploy.
3. On VPS (ssh noorinalabs-prod): `docker ps --filter name=kafka --format '{{.Names}}: {{.Status}}'`
   - Expect: all three (`kafka`, `kafka-init`, `kafka-ui`) healthy or ran-to-completion.
4. `docker logs noorinalabs-kafka-1 | grep -iE "permission|started|ready"` — no permission errors, expect "Kafka Server started".
5. `docker logs noorinalabs-kafka-init-1` — exits 0, shows topic creation.
6. Optional full operator check: ssh tunnel to 8085, log in to kafka-ui with KAFKA_UI_* creds, confirm cluster is visible + topics exist.

## Scope out

- Bitnami image migration (#100) — owner-decision-gated, larger change.
- Broader #123 triage (alertmanager, promtail, user-service unhealthy) — independent issues.