### PR TITLE
test(integration): fake_oauth FastAPI container + real OAuth callback test (noorinalabs-main#135)

### DIFF
--- a/integration-tests/docker-compose.test.yml
+++ b/integration-tests/docker-compose.test.yml
@@ -43,6 +43,12 @@ services:
       JWT_REFRESH_TOKEN_EXPIRE_DAYS: "7"
       CORS_ORIGINS: '["http://testnet"]'
       AUTH_OAUTH_REDIRECT_BASE_URL: http://user-service:8000
+      AUTH_GOOGLE_CLIENT_ID: fake-google-client-id
+      AUTH_GOOGLE_CLIENT_SECRET: fake-google-client-secret
+      # #135: route all OAuth provider traffic to the fake_oauth container.
+      # Requires ENVIRONMENT=test per user-service#78 HTTP-downgrade guard.
+      ENVIRONMENT: test
+      OAUTH_PROVIDER_BASE_URL_OVERRIDE: http://fake_oauth:8080
       TOTP_ENCRYPTION_KEY: ${TOTP_ENCRYPTION_KEY}
       WEBHOOK_SIGNING_SECRET: integration_webhook_secret
     healthcheck:
@@ -55,6 +61,8 @@ services:
       user-postgres:
         condition: service_healthy
       user-redis:
+        condition: service_healthy
+      fake_oauth:
         condition: service_healthy
     # NOTE: `alembic upgrade heads` (plural) is a temporary work-around —
     # user-service's migration history has three unmerged heads (0003, 0020, 0030
@@ -69,6 +77,25 @@ services:
     networks:
       - user-backend
       - testnet
+
+  # --- Fake OAuth provider (noorinalabs-main#135) ---
+  # Replaces real Google/GitHub/Apple/Facebook endpoints when user-service's
+  # OAUTH_PROVIDER_BASE_URL_OVERRIDE routes here. Only Google's endpoints are
+  # meaningfully implemented; the other providers still use the Redis shim
+  # in conftest.py.
+  fake_oauth:
+    build:
+      context: ./fake_oauth
+    environment:
+      FAKE_OAUTH_AUDIENCE: fake-google-client-id
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8080/health')\" || exit 1"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
+    networks:
+      - user-backend
 
   # --- isnad-graph stack (minimal: api + neo4j + pg + redis) ---
 

--- a/integration-tests/fake_oauth/Dockerfile
+++ b/integration-tests/fake_oauth/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY main.py .
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=3s --timeout=3s --retries=10 --start-period=5s \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')" || exit 1
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/integration-tests/fake_oauth/README.md
+++ b/integration-tests/fake_oauth/README.md
@@ -1,0 +1,51 @@
+# fake_oauth
+
+Minimal FastAPI impersonation of Google's OAuth 2.0 / OpenID Connect endpoints
+for the integration-test stack. Exists so the real `/auth/oauth/google/callback`
+code path in `noorinalabs-user-service` can be exercised end-to-end — closing
+out the `#135` follow-up that `integration-tests/tests/conftest.py` used to
+name explicitly.
+
+Activated by wiring two env vars into the `user-service` container:
+
+- `OAUTH_PROVIDER_BASE_URL_OVERRIDE=http://fake_oauth:8080` — landed in
+  `noorinalabs-user-service#77`, rewrites every provider's authorize / token /
+  userinfo scheme+host to this base while preserving paths.
+- `ENVIRONMENT=test` — required by the production-guard validator in
+  `user-service#78` before HTTP overrides are accepted.
+
+## Endpoints
+
+- `GET /health` — liveness.
+- `GET /o/oauth2/v2/auth` — authorize; 302s back to `redirect_uri` with a fake
+  `code=FAKE_CODE_<random>` and the caller's `state`.
+- `POST /token` — accepts any form-posted `code`, returns canned
+  `access_token` / `id_token` / `refresh_token`.
+- `GET /oauth2/v3/userinfo` — returns a deterministic fake user keyed to the
+  access-token suffix so `sub` and `email` stay stable within one flow.
+
+## Scope — Google only
+
+One provider is enough to prove the plumbing and unblock #135. GitHub / Apple
+/ Facebook test paths still use the pre-#135 Redis shim in `conftest.py`. Add
+more provider fixtures here if/when those flows need end-to-end coverage.
+
+## Local exercise
+
+```bash
+# From this directory
+docker build -t fake_oauth:dev .
+docker run --rm -p 8080:8080 -e FAKE_OAUTH_AUDIENCE=test-client-id fake_oauth:dev
+
+# In another terminal
+curl -i 'http://localhost:8080/o/oauth2/v2/auth?redirect_uri=http://x/cb&state=abc'
+curl -s -X POST http://localhost:8080/token -d 'code=abc' | jq
+curl -s http://localhost:8080/oauth2/v3/userinfo -H 'Authorization: Bearer fake-access-deadbeef' | jq
+```
+
+## Image size
+
+Target under 100 MB. `python:3.12-slim` + fastapi + uvicorn[standard] +
+python-multipart weighs in around ~160 MB uncompressed; that's acceptable
+for a test-only container. Don't add DBs, Redis clients, or crypto libs —
+id_token signature verification is not required for Google's flow.

--- a/integration-tests/fake_oauth/main.py
+++ b/integration-tests/fake_oauth/main.py
@@ -1,0 +1,105 @@
+"""Fake OAuth provider for integration tests (noorinalabs-main#135).
+
+Implements just enough of Google's OAuth 2.0 / OpenID Connect surface to
+satisfy user-service's GoogleOAuthProvider when
+OAUTH_PROVIDER_BASE_URL_OVERRIDE points all four providers' hosts here.
+Only Google is exercised end-to-end; the other providers' tests still use
+the pre-#135 Redis shim in conftest.py.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import time
+
+from fastapi import FastAPI, Form, Request
+from fastapi.responses import JSONResponse, RedirectResponse
+
+AUDIENCE = os.environ.get("FAKE_OAUTH_AUDIENCE", "fake-google-client-id")
+
+app = FastAPI(title="fake_oauth", version="1.0.0")
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/o/oauth2/v2/auth")
+def google_authorize(request: Request) -> RedirectResponse:
+    """Google's authorize endpoint.
+
+    Redirects 302 back to the caller's redirect_uri with a fake code + the
+    incoming state. Tests typically skip this step and POST a fabricated
+    code straight to user-service's callback; the endpoint exists for
+    completeness.
+    """
+    params = request.query_params
+    redirect_uri = params.get("redirect_uri", "")
+    state = params.get("state", "")
+    code = f"FAKE_CODE_{secrets.token_urlsafe(16)}"
+    sep = "&" if "?" in redirect_uri else "?"
+    return RedirectResponse(
+        url=f"{redirect_uri}{sep}code={code}&state={state}",
+        status_code=302,
+    )
+
+
+@app.post("/token")
+async def google_token(request: Request) -> JSONResponse:
+    """Google's token endpoint.
+
+    Accepts any authorization code (the fake issued above, or one crafted
+    directly by a test) and returns canned tokens. id_token is a stub
+    string — Google's flow never verifies it in user-service; only Apple
+    does, and Apple isn't exercised here.
+    """
+    # Read form body defensively — user-service posts form-encoded data.
+    try:
+        form = await request.form()
+        code = str(form.get("code", ""))
+    except Exception:
+        code = ""
+
+    if not code:
+        return JSONResponse(
+            {"error": "invalid_request", "error_description": "missing code"},
+            status_code=400,
+        )
+
+    now = int(time.time())
+    fake_suffix = secrets.token_urlsafe(8)
+    return JSONResponse(
+        {
+            "access_token": f"fake-access-{fake_suffix}",
+            "id_token": f"fake-id-token.{AUDIENCE}.{now}",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "refresh_token": f"fake-refresh-{fake_suffix}",
+            "scope": "openid email profile",
+        }
+    )
+
+
+@app.get("/oauth2/v3/userinfo")
+def google_userinfo(request: Request) -> JSONResponse:
+    """Google's userinfo endpoint.
+
+    Returns a deterministic fake user keyed off a random suffix baked into
+    the access_token on the fly. We derive the suffix to keep sub/email
+    stable within a single test flow (one token → one userinfo lookup).
+    """
+    auth = request.headers.get("authorization", "")
+    token = auth.removeprefix("Bearer ").strip()
+    suffix = token.removeprefix("fake-access-") if token.startswith("fake-access-") else "anon"
+
+    return JSONResponse(
+        {
+            "sub": f"fake-user-{suffix}",
+            "email": f"fake-{suffix}@example.com",
+            "email_verified": True,
+            "name": f"Fake User {suffix}",
+            "picture": "https://example.invalid/avatar.png",
+        }
+    )

--- a/integration-tests/fake_oauth/requirements.txt
+++ b/integration-tests/fake_oauth/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.115.0
+uvicorn[standard]==0.32.0
+python-multipart==0.0.12

--- a/integration-tests/tests/conftest.py
+++ b/integration-tests/tests/conftest.py
@@ -3,11 +3,15 @@
 These fixtures talk to the *running* services over the docker Compose network.
 Each fixture that creates state also cleans it up.
 
-Why the auth-code shim? The OAuth provider exchange calls real Google/GitHub
-URLs that are hardcoded in `src/app/services/oauth.py`. Rather than adding a
-provider URL override (follow-up), we short-circuit to the *post-callback* point
-in the flow: seed a user in user-postgres and an auth code in user-redis, then
-exercise `/auth/token` through the rest of the stack end-to-end.
+Two auth-flow paths are exercised against the same stack:
+  * Real-callback path — `test_oauth_callback_to_token_issue` exercises
+    `/auth/oauth/google/callback` end-to-end against the `fake_oauth`
+    container, reaching user-service via OAUTH_PROVIDER_BASE_URL_OVERRIDE
+    (user-service#77/#78, deploy #135).
+  * Shim path — the factory below seeds a user in user-postgres and an auth
+    code in user-redis, short-circuiting to `/auth/token`. Predates the
+    override; retained for regression coverage and for other providers that
+    do not yet have fake_oauth support (GitHub / Apple / Facebook).
 """
 
 from __future__ import annotations

--- a/integration-tests/tests/test_auth_flow.py
+++ b/integration-tests/tests/test_auth_flow.py
@@ -1,8 +1,11 @@
 """Scenario 1: OAuth (shimmed) → JWT issuance → isnad-graph API access.
 Scenario 2: Token refresh across the service boundary.
+Scenario 3: Real OAuth callback against fake_oauth container (noorinalabs-main#135).
 """
 
 from __future__ import annotations
+
+import secrets
 
 import httpx
 import pytest
@@ -79,3 +82,79 @@ async def test_token_validation_endpoint(
     body = r.json()
     assert body["valid"] is True
     assert body["email"] == seeded.email
+
+
+@pytest.mark.asyncio
+async def test_oauth_callback_to_token_issue(
+    user_service: httpx.AsyncClient,
+    isnad_graph: httpx.AsyncClient,
+    user_pg,
+) -> None:
+    """noorinalabs-main#135 — real OAuth callback against fake_oauth.
+
+    Exercises the full Google flow:
+      1. /auth/oauth/google/login — get a state + code_verifier
+      2. /auth/oauth/google/callback — user-service hits fake_oauth's
+         /token + /oauth2/v3/userinfo via OAUTH_PROVIDER_BASE_URL_OVERRIDE,
+         creates the user, returns a one-time authorization_code
+      3. /auth/token — exchange that authorization_code for a JWT pair
+      4. isnad-graph /api/v1/narrators — verify the JWT is accepted
+    """
+    # 1. Bootstrap PKCE by hitting the real login endpoint. Returns a
+    # state + code_verifier that user-service will happily accept back
+    # on the callback — the current callback impl does not re-check
+    # state/verifier against Redis, it just forwards the verifier to
+    # the token endpoint.
+    r = await user_service.get("/auth/oauth/google/login")
+    assert r.status_code == 200, r.text
+    login = r.json()
+    assert login["state"]
+    assert login["code_verifier"]
+
+    # 2. POST the callback. fake_oauth accepts any `code`; the resulting
+    # user's sub/email is derived from the access_token suffix, so the
+    # email is unique per flow and collisions across runs are avoided.
+    fake_code = f"FAKE_CODE_{secrets.token_urlsafe(12)}"
+    r = await user_service.post(
+        "/auth/oauth/google/callback",
+        json={
+            "code": fake_code,
+            "state": login["state"],
+            "code_verifier": login["code_verifier"],
+        },
+    )
+    assert r.status_code == 200, (
+        f"callback failed — fake_oauth reachable? override set? resp={r.text}"
+    )
+    callback = r.json()
+    assert callback["provider"] == "google"
+    assert callback["email"].startswith("fake-") and "@example.com" in callback["email"]
+    authorization_code = callback["authorization_code"]
+    assert authorization_code
+
+    # 3. Exchange the authorization code for JWTs.
+    tokens = await issue_token_for(user_service, authorization_code)
+    assert tokens["access_token"]
+    assert tokens["refresh_token"]
+
+    # 4. Access a protected isnad-graph endpoint — same bar as the
+    # shim-path test: 401 means JWT rejected, anything else is fine.
+    headers = {"Authorization": f"Bearer {tokens['access_token']}"}
+    r = await isnad_graph.get(
+        "/api/v1/narrators", headers=headers, params={"limit": 1}
+    )
+    assert r.status_code != 401, (
+        f"isnad-graph rejected JWT minted via fake_oauth flow: {r.text}"
+    )
+
+    # Cleanup — find_or_create_oauth_user persisted a row; remove it to
+    # keep the test DB tidy. Match by email (unique) to get the user_id.
+    uid = await user_pg.fetchval(
+        "SELECT id FROM users WHERE email = $1", callback["email"]
+    )
+    if uid is not None:
+        await user_pg.execute("DELETE FROM sessions WHERE user_id = $1", uid)
+        await user_pg.execute("DELETE FROM user_roles WHERE user_id = $1", uid)
+        await user_pg.execute("DELETE FROM subscriptions WHERE user_id = $1", uid)
+        await user_pg.execute("DELETE FROM oauth_accounts WHERE user_id = $1", uid)
+        await user_pg.execute("DELETE FROM users WHERE id = $1", uid)


### PR DESCRIPTION
## Summary

Deploy-repo half of [noorinalabs-main#135](https://github.com/noorinalabs/noorinalabs-main/issues/135). Closes the follow-up that `integration-tests/tests/conftest.py` has named by issue number since #49 went in: a real `/auth/oauth/google/callback` path in the integration suite instead of the pre-callback Redis shim.

User-service half landed separately:
- [user-service#77](https://github.com/noorinalabs/noorinalabs-user-service/pull/77) — `OAUTH_PROVIDER_BASE_URL_OVERRIDE` setting + `_maybe_override` rewrite helper across all four providers.
- [user-service#78](https://github.com/noorinalabs/noorinalabs-user-service/pull/78) — production guards (`ENVIRONMENT=test` required for http, scheme whitelist).

## Design

- `integration-tests/fake_oauth/` — minimal FastAPI service (python:3.12-slim + fastapi + uvicorn + python-multipart). Impersonates Google only.
  - `GET /health` — liveness for compose healthcheck.
  - `GET /o/oauth2/v2/auth` — 302s back to `redirect_uri` with `code=FAKE_CODE_<random>` + incoming `state`.
  - `POST /token` — accepts any form-posted `code`, returns canned access/id/refresh tokens.
  - `GET /oauth2/v3/userinfo` — returns a deterministic fake user keyed off the access-token suffix, so `sub`/`email` are stable within a flow and unique across flows.
- No JWKS / id_token signing — user-service's `GoogleOAuthProvider` never verifies Google's id_token (only Apple does). Dropping the JWKS endpoint keeps the image lean and the fake's dependency surface tiny.
- Image size: 55 MB unpacked single-arch (Docker displays 230 MB because of attestation layers).

## Compose wiring

- New `fake_oauth` service on the `user-backend` internal network — same internal net as `user-service`, **not** reachable from `test-runner` or `isnad-graph-api`. Isolation invariant preserved.
- `user-service` env now includes:
  - `OAUTH_PROVIDER_BASE_URL_OVERRIDE=http://fake_oauth:8080`
  - `ENVIRONMENT=test` (required by user-service#78 HTTP-downgrade guard)
  - `AUTH_GOOGLE_CLIENT_ID`/`AUTH_GOOGLE_CLIENT_SECRET` set to fake values (Google provider needs them for `__init__` even though the fake accepts any value).
- `user-service` now `depends_on` `fake_oauth: service_healthy`.

## New test

`tests/test_auth_flow.py::test_oauth_callback_to_token_issue`:
1. `GET /auth/oauth/google/login` to get a real state + PKCE `code_verifier`.
2. `POST /auth/oauth/google/callback` with a fabricated `code` — user-service calls `fake_oauth/token` then `fake_oauth/oauth2/v3/userinfo` via the override, creates the user, returns an `authorization_code`.
3. `POST /auth/token` with that authorization code → JWT pair.
4. `GET isnad-graph /api/v1/narrators` with the access token — asserts non-401.
5. Cleans up the persisted user.

Existing shim-path tests (`test_auth_code_grants_jwt_that_isnad_graph_accepts`, `test_refresh_token_rotation`, `test_token_validation_endpoint`) are unchanged and continue to run. The conftest top-of-file comment was rewritten to describe both paths now coexisting.

## Local verification

- Built `fake_oauth:test` image (Dockerfile syntax + install both clean).
- Ran standalone — confirmed `/health` 200, `/o/oauth2/v2/auth` 302 with correct query params, `/token` returns shape user-service expects, `/oauth2/v3/userinfo` returns valid Google userinfo shape.
- Could not run `run-tests.sh` end-to-end from the worktree because `docker-compose.test.yml` builds user-service from `../../noorinalabs-user-service`, which resolves outside the worktree tree. This is a worktree limitation, not a fix needed in this PR — CI checks out `noorinalabs-user-service@main` (currently at `d4528e7`, which has the override) into a path where the relative build context is correct.

## Scope limits (per issue)

Google only. GitHub / Apple / Facebook still use the pre-#135 Redis shim in `conftest.py`. Extend by adding provider-specific endpoints and provider-gated tests — not in this PR.

## Reviewer requests

See review-request comments posted after this PR opens.

## Test plan

- [ ] CI integration-tests workflow runs the new `test_oauth_callback_to_token_issue` and it passes
- [ ] All existing shim-path tests still pass (no regression)
- [ ] `fake_oauth` healthcheck reports healthy in compose logs
- [ ] User-service logs show outbound calls hitting `http://fake_oauth:8080` (override working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)