### PR TITLE
fix(compose): give user-service egress via frontend network (#138)

### DIFF
--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -348,8 +348,12 @@ services:
         max-size: "10m"
         max-file: "5"
     networks:
+      # frontend is non-internal — gives user-service outbound egress for OAuth
+      # provider calls (Google, GitHub, etc.). backend + user-backend are internal
+      # for DB isolation. See deploy#138.
       - backend
       - user-backend
+      - frontend
     command: /app/.venv/bin/uvicorn src.app.main:create_app --factory --host 0.0.0.0 --port 8000 --workers 2
     restart: unless-stopped
 


### PR DESCRIPTION
## Summary

One-line compose change: add `frontend` to `user-service`'s networks list so the container has outbound internet egress. Without it, OAuth token exchange with Google/GitHub fails at the DNS resolution step.

## Diagnostic chain

This is the third (and hopefully last) fix in the prod OAuth login chain:

1. **#134** — Caddy routed `/auth/callback/*` to the frontend (first visible symptom was a 404 on the callback).
2. **user-service#72** — Added diagnostic logging around the OAuth token exchange. Logs then revealed DNS resolution failures when user-service tried to reach `oauth2.googleapis.com`.
3. **#138 (this PR)** — Root cause: `user-service`'s networks (`backend`, `user-backend`) are both `internal: true`. The service has no route to the public internet, so DNS/HTTPS to OAuth providers silently fail.

## Why the `frontend` network

From `ontology/repos/deploy.yaml`:

```yaml
networks:
  backend:      { internal: true,  description: "Databases, API, observability" }
  frontend:     { internal: false, description: "Public-facing via Caddy" }
  user-backend: { internal: true,  description: "User service + dedicated DBs" }
```

`frontend` is the only non-internal network in the stack. Adding user-service to it gives egress without weakening DB isolation — `backend` and `user-backend` remain internal so Postgres/Redis traffic stays off the public-facing network.

## Diff

```diff
     networks:
+      # frontend is non-internal — gives user-service outbound egress for OAuth
+      # provider calls (Google, GitHub, etc.). backend + user-backend are internal
+      # for DB isolation. See deploy#138.
       - backend
       - user-backend
+      - frontend
```

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('compose/docker-compose.prod.yml'))"` parses cleanly
- [ ] Post-deploy: `docker exec user-service getent hosts oauth2.googleapis.com` resolves
- [ ] Post-deploy: Google OAuth login completes end-to-end on prod
- [ ] Post-deploy: GitHub OAuth login completes end-to-end on prod
- [ ] Verify `user-service` still cannot reach the API on `backend` via a non-`user-backend` path (isolation preserved)

Closes #138.
