### PR TITLE
fix(caddy): route /auth/callback/* to frontend (#133)

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -18,6 +18,13 @@ noorinalabs.com {
 isnad-graph.noorinalabs.com {
     # ── User service routes ──────────────────────────────────────────
 
+    # OAuth post-login redirect target lives on the frontend (React Router
+    # AuthCallbackPage), NOT user-service. Carve out before /auth/* which
+    # goes to user-service. See deploy#133, user-service#67.
+    handle /auth/callback/* {
+        reverse_proxy frontend:80
+    }
+
     # User service — auth endpoints
     # NOTE: rate limiting on /auth/* should be enforced at the app layer
     handle /auth/* {


### PR DESCRIPTION
Closes #133. OAuth post-login redirect was 404'ing because /auth/* matched user-service before /auth/callback/* could reach the frontend. Surfaced 2026-04-19 by owner's first end-to-end Google login attempt. Companion PR for the silent-exchange-exception diagnostic logging is in user-service#71.
