### PR TITLE
fix(observability): unbreak alertmanager config + bump promtail (#127, #128)

### DIFF
--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -564,18 +564,20 @@ services:
         max-file: "3"
 
   promtail:
-    image: grafana/promtail:2.9.10
+    # 3.x bundles a Docker API client compatible with Docker 26+ daemons (API 1.44).
+    # 2.9.10 shipped a 1.42 client which can't enumerate containers on the prod
+    # VPS — see #128. Push API stays compatible with Loki 2.9.x; no Loki bump needed.
+    image: grafana/promtail:3.4.1
     volumes:
       - ../infra/promtail/promtail-config.yml:/etc/promtail/config.yml:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
     command:
       - "-config.file=/etc/promtail/config.yml"
-    healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:9080/ready || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
+    # Healthcheck removed — promtail's distroless image has no wget/curl/nc, so
+    # any HTTP-probe healthcheck fails permanently (888-deep failing streak observed
+    # pre-fix). Liveness signal is restart-policy + Prometheus alerting on log-rate
+    # drop. Long-term: migrate to grafana/alloy (richer base image). See #128.
     depends_on:
       loki:
         condition: service_healthy

--- a/infra/alertmanager/alertmanager.yml
+++ b/infra/alertmanager/alertmanager.yml
@@ -16,7 +16,10 @@ route:
 receivers:
   - name: default
     webhook_configs:
-      - url: "${ALERTMANAGER_WEBHOOK_URL:-http://localhost:9095/webhook}"
+      # Alertmanager does NOT expand ${VAR} in config files. URL must be literal.
+      # This points at a non-existent local webhook so config loads cleanly until
+      # real alert routing (PagerDuty/Slack/email) is set up. See #127.
+      - url: "http://localhost:9095/webhook"
         send_resolved: true
     # Uncomment to enable email notifications:
     # email_configs:
@@ -29,7 +32,10 @@ receivers:
 
   - name: critical
     webhook_configs:
-      - url: "${ALERTMANAGER_WEBHOOK_URL:-http://localhost:9095/webhook}"
+      # Alertmanager does NOT expand ${VAR} in config files. URL must be literal.
+      # This points at a non-existent local webhook so config loads cleanly until
+      # real alert routing (PagerDuty/Slack/email) is set up. See #127.
+      - url: "http://localhost:9095/webhook"
         send_resolved: true
     # Uncomment to enable email notifications for critical alerts:
     # email_configs:


### PR DESCRIPTION
Closes #127. Closes #128. Part of #123 triage closeout (final two items).

## Summary

Two latent observability-stack bugs surfaced 2026-04-19 by the first successful GHCR-cutover deploy. Both fixes touch only `infra/` config + the promtail compose block.

## #127 — alertmanager: `${VAR}` in config not expanded

`alertmanager.yml` had `url: "${ALERTMANAGER_WEBHOOK_URL:-http://localhost:9095/webhook}"` in two webhook receivers. Alertmanager doesn't do shell expansion in its config; the literal `${...}` string was parsed as a URL and failed at the colon in the default value.

Fix: hard-code the placeholder local URL (no real webhook is configured anyway). When real alert routing is set up, replace inline with the receiver-specific block. Inline comment documents why.

## #128 — promtail: two compounding issues

1. **Docker API client too old.** `grafana/promtail:2.9.10` bundles a Docker API v1.42 client; the prod VPS daemon requires v1.44+. Container discovery fully broken — Loki receiving no logs from any container.
2. **Healthcheck command not in image.** Compose's `wget -qO- http://localhost:9080/ready || exit 1` healthcheck — but the promtail distroless image has no wget. 888-deep failing streak observed.

Fix: bump image to `grafana/promtail:3.4.1`. Push API stays compatible with Loki 2.9.x — no Loki bump needed. Drop the broken healthcheck — distroless has no wget/curl/nc, so any HTTP-probe healthcheck is brittle. Liveness now comes from restart-policy + Prometheus alerting on log-rate drop. Inline comment documents the rationale + flags grafana/alloy as the long-term migration target.

## Diff size

`infra/alertmanager/alertmanager.yml`: +6 / -2
`compose/docker-compose.prod.yml`: +8 / -6

## Test plan

1. Merge → workflow_dispatch deploy.
2. `docker logs noorinalabs-alertmanager-1 | grep ERROR` — empty.
3. `docker ps --filter name=alertmanager --format '{{.Status}}'` — `Up (healthy)`.
4. `docker logs noorinalabs-promtail-1 | grep "API version"` — empty.
5. `docker ps --filter name=promtail --format '{{.Status}}'` — `Up` (no health status, intentional).
6. From inside VPS: `curl -G "http://loki:3100/loki/api/v1/query" --data-urlencode 'query={container="noorinalabs-api-1"}'` — returns recent log entries (proves the docker discovery + push pipeline works end-to-end).

## Out of scope

- Real alert routing (Slack/PagerDuty/email) — separate follow-up when needed.
- Grafana Alloy migration — observability-stack-modernization issue when promtail-as-maintenance becomes painful.