### PR TITLE
feat(ci): alembic upgrade head pre-deploy gate with heads-count assertion (#85)

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -1,0 +1,209 @@
+name: DB Migrate (user-service alembic)
+
+# Reusable workflow. Invoked by the promotion workflow (deploy#84) as a
+# pre-deploy gate. Runs `alembic upgrade head` inside a user-service container
+# against the target env's user-postgres. Fails fast on migration failure;
+# a stg failure must block the prod promotion in the caller's job graph.
+#
+# Belt-and-suspenders (deploy#85, per Anya.Kowalczyk 2026-04-23): before
+# `alembic upgrade head`, assert that `alembic heads` reports exactly ONE
+# line containing `0040` — the merge-migration revision introduced by
+# user-service#80. This catches a future migration landing without bumping
+# `down_revision` properly (a silent divergence `alembic upgrade head` alone
+# would mask).
+
+on:
+  workflow_call:
+    inputs:
+      env:
+        description: "Target env — stg or prod"
+        required: true
+        type: string
+      image_tag:
+        description: "user-service image tag to run alembic from (defaults to <env>-latest per isnad-graph#815 Contract v5)"
+        required: false
+        type: string
+        default: ""
+    outputs:
+      migrated:
+        description: "true if alembic upgrade head succeeded, false otherwise"
+        value: ${{ jobs.migrate.outputs.migrated }}
+
+  workflow_dispatch:
+    inputs:
+      env:
+        description: "Target env — stg or prod"
+        required: true
+        type: choice
+        options: [stg, prod]
+      image_tag:
+        description: "user-service image tag (leave empty for <env>-latest)"
+        required: false
+        type: string
+        default: ""
+
+concurrency:
+  # Serialize migrations per env. Never run two alembic upgrades against the
+  # same Postgres concurrently — alembic's version-table lock would serialize
+  # them anyway, but failing a second run loudly is cleaner than a 30s wait.
+  group: db-migrate-${{ inputs.env }}
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    name: alembic upgrade head (${{ inputs.env }})
+    runs-on: ubuntu-latest
+    # Maps to GH Environment protection rules — same pattern as terraform.yml
+    # (stg → staging, prod → production). Per-env secrets resolve from the
+    # matching Environment; no cross-env leakage.
+    environment: ${{ inputs.env == 'prod' && 'production' || 'staging' }}
+    permissions:
+      # GHCR pull happens on the VPS via the runtime GITHUB_TOKEN that the
+      # promotion workflow already injects; this job only SSHes.
+      contents: read
+    outputs:
+      migrated: ${{ steps.run.outputs.migrated }}
+    env:
+      # Expected merge-migration revision. Bump this line in the same PR that
+      # lands a future alembic merge migration in user-service. A mismatch
+      # here means "the migration DAG moved under us" and is a hard stop.
+      EXPECTED_MERGE_HEAD: "0040"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve image tag
+        id: tag
+        run: |
+          set -euo pipefail
+          tag="${{ inputs.image_tag }}"
+          if [ -z "$tag" ]; then
+            # Contract v5 (isnad-graph#815 issuecomment-4301487132, option C):
+            # env-scoped floating tag `<env>-latest` always resolves to the
+            # current promoted image for that env. Pinned `<env>-<short>` tags
+            # are preferred for auditability; fall back here is for dispatch
+            # testing only.
+            tag="${{ inputs.env }}-latest"
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Using user-service image tag: $tag"
+
+      - name: Run alembic pre-deploy gate on ${{ inputs.env }} VPS
+        id: run
+        uses: appleboy/ssh-action@v1
+        env:
+          ENV_NAME: ${{ inputs.env }}
+          IMAGE_TAG: ${{ steps.tag.outputs.tag }}
+          EXPECTED_MERGE_HEAD: ${{ env.EXPECTED_MERGE_HEAD }}
+          # DATABASE_URL is assembled on the VPS from the existing user-*
+          # compose env-file the deploy user already writes. We do NOT pass
+          # USER_POSTGRES_PASSWORD through the GH Actions transport here —
+          # the env-file on the VPS is the single source of truth and has
+          # already been gated by the environment-protection approval.
+          USER_POSTGRES_USER: ${{ secrets.USER_POSTGRES_USER }}
+          USER_POSTGRES_DB: ${{ secrets.USER_POSTGRES_DB }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.repository_owner }}
+        with:
+          host: ${{ vars.VPS_HOST }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          envs: ENV_NAME,IMAGE_TAG,EXPECTED_MERGE_HEAD,USER_POSTGRES_USER,USER_POSTGRES_DB,GITHUB_TOKEN,GITHUB_ACTOR
+          script: |
+            set -euo pipefail
+
+            cd /opt/noorinalabs-deploy
+
+            # .env on the VPS holds USER_POSTGRES_PASSWORD / USER_POSTGRES_USER
+            # / USER_POSTGRES_DB. It was written most recently by the deploy
+            # workflow for this env and has mode 600. Read it with `set -a`
+            # so every KEY=VAL becomes exported, matching docker-compose.
+            if [ ! -f .env ]; then
+              echo "ERROR: /opt/noorinalabs-deploy/.env is missing on ${ENV_NAME} VPS."
+              echo "       The deploy workflow has never written env-file here, or it was removed."
+              exit 1
+            fi
+            set -a
+            . ./.env
+            set +a
+
+            # Log into GHCR so we can pull the user-service image this gate
+            # runs alembic from. The trap logs out at end-of-run so no
+            # credentials persist on the VPS (matches deploy-isnad-graph.yml).
+            trap 'docker logout ghcr.io >/dev/null 2>&1 || true' EXIT
+            echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+
+            IMAGE="ghcr.io/noorinalabs/noorinalabs-user-service:${IMAGE_TAG}"
+            echo "==> Pulling ${IMAGE}..."
+            docker pull "${IMAGE}"
+
+            # DATABASE_URL — psycopg driver, sync, because alembic's env.py
+            # is synchronous. user-postgres resolves on the user-backend
+            # docker network which this one-shot container joins explicitly.
+            DATABASE_URL="postgresql+psycopg://${USER_POSTGRES_USER}:${USER_POSTGRES_PASSWORD}@user-postgres:5432/${USER_POSTGRES_DB}"
+
+            # -------- Belt-and-suspenders head-count assertion (Anya, 2026-04-23) --------
+            echo "==> [${ENV_NAME}] alembic heads — heads-count assertion"
+            HEADS_OUT="$(
+              docker run --rm \
+                --network noorinalabs_user-backend \
+                -e DATABASE_URL="${DATABASE_URL}" \
+                "${IMAGE}" \
+                /app/.venv/bin/alembic heads 2>&1
+            )"
+
+            # Log raw output on stdout for CI visibility.
+            echo "$HEADS_OUT"
+
+            # Count non-empty lines. alembic prints one revision per line in
+            # the form "<revid> (head)". Any count != 1 is a hard stop.
+            HEADS_COUNT="$(printf '%s\n' "$HEADS_OUT" | grep -cE '\(head\)')"
+            if [ "$HEADS_COUNT" -ne 1 ]; then
+              echo "ERROR: [${ENV_NAME}] alembic heads reported ${HEADS_COUNT} heads, expected exactly 1."
+              echo "       Multiple heads means a migration was added without bumping down_revision,"
+              echo "       or the merge migration was reverted. \`alembic upgrade head\` would fail"
+              echo "       or silently pick a branch. Fix upstream in user-service before retrying."
+              echo "migrated=false" >> "$GITHUB_OUTPUT"
+              exit 1
+            fi
+
+            # Confirm the single head matches the expected merge-migration id.
+            # If a future merge migration lands in user-service, the PR that
+            # lands it must also bump EXPECTED_MERGE_HEAD in this workflow.
+            if ! printf '%s' "$HEADS_OUT" | grep -qE "^${EXPECTED_MERGE_HEAD}[[:space:]]+\(head\)"; then
+              echo "ERROR: [${ENV_NAME}] alembic heads reports a single head, but it is NOT the"
+              echo "       expected merge-migration revision '${EXPECTED_MERGE_HEAD}'."
+              echo "       A new merge migration was probably added in user-service without"
+              echo "       bumping EXPECTED_MERGE_HEAD in .github/workflows/db-migrate.yml."
+              echo "       Update the workflow in the same PR as the migration, then retry."
+              echo "migrated=false" >> "$GITHUB_OUTPUT"
+              exit 1
+            fi
+
+            echo "==> [${ENV_NAME}] heads-count assertion passed: 1 head, matches ${EXPECTED_MERGE_HEAD}"
+
+            # -------- alembic upgrade head (singular) --------
+            echo "==> [${ENV_NAME}] alembic upgrade head"
+            docker run --rm \
+              --network noorinalabs_user-backend \
+              -e DATABASE_URL="${DATABASE_URL}" \
+              "${IMAGE}" \
+              /app/.venv/bin/alembic upgrade head
+
+            echo "==> [${ENV_NAME}] alembic upgrade head succeeded"
+            echo "migrated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Report migration result
+        if: always()
+        run: |
+          {
+            echo "## DB Migrate (${{ inputs.env }}): ${{ job.status }}"
+            echo ""
+            echo "- **Env:** ${{ inputs.env }}"
+            echo "- **Image tag:** ${{ steps.tag.outputs.tag }}"
+            echo "- **Expected head:** ${{ env.EXPECTED_MERGE_HEAD }}"
+            echo "- **Migrated output:** ${{ steps.run.outputs.migrated }}"
+            echo ""
+            if [ "${{ job.status }}" != "success" ]; then
+              echo "Runbook: [docs/runbooks/user-service-alembic.md](../blob/${{ github.sha }}/docs/runbooks/user-service-alembic.md)"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -62,7 +62,7 @@ jobs:
       # promotion workflow already injects; this job only SSHes.
       contents: read
     outputs:
-      migrated: ${{ steps.run.outputs.migrated }}
+      migrated: ${{ steps.record.outputs.migrated }}
     env:
       # Expected merge-migration revision. Bump this line in the same PR that
       # lands a future alembic merge migration in user-service. A mismatch
@@ -90,6 +90,13 @@ jobs:
 
       - name: Run alembic pre-deploy gate on ${{ inputs.env }} VPS
         id: run
+        # continue-on-error so the runner-side `Record migration result` step
+        # below can observe `steps.run.outcome` and emit the `migrated` output
+        # the caller (#155 promotion workflow) gates on. Without this, set -e
+        # at the job level short-circuits before we can record the signal.
+        # The trailing `exit 1` in the record step preserves job failure for
+        # the caller's `if: needs.migrate.result == 'success'` gating.
+        continue-on-error: true
         uses: appleboy/ssh-action@v1
         env:
           ENV_NAME: ${{ inputs.env }}
@@ -163,7 +170,6 @@ jobs:
               echo "       Multiple heads means a migration was added without bumping down_revision,"
               echo "       or the merge migration was reverted. \`alembic upgrade head\` would fail"
               echo "       or silently pick a branch. Fix upstream in user-service before retrying."
-              echo "migrated=false" >> "$GITHUB_OUTPUT"
               exit 1
             fi
 
@@ -176,7 +182,6 @@ jobs:
               echo "       A new merge migration was probably added in user-service without"
               echo "       bumping EXPECTED_MERGE_HEAD in .github/workflows/db-migrate.yml."
               echo "       Update the workflow in the same PR as the migration, then retry."
-              echo "migrated=false" >> "$GITHUB_OUTPUT"
               exit 1
             fi
 
@@ -191,7 +196,25 @@ jobs:
               /app/.venv/bin/alembic upgrade head
 
             echo "==> [${ENV_NAME}] alembic upgrade head succeeded"
-            echo "migrated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Record migration result
+        id: record
+        # Runner-side step — `$GITHUB_OUTPUT` is only writeable from runner
+        # context, never from inside `appleboy/ssh-action` (its `envs:` allow-
+        # list does not include GHA-internal vars). Reads `steps.run.outcome`
+        # to derive the boolean, then exits non-zero on failure to preserve
+        # job-level failure for the caller's `needs.migrate.result` gating.
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.run.outcome }}" = "success" ]; then
+            echo "migrated=true"  >> "$GITHUB_OUTPUT"
+            echo "Migration succeeded — recorded migrated=true"
+          else
+            echo "migrated=false" >> "$GITHUB_OUTPUT"
+            echo "Migration failed (ssh-action outcome=${{ steps.run.outcome }}) — recorded migrated=false"
+            exit 1
+          fi
 
       - name: Report migration result
         if: always()
@@ -202,7 +225,7 @@ jobs:
             echo "- **Env:** ${{ inputs.env }}"
             echo "- **Image tag:** ${{ steps.tag.outputs.tag }}"
             echo "- **Expected head:** ${{ env.EXPECTED_MERGE_HEAD }}"
-            echo "- **Migrated output:** ${{ steps.run.outputs.migrated }}"
+            echo "- **Migrated output:** ${{ steps.record.outputs.migrated }}"
             echo ""
             if [ "${{ job.status }}" != "success" ]; then
               echo "Runbook: [docs/runbooks/user-service-alembic.md](../blob/${{ github.sha }}/docs/runbooks/user-service-alembic.md)"

--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -20,7 +20,7 @@ on:
         required: true
         type: string
       image_tag:
-        description: "user-service image tag to run alembic from (defaults to <env>-latest per isnad-graph#815 Contract v5)"
+        description: "user-service image tag to run alembic from (defaults to <env>-latest per isnad-graph#815 Contract v6)"
         required: false
         type: string
         default: ""
@@ -77,10 +77,11 @@ jobs:
           set -euo pipefail
           tag="${{ inputs.image_tag }}"
           if [ -z "$tag" ]; then
-            # Contract v5 (isnad-graph#815 issuecomment-4301487132, option C):
-            # env-scoped floating tag `<env>-latest` always resolves to the
-            # current promoted image for that env. Pinned `<env>-<short>` tags
-            # are preferred for auditability; fall back here is for dispatch
+            # Contract v6 (isnad-graph#815 issuecomment-4301538921, option C,
+            # program-director ruling — supersedes v5/earlier): env-scoped
+            # floating tag `<env>-latest` always resolves to the current
+            # promoted image for that env. Pinned `<env>-<short>` tags are
+            # preferred for auditability; fall back here is for dispatch
             # testing only.
             tag="${{ inputs.env }}-latest"
           fi

--- a/docs/runbooks/user-service-alembic.md
+++ b/docs/runbooks/user-service-alembic.md
@@ -1,6 +1,6 @@
 # Runbook: user-service alembic pre-deploy gate (deploy#85)
 
-**Scope:** the `alembic upgrade head` pre-deploy gate that runs before any user-service deploy to stg or prod. Implemented in `.github/workflows/db-migrate.yml`, invoked by the promotion workflow (`deploy#84`).
+**Scope:** the `alembic upgrade head` pre-deploy gate that runs before any user-service deploy to stg or prod. Implemented in `.github/workflows/db-migrate.yml`, invoked by the promotion workflow (`promote.yml` — landed via [`deploy#155`](https://github.com/noorinalabs/noorinalabs-deploy/pull/155) for issue #84). The wiring step that adds `uses: ./.github/workflows/db-migrate.yml` to the promotion workflow is tracked in [`deploy#160`](https://github.com/noorinalabs/noorinalabs-deploy/issues/160).
 
 **NOT in scope:**
 - Data migrations (user data Neo4j→Postgres) — see `user-service-migration.md`.
@@ -10,7 +10,7 @@
 ## Architecture summary
 
 ```
-promotion workflow (deploy#84)
+promotion workflow (promote.yml — deploy#155, merged)
     │
     ├── pre-deploy gate (this workflow): db-migrate.yml
     │       │
@@ -26,7 +26,7 @@ promotion workflow (deploy#84)
     └── deploy step (docker compose up)  —  ONLY runs if the gate succeeded.
 ```
 
-Stg-first is enforced by the caller (deploy#84) — `matrix: [stg, prod]` with `max-parallel: 1`, same pattern as `terraform.yml`. A stg gate failure halts the workflow before the prod job can be manually approved.
+Stg-first is enforced by the caller (`promote.yml`, landed via deploy#155) — `matrix: [stg, prod]` with `max-parallel: 1`, same pattern as `terraform.yml`. A stg gate failure halts the workflow before the prod job can be manually approved.
 
 ## Environment protection
 
@@ -141,7 +141,7 @@ If a migration needs to land urgently (e.g., a prod outage fix):
 
 1. Land the alembic migration in `noorinalabs-user-service` → merge to the wave branch.
 2. Wait for the image publish workflow to produce a new `<env>-latest` tag.
-3. Promote via the normal promotion workflow (`deploy#84`). Do NOT bypass the gate — even for hotfixes.
+3. Promote via the normal promotion workflow (`promote.yml`, deploy#155). Do NOT bypass the gate — even for hotfixes.
 4. If the gate flags an unexpected head and the migration is genuinely additive and safe, the correct action is still to update `EXPECTED_MERGE_HEAD` in `db-migrate.yml` — not to skip the assertion. This is a 1-line PR and reviewable in minutes.
 
 ## Escalation
@@ -156,12 +156,22 @@ If a migration needs to land urgently (e.g., a prod outage fix):
 
 ## Observability
 
-A Prometheus alert `UserServiceAlembicGateFailure` fires when this workflow writes a failure to the GH Actions summary and the failure flag is scraped by the per-env health probe. The alert routes via `infra/alertmanager/alertmanager.yml` critical receiver. This alert intentionally has a short `for:` interval because the gate is a one-shot — not a persistent signal — and a miss here is "we just tried to deploy and the DB wasn't migrated", which is always actionable.
+**Status: aspirational — deferred to W11 follow-up [`deploy#161`](https://github.com/noorinalabs/noorinalabs-deploy/issues/161).**
+
+The intended end state is a Prometheus alert `UserServiceAlembicGateFailure` that fires when the gate fails — short `for:` interval because the gate is one-shot and a miss is always actionable. The infrastructure to support this (textfile-collector writeout in `db-migrate.yml`, `--collector.textfile.directory=` flag + volume mount on `node-exporter` in `compose/docker-compose.prod.yml`) is **not** in place today. That plumbing is tracked in `deploy#161`.
+
+Until #161 lands, gate failures surface via:
+
+1. **GitHub Actions UI** — the `Report migration result` step in `db-migrate.yml` writes a structured summary to `$GITHUB_STEP_SUMMARY` for every run (success or failure) including env, image tag, expected head, and the `migrated` boolean. The runbook link is included on failure.
+2. **Caller workflow signal** — the reusable workflow's `migrated` output is `false` (and the job result is `failure`) on any gate failure, which the promotion workflow (#155 → `promote.yml`) gates on. A failed stg gate hard-stops before prod manual-approval is even offered.
+3. **On-call escalation** — the table above (§ Escalation) lists primary/secondary owners per failure class. Until the Prometheus alert exists, the on-call engineer learns of a failure when the promotion workflow surfaces a failed run.
 
 ## Related issues
 
 - **deploy#85** — this PR.
-- **deploy#84** — promotion workflow that calls this gate. Must merge before this one goes ready-for-review.
+- **deploy#155** — promotion workflow that will call this gate (merged 2026-04-23, produced `promote.yml` + `deploy-stg.yml` + `deploy-prod.yml`). Issue #84.
+- **deploy#160** — wires `promote.yml` to `uses: ./.github/workflows/db-migrate.yml`. Follow-up.
+- **deploy#161** — textfile-collector plumbing for the deferred `UserServiceAlembicGateFailure` Prometheus alert. P2W11.
 - **user-service#80** — alembic merge migration producing revision `0040`. Upstream unblock.
 - **user-service#63** — original alembic merge migration issue (closed by #80).
 - **deploy#141** — fresh-volume alembic-in-compose-up init container. Out of scope here.

--- a/docs/runbooks/user-service-alembic.md
+++ b/docs/runbooks/user-service-alembic.md
@@ -1,0 +1,167 @@
+# Runbook: user-service alembic pre-deploy gate (deploy#85)
+
+**Scope:** the `alembic upgrade head` pre-deploy gate that runs before any user-service deploy to stg or prod. Implemented in `.github/workflows/db-migrate.yml`, invoked by the promotion workflow (`deploy#84`).
+
+**NOT in scope:**
+- Data migrations (user data Neo4j→Postgres) — see `user-service-migration.md`.
+- Fresh-volume alembic (first-ever boot on a new VPS) — tracked in `deploy#141`.
+- Neo4j schema DDL — runs on isnad-graph startup, not alembic.
+
+## Architecture summary
+
+```
+promotion workflow (deploy#84)
+    │
+    ├── pre-deploy gate (this workflow): db-migrate.yml
+    │       │
+    │       ├── step 1: alembic heads  (belt-and-suspenders)
+    │       │     ├── must print exactly 1 line with "(head)"
+    │       │     └── that line must contain EXPECTED_MERGE_HEAD (currently 0040)
+    │       │
+    │       └── step 2: alembic upgrade head  (singular)
+    │             └── runs inside ghcr.io/noorinalabs/noorinalabs-user-service:<tag>
+    │                 container, joined to docker network noorinalabs_user-backend,
+    │                 with DATABASE_URL pointing at user-postgres:5432.
+    │
+    └── deploy step (docker compose up)  —  ONLY runs if the gate succeeded.
+```
+
+Stg-first is enforced by the caller (deploy#84) — `matrix: [stg, prod]` with `max-parallel: 1`, same pattern as `terraform.yml`. A stg gate failure halts the workflow before the prod job can be manually approved.
+
+## Environment protection
+
+- `env: stg`  → GH Environment `staging`    → staging secrets, no manual approval.
+- `env: prod` → GH Environment `production` → production secrets, **manual approval required**.
+
+Per-env secrets (`USER_POSTGRES_USER`, `USER_POSTGRES_DB`, `DEPLOY_SSH_PRIVATE_KEY`, etc.) resolve from whichever Environment the job maps to. No cross-env leakage — if the prod-env job tries to use stg secrets, the Environment mapping simply returns empty strings and the SSH step fails loudly.
+
+## Failure modes and recovery
+
+### 1. Heads-count assertion fails — count != 1
+
+```
+ERROR: [stg] alembic heads reported 2 heads, expected exactly 1.
+```
+
+**Cause:** a PR in `noorinalabs-user-service` added a new migration without a proper `down_revision`, creating a second head. `alembic upgrade head` would then either fail or silently pick a branch.
+
+**Recovery:**
+
+1. Do NOT retry the gate. Retrying will not fix multiple heads.
+2. In `noorinalabs-user-service`, run locally:
+   ```bash
+   cd noorinalabs-user-service
+   alembic heads
+   alembic branches  # shows the DAG split point
+   ```
+3. Either (a) add a merge migration — same pattern as user-service#80 — or (b) fix the offending migration's `down_revision` to linearize the DAG.
+4. Open a PR. Once merged to the wave branch, rebuild the user-service image and retry the promotion.
+
+**Do not bypass the gate.** The gate is protecting prod.
+
+### 2. Heads-count assertion fails — head != EXPECTED_MERGE_HEAD
+
+```
+ERROR: [stg] alembic heads reports a single head, but it is NOT the
+       expected merge-migration revision '0040'.
+```
+
+**Cause:** a new migration landed in user-service (probably another merge migration down the line) and `EXPECTED_MERGE_HEAD` in `db-migrate.yml` was not bumped in the same PR.
+
+**Recovery:**
+
+1. Confirm the migration chain in user-service:
+   ```bash
+   docker run --rm ghcr.io/noorinalabs/noorinalabs-user-service:<tag> \
+     /app/.venv/bin/alembic heads
+   ```
+2. If the new head is legitimate, open a same-wave PR in `noorinalabs-deploy` that updates `EXPECTED_MERGE_HEAD` in `.github/workflows/db-migrate.yml` to the new revision id. Merge that PR, then retry the promotion.
+3. If the new head is NOT legitimate (someone committed it by mistake), revert in user-service and restart the promotion.
+
+### 3. `alembic upgrade head` fails
+
+```
+ERROR: [stg] alembic upgrade head
+alembic.util.exc.CommandError: ...
+```
+
+Most common causes:
+
+| Symptom | Likely cause | Recovery |
+|---|---|---|
+| `duplicate column` / `relation already exists` | migration not idempotent, db partially migrated by a previous run that crashed between statements | Inspect `alembic_version` table; manually stamp to the revision already applied; re-run gate |
+| `relation "..." does not exist` when dropping/altering | earlier migration never ran (skipped) | `alembic current` to see where you are, then `alembic upgrade +1` until head |
+| Connection refused / timeout | `user-postgres` container not running, or network `noorinalabs_user-backend` missing | `docker compose -f compose/docker-compose.prod.yml ps user-postgres`; `docker network ls \| grep user-backend` |
+| Permission denied | `USER_POSTGRES_USER` is not owner of the objects being altered | Check that the compose env-file matches the db (user mismatch from a secret rotation) |
+
+**Manual rollback:** alembic itself can downgrade — but only if the failed migration wrote a proper `downgrade()`:
+
+```bash
+# On the VPS, in the same shape the gate uses:
+docker run --rm \
+  --network noorinalabs_user-backend \
+  -e DATABASE_URL="postgresql+psycopg://${USER_POSTGRES_USER}:${USER_POSTGRES_PASSWORD}@user-postgres:5432/${USER_POSTGRES_DB}" \
+  ghcr.io/noorinalabs/noorinalabs-user-service:<previous-tag> \
+  /app/.venv/bin/alembic downgrade -1
+```
+
+If `downgrade()` is empty or unsafe, rollback = restore from pre-promotion backup (see `user-service-migration.md` §9 Rollback). Backup should have been taken by the caller workflow before invoking the gate — `deploy#84` must snapshot `user-postgres` before each promotion, not this workflow's responsibility.
+
+### 4. SSH step fails — `.env missing on <env> VPS`
+
+```
+ERROR: /opt/noorinalabs-deploy/.env is missing on stg VPS.
+```
+
+**Cause:** the VPS is fresh, or someone ran `rm .env` during a debug session. The deploy workflow writes `.env` each time it runs; the gate requires the most recent env-file to assemble `DATABASE_URL`.
+
+**Recovery:**
+
+1. Run the main deploy workflow (`deploy-isnad-graph.yml`) against the env once — it writes `.env`.
+2. Retry the promotion / gate.
+3. If this happens on prod, treat it as a sev-2 incident: something deleted the env-file mid-deploy. Escalate to Bereket.
+
+### 5. GHCR pull fails
+
+```
+Error response from daemon: manifest for ghcr.io/...:stg-latest not found
+```
+
+**Cause:** no image has been tagged for this env yet. Usual on first W10 promotion before the Contract is fully wired through.
+
+**Recovery:**
+
+1. Confirm `isnad-graph#815` and `user-service#64` Contract consumer PRs have merged.
+2. Confirm a CI run has published at least one image with the expected tag (`stg-<short>` or `<env>-latest`).
+3. If needed, dispatch `db-migrate.yml` manually with an explicit known-good `image_tag` input to unstick.
+
+## Hotfix cadence
+
+If a migration needs to land urgently (e.g., a prod outage fix):
+
+1. Land the alembic migration in `noorinalabs-user-service` → merge to the wave branch.
+2. Wait for the image publish workflow to produce a new `<env>-latest` tag.
+3. Promote via the normal promotion workflow (`deploy#84`). Do NOT bypass the gate — even for hotfixes.
+4. If the gate flags an unexpected head and the migration is genuinely additive and safe, the correct action is still to update `EXPECTED_MERGE_HEAD` in `db-migrate.yml` — not to skip the assertion. This is a 1-line PR and reviewable in minutes.
+
+## Escalation
+
+| Failure | Primary | Secondary |
+|---|---|---|
+| heads-count assertion fails | Lucas.Ferreira (SRE) | Anya.Kowalczyk (user-service, DAG owner) |
+| `alembic upgrade head` fails on stg | Lucas.Ferreira | Aisha.Idrissi (SRE) |
+| `alembic upgrade head` fails on prod | Bereket.Tadesse (IM) | Nadia.Boukhari (user-service manager) |
+| SSH / VPS state problem | Lucas.Ferreira | Weronika.Zielinska (Platform Architect) |
+| Secret mismatch / env-file drift | Nino.Kavtaradze (Security) | Bereket.Tadesse |
+
+## Observability
+
+A Prometheus alert `UserServiceAlembicGateFailure` fires when this workflow writes a failure to the GH Actions summary and the failure flag is scraped by the per-env health probe. The alert routes via `infra/alertmanager/alertmanager.yml` critical receiver. This alert intentionally has a short `for:` interval because the gate is a one-shot — not a persistent signal — and a miss here is "we just tried to deploy and the DB wasn't migrated", which is always actionable.
+
+## Related issues
+
+- **deploy#85** — this PR.
+- **deploy#84** — promotion workflow that calls this gate. Must merge before this one goes ready-for-review.
+- **user-service#80** — alembic merge migration producing revision `0040`. Upstream unblock.
+- **user-service#63** — original alembic merge migration issue (closed by #80).
+- **deploy#141** — fresh-volume alembic-in-compose-up init container. Out of scope here.

--- a/infra/prometheus/alerts.yml
+++ b/infra/prometheus/alerts.yml
@@ -108,28 +108,3 @@ groups:
           description: >-
             The last successful backup was more than 24 hours ago.
           runbook: "docs/deployment/alerting.md#backupfailure"
-
-  - name: db_migrations
-    rules:
-      # Emitted by the db-migrate.yml workflow (deploy#85) via a node_exporter
-      # textfile collector drop on the VPS. Absence of a fresh success for
-      # the target env after a promotion attempt is what trips this rule.
-      # The `for:` is short because the gate is one-shot — any persistent
-      # failure means a promotion attempt aborted and needs human eyes.
-      - alert: UserServiceAlembicGateFailure
-        expr: |
-          user_service_alembic_gate_last_run_success == 0
-          and
-          (time() - user_service_alembic_gate_last_run_timestamp_seconds) < 3600
-        for: 2m
-        labels:
-          severity: critical
-        annotations:
-          summary: "user-service alembic pre-deploy gate failed (env={{ $labels.env }})"
-          description: >-
-            The alembic pre-deploy gate in .github/workflows/db-migrate.yml
-            reported a failure for env={{ $labels.env }} within the last hour
-            and has not been re-run successfully since. The promotion this
-            gate was protecting did NOT proceed to `docker compose up`.
-            Investigate per runbook before retrying.
-          runbook: "docs/runbooks/user-service-alembic.md"

--- a/infra/prometheus/alerts.yml
+++ b/infra/prometheus/alerts.yml
@@ -108,3 +108,28 @@ groups:
           description: >-
             The last successful backup was more than 24 hours ago.
           runbook: "docs/deployment/alerting.md#backupfailure"
+
+  - name: db_migrations
+    rules:
+      # Emitted by the db-migrate.yml workflow (deploy#85) via a node_exporter
+      # textfile collector drop on the VPS. Absence of a fresh success for
+      # the target env after a promotion attempt is what trips this rule.
+      # The `for:` is short because the gate is one-shot — any persistent
+      # failure means a promotion attempt aborted and needs human eyes.
+      - alert: UserServiceAlembicGateFailure
+        expr: |
+          user_service_alembic_gate_last_run_success == 0
+          and
+          (time() - user_service_alembic_gate_last_run_timestamp_seconds) < 3600
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "user-service alembic pre-deploy gate failed (env={{ $labels.env }})"
+          description: >-
+            The alembic pre-deploy gate in .github/workflows/db-migrate.yml
+            reported a failure for env={{ $labels.env }} within the last hour
+            and has not been re-run successfully since. The promotion this
+            gate was protecting did NOT proceed to `docker compose up`.
+            Investigate per runbook before retrying.
+          runbook: "docs/runbooks/user-service-alembic.md"


### PR DESCRIPTION
Closes #85. Part of Wave 10 meta-issue noorinalabs-main#141 (section A, alembic pre-deploy gate).

## Status — 2026-04-24

All draft-blockers cleared and B1+B2 from Aisha's primary review addressed in commit `76d7d7f`:

- ✅ `noorinalabs-user-service#80` merged → US wave-10 has `0040_merge_multi_heads.py` (single head).
- ✅ `deploy#159` merged → integration-tests workflow is wave-aware (resolves sibling-repo refs to wave branch with `main` fallback). The `heads`→`head` workaround revert landed cleanly.
- ✅ B1 fixed: `migrated` job output is now wired runner-side (was unset under `appleboy/ssh-action`).
- ✅ B2 deferred per Aisha's option B: alert rule dropped from this PR; runbook §Observability softened to "aspirational" with explicit pointer to W11 follow-up `deploy#161` (textfile-collector plumbing).

## Summary

Adds a reusable GitHub Actions workflow (`.github/workflows/db-migrate.yml`) that runs `alembic upgrade head` inside a user-service container against the target env's `user-postgres` before any user-service deploy. The caller — promotion workflow `promote.yml` (landed via [`deploy#155`](https://github.com/noorinalabs/noorinalabs-deploy/pull/155) for issue #84, merged 2026-04-23) — will invoke this gate stg-first; a stg failure halts the promotion before prod's manual approval can proceed. The actual `uses: ./.github/workflows/db-migrate.yml` wiring step is tracked as a follow-up in [`deploy#160`](https://github.com/noorinalabs/noorinalabs-deploy/issues/160).

## What lands in this PR

| File | Purpose |
|---|---|
| `.github/workflows/db-migrate.yml` | Reusable workflow (`workflow_call` + `workflow_dispatch`). Per-env GH Environment mapping (stg → staging, prod → production). Heads-count assertion + `alembic upgrade head` (singular). `migrated` output wired runner-side via `Record migration result` step. |
| `docs/runbooks/user-service-alembic.md` | Failure modes, manual rollback, hotfix cadence, escalation matrix, observability status (aspirational pending #161). |

## Belt-and-suspenders heads-count assertion

Per Anya.Kowalczyk's 2026-04-23 ask. Before `alembic upgrade head`, the workflow runs `alembic heads` and asserts:

1. Output contains exactly **one** line matching `(head)`.
2. That line's revision id equals `EXPECTED_MERGE_HEAD` (currently `0040`, the merge migration from user-service#80).

Either condition breaking fails the gate with an actionable error pointing at the runbook. Catches "future migration added without bumping `down_revision`" that `alembic upgrade head` alone would silently paper over (branch pick / surprise rollback).

If a future legitimate merge migration lands in user-service, the SAME PR must also bump `EXPECTED_MERGE_HEAD` in `db-migrate.yml`. This is a 1-line change and reviewable in minutes — it is NOT a reason to bypass the gate.

## Stg-first gate semantics

The gate is a reusable workflow. The merged `promote.yml` (deploy#155) will call it twice — once with `env: stg`, once with `env: prod` — sequenced via `max-parallel: 1` and `[stg, prod]` matrix ordering, same pattern as `terraform.yml`. A stg gate failure short-circuits the matrix before the prod job runs or is approved.

The `migrated` output on this workflow (`true`/`false`, set by the runner-side `Record migration result` step) is available for the caller to condition on. The caller's `needs.migrate.result == 'success'` gate also works because `Record migration result` exits non-zero on failure to preserve job-level failure.

## Per-env secret isolation

- `env: stg`  → GH Environment `staging`    → staging secrets.
- `env: prod` → GH Environment `production` → production secrets (manual approval required by the Environment protection rule).

No cross-env leakage by construction — if the prod-env job tried to read stg secrets it simply wouldn't see them, and the SSH step would fail loudly.

## Runtime secret flow

`DATABASE_URL` is NOT passed through the GH Actions SSH transport. Instead it is assembled on the VPS from the existing `/opt/noorinalabs-deploy/.env` file that the main deploy workflow writes. This avoids a second authoritative source of `USER_POSTGRES_PASSWORD` (and matches the existing env-file discipline from `deploy-isnad-graph.yml`). The gate fails fast if the env-file is missing — documented in the runbook.

## Out of scope (intentional follow-ups)

- The alembic merge migration itself (user-service#80, Anya.Kowalczyk — merged 2026-04-23).
- Image tag emission / promotion semantics (`isnad-graph#815` Contract v6, `deploy#155`).
- Neo4j schema DDL (isnad-graph startup, separate path).
- Wiring `promote.yml` to call this gate via `uses: ./.github/workflows/db-migrate.yml` → [`deploy#160`](https://github.com/noorinalabs/noorinalabs-deploy/issues/160).
- Prometheus alert + node-exporter textfile-collector plumbing → [`deploy#161`](https://github.com/noorinalabs/noorinalabs-deploy/issues/161) (P2W11). Until then, gate failures surface via the GH Actions UI summary, the caller workflow signal, and the runbook escalation matrix (see runbook §Observability).

## Acceptance criteria

- [x] Workflow runs `alembic upgrade head` against target env's user-postgres inside user-service image.
- [x] Heads-count assertion fails loudly on count != 1 or head != expected.
- [x] Stg failure signal exposed via job output (`migrated`), consumable by promotion workflow — fixed in commit `76d7d7f` to wire output runner-side (was previously broken — see B1 in Aisha's review and the fix commit message).
- [x] Prod failure → deploy aborts, previous deploy state preserved (no `docker compose up` invoked) — preserved by the runner-side step's `exit 1` on failure.
- [ ] ~~Alert rule added for gate failure~~ — **deferred to `deploy#161`** (P2W11). Textfile-collector plumbing on node-exporter is required before the alert rule has anything to scrape; in-scope for #161.
- [x] Runbook covers failure modes and recovery (and now correctly marks observability as aspirational).
- [ ] End-to-end: deferred to first run of the promotion workflow once `deploy#160` wires the `uses:`. Expected behavior verified against the workflow's static structure and the established `appleboy/ssh-action` + runner-side-output pattern from `promote.yml` / `deploy-stg.yml`.

## Contract references

- **Contract v6 (canonical):** https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/815#issuecomment-4301538921 — env-scoped `<env>-<short>` + `<env>-latest` image tags. The gate defaults `image_tag` to `<env>-latest` when not supplied by the caller.

## Test plan

- [x] CI: YAML syntax valid for `db-migrate.yml` (verified locally with `python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [x] Local: dispatch-side spec validated (`workflow_dispatch` inputs, `workflow_call` outputs)
- [ ] CI: full re-run on commit `76d7d7f` (wave-branch base, wave-aware sibling-checkout from #159)
- [ ] Reviewer (Aisha): re-verify B1 fix — runner-side `Record migration result` step correctly emits `migrated=true|false` and preserves job-failure on the failure path
- [ ] Reviewer (Aisha): confirm B2 option B (deferred alert + runbook softening + #161 reference) matches what was agreed
- [ ] Reviewer (Weronika): workflow + plumbing angle (reusable-workflow shape, concurrency group, env-file discipline, GHCR auth convention parity with sibling workflows)
- [ ] Post-merge: `deploy#160` will wire `promote.yml` to call this gate; that PR will provide the first end-to-end validation

## Reviewers

- **Primary:** @AishaIdrissi (SRE, Senior) — fresh alembic-flow context from #159, plus Contract advisory on #155 promotion workflow.
- **Secondary:** @WeronikaZielinska (Platform Architect) — workflow + deploy plumbing angle.

Both reviewers please use the charter comment format (`Requestor:` / `Requestee:` / `RequestOrReplied:` / `TechDebt:`).

---

Requestor: Lucas.Ferreira
Requestee: Aisha.Idrissi, Weronika.Zielinska
RequestOrReplied: Request
TechDebt: none
