### PR TITLE
fix(compose): wire AUTH_USER_SERVICE_URL for isnad-graph api (#142)

### DIFF
--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -141,6 +141,7 @@ services:
       - AUTH_GITHUB_CLIENT_ID=${AUTH_GITHUB_CLIENT_ID:-}
       - AUTH_GITHUB_CLIENT_SECRET=${AUTH_GITHUB_CLIENT_SECRET:-}
       - AUTH_OAUTH_REDIRECT_BASE_URL=https://isnad-graph.noorinalabs.com
+      - AUTH_USER_SERVICE_URL=http://user-service:8000
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/health')\" || exit 1"]
       interval: 15s


### PR DESCRIPTION
**URGENT — production 503, expedite review.**

## What

Add `AUTH_USER_SERVICE_URL=http://user-service:8000` to the `api` service's `environment:` block in `compose/docker-compose.prod.yml`. One line, no other changes.

## Why

The isnad-graph api container was missing `AUTH_USER_SERVICE_URL`, so its `AuthSettings` default (`http://localhost:8001`) took effect. Every JWKS fetch from the api container threw `httpx.ConnectError`, and every authenticated isnad-graph API call returned `503 Authentication service unavailable` in production. The project owner was locked out of the admin dashboard as a result.

`user-service` is reachable at `http://user-service:8000` over the shared `backend` docker network (verified in the resolved compose graph).

## Scope

- Single-line env addition to the `api` service.
- No changes to isnad-graph `src/config.py` default (a hardening follow-up is already noted in #142 body; not in scope here).
- No other compose reformatting / reorder / cleanup.

## Post-merge

**A manual deploy is required after merge.** The notify-deploy chain is currently broken (tracked as noorinalabs-main#162), so merging will not automatically trigger the `Deploy noorinalabs-isnad-graph` workflow. The orchestrator will dispatch it manually once this PR lands.

## Validation

- YAML parses cleanly (`yaml.safe_load`).
- `AUTH_USER_SERVICE_URL` appears exactly once in `services.api.environment` and is not added to `user-service` (which obviously doesn't need it).
- `api` and `user-service` both attach to the `backend` network (confirmed via parsed compose).
- CI `Compose & Infra Validate` will lint/parse the file on PR.
- `docker compose config` was not run locally (no docker in WSL); CI covers that.

Closes #142
