### PR TITLE
ci(integration-tests): remove branches filter so wave PRs trigger (#152)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,7 +2,6 @@ name: Integration Tests — cross-repo (#49)
 
 on:
   pull_request:
-    branches: ["main"]
     paths:
       - "integration-tests/**"
       - ".github/workflows/integration-tests.yml"


### PR DESCRIPTION
Closes #152. Part of Wave 10 meta-issue noorinalabs-main#141 (CI signal unblock).

## Summary

`integration-tests.yml` had `branches: ["main"]` on its `pull_request` trigger — wave-branch PRs that modify `integration-tests/**` or the workflow file itself skipped CI entirely. Removing the filter so the workflow runs on any PR regardless of base branch. The `push:` trigger stays gated to `main` (actual test runs against user-service and isnad-graph `main`).

## Why

Audited by Bereket.Tadesse 2026-04-23 (full table in the issue):

| Workflow | `pull_request` branches filter | Wave-10 PRs trigger? |
|---|---|---|
| `terraform.yml` | none | YES (Weronika #150 confirmed) |
| `compose-validate.yml` | none | YES |
| `integration-tests.yml` | `["main"]` | **NO** — the gap |

Removing the filter matches `terraform.yml` and `compose-validate.yml` exactly. Considered the alternative "add `deployments/**` to the allowlist" — rejected because keeping all three workflows shaped identically means the next wave branch doesn't require re-touching this.

## Impact

Unblocks CI signal for:
- `deploy#85` / PR#153 (alembic pre-deploy gate) — mine
- `deploy#87` (verify-deploy split) — Aisha.Idrissi, forthcoming
- Anya.Kowalczyk's integration-test `heads`→`head` revert PR (post user-service#80 merge)

Parallel issue on `user-service` side is filed by Nadia.Boukhari per the issue body.

## Diff

```diff
 on:
   pull_request:
-    branches: ["main"]
     paths:
       - "integration-tests/**"
       - ".github/workflows/integration-tests.yml"
```

One line removed.

## Test plan

- [ ] CI: this PR itself should trigger `Integration Tests — cross-repo (#49)` if the base matches the `paths:` filter (it does — this PR modifies the workflow file). If CI triggers here, the fix is self-confirming.
- [ ] Post-merge: when `deploy#85` / PR#153 pushes a change touching `integration-tests/` (or Anya's revert PR does), confirm the workflow runs.

## Sequencing

- Can merge independently of #85 / #153. In fact, **should merge first** so PR#153's next push (or Anya's revert) gets CI signal.

## Reviewers

- **Primary:** @AishaIdrissi (SRE) — she owns #87 which has the same CI dependency
- **Secondary:** @WeronikaZielinska (Platform Architect) — she confirmed the equivalent pattern in `terraform.yml` / `compose-validate.yml` under #150

Charter comment format please.

---

Requestor: Lucas.Ferreira
Requestee: Aisha.Idrissi, Weronika.Zielinska
RequestOrReplied: Request
TechDebt: none
