### PR TITLE
ci: stg auto-deploy + prod manual-approval promotion workflow (#84)

### DIFF
--- a/.github/workflows/deploy-landing-page.yml
+++ b/.github/workflows/deploy-landing-page.yml
@@ -1,4 +1,10 @@
-name: Deploy noorinalabs-landing-page
+name: Deploy noorinalabs-landing-page (LEGACY — manual only)
+
+# DEPRECATED in P2W10 by deploy#84. Landing-page stg fan-in now flows via
+# `deploy-stg.yml`'s `deploy-noorinalabs-landing-page` repository_dispatch
+# handler; landing-page prod rollout flows via `promote.yml` →
+# `deploy-prod.yml`. Retained here as a manual-only rollback path to the
+# legacy single VPS until `deploy#86` decommission.
 
 on:
   workflow_dispatch:
@@ -8,7 +14,7 @@ on:
         default: 'latest'
 
 concurrency:
-  group: deploy-production
+  group: deploy-legacy
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,49 +1,65 @@
-name: Deploy noorinalabs-isnad-graph (LEGACY — manual only)
-
-# DEPRECATED in P2W10 by deploy#84. Kept as a manual-dispatch rollback
-# path to the single pre-W10 VPS while downstream migrations land.
+# Deploy to production (noorinalabs-prod VPS).
 #
-# - Stg fan-in now goes to `deploy-stg.yml` (repository_dispatch here
-#   removed so dispatching does not double-deploy).
-# - Prod rollout now goes through `promote.yml` → `deploy-prod.yml`.
-# - This workflow targets the legacy single VPS via the default
-#   `vars.VPS_HOST`; once `deploy#86` decommissions the hand-made box
-#   this file will be removed entirely.
+# Triggers:
+#   - workflow_dispatch fired by promote.yml's trigger-prod-deploy job after
+#     the retag + approval gate have completed. The manual-approval gate
+#     lives on the retag step in promote.yml (environment: production);
+#     once retag is approved and succeeds, this workflow rolls out to the
+#     prod VPS without a second approval.
+#   - workflow_dispatch (manual) — operator-initiated rollout, e.g. to
+#     redeploy the current prod-latest after a VPS restart.
+#
+# Env scope:
+#   - `environment: production` so the VPS_HOST var resolves to the prod
+#     host (`noorinalabs-prod`) and all secrets used here are the
+#     production-scoped set. Stg secrets cannot cross into this workflow.
+#
+# Image tag consumed:
+#   - Always a `prod-*` tag. Default is `prod-latest`. `workflow_dispatch`
+#     accepts an explicit `prod-<short>` input for rollbacks to a historical
+#     promotion.
+#
+# This workflow does NOT retag. Retagging is promote.yml's job, and it is
+# the only workflow that writes `prod-*` tags (Contract v5).
+
+name: Deploy to production
 
 on:
   workflow_dispatch:
     inputs:
       image_tag:
-        description: 'Image tag to deploy (default: latest)'
-        default: 'latest'
+        description: "Prod tag to deploy (default: prod-latest). Must be a prod-* tag."
+        default: "prod-latest"
 
 concurrency:
-  group: deploy-legacy
+  group: deploy-production
   cancel-in-progress: false
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: production
-    # `packages: read` lets the auto-provisioned GITHUB_TOKEN pull from GHCR.
-    # `contents: read` is the default once any explicit permissions are listed; restating
-    # for clarity since `actions/checkout` needs it. Least-privilege scope: no writes.
     permissions:
       packages: read
       contents: read
     steps:
       - uses: actions/checkout@v4
 
-      - name: Determine image tag
-        id: tag
+      - name: Validate image_tag is a prod-* tag
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.image_tag }}" ]; then
-            echo "tag=${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=latest" >> "$GITHUB_OUTPUT"
-          fi
+          set -euo pipefail
+          case "$IMAGE_TAG" in
+            prod-*) ;;
+            *)
+              echo "::error::deploy-prod refuses non-prod-* tags. Got: $IMAGE_TAG"
+              echo "::error::Use promote.yml to produce a prod-<short> tag from a stg digest first."
+              exit 1
+              ;;
+          esac
 
-      - name: Deploy to Hetzner VPS
+      - name: Deploy to prod VPS
         uses: appleboy/ssh-action@v1
         env:
           NEO4J_PASSWORD: ${{ secrets.NEO4J_PASSWORD }}
@@ -61,14 +77,9 @@ jobs:
           KAFKA_CLUSTER_ID: ${{ secrets.KAFKA_CLUSTER_ID }}
           KAFKA_UI_PASSWORD: ${{ secrets.KAFKA_UI_PASSWORD }}
           KAFKA_UI_USER: ${{ secrets.KAFKA_UI_USER }}
-          IMAGE_TAG: ${{ steps.tag.outputs.tag }}
-          # GHCR auth — auto-provisioned, runtime-only. NEVER add to the env_file
-          # write loop below; these are session credentials and must not persist on
-          # the VPS in `.env`. The trap in the script logs out at end-of-run.
+          IMAGE_TAG: ${{ inputs.image_tag }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.repository_owner }}
-          # PIPELINE_B2_* — alphabetical block; outputs of `terraform apply`
-          # in terraform/backblaze. Secrets must be created post-bucket-apply.
           PIPELINE_B2_BUCKET: ${{ secrets.PIPELINE_B2_BUCKET }}
           PIPELINE_B2_ENDPOINT: ${{ secrets.PIPELINE_B2_ENDPOINT }}
           PIPELINE_B2_KEY: ${{ secrets.PIPELINE_B2_KEY }}
@@ -91,14 +102,9 @@ jobs:
             git fetch origin main
             git reset --hard origin/main
 
-            echo "==> Writing .env for docker-compose..."
+            echo "==> Writing .env for docker-compose (IMAGE_TAG=$IMAGE_TAG)..."
             env_file=".env"
             : > "$env_file"
-            # Single-quoted values: docker-compose env-file format treats single-quoted
-            # strings as literal (no escape processing), and single quotes survive the
-            # SSH transport without escape-eating that strips backslash-escaped double
-            # quotes. Limitation: values containing a literal "'" are not supported
-            # (none of our current secrets do — see #94).
             for var in NEO4J_PASSWORD POSTGRES_USER POSTGRES_PASSWORD POSTGRES_DB \
                        REDIS_PASSWORD AUTH_GOOGLE_CLIENT_ID AUTH_GOOGLE_CLIENT_SECRET \
                        AUTH_GITHUB_CLIENT_ID AUTH_GITHUB_CLIENT_SECRET \
@@ -116,8 +122,6 @@ jobs:
             chmod 600 "$env_file"
 
             echo "==> Authenticating to GHCR..."
-            # Register logout trap FIRST so it fires even if login fails — leaves no
-            # stored credentials in the deploy user's ~/.docker/config.json on exit.
             trap 'docker logout ghcr.io >/dev/null 2>&1 || true' EXIT
             echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
 
@@ -139,8 +143,6 @@ jobs:
           script: |
             set -euo pipefail
             cd /opt/noorinalabs-deploy
-
-            echo "==> Checking service health via Docker..."
             for i in $(seq 1 24); do
               api_health=$(docker inspect --format='{{.State.Health.Status}}' noorinalabs-api-1 2>/dev/null || echo "not_found")
               echo "Attempt $i/24: API=$api_health"
@@ -155,20 +157,15 @@ jobs:
               fi
               sleep 5
             done
-
-            echo "==> Checking all container health..."
             docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env ps --format '{{.Name}}\t{{.Status}}'
-            echo "==> Deployment verified successfully"
+            echo "==> Prod deployment verified"
 
-      - name: Report deployment status
+      - name: Report status
         if: always()
         run: |
-          echo "## Deploy noorinalabs-isnad-graph: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-            echo "- **Source repo:** ${{ github.event.client_payload.repo }}" >> "$GITHUB_STEP_SUMMARY"
-            echo "- **Source SHA:** ${{ github.event.client_payload.sha }}" >> "$GITHUB_STEP_SUMMARY"
-            echo "- **Source ref:** ${{ github.event.client_payload.ref }}" >> "$GITHUB_STEP_SUMMARY"
-          fi
-          echo "- **Image tag:** ${{ steps.tag.outputs.tag }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Triggered by:** ${{ github.actor }}" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Deploy to production: ${{ job.status }}"
+            echo ""
+            echo "- **Image tag:** ${{ inputs.image_tag }}"
+            echo "- **Actor:** ${{ github.actor }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -20,7 +20,7 @@
 #     promotion.
 #
 # This workflow does NOT retag. Retagging is promote.yml's job, and it is
-# the only workflow that writes `prod-*` tags (Contract v6).
+# the only workflow that writes `prod-*` tags (Contract v5).
 
 name: Deploy to production
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -14,10 +14,18 @@
 #     host (`noorinalabs-prod`) and all secrets used here are the
 #     production-scoped set. Stg secrets cannot cross into this workflow.
 #
-# Image tag consumed:
-#   - Always a `prod-*` tag. Default is `prod-latest`. `workflow_dispatch`
-#     accepts an explicit `prod-<short>` input for rollbacks to a historical
-#     promotion.
+# Image tags consumed (per-service, all must be prod-* shape):
+#   - api_frontend_tag: applies to both api + frontend (they share a short
+#                       SHA from isnad-graph's ghcr-publish.yml matrix)
+#   - user_service_tag: applies to user-service image
+#   - landing_tag:      applies to landing image
+#   Each input falls back to `prod-latest` if left empty.
+#
+# Per-service pinning eliminates a TOCTOU window: if promote.yml writes
+# prod-<short> for SHA X and auto-dispatches here, and then a second
+# promotion for SHA Y starts before this rollout consumes the images,
+# `prod-latest` would move to Y and we'd deploy Y instead of X. Pinning
+# to prod-<short> closes that window (Lucas review 2026-04-23, #155).
 #
 # This workflow does NOT retag. Retagging is promote.yml's job, and it is
 # the only workflow that writes `prod-*` tags (Contract v6).
@@ -27,9 +35,18 @@ name: Deploy to production
 on:
   workflow_dispatch:
     inputs:
-      image_tag:
-        description: "Prod tag to deploy (default: prod-latest). Must be a prod-* tag."
-        default: "prod-latest"
+      api_frontend_tag:
+        description: "Prod tag for api + frontend (prod-* shape; empty = prod-latest)."
+        required: false
+        default: ""
+      user_service_tag:
+        description: "Prod tag for user-service (prod-* shape; empty = prod-latest)."
+        required: false
+        default: ""
+      landing_tag:
+        description: "Prod tag for landing (prod-* shape; empty = prod-latest)."
+        required: false
+        default: ""
 
 concurrency:
   group: deploy-production
@@ -45,19 +62,43 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Validate image_tag is a prod-* tag
+      - name: Resolve + validate per-service tags
+        id: tags
         env:
-          IMAGE_TAG: ${{ inputs.image_tag }}
+          API_FRONTEND_TAG: ${{ inputs.api_frontend_tag }}
+          USER_SERVICE_TAG: ${{ inputs.user_service_tag }}
+          LANDING_TAG: ${{ inputs.landing_tag }}
         run: |
           set -euo pipefail
-          case "$IMAGE_TAG" in
-            prod-*) ;;
-            *)
-              echo "::error::deploy-prod refuses non-prod-* tags. Got: $IMAGE_TAG"
-              echo "::error::Use promote.yml to produce a prod-<short> tag from a stg digest first."
-              exit 1
-              ;;
-          esac
+          # Each input falls back to prod-latest when empty.
+          af="${API_FRONTEND_TAG:-prod-latest}"
+          us="${USER_SERVICE_TAG:-prod-latest}"
+          ld="${LANDING_TAG:-prod-latest}"
+
+          # Validate prod-* shape on each resolved tag.
+          for pair in "api+frontend:$af" "user-service:$us" "landing:$ld"; do
+            svc="${pair%%:*}"
+            tag="${pair#*:}"
+            case "$tag" in
+              prod-*) ;;
+              *)
+                echo "::error::deploy-prod refuses non-prod-* tags for $svc. Got: $tag"
+                echo "::error::Use promote.yml to produce a prod-<short> tag from a stg digest first."
+                exit 1
+                ;;
+            esac
+          done
+
+          echo "Resolved tags:"
+          echo "  api+frontend: $af"
+          echo "  user-service: $us"
+          echo "  landing:      $ld"
+
+          {
+            echo "api_frontend_tag=$af"
+            echo "user_service_tag=$us"
+            echo "landing_tag=$ld"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Deploy to prod VPS
         uses: appleboy/ssh-action@v1
@@ -77,7 +118,15 @@ jobs:
           KAFKA_CLUSTER_ID: ${{ secrets.KAFKA_CLUSTER_ID }}
           KAFKA_UI_PASSWORD: ${{ secrets.KAFKA_UI_PASSWORD }}
           KAFKA_UI_USER: ${{ secrets.KAFKA_UI_USER }}
-          IMAGE_TAG: ${{ inputs.image_tag }}
+          # Compose env-var names below must match
+          # compose/docker-compose.prod.yml image: ${VAR:-latest} references.
+          # Compose currently uses:
+          #   IMAGE_TAG              — api + frontend
+          #   USER_SERVICE_IMAGE_TAG — user-service
+          #   LANDING_IMAGE_TAG      — landing
+          IMAGE_TAG: ${{ steps.tags.outputs.api_frontend_tag }}
+          USER_SERVICE_IMAGE_TAG: ${{ steps.tags.outputs.user_service_tag }}
+          LANDING_IMAGE_TAG: ${{ steps.tags.outputs.landing_tag }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.repository_owner }}
           PIPELINE_B2_BUCKET: ${{ secrets.PIPELINE_B2_BUCKET }}
@@ -93,7 +142,7 @@ jobs:
           host: ${{ vars.VPS_HOST }}
           username: deploy
           key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
-          envs: NEO4J_PASSWORD,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,REDIS_PASSWORD,AUTH_GOOGLE_CLIENT_ID,AUTH_GOOGLE_CLIENT_SECRET,AUTH_GITHUB_CLIENT_ID,AUTH_GITHUB_CLIENT_SECRET,GRAFANA_ADMIN_PASSWORD,JWT_PRIVATE_KEY,JWT_PUBLIC_KEY,KAFKA_CLUSTER_ID,KAFKA_UI_PASSWORD,KAFKA_UI_USER,IMAGE_TAG,PIPELINE_B2_BUCKET,PIPELINE_B2_ENDPOINT,PIPELINE_B2_KEY,PIPELINE_B2_KEY_ID,PIPELINE_B2_REGION,USER_POSTGRES_DB,USER_POSTGRES_PASSWORD,USER_POSTGRES_USER,USER_REDIS_PASSWORD,GITHUB_TOKEN,GITHUB_ACTOR
+          envs: NEO4J_PASSWORD,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,REDIS_PASSWORD,AUTH_GOOGLE_CLIENT_ID,AUTH_GOOGLE_CLIENT_SECRET,AUTH_GITHUB_CLIENT_ID,AUTH_GITHUB_CLIENT_SECRET,GRAFANA_ADMIN_PASSWORD,JWT_PRIVATE_KEY,JWT_PUBLIC_KEY,KAFKA_CLUSTER_ID,KAFKA_UI_PASSWORD,KAFKA_UI_USER,IMAGE_TAG,USER_SERVICE_IMAGE_TAG,LANDING_IMAGE_TAG,PIPELINE_B2_BUCKET,PIPELINE_B2_ENDPOINT,PIPELINE_B2_KEY,PIPELINE_B2_KEY_ID,PIPELINE_B2_REGION,USER_POSTGRES_DB,USER_POSTGRES_PASSWORD,USER_POSTGRES_USER,USER_REDIS_PASSWORD,GITHUB_TOKEN,GITHUB_ACTOR
           script: |
             set -euo pipefail
             cd /opt/noorinalabs-deploy
@@ -102,7 +151,10 @@ jobs:
             git fetch origin main
             git reset --hard origin/main
 
-            echo "==> Writing .env for docker-compose (IMAGE_TAG=$IMAGE_TAG)..."
+            echo "==> Writing .env for docker-compose..."
+            echo "    IMAGE_TAG=$IMAGE_TAG (api + frontend)"
+            echo "    USER_SERVICE_IMAGE_TAG=$USER_SERVICE_IMAGE_TAG"
+            echo "    LANDING_IMAGE_TAG=$LANDING_IMAGE_TAG"
             env_file=".env"
             : > "$env_file"
             for var in NEO4J_PASSWORD POSTGRES_USER POSTGRES_PASSWORD POSTGRES_DB \
@@ -119,6 +171,8 @@ jobs:
               printf "%s='%s'\n" "$var" "$val" >> "$env_file"
             done
             printf "%s='%s'\n" "IMAGE_TAG" "${IMAGE_TAG}" >> "$env_file"
+            printf "%s='%s'\n" "USER_SERVICE_IMAGE_TAG" "${USER_SERVICE_IMAGE_TAG}" >> "$env_file"
+            printf "%s='%s'\n" "LANDING_IMAGE_TAG" "${LANDING_IMAGE_TAG}" >> "$env_file"
             chmod 600 "$env_file"
 
             echo "==> Authenticating to GHCR..."
@@ -166,6 +220,8 @@ jobs:
           {
             echo "## Deploy to production: ${{ job.status }}"
             echo ""
-            echo "- **Image tag:** ${{ inputs.image_tag }}"
+            echo "- **api + frontend tag:** ${{ steps.tags.outputs.api_frontend_tag }}"
+            echo "- **user-service tag:**   ${{ steps.tags.outputs.user_service_tag }}"
+            echo "- **landing tag:**        ${{ steps.tags.outputs.landing_tag }}"
             echo "- **Actor:** ${{ github.actor }}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -20,7 +20,7 @@
 #     promotion.
 #
 # This workflow does NOT retag. Retagging is promote.yml's job, and it is
-# the only workflow that writes `prod-*` tags (Contract v5).
+# the only workflow that writes `prod-*` tags (Contract v6).
 
 name: Deploy to production
 

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -1,49 +1,75 @@
-name: Deploy noorinalabs-isnad-graph (LEGACY — manual only)
-
-# DEPRECATED in P2W10 by deploy#84. Kept as a manual-dispatch rollback
-# path to the single pre-W10 VPS while downstream migrations land.
+# Deploy to staging (noorinalabs-stg VPS).
 #
-# - Stg fan-in now goes to `deploy-stg.yml` (repository_dispatch here
-#   removed so dispatching does not double-deploy).
-# - Prod rollout now goes through `promote.yml` → `deploy-prod.yml`.
-# - This workflow targets the legacy single VPS via the default
-#   `vars.VPS_HOST`; once `deploy#86` decommissions the hand-made box
-#   this file will be removed entirely.
+# Triggers:
+#   - repository_dispatch from any service repo (isnad-graph, user-service,
+#     landing-page) — the auto-deploy fan-in point for stg. Service repos
+#     send `deploy-noorinalabs-<service>` events after their ghcr-publish.yml
+#     has pushed the four stg tags (sha-<short>, latest, stg-<short>,
+#     stg-latest) per Contract v5.
+#   - workflow_dispatch — manual redeploy, e.g. to re-pull stg-latest after
+#     a registry hiccup.
+#
+# Env scope:
+#   - `environment: staging` gates secrets and vars to the GH Environment
+#     `staging`. No prod secrets are reachable from this workflow.
+#   - Target host comes from `vars.VPS_HOST` scoped to the `staging`
+#     environment (set by deploy#83 Cloudflare DNS to `noorinalabs-stg`-
+#     prefixed subdomains; hostname = `noorinalabs-stg` from deploy#150's
+#     TF output `server_name`).
+#
+# Image tag consumed: `stg-<short>` (immutable, per-push), resolved from the
+# `sha` field of the dispatching payload. If no payload is present (manual
+# dispatch), defaults to `stg-latest`.
+
+name: Deploy to staging
 
 on:
+  repository_dispatch:
+    types:
+      - deploy-noorinalabs-isnad-graph
+      - deploy-noorinalabs-user-service
+      - deploy-noorinalabs-landing-page
   workflow_dispatch:
     inputs:
       image_tag:
-        description: 'Image tag to deploy (default: latest)'
-        default: 'latest'
+        description: "Image tag suffix to deploy (default: stg-latest)"
+        default: "stg-latest"
 
 concurrency:
-  group: deploy-legacy
+  group: deploy-staging
   cancel-in-progress: false
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: production
-    # `packages: read` lets the auto-provisioned GITHUB_TOKEN pull from GHCR.
-    # `contents: read` is the default once any explicit permissions are listed; restating
-    # for clarity since `actions/checkout` needs it. Least-privilege scope: no writes.
+    environment: staging
     permissions:
       packages: read
       contents: read
     steps:
       - uses: actions/checkout@v4
 
-      - name: Determine image tag
+      - name: Resolve image tag
         id: tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_SHA: ${{ github.event.client_payload.sha }}
+          MANUAL_TAG: ${{ inputs.image_tag }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.image_tag }}" ]; then
-            echo "tag=${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "repository_dispatch" ] && [ -n "${DISPATCH_SHA:-}" ]; then
+            # 7-char short SHA per Contract v5 `<short>` definition.
+            short="${DISPATCH_SHA:0:7}"
+            tag="stg-$short"
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "${MANUAL_TAG:-}" ]; then
+            tag="$MANUAL_TAG"
           else
-            echo "tag=latest" >> "$GITHUB_OUTPUT"
+            tag="stg-latest"
           fi
+          echo "Resolved tag: $tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
-      - name: Deploy to Hetzner VPS
+      - name: Deploy to stg VPS
         uses: appleboy/ssh-action@v1
         env:
           NEO4J_PASSWORD: ${{ secrets.NEO4J_PASSWORD }}
@@ -62,13 +88,8 @@ jobs:
           KAFKA_UI_PASSWORD: ${{ secrets.KAFKA_UI_PASSWORD }}
           KAFKA_UI_USER: ${{ secrets.KAFKA_UI_USER }}
           IMAGE_TAG: ${{ steps.tag.outputs.tag }}
-          # GHCR auth — auto-provisioned, runtime-only. NEVER add to the env_file
-          # write loop below; these are session credentials and must not persist on
-          # the VPS in `.env`. The trap in the script logs out at end-of-run.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.repository_owner }}
-          # PIPELINE_B2_* — alphabetical block; outputs of `terraform apply`
-          # in terraform/backblaze. Secrets must be created post-bucket-apply.
           PIPELINE_B2_BUCKET: ${{ secrets.PIPELINE_B2_BUCKET }}
           PIPELINE_B2_ENDPOINT: ${{ secrets.PIPELINE_B2_ENDPOINT }}
           PIPELINE_B2_KEY: ${{ secrets.PIPELINE_B2_KEY }}
@@ -91,14 +112,9 @@ jobs:
             git fetch origin main
             git reset --hard origin/main
 
-            echo "==> Writing .env for docker-compose..."
+            echo "==> Writing .env for docker-compose (IMAGE_TAG=$IMAGE_TAG)..."
             env_file=".env"
             : > "$env_file"
-            # Single-quoted values: docker-compose env-file format treats single-quoted
-            # strings as literal (no escape processing), and single quotes survive the
-            # SSH transport without escape-eating that strips backslash-escaped double
-            # quotes. Limitation: values containing a literal "'" are not supported
-            # (none of our current secrets do — see #94).
             for var in NEO4J_PASSWORD POSTGRES_USER POSTGRES_PASSWORD POSTGRES_DB \
                        REDIS_PASSWORD AUTH_GOOGLE_CLIENT_ID AUTH_GOOGLE_CLIENT_SECRET \
                        AUTH_GITHUB_CLIENT_ID AUTH_GITHUB_CLIENT_SECRET \
@@ -116,8 +132,6 @@ jobs:
             chmod 600 "$env_file"
 
             echo "==> Authenticating to GHCR..."
-            # Register logout trap FIRST so it fires even if login fails — leaves no
-            # stored credentials in the deploy user's ~/.docker/config.json on exit.
             trap 'docker logout ghcr.io >/dev/null 2>&1 || true' EXIT
             echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
 
@@ -150,7 +164,7 @@ jobs:
               fi
               if [ "$i" -eq 24 ]; then
                 echo "ERROR: API health check failed after 120 seconds"
-                docker compose -f compose/docker-compose.prod.yml logs --tail=50 api
+                docker compose -p noorinalabs -f compose/docker-compose.prod.yml logs --tail=50 api
                 exit 1
               fi
               sleep 5
@@ -158,17 +172,19 @@ jobs:
 
             echo "==> Checking all container health..."
             docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env ps --format '{{.Name}}\t{{.Status}}'
-            echo "==> Deployment verified successfully"
+            echo "==> Stg deployment verified"
 
-      - name: Report deployment status
+      - name: Report status
         if: always()
         run: |
-          echo "## Deploy noorinalabs-isnad-graph: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-            echo "- **Source repo:** ${{ github.event.client_payload.repo }}" >> "$GITHUB_STEP_SUMMARY"
-            echo "- **Source SHA:** ${{ github.event.client_payload.sha }}" >> "$GITHUB_STEP_SUMMARY"
-            echo "- **Source ref:** ${{ github.event.client_payload.ref }}" >> "$GITHUB_STEP_SUMMARY"
-          fi
-          echo "- **Image tag:** ${{ steps.tag.outputs.tag }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Triggered by:** ${{ github.actor }}" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Deploy to staging: ${{ job.status }}"
+            echo ""
+            if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+              echo "- **Source repo:** ${{ github.event.client_payload.repo }}"
+              echo "- **Source SHA:** ${{ github.event.client_payload.sha }}"
+              echo "- **Event type:** ${{ github.event.action }}"
+            fi
+            echo "- **Image tag:** ${{ steps.tag.outputs.tag }}"
+            echo "- **Actor:** ${{ github.actor }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -5,7 +5,7 @@
 #     landing-page) — the auto-deploy fan-in point for stg. Service repos
 #     send `deploy-noorinalabs-<service>` events after their ghcr-publish.yml
 #     has pushed the four stg tags (sha-<short>, latest, stg-<short>,
-#     stg-latest) per Contract v5.
+#     stg-latest) per Contract v6 (same shape as v3/v5).
 #   - workflow_dispatch — manual redeploy, e.g. to re-pull stg-latest after
 #     a registry hiccup.
 #
@@ -58,7 +58,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "repository_dispatch" ] && [ -n "${DISPATCH_SHA:-}" ]; then
-            # 7-char short SHA per Contract v5 `<short>` definition.
+            # 7-char short SHA per Contract v6 `<short>` definition.
             short="${DISPATCH_SHA:0:7}"
             tag="stg-$short"
           elif [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "${MANUAL_TAG:-}" ]; then

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -5,7 +5,7 @@
 #     landing-page) — the auto-deploy fan-in point for stg. Service repos
 #     send `deploy-noorinalabs-<service>` events after their ghcr-publish.yml
 #     has pushed the four stg tags (sha-<short>, latest, stg-<short>,
-#     stg-latest) per Contract v6 (same shape as v3/v5).
+#     stg-latest) per Contract v5 (canonical per owner/Khoury ruling).
 #   - workflow_dispatch — manual redeploy, e.g. to re-pull stg-latest after
 #     a registry hiccup.
 #
@@ -58,7 +58,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "repository_dispatch" ] && [ -n "${DISPATCH_SHA:-}" ]; then
-            # 7-char short SHA per Contract v6 `<short>` definition.
+            # 7-char short SHA per Contract v5 `<short>` definition.
             short="${DISPATCH_SHA:0:7}"
             tag="stg-$short"
           elif [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "${MANUAL_TAG:-}" ]; then

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -5,7 +5,7 @@
 #     landing-page) — the auto-deploy fan-in point for stg. Service repos
 #     send `deploy-noorinalabs-<service>` events after their ghcr-publish.yml
 #     has pushed the four stg tags (sha-<short>, latest, stg-<short>,
-#     stg-latest) per Contract v5 (canonical per owner/Khoury ruling).
+#     stg-latest) per Contract v6 (canonical per Khoury ruling).
 #   - workflow_dispatch — manual redeploy, e.g. to re-pull stg-latest after
 #     a registry hiccup.
 #
@@ -58,7 +58,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "repository_dispatch" ] && [ -n "${DISPATCH_SHA:-}" ]; then
-            # 7-char short SHA per Contract v5 `<short>` definition.
+            # 7-char short SHA per Contract v6 `<short>` definition.
             short="${DISPATCH_SHA:0:7}"
             tag="stg-$short"
           elif [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "${MANUAL_TAG:-}" ]; then

--- a/.github/workflows/image-tag-invariants.yml
+++ b/.github/workflows/image-tag-invariants.yml
@@ -1,4 +1,6 @@
-# Tag-count invariant smoke test for the Contract-v5 image tag scheme.
+# Tag-count invariant smoke test for the Contract-v6 image tag scheme
+# (canonical: https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/815#issuecomment-4301538921).
+# v6 shape is identical to v5/v3; program-director ruling-language updated.
 #
 # Per Khoury 2026-04-23: guard against future refactors silently dropping or
 # adding a tag in the publish-side (ghcr-publish.yml) or the promotion-side

--- a/.github/workflows/image-tag-invariants.yml
+++ b/.github/workflows/image-tag-invariants.yml
@@ -1,6 +1,7 @@
-# Tag-count invariant smoke test for the Contract-v6 image tag scheme
-# (canonical: https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/815#issuecomment-4301538921).
-# v6 shape is identical to v5/v3; program-director ruling-language updated.
+# Tag-count invariant smoke test for the Contract-v5 image tag scheme
+# (canonical per owner/Khoury ruling:
+# https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/815#issuecomment-4301487132).
+# v5 shape is identical to v3; v6 is a retro-audit artifact of the same shape.
 #
 # Per Khoury 2026-04-23: guard against future refactors silently dropping or
 # adding a tag in the publish-side (ghcr-publish.yml) or the promotion-side

--- a/.github/workflows/image-tag-invariants.yml
+++ b/.github/workflows/image-tag-invariants.yml
@@ -1,0 +1,67 @@
+# Tag-count invariant smoke test for the Contract-v5 image tag scheme.
+#
+# Per Khoury 2026-04-23: guard against future refactors silently dropping or
+# adding a tag in the publish-side (ghcr-publish.yml) or the promotion-side
+# (deploy#84 promote.yml).
+#
+# Invariants asserted per image:
+#   publish-side  — exactly FOUR tags per push point at the digest of the
+#                   latest main HEAD: sha-<short>, latest, stg-<short>,
+#                   stg-latest.
+#   promote-side  — exactly TWO tags per promotion point at the digest of
+#                   the most recently promoted image: prod-<short>,
+#                   prod-latest. (Skipped if no promotion has ever run.)
+#
+# The check uses the GHCR v2 API to list tags, then groups tags by the
+# digest they resolve to. It does NOT need to SSH anywhere.
+#
+# Triggers:
+#   - on every push to wave branches + main so a refactor to either
+#     ghcr-publish.yml or promote.yml that drops a tag is caught at CI.
+#   - schedule: daily, so a state drift in the registry (e.g. a manual tag
+#     deletion) is caught without waiting for a commit.
+#   - workflow_dispatch for operator-initiated runs.
+
+name: Image tag invariants
+
+on:
+  push:
+    branches:
+      - main
+      - "deployments/phase-*/wave-*"
+    paths:
+      - ".github/workflows/ghcr-publish.yml"
+      - ".github/workflows/promote.yml"
+      - ".github/workflows/image-tag-invariants.yml"
+      - "integration-tests/scripts/check_tag_invariants.py"
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  check:
+    name: Check tag invariants
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - noorinalabs/noorinalabs-isnad-graph
+          - noorinalabs/noorinalabs-isnad-graph-frontend
+          - noorinalabs/noorinalabs-user-service
+          - noorinalabs/noorinalabs-landing-page
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check publish + promote tag invariants
+        env:
+          IMAGE: ${{ matrix.image }}
+          GH_ACTOR: ${{ github.actor }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 integration-tests/scripts/check_tag_invariants.py "$IMAGE"

--- a/.github/workflows/image-tag-invariants.yml
+++ b/.github/workflows/image-tag-invariants.yml
@@ -1,7 +1,7 @@
-# Tag-count invariant smoke test for the Contract-v5 image tag scheme
-# (canonical per owner/Khoury ruling:
-# https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/815#issuecomment-4301487132).
-# v5 shape is identical to v3; v6 is a retro-audit artifact of the same shape.
+# Tag-count invariant smoke test for the Contract-v6 image tag scheme
+# (canonical per Khoury ruling:
+# https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/815#issuecomment-4301538921).
+# v6 shape is identical to v5 / v3; v6 is the canonical citation target.
 #
 # Per Khoury 2026-04-23: guard against future refactors silently dropping or
 # adding a tag in the publish-side (ghcr-publish.yml) or the promotion-side

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,11 +1,10 @@
 # Promote image from stg → prod via registry-side retag.
 #
-# Consumes the image-tag Contract v5 (option C) owned by
+# Consumes the image-tag Contract v6 (option C) owned by
 # noorinalabs-isnad-graph#815 (canonical comment per program-director ruling:
-# https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/815#issuecomment-4301487132).
-# v5 shape is identical to v3 (4301425114); v6 (4301538921) is a retro-audit
-# artifact that re-states v5 content. Owner/Khoury selected v5 URL as
-# canonical citation target.
+# https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/815#issuecomment-4301538921).
+# v6 shape is identical to v5 (4301487132) / v3 (4301425114); v6 is the
+# canonical citation target per Khoury ruling 2026-04-23.
 #
 # Source tags (written by each service's ghcr-publish.yml, NOT here):
 #   sha-<short>, latest, stg-<short>, stg-latest

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -28,6 +28,13 @@
 #     per the GH Environments protection rule (owner is the sole reviewer).
 #   - Stg deploy is automatic (repository_dispatch fan-in from each service
 #     repo) — see deploy-stg.yml.
+#
+# Per-service tag pinning (Lucas review 2026-04-23): short-SHA resolution
+# happens in the `plan` job up-front and is threaded through to both the
+# `retag` matrix AND the `trigger-prod-deploy` dispatch. This guarantees
+# `deploy-prod.yml` rolls out the exact same prod-<short> that our manual
+# approval just gated, not whatever `prod-latest` happens to point at if a
+# second promotion has started in parallel.
 
 name: Promote to production (image retag)
 
@@ -64,38 +71,56 @@ jobs:
     name: Plan promotion
     runs-on: ubuntu-latest
     outputs:
-      short_sha: ${{ steps.resolve.outputs.short_sha }}
-      images_json: ${{ steps.filter.outputs.images_json }}
+      # Each matrix cell of `retag` picks its per-image short from here.
+      # Shape: [{"key": "api", "image": "...", "short": "a1b2c3d"}, ...]
+      images_json: ${{ steps.resolve.outputs.images_json }}
+      # Flat per-service shorts for trigger-prod-deploy's input mapping.
+      api_short:          ${{ steps.resolve.outputs.api_short }}
+      frontend_short:     ${{ steps.resolve.outputs.frontend_short }}
+      user_service_short: ${{ steps.resolve.outputs.user_service_short }}
+      landing_short:      ${{ steps.resolve.outputs.landing_short }}
     steps:
-      - name: Resolve short SHA
+      - name: Log in to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Resolve per-image shorts
         id: resolve
+        env:
+          SOURCE_SHA_INPUT: ${{ inputs.source_sha }}
+          IMAGES_INPUT: ${{ inputs.images }}
+          REGISTRY: ${{ env.REGISTRY }}
+          GH_ACTOR: ${{ github.actor }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          raw="${{ inputs.source_sha }}"
-          # Strip an optional `sha-` prefix, then validate 7-char lowercase hex.
-          raw="${raw#sha-}"
-          if [ -z "$raw" ]; then
-            echo "No source_sha input — resolving from stg-latest at deploy time per image."
-            echo "short_sha=" >> "$GITHUB_OUTPUT"
-          else
+
+          # Normalize + validate source_sha.
+          raw="${SOURCE_SHA_INPUT#sha-}"
+          if [ -n "$raw" ]; then
             if ! printf '%s' "$raw" | grep -qE '^[0-9a-f]{7}$'; then
-              echo "::error::source_sha must be 7 lowercase hex chars (optionally prefixed 'sha-'). Got: ${{ inputs.source_sha }}"
+              echo "::error::source_sha must be 7 lowercase hex chars (optionally prefixed 'sha-'). Got: $SOURCE_SHA_INPUT"
               exit 1
             fi
-            echo "Resolved explicit short SHA: $raw"
-            echo "short_sha=$raw" >> "$GITHUB_OUTPUT"
+            explicit_short="$raw"
+          else
+            explicit_short=""
           fi
 
-      - name: Filter image set
-        id: filter
-        env:
-          IMAGES_INPUT: ${{ inputs.images }}
-        run: |
-          set -euo pipefail
-          # Map service keys to GHCR image names. Keep parallel to the
-          # ghcr-publish.yml matrix in each service repo.
-          python3 - <<'PY'
-          import json, os
+          # Build the image set + resolve each image's short-SHA up front.
+          # For the default path (explicit_short empty), walk each image's
+          # `stg-latest` → find the `sha-<short>` that matches. Done once
+          # here rather than per-retag-matrix-cell so that both `retag` and
+          # `trigger-prod-deploy` see the same short without each re-deriving.
+          export _EXPLICIT_SHORT="$explicit_short"
+          python3 - <<'PY' > /tmp/plan.json
+          import json, os, sys
           mapping = {
               "api":          "noorinalabs/noorinalabs-isnad-graph",
               "frontend":     "noorinalabs/noorinalabs-isnad-graph-frontend",
@@ -106,13 +131,88 @@ jobs:
           requested = [s.strip() for s in raw.split(",") if s.strip()]
           unknown = [s for s in requested if s not in mapping]
           if unknown:
-              raise SystemExit(f"Unknown image keys: {unknown}. Valid: {list(mapping)}")
-          selected = [{"key": k, "image": mapping[k]} for k in requested]
-          out = os.environ["GITHUB_OUTPUT"]
-          with open(out, "a") as fh:
-              fh.write("images_json=" + json.dumps(selected) + "\n")
-          print("Selected:", selected)
+              print(f"::error::Unknown image keys: {unknown}. Valid: {list(mapping)}", file=sys.stderr)
+              sys.exit(1)
+          explicit = os.environ.get("_EXPLICIT_SHORT", "")
+          # Plan is deterministic: if an explicit short is given, every image
+          # uses it. Otherwise each image resolves its own via stg-latest walk
+          # in the bash block that follows.
+          out = [{"key": k, "image": mapping[k], "short": explicit} for k in requested]
+          print(json.dumps(out))
           PY
+
+          # If explicit_short is empty, resolve per-image from stg-latest.
+          # We do this in bash since we already have buildx + curl available.
+          if [ -z "$explicit_short" ]; then
+            : > /tmp/resolved_shorts.jsonl
+            while IFS= read -r entry; do
+              key=$(printf '%s' "$entry" | python3 -c "import sys,json;print(json.loads(sys.stdin.read())['key'])")
+              image=$(printf '%s' "$entry" | python3 -c "import sys,json;print(json.loads(sys.stdin.read())['image'])")
+              full="${REGISTRY}/${image}"
+
+              # Resolve stg-latest digest via registry-reported digest
+              # (authoritative), not sha256-of-raw-bytes.
+              stg_digest=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$full:stg-latest")
+
+              # Walk sha-* tags, find match.
+              image_path="$image"
+              token=$(curl -s -u "${GH_ACTOR}:${GH_TOKEN}" \
+                "https://${REGISTRY}/token?scope=repository:${image_path}:pull" \
+                | python3 -c "import sys,json;print(json.load(sys.stdin)['token'])")
+              tags=$(curl -sH "Authorization: Bearer $token" \
+                "https://${REGISTRY}/v2/${image_path}/tags/list" \
+                | python3 -c "import sys,json;print('\n'.join(json.load(sys.stdin).get('tags') or []))")
+              short=""
+              while IFS= read -r tag; do
+                case "$tag" in
+                  sha-*)
+                    cand=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$full:$tag" 2>/dev/null || true)
+                    if [ "$cand" = "$stg_digest" ]; then
+                      short="${tag#sha-}"
+                      break
+                    fi
+                    ;;
+                esac
+              done <<< "$tags"
+              if [ -z "$short" ]; then
+                echo "::error::Could not resolve sha-<short> matching stg-latest digest for $full"
+                exit 1
+              fi
+              echo "[plan] $key ($image): resolved short=$short (digest=$stg_digest)"
+              # Write one JSON object per line for downstream aggregation.
+              KEY="$key" IMAGE_NAME="$image" SHORT="$short" python3 -c "
+          import json, os
+          print(json.dumps({'key': os.environ['KEY'], 'image': os.environ['IMAGE_NAME'], 'short': os.environ['SHORT']}))
+          " >> /tmp/resolved_shorts.jsonl
+            done < <(python3 -c "
+          import json
+          for e in json.load(open('/tmp/plan.json')):
+              print(json.dumps(e))
+          ")
+            # Aggregate the per-line JSON back into a single list.
+            python3 -c "
+          import json
+          with open('/tmp/resolved_shorts.jsonl') as fh:
+              rows = [json.loads(line) for line in fh if line.strip()]
+          json.dump(rows, open('/tmp/plan.json', 'w'))
+          "
+          fi
+
+          # Emit aggregated matrix JSON + per-service short outputs.
+          python3 - <<'PY3'
+          import json, os
+          data = json.load(open("/tmp/plan.json"))
+          out_path = os.environ["GITHUB_OUTPUT"]
+          with open(out_path, "a") as fh:
+              fh.write("images_json=" + json.dumps(data) + "\n")
+              # Per-service flat shorts (empty string if service not in set).
+              by_key = {e["key"]: e["short"] for e in data}
+              fh.write(f"api_short={by_key.get('api', '')}\n")
+              fh.write(f"frontend_short={by_key.get('frontend', '')}\n")
+              fh.write(f"user_service_short={by_key.get('user-service', '')}\n")
+              fh.write(f"landing_short={by_key.get('landing', '')}\n")
+          print("[plan] matrix:", json.dumps(data, indent=2))
+          PY3
 
   retag:
     name: Retag ${{ matrix.key }} (stg → prod)
@@ -145,86 +245,31 @@ jobs:
       - name: Resolve source tag
         id: src
         env:
-          SHORT_SHA: ${{ needs.plan.outputs.short_sha }}
+          # Matrix short is plan-resolved; if plan received an explicit
+          # source_sha, `short` is that SHA and source tag is `sha-<short>`.
+          # If plan walked from stg-latest, `short` is the matched sha-<short>
+          # and we still source from `stg-latest` (same digest; using the
+          # short-tag gives slightly better audit trace).
+          SHORT: ${{ matrix.short }}
           IMAGE: ${{ env.REGISTRY }}/${{ matrix.image }}
+          EXPLICIT: ${{ inputs.source_sha }}
         run: |
           set -euo pipefail
-          if [ -n "$SHORT_SHA" ]; then
-            # Explicit rollback / specific-SHA promotion.
-            source_tag="sha-${SHORT_SHA}"
+          if [ -n "$EXPLICIT" ]; then
+            # Operator-provided sha: pin to that specific sha-<short>.
+            source_tag="sha-${SHORT}"
           else
-            # Default path: whatever stg-latest currently points to.
+            # Auto-promote from stg-latest. Same digest as sha-${SHORT}.
             source_tag="stg-latest"
           fi
-          echo "Using source tag: $IMAGE:$source_tag"
-          # Resolve the concrete digest so we have one unambiguous target,
-          # AND so the prod-<short> we emit pins to a SHA even when the
-          # input path was the moving stg-latest pointer. `imagetools
-          # inspect --raw` prints the manifest-list JSON; we compute its
-          # digest with GNU coreutils.
-          raw_manifest=$(docker buildx imagetools inspect --raw "$IMAGE:$source_tag")
-          # Digest of the manifest-list itself = sha256 of the raw bytes.
-          digest="sha256:$(printf '%s' "$raw_manifest" | sha256sum | awk '{print $1}')"
-          echo "Resolved digest: $digest"
-          # Emit source-tag and digest for the retag step.
-          {
-            echo "source_tag=$source_tag"
-            echo "digest=$digest"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Resolve short SHA for prod-<short> tag
-        id: shortsha
-        env:
-          SHORT_SHA: ${{ needs.plan.outputs.short_sha }}
-          IMAGE: ${{ env.REGISTRY }}/${{ matrix.image }}
-        run: |
-          set -euo pipefail
-          if [ -n "$SHORT_SHA" ]; then
-            # The input already gives us the short SHA.
-            short="$SHORT_SHA"
-          else
-            # Walk the registry's tag list for this image, pick the
-            # sha-<short> whose digest matches stg-latest's digest.
-            #
-            # GitHub container-registry GET /v2/.../tags/list is paginated
-            # but returns all tags for our image sizes without pagination
-            # concerns. We resolve by iterating sha-* tags and matching
-            # manifest digest.
-            stg_digest=$(docker buildx imagetools inspect --raw "$IMAGE:stg-latest" \
-              | sha256sum | awk '{print "sha256:" $1}')
-            # Fetch tag list via GHCR v2 API (needs bearer token).
-            image_path="${IMAGE#${{ env.REGISTRY }}/}"
-            token=$(curl -s -u "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
-              "https://ghcr.io/token?scope=repository:${image_path}:pull" | python3 -c "import sys,json;print(json.load(sys.stdin)['token'])")
-            tags=$(curl -sH "Authorization: Bearer $token" \
-              "https://ghcr.io/v2/${image_path}/tags/list" \
-              | python3 -c "import sys,json;print('\n'.join(json.load(sys.stdin).get('tags') or []))")
-            short=""
-            while IFS= read -r tag; do
-              case "$tag" in
-                sha-*)
-                  cand=$(docker buildx imagetools inspect --raw "$IMAGE:$tag" 2>/dev/null \
-                    | sha256sum | awk '{print "sha256:" $1}' || true)
-                  if [ "$cand" = "$stg_digest" ]; then
-                    short="${tag#sha-}"
-                    break
-                  fi
-                  ;;
-              esac
-            done <<< "$tags"
-            if [ -z "$short" ]; then
-              echo "::error::Could not resolve sha-<short> matching stg-latest digest for $IMAGE"
-              exit 1
-            fi
-          fi
-          echo "prod-<short> target: prod-$short"
-          echo "short=$short" >> "$GITHUB_OUTPUT"
+          echo "Using source tag: $IMAGE:$source_tag (matches short=$SHORT)"
+          echo "source_tag=$source_tag" >> "$GITHUB_OUTPUT"
 
       - name: Retag (write prod-<short> + prod-latest atomically)
         env:
           IMAGE: ${{ env.REGISTRY }}/${{ matrix.image }}
           SOURCE_TAG: ${{ steps.src.outputs.source_tag }}
-          SHORT: ${{ steps.shortsha.outputs.short }}
+          SHORT: ${{ matrix.short }}
         run: |
           set -euo pipefail
           # Single invocation writes BOTH destinations against the same
@@ -251,18 +296,19 @@ jobs:
         env:
           IMAGE: ${{ env.REGISTRY }}/${{ matrix.image }}
           SOURCE_TAG: ${{ steps.src.outputs.source_tag }}
-          SHORT: ${{ steps.shortsha.outputs.short }}
+          SHORT: ${{ matrix.short }}
         run: |
           set -euo pipefail
           # Defense in depth: the retag is registry-side so digests MUST
           # match, but verifying catches registry bugs or accidental
-          # buildx flag drift.
-          src=$(docker buildx imagetools inspect --raw "$IMAGE:$SOURCE_TAG" | sha256sum | awk '{print $1}')
-          ps=$(docker buildx imagetools inspect --raw "$IMAGE:prod-$SHORT" | sha256sum | awk '{print $1}')
-          pl=$(docker buildx imagetools inspect --raw "$IMAGE:prod-latest" | sha256sum | awk '{print $1}')
-          echo "source digest:       sha256:$src"
-          echo "prod-<short> digest: sha256:$ps"
-          echo "prod-latest digest:  sha256:$pl"
+          # buildx flag drift. Use `--format '{{.Manifest.Digest}}'` to
+          # read registry-authoritative digest.
+          src=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$IMAGE:$SOURCE_TAG")
+          ps=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$IMAGE:prod-$SHORT")
+          pl=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$IMAGE:prod-latest")
+          echo "source digest:       $src"
+          echo "prod-<short> digest: $ps"
+          echo "prod-latest digest:  $pl"
           if [ "$src" != "$ps" ] || [ "$src" != "$pl" ]; then
             echo "::error::Digest parity check failed — source/prod-<short>/prod-latest diverged."
             exit 1
@@ -272,7 +318,7 @@ jobs:
         if: always()
         env:
           IMAGE: ${{ env.REGISTRY }}/${{ matrix.image }}
-          SHORT: ${{ steps.shortsha.outputs.short }}
+          SHORT: ${{ matrix.short }}
         run: |
           {
             echo "## Promotion: ${{ matrix.key }} — ${{ job.status }}"
@@ -285,17 +331,57 @@ jobs:
 
   trigger-prod-deploy:
     name: Trigger prod VPS rollout
-    needs: retag
+    needs: [plan, retag]
     runs-on: ubuntu-latest
     # NOT env-gated — the approval already happened at retag.
     # Firing deploy-prod.yml here is the rollout-execution step.
+    #
+    # Per-service tag pinning: we dispatch deploy-prod.yml with each
+    # service's `prod-<short>` — NOT `prod-latest` — so that a second
+    # promotion started in parallel cannot race us. If operator A runs
+    # promote.yml for SHA X and operator B starts promote.yml for SHA Y
+    # before A's deploy-prod.yml dispatch consumes the image, `prod-latest`
+    # would move to Y and A's VPS rollout would deploy Y instead of X
+    # (Lucas review 2026-04-23).
     steps:
-      - name: Dispatch deploy-prod.yml
+      - name: Dispatch deploy-prod.yml (per-service pinned)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          API_SHORT:          ${{ needs.plan.outputs.api_short }}
+          FRONTEND_SHORT:     ${{ needs.plan.outputs.frontend_short }}
+          USER_SERVICE_SHORT: ${{ needs.plan.outputs.user_service_short }}
+          LANDING_SHORT:      ${{ needs.plan.outputs.landing_short }}
         run: |
           set -euo pipefail
+          # Each tag is `prod-<short>` for its service, OR empty if that
+          # service wasn't in this promotion's image set. deploy-prod.yml
+          # falls back to `prod-latest` for any empty input, so partial
+          # promotions still deploy the remaining services from their
+          # last-promoted pointer.
+          #
+          # api + frontend share one short SHA (both built from the same
+          # isnad-graph commit in ghcr-publish.yml). We pass api's short
+          # as the canonical `api_frontend_tag`. If the two ever diverge
+          # (e.g. independent frontend repo in a future split) this check
+          # will fail loudly.
+          if [ -n "$API_SHORT" ] && [ -n "$FRONTEND_SHORT" ] && [ "$API_SHORT" != "$FRONTEND_SHORT" ]; then
+            echo "::error::api short ($API_SHORT) != frontend short ($FRONTEND_SHORT)."
+            echo "::error::api + frontend are expected to share a single short SHA from isnad-graph's ghcr-publish.yml."
+            exit 1
+          fi
+          af_short="${API_SHORT:-$FRONTEND_SHORT}"
+
+          api_frontend_tag="${af_short:+prod-$af_short}"
+          user_service_tag="${USER_SERVICE_SHORT:+prod-$USER_SERVICE_SHORT}"
+          landing_tag="${LANDING_SHORT:+prod-$LANDING_SHORT}"
+
+          echo "Dispatching deploy-prod.yml with per-service tags:"
+          echo "  api+frontend: ${api_frontend_tag:-<unset — will fall back to prod-latest>}"
+          echo "  user-service: ${user_service_tag:-<unset — will fall back to prod-latest>}"
+          echo "  landing:      ${landing_tag:-<unset — will fall back to prod-latest>}"
+
           gh workflow run deploy-prod.yml \
             --ref "${{ github.ref }}" \
-            -f image_tag="prod-latest"
-          echo "Triggered deploy-prod.yml (image_tag=prod-latest)"
+            -f api_frontend_tag="$api_frontend_tag" \
+            -f user_service_tag="$user_service_tag" \
+            -f landing_tag="$landing_tag"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,10 +1,11 @@
 # Promote image from stg → prod via registry-side retag.
 #
-# Consumes the image-tag Contract v6 (option C, v3 shape restored) owned
-# by noorinalabs-isnad-graph#815 (canonical comment:
-# https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/815#issuecomment-4301538921).
-# v6 is substantively identical to v5 (4301487132) / v3 (4301425114);
-# ruling-language updated per program-director instruction 2026-04-23.
+# Consumes the image-tag Contract v5 (option C) owned by
+# noorinalabs-isnad-graph#815 (canonical comment per program-director ruling:
+# https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/815#issuecomment-4301487132).
+# v5 shape is identical to v3 (4301425114); v6 (4301538921) is a retro-audit
+# artifact that re-states v5 content. Owner/Khoury selected v5 URL as
+# canonical citation target.
 #
 # Source tags (written by each service's ghcr-publish.yml, NOT here):
 #   sha-<short>, latest, stg-<short>, stg-latest

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,299 @@
+# Promote image from stg → prod via registry-side retag.
+#
+# Consumes the image-tag Contract v5 (option C) owned by
+# noorinalabs-isnad-graph#815 (canonical comment:
+# https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/815#issuecomment-4301487132).
+#
+# Source tags (written by each service's ghcr-publish.yml, NOT here):
+#   sha-<short>, latest, stg-<short>, stg-latest
+#
+# Tags written by THIS workflow, exclusively:
+#   prod-<short>, prod-latest
+#
+# Mechanism: `docker buildx imagetools create` rewrites the multi-arch
+# manifest-list at the registry level. No layer pull, no layer push — the
+# target digest is identical to the source digest. Both prod-<short> and
+# prod-latest are written in a single invocation.
+#
+# Promotion sources:
+#   1. Default: resolve digest of `stg-latest` for each image.
+#   2. Rollback / specific-SHA: `workflow_dispatch` input `source_sha` of the
+#      form `sha-<short>` or bare `<short>` — either resolves to the
+#      corresponding `sha-<short>` tag on the registry.
+#
+# Environment gating:
+#   - environment: production forces a reviewer-required manual-approval gate
+#     per the GH Environments protection rule (owner is the sole reviewer).
+#   - Stg deploy is automatic (repository_dispatch fan-in from each service
+#     repo) — see deploy-stg.yml.
+
+name: Promote to production (image retag)
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: >-
+          Short SHA to promote (7 chars, with or without `sha-` prefix).
+          Leave empty to promote the digest currently pointed to by
+          `stg-latest` for each image.
+        required: false
+        default: ""
+      images:
+        description: "Comma-separated image set to promote (default: all)."
+        required: false
+        default: "api,frontend,user-service,landing"
+
+concurrency:
+  # All promotions serialize globally — we never want two promotions racing
+  # to write prod-latest.
+  group: promote-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  plan:
+    name: Plan promotion
+    runs-on: ubuntu-latest
+    outputs:
+      short_sha: ${{ steps.resolve.outputs.short_sha }}
+      images_json: ${{ steps.filter.outputs.images_json }}
+    steps:
+      - name: Resolve short SHA
+        id: resolve
+        run: |
+          set -euo pipefail
+          raw="${{ inputs.source_sha }}"
+          # Strip an optional `sha-` prefix, then validate 7-char lowercase hex.
+          raw="${raw#sha-}"
+          if [ -z "$raw" ]; then
+            echo "No source_sha input — resolving from stg-latest at deploy time per image."
+            echo "short_sha=" >> "$GITHUB_OUTPUT"
+          else
+            if ! printf '%s' "$raw" | grep -qE '^[0-9a-f]{7}$'; then
+              echo "::error::source_sha must be 7 lowercase hex chars (optionally prefixed 'sha-'). Got: ${{ inputs.source_sha }}"
+              exit 1
+            fi
+            echo "Resolved explicit short SHA: $raw"
+            echo "short_sha=$raw" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Filter image set
+        id: filter
+        env:
+          IMAGES_INPUT: ${{ inputs.images }}
+        run: |
+          set -euo pipefail
+          # Map service keys to GHCR image names. Keep parallel to the
+          # ghcr-publish.yml matrix in each service repo.
+          python3 - <<'PY'
+          import json, os
+          mapping = {
+              "api":          "noorinalabs/noorinalabs-isnad-graph",
+              "frontend":     "noorinalabs/noorinalabs-isnad-graph-frontend",
+              "user-service": "noorinalabs/noorinalabs-user-service",
+              "landing":      "noorinalabs/noorinalabs-landing-page",
+          }
+          raw = os.environ.get("IMAGES_INPUT", "").strip() or ",".join(mapping)
+          requested = [s.strip() for s in raw.split(",") if s.strip()]
+          unknown = [s for s in requested if s not in mapping]
+          if unknown:
+              raise SystemExit(f"Unknown image keys: {unknown}. Valid: {list(mapping)}")
+          selected = [{"key": k, "image": mapping[k]} for k in requested]
+          out = os.environ["GITHUB_OUTPUT"]
+          with open(out, "a") as fh:
+              fh.write("images_json=" + json.dumps(selected) + "\n")
+          print("Selected:", selected)
+          PY
+
+  retag:
+    name: Retag ${{ matrix.key }} (stg → prod)
+    needs: plan
+    runs-on: ubuntu-latest
+    # The production GH Environment carries the manual-approval reviewer rule.
+    # This job does NOT touch a VPS — it only rewrites tags at GHCR. The
+    # manual gate here enforces "who decides prod goes out?"; the actual
+    # rollout to the prod VPS happens in deploy-prod.yml after this completes.
+    environment: production
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.plan.outputs.images_json) }}
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          # GITHUB_TOKEN needs `packages: write` on this repo for the image
+          # namespace. Cross-repo GHCR writes work because all images live
+          # under the same org (noorinalabs) — GitHub resolves org-scoped
+          # package permissions from the workflow's repo token.
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Resolve source tag
+        id: src
+        env:
+          SHORT_SHA: ${{ needs.plan.outputs.short_sha }}
+          IMAGE: ${{ env.REGISTRY }}/${{ matrix.image }}
+        run: |
+          set -euo pipefail
+          if [ -n "$SHORT_SHA" ]; then
+            # Explicit rollback / specific-SHA promotion.
+            source_tag="sha-${SHORT_SHA}"
+          else
+            # Default path: whatever stg-latest currently points to.
+            source_tag="stg-latest"
+          fi
+          echo "Using source tag: $IMAGE:$source_tag"
+          # Resolve the concrete digest so we have one unambiguous target,
+          # AND so the prod-<short> we emit pins to a SHA even when the
+          # input path was the moving stg-latest pointer. `imagetools
+          # inspect --raw` prints the manifest-list JSON; we compute its
+          # digest with GNU coreutils.
+          raw_manifest=$(docker buildx imagetools inspect --raw "$IMAGE:$source_tag")
+          # Digest of the manifest-list itself = sha256 of the raw bytes.
+          digest="sha256:$(printf '%s' "$raw_manifest" | sha256sum | awk '{print $1}')"
+          echo "Resolved digest: $digest"
+          # Emit source-tag and digest for the retag step.
+          {
+            echo "source_tag=$source_tag"
+            echo "digest=$digest"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Resolve short SHA for prod-<short> tag
+        id: shortsha
+        env:
+          SHORT_SHA: ${{ needs.plan.outputs.short_sha }}
+          IMAGE: ${{ env.REGISTRY }}/${{ matrix.image }}
+        run: |
+          set -euo pipefail
+          if [ -n "$SHORT_SHA" ]; then
+            # The input already gives us the short SHA.
+            short="$SHORT_SHA"
+          else
+            # Walk the registry's tag list for this image, pick the
+            # sha-<short> whose digest matches stg-latest's digest.
+            #
+            # GitHub container-registry GET /v2/.../tags/list is paginated
+            # but returns all tags for our image sizes without pagination
+            # concerns. We resolve by iterating sha-* tags and matching
+            # manifest digest.
+            stg_digest=$(docker buildx imagetools inspect --raw "$IMAGE:stg-latest" \
+              | sha256sum | awk '{print "sha256:" $1}')
+            # Fetch tag list via GHCR v2 API (needs bearer token).
+            image_path="${IMAGE#${{ env.REGISTRY }}/}"
+            token=$(curl -s -u "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
+              "https://ghcr.io/token?scope=repository:${image_path}:pull" | python3 -c "import sys,json;print(json.load(sys.stdin)['token'])")
+            tags=$(curl -sH "Authorization: Bearer $token" \
+              "https://ghcr.io/v2/${image_path}/tags/list" \
+              | python3 -c "import sys,json;print('\n'.join(json.load(sys.stdin).get('tags') or []))")
+            short=""
+            while IFS= read -r tag; do
+              case "$tag" in
+                sha-*)
+                  cand=$(docker buildx imagetools inspect --raw "$IMAGE:$tag" 2>/dev/null \
+                    | sha256sum | awk '{print "sha256:" $1}' || true)
+                  if [ "$cand" = "$stg_digest" ]; then
+                    short="${tag#sha-}"
+                    break
+                  fi
+                  ;;
+              esac
+            done <<< "$tags"
+            if [ -z "$short" ]; then
+              echo "::error::Could not resolve sha-<short> matching stg-latest digest for $IMAGE"
+              exit 1
+            fi
+          fi
+          echo "prod-<short> target: prod-$short"
+          echo "short=$short" >> "$GITHUB_OUTPUT"
+
+      - name: Retag (write prod-<short> + prod-latest atomically)
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ matrix.image }}
+          SOURCE_TAG: ${{ steps.src.outputs.source_tag }}
+          SHORT: ${{ steps.shortsha.outputs.short }}
+        run: |
+          set -euo pipefail
+          # Single invocation writes BOTH destinations against the same
+          # manifest-list. This is a pure registry-side operation — no
+          # blobs pulled, no blobs pushed. Multi-arch manifest-list is
+          # preserved identically.
+          #
+          # Failure mode we want: if either tag write fails, the command
+          # errors out. `imagetools create` writes each --tag in sequence
+          # but same run, so a partial success leaves us with prod-<short>
+          # set but prod-latest stale — which is recoverable by rerunning.
+          # We do NOT try to roll back prod-<short> on prod-latest failure;
+          # a stale prod-latest is a known-safe state (points at previous
+          # promotion).
+          docker buildx imagetools create \
+            --tag "$IMAGE:prod-$SHORT" \
+            --tag "$IMAGE:prod-latest" \
+            "$IMAGE:$SOURCE_TAG"
+          echo "== Written tags =="
+          echo "  $IMAGE:prod-$SHORT"
+          echo "  $IMAGE:prod-latest"
+
+      - name: Verify digest parity (source == prod-<short> == prod-latest)
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ matrix.image }}
+          SOURCE_TAG: ${{ steps.src.outputs.source_tag }}
+          SHORT: ${{ steps.shortsha.outputs.short }}
+        run: |
+          set -euo pipefail
+          # Defense in depth: the retag is registry-side so digests MUST
+          # match, but verifying catches registry bugs or accidental
+          # buildx flag drift.
+          src=$(docker buildx imagetools inspect --raw "$IMAGE:$SOURCE_TAG" | sha256sum | awk '{print $1}')
+          ps=$(docker buildx imagetools inspect --raw "$IMAGE:prod-$SHORT" | sha256sum | awk '{print $1}')
+          pl=$(docker buildx imagetools inspect --raw "$IMAGE:prod-latest" | sha256sum | awk '{print $1}')
+          echo "source digest:       sha256:$src"
+          echo "prod-<short> digest: sha256:$ps"
+          echo "prod-latest digest:  sha256:$pl"
+          if [ "$src" != "$ps" ] || [ "$src" != "$pl" ]; then
+            echo "::error::Digest parity check failed — source/prod-<short>/prod-latest diverged."
+            exit 1
+          fi
+
+      - name: Summary
+        if: always()
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ matrix.image }}
+          SHORT: ${{ steps.shortsha.outputs.short }}
+        run: |
+          {
+            echo "## Promotion: ${{ matrix.key }} — ${{ job.status }}"
+            echo ""
+            echo "- **Image:** \`$IMAGE\`"
+            echo "- **Source:** \`${{ steps.src.outputs.source_tag }}\`"
+            echo "- **Written:** \`prod-$SHORT\` + \`prod-latest\`"
+            echo "- **Actor:** ${{ github.actor }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  trigger-prod-deploy:
+    name: Trigger prod VPS rollout
+    needs: retag
+    runs-on: ubuntu-latest
+    # NOT env-gated — the approval already happened at retag.
+    # Firing deploy-prod.yml here is the rollout-execution step.
+    steps:
+      - name: Dispatch deploy-prod.yml
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh workflow run deploy-prod.yml \
+            --ref "${{ github.ref }}" \
+            -f image_tag="prod-latest"
+          echo "Triggered deploy-prod.yml (image_tag=prod-latest)"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,8 +1,10 @@
 # Promote image from stg → prod via registry-side retag.
 #
-# Consumes the image-tag Contract v5 (option C) owned by
-# noorinalabs-isnad-graph#815 (canonical comment:
-# https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/815#issuecomment-4301487132).
+# Consumes the image-tag Contract v6 (option C, v3 shape restored) owned
+# by noorinalabs-isnad-graph#815 (canonical comment:
+# https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/815#issuecomment-4301538921).
+# v6 is substantively identical to v5 (4301487132) / v3 (4301425114);
+# ruling-language updated per program-director instruction 2026-04-23.
 #
 # Source tags (written by each service's ghcr-publish.yml, NOT here):
 #   sha-<short>, latest, stg-<short>, stg-latest

--- a/integration-tests/scripts/check_tag_invariants.py
+++ b/integration-tests/scripts/check_tag_invariants.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Assert Contract-v5 tag-count invariants for a GHCR image.
+"""Assert Contract-v6 tag-count invariants for a GHCR image.
 
 Publish-side (per push): exactly FOUR tags per publish-digest:
     sha-<short>, latest, stg-<short>, stg-latest
@@ -7,9 +7,9 @@ Publish-side (per push): exactly FOUR tags per publish-digest:
 Promote-side (per promotion): exactly TWO tags per promoted-digest:
     prod-<short>, prod-latest
 
-Canonical contract (per owner/Khoury ruling): noorinalabs-isnad-graph#815
-comment 4301487132 (v5). v5 shape is identical to v3 (4301425114); v6
-(4301538921) is a retro-audit artifact re-stating v5 content.
+Canonical contract (per Khoury ruling 2026-04-23): noorinalabs-isnad-graph
+#815 comment 4301538921 (v6). v6 shape is identical to v5 (4301487132) /
+v3 (4301425114); v6 is the canonical citation target.
 
 Usage:
     check_tag_invariants.py <image-path>
@@ -147,7 +147,7 @@ def check_publish_side(image_path: str, tags: list[str], token: str) -> list[str
     # Invariant: the group size is exactly 4 — catches the "added a 5th tag" regression too.
     if len(grouped) != 4:
         errors.append(
-            f"[publish] {image_path}: Contract-v5 requires EXACTLY 4 tags per push at the publish digest. "
+            f"[publish] {image_path}: Contract-v6 requires EXACTLY 4 tags per push at the publish digest. "
             f"Found {len(grouped)}: {sorted(grouped)}"
         )
     else:
@@ -198,7 +198,7 @@ def check_promote_side(image_path: str, tags: list[str], token: str) -> list[str
         )
     if len(grouped) != 2:
         errors.append(
-            f"[promote] {image_path}: Contract-v5 requires EXACTLY 2 tags per promotion at the prod digest. "
+            f"[promote] {image_path}: Contract-v6 requires EXACTLY 2 tags per promotion at the prod digest. "
             f"Found {len(grouped)}: {sorted(grouped)}"
         )
     else:

--- a/integration-tests/scripts/check_tag_invariants.py
+++ b/integration-tests/scripts/check_tag_invariants.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Assert Contract-v5 tag-count invariants for a GHCR image.
+"""Assert Contract-v6 tag-count invariants for a GHCR image.
 
 Publish-side (per push): exactly FOUR tags per publish-digest:
     sha-<short>, latest, stg-<short>, stg-latest
@@ -7,7 +7,9 @@ Publish-side (per push): exactly FOUR tags per publish-digest:
 Promote-side (per promotion): exactly TWO tags per promoted-digest:
     prod-<short>, prod-latest
 
-Canonical contract: noorinalabs-isnad-graph#815 comment 4301487132.
+Canonical contract: noorinalabs-isnad-graph#815 comment 4301538921 (v6).
+v6 is substantively identical to v5 (4301487132) / v3 (4301425114) — same
+tag shape. v6 exists to lock program-director ruling language.
 
 Usage:
     check_tag_invariants.py <image-path>
@@ -145,7 +147,7 @@ def check_publish_side(image_path: str, tags: list[str], token: str) -> list[str
     # Invariant: the group size is exactly 4 — catches the "added a 5th tag" regression too.
     if len(grouped) != 4:
         errors.append(
-            f"[publish] {image_path}: Contract-v5 requires EXACTLY 4 tags per push at the publish digest. "
+            f"[publish] {image_path}: Contract-v6 requires EXACTLY 4 tags per push at the publish digest. "
             f"Found {len(grouped)}: {sorted(grouped)}"
         )
     else:
@@ -196,7 +198,7 @@ def check_promote_side(image_path: str, tags: list[str], token: str) -> list[str
         )
     if len(grouped) != 2:
         errors.append(
-            f"[promote] {image_path}: Contract-v5 requires EXACTLY 2 tags per promotion at the prod digest. "
+            f"[promote] {image_path}: Contract-v6 requires EXACTLY 2 tags per promotion at the prod digest. "
             f"Found {len(grouped)}: {sorted(grouped)}"
         )
     else:

--- a/integration-tests/scripts/check_tag_invariants.py
+++ b/integration-tests/scripts/check_tag_invariants.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Assert Contract-v5 tag-count invariants for a GHCR image.
+
+Publish-side (per push): exactly FOUR tags per publish-digest:
+    sha-<short>, latest, stg-<short>, stg-latest
+
+Promote-side (per promotion): exactly TWO tags per promoted-digest:
+    prod-<short>, prod-latest
+
+Canonical contract: noorinalabs-isnad-graph#815 comment 4301487132.
+
+Usage:
+    check_tag_invariants.py <image-path>
+        where <image-path> is e.g. `noorinalabs/noorinalabs-isnad-graph`
+        (without the `ghcr.io/` prefix).
+
+Auth: uses GH_ACTOR + GH_TOKEN from env if set (supplied by the CI job);
+otherwise falls back to an anonymous ghcr.io pull token which works for
+public packages.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+
+REGISTRY = "ghcr.io"
+
+SHA_SHORT_RE = re.compile(r"^sha-([0-9a-f]{7})$")
+STG_SHORT_RE = re.compile(r"^stg-([0-9a-f]{7})$")
+PROD_SHORT_RE = re.compile(r"^prod-([0-9a-f]{7})$")
+
+
+def _http_get(url: str, headers: dict[str, str]) -> bytes:
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req) as r:
+        return r.read()
+
+
+def _bearer_token(image_path: str) -> str:
+    """Fetch a pull-scoped bearer token from ghcr.io."""
+    actor = os.environ.get("GH_ACTOR") or ""
+    gh_token = os.environ.get("GH_TOKEN") or ""
+    scope = f"repository:{image_path}:pull"
+    url = f"https://{REGISTRY}/token?scope={urllib.parse.quote(scope, safe=':')}"
+    headers: dict[str, str] = {}
+    if actor and gh_token:
+        import base64
+        auth = base64.b64encode(f"{actor}:{gh_token}".encode()).decode()
+        headers["Authorization"] = f"Basic {auth}"
+    data = json.loads(_http_get(url, headers))
+    return data["token"]
+
+
+def _list_tags(image_path: str, token: str) -> list[str]:
+    url = f"https://{REGISTRY}/v2/{image_path}/tags/list"
+    headers = {"Authorization": f"Bearer {token}"}
+    data = json.loads(_http_get(url, headers))
+    return list(data.get("tags") or [])
+
+
+def _resolve_digest(image_path: str, tag: str, token: str) -> str:
+    """Return the content-addressable digest of a tag's manifest.
+
+    Uses HEAD on the v2 manifest endpoint and reads the Docker-Content-Digest
+    header, which the registry provides for both manifest-lists and
+    single-arch manifests. We accept both v2 manifest-list and OCI index
+    media types.
+    """
+    url = f"https://{REGISTRY}/v2/{image_path}/manifests/{tag}"
+    accept = ", ".join([
+        "application/vnd.oci.image.index.v1+json",
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+        "application/vnd.docker.distribution.manifest.v2+json",
+    ])
+    req = urllib.request.Request(
+        url,
+        headers={"Authorization": f"Bearer {token}", "Accept": accept},
+        method="HEAD",
+    )
+    with urllib.request.urlopen(req) as r:
+        dig = r.headers.get("Docker-Content-Digest")
+    if not dig:
+        raise RuntimeError(f"No Docker-Content-Digest for {image_path}:{tag}")
+    return dig
+
+
+def check_publish_side(image_path: str, tags: list[str], token: str) -> list[str]:
+    """Group publish-side tags by digest; assert each group is exactly 4.
+
+    We consider only the digest pointed to by `latest`, because that is
+    the digest of the most recent main push. A healthy publish-side emits
+    {sha-<short>, latest, stg-<short>, stg-latest} all at that digest.
+    """
+    errors: list[str] = []
+    if "latest" not in tags:
+        # No main push has ever happened for this image — skip (not a regression).
+        print(f"[publish] {image_path}: no `latest` tag yet; skipping (no main push observed).")
+        return errors
+    latest_digest = _resolve_digest(image_path, "latest", token)
+
+    # Gather all tags that resolve to `latest_digest`.
+    grouped: list[str] = ["latest"]
+    for tag in tags:
+        if tag == "latest":
+            continue
+        if not (
+            SHA_SHORT_RE.match(tag)
+            or STG_SHORT_RE.match(tag)
+            or tag == "stg-latest"
+        ):
+            continue
+        try:
+            d = _resolve_digest(image_path, tag, token)
+        except Exception as exc:
+            errors.append(f"[publish] failed to resolve {tag}: {exc}")
+            continue
+        if d == latest_digest:
+            grouped.append(tag)
+
+    # Exactly one of each expected shape.
+    sha_short = [t for t in grouped if SHA_SHORT_RE.match(t)]
+    stg_short = [t for t in grouped if STG_SHORT_RE.match(t)]
+    has_latest = "latest" in grouped
+    has_stg_latest = "stg-latest" in grouped
+
+    if len(sha_short) != 1:
+        errors.append(
+            f"[publish] {image_path}: expected exactly 1 sha-<short> tag at latest digest, got {len(sha_short)}: {sha_short}"
+        )
+    if len(stg_short) != 1:
+        errors.append(
+            f"[publish] {image_path}: expected exactly 1 stg-<short> tag at latest digest, got {len(stg_short)}: {stg_short}"
+        )
+    if not has_latest:
+        errors.append(f"[publish] {image_path}: `latest` tag missing from latest-digest group")
+    if not has_stg_latest:
+        errors.append(f"[publish] {image_path}: `stg-latest` tag missing from latest-digest group")
+
+    # Invariant: the group size is exactly 4 — catches the "added a 5th tag" regression too.
+    if len(grouped) != 4:
+        errors.append(
+            f"[publish] {image_path}: Contract-v5 requires EXACTLY 4 tags per push at the publish digest. "
+            f"Found {len(grouped)}: {sorted(grouped)}"
+        )
+    else:
+        print(f"[publish] {image_path}: OK — 4 tags at latest digest: {sorted(grouped)}")
+
+    # Short-SHA parity: the 7-char suffixes on sha-* and stg-* must match.
+    if len(sha_short) == 1 and len(stg_short) == 1:
+        s_sha = SHA_SHORT_RE.match(sha_short[0]).group(1)
+        s_stg = STG_SHORT_RE.match(stg_short[0]).group(1)
+        if s_sha != s_stg:
+            errors.append(
+                f"[publish] {image_path}: short-SHA mismatch between sha-{s_sha} and stg-{s_stg} at same digest"
+            )
+
+    return errors
+
+
+def check_promote_side(image_path: str, tags: list[str], token: str) -> list[str]:
+    """Group promote-side tags by digest; assert each group is exactly 2.
+
+    Skipped when `prod-latest` does not yet exist (no promotion has run).
+    """
+    errors: list[str] = []
+    if "prod-latest" not in tags:
+        print(f"[promote] {image_path}: no `prod-latest` tag yet; skipping (no promotion observed).")
+        return errors
+
+    prod_digest = _resolve_digest(image_path, "prod-latest", token)
+
+    grouped: list[str] = ["prod-latest"]
+    for tag in tags:
+        if tag == "prod-latest":
+            continue
+        if not PROD_SHORT_RE.match(tag):
+            continue
+        try:
+            d = _resolve_digest(image_path, tag, token)
+        except Exception as exc:
+            errors.append(f"[promote] failed to resolve {tag}: {exc}")
+            continue
+        if d == prod_digest:
+            grouped.append(tag)
+
+    prod_short = [t for t in grouped if PROD_SHORT_RE.match(t)]
+    if len(prod_short) != 1:
+        errors.append(
+            f"[promote] {image_path}: expected exactly 1 prod-<short> at prod-latest digest, got {len(prod_short)}: {prod_short}"
+        )
+    if len(grouped) != 2:
+        errors.append(
+            f"[promote] {image_path}: Contract-v5 requires EXACTLY 2 tags per promotion at the prod digest. "
+            f"Found {len(grouped)}: {sorted(grouped)}"
+        )
+    else:
+        print(f"[promote] {image_path}: OK — 2 tags at prod-latest digest: {sorted(grouped)}")
+
+    return errors
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: check_tag_invariants.py <image-path-without-ghcr-prefix>", file=sys.stderr)
+        return 2
+    image_path = sys.argv[1]
+    token = _bearer_token(image_path)
+    tags = _list_tags(image_path, token)
+    print(f"[info] {image_path}: {len(tags)} tags visible")
+
+    errors: list[str] = []
+    errors.extend(check_publish_side(image_path, tags, token))
+    errors.extend(check_promote_side(image_path, tags, token))
+
+    if errors:
+        print("")
+        print("TAG INVARIANT FAILURES:")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+    print(f"[ok] {image_path}: all tag invariants satisfied.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/integration-tests/scripts/check_tag_invariants.py
+++ b/integration-tests/scripts/check_tag_invariants.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Assert Contract-v6 tag-count invariants for a GHCR image.
+"""Assert Contract-v5 tag-count invariants for a GHCR image.
 
 Publish-side (per push): exactly FOUR tags per publish-digest:
     sha-<short>, latest, stg-<short>, stg-latest
@@ -7,9 +7,9 @@ Publish-side (per push): exactly FOUR tags per publish-digest:
 Promote-side (per promotion): exactly TWO tags per promoted-digest:
     prod-<short>, prod-latest
 
-Canonical contract: noorinalabs-isnad-graph#815 comment 4301538921 (v6).
-v6 is substantively identical to v5 (4301487132) / v3 (4301425114) — same
-tag shape. v6 exists to lock program-director ruling language.
+Canonical contract (per owner/Khoury ruling): noorinalabs-isnad-graph#815
+comment 4301487132 (v5). v5 shape is identical to v3 (4301425114); v6
+(4301538921) is a retro-audit artifact re-stating v5 content.
 
 Usage:
     check_tag_invariants.py <image-path>
@@ -147,7 +147,7 @@ def check_publish_side(image_path: str, tags: list[str], token: str) -> list[str
     # Invariant: the group size is exactly 4 — catches the "added a 5th tag" regression too.
     if len(grouped) != 4:
         errors.append(
-            f"[publish] {image_path}: Contract-v6 requires EXACTLY 4 tags per push at the publish digest. "
+            f"[publish] {image_path}: Contract-v5 requires EXACTLY 4 tags per push at the publish digest. "
             f"Found {len(grouped)}: {sorted(grouped)}"
         )
     else:
@@ -198,7 +198,7 @@ def check_promote_side(image_path: str, tags: list[str], token: str) -> list[str
         )
     if len(grouped) != 2:
         errors.append(
-            f"[promote] {image_path}: Contract-v6 requires EXACTLY 2 tags per promotion at the prod digest. "
+            f"[promote] {image_path}: Contract-v5 requires EXACTLY 2 tags per promotion at the prod digest. "
             f"Found {len(grouped)}: {sorted(grouped)}"
         )
     else:


### PR DESCRIPTION
Closes #84. Part of Wave 10 meta-issue `noorinalabs-main#141` (section A, deploy cluster — Cross-Contract PR 2/2).

**Status:** READY FOR REVIEW. Three of four sequencing gates cleared; `#83` (Cloudflare DNS) is the outstanding hard gate — PR #157 is OPEN, CI 9/9, awaiting merge. Reviewers can engage on workflow logic in parallel.
1. ~~`deploy#150` (Weronika, TF per-env provisioning)~~ — **MERGED 2026-04-23 03:44:54Z** (squash `1716c7a`, #82 closed).
2. `deploy#83` (Weronika, Cloudflare subdomains) — **pending** (in scaffolding). Blocks mergeability but NOT ready-for-review; reviewers can engage on workflow logic while DNS lands.
3. ~~`deploy#154` (Lucas, integration-tests trigger fix)~~ — **MERGED 2026-04-23 03:54:21Z** (squash `311ecb7`, #152 closed).
4. `isnad-graph#815` (Linh, rework) — soft gate. Blocks first real end-to-end promotion execution; does NOT block this PR's ready-for-review or merge.

`user-service#64` + `landing-page#68` may land after this; they MUST land before a real end-to-end promotion is observed across all four images.

## Summary

Builds the two-stage deployment workflow: push-to-main in any service repo auto-deploys to stg; a manual-approval gate in GitHub Actions environments promotes the SAME image digest to prod via registry-side retag (no rebuild, no layer re-push).

### Files added

| File | Purpose |
|---|---|
| `.github/workflows/promote.yml` | Manual-approval stg→prod retag. Single `docker buildx imagetools create` per image writes BOTH `prod-<short>` AND `prod-latest` against the source digest. |
| `.github/workflows/deploy-stg.yml` | `repository_dispatch` fan-in from all service repos (isnad-graph, user-service, landing-page). Env-scoped to `staging`. Consumes `stg-<short>` resolved from the dispatch payload's `sha`. |
| `.github/workflows/deploy-prod.yml` | VPS rollout of a `prod-*` tag. Env-scoped to `production`. Refuses any non-`prod-*` tag. |
| `.github/workflows/image-tag-invariants.yml` | Per Khoury 2026-04-23 tag-count invariant guard. Runs per-image, per-push to wave/main, plus daily schedule. |
| `integration-tests/scripts/check_tag_invariants.py` | The invariant probe: GHCR v2 tag-list + `Docker-Content-Digest` grouping. |

### Files marked legacy (no behavior change, fan-in removed to avoid double-deploy)

| File | Change |
|---|---|
| `.github/workflows/deploy-isnad-graph.yml` | `repository_dispatch` trigger removed; now manual-only. Will be deleted in `deploy#86` after hand-made VPS decommission. |
| `.github/workflows/deploy-landing-page.yml` | Header + comments only; already manual-only. |

## Consumption of #82 output shape

`#150` (now merged) publishes these outputs per env from `terraform/hetzner/envs/{stg,prod}/`:

| Output | Type | Example value | Consumer in this PR |
|---|---|---|---|
| `env` | `string` | `"stg"` / `"prod"` | matches the GH Environment name, used as a self-check in workflow logs |
| `server_name` | `string` | `noorinalabs-stg` / `noorinalabs-prod` | **hostname target** — resolves to `vars.VPS_HOST` set per GH Environment (operator step) |
| `server_ip` | `string` | IPv4 | fallback SSH target if DNS lag / rotation during `deploy#83` cutover |
| `server_ipv6` | `string` | IPv6 | not used (v4 only today) |
| `labels` | `map` | `{ project, environment }` | cross-checked on the VPS via `docker inspect` in verify step — defers to `#87` |

### Why `vars.VPS_HOST` and not `terraform_remote_state` data source

I considered pulling TF outputs live in the workflow via a `terraform_remote_state` data source reading the B2 backend. Rejected for three reasons:

1. **Every workflow run would pull state from B2.** Requires the workflow to carry `TF_STATE_B2_*` credentials on every deploy, broadening the secret surface.
2. **Plaintext state access from a deploy workflow.** `terraform_remote_state` exposes the entire state file; the deploy workflow only needs `server_name`. Principle of least privilege says export just that one value.
3. **Failure-mode entanglement.** A B2 hiccup would break every deploy, not just state-management operations. `vars.VPS_HOST` set once per env from the operator step decouples the two concerns.

Operator step for `vars.VPS_HOST` (one-time per env, documented in the prod runbook — follow-up):
```bash
cd terraform/hetzner/envs/stg && HOST=$(terraform output -raw server_name)
gh variable set VPS_HOST --env staging --body "$HOST"
```
Same for prod. The host resolves to the DNS-A record maintained by `#83` (pending merge).

### Dry-run promotion plan (once `#815` merges)

1. Push any commit to `main` on `noorinalabs-isnad-graph` — `ghcr-publish.yml` emits the four stg tags (`sha-<short>`, `latest`, `stg-<short>`, `stg-latest`) against one digest. `notify-deploy` fires `repository_dispatch` type `deploy-noorinalabs-isnad-graph` to deploy repo.
2. `deploy-stg.yml` receives the event, resolves tag as `stg-<sha[:7]>`, SSHes to `vars.VPS_HOST` (stg environment = `noorinalabs-stg`), pulls + restarts services, health-checks for 120s.
3. Operator triggers `promote.yml` via `workflow_dispatch` (empty `source_sha` = promote current `stg-latest`). The `plan` job resolves the image matrix; the `retag` job per-image waits on `environment: production` manual-approval gate.
4. Approval granted → `retag` job runs `docker buildx imagetools create --tag prod-<short> --tag prod-latest <image>:stg-latest`, verifies digest parity across source/`prod-<short>`/`prod-latest`.
5. `trigger-prod-deploy` job auto-dispatches `deploy-prod.yml` with `image_tag=prod-latest`. That workflow resolves `vars.VPS_HOST` under the `production` environment (`noorinalabs-prod`), pulls + restarts services, health-checks.
6. `image-tag-invariants.yml` runs on the next wave/main push, asserting 4-tag publish-side + 2-tag promote-side invariants per image.

**Rollback path:** `workflow_dispatch` on `promote.yml` with explicit `source_sha=sha-<short>` → produces a new `prod-<short>` for that historical SHA and updates `prod-latest` accordingly. `deploy-prod.yml` rollout triggered automatically.

## Contract

**Contract owner:** Aisha Idrissi for the workflow-level promotion Contract. Image-tag Contract (consumed verbatim here) is owned upstream by Nadia Boukhari. Canonical citation URL per Khoury ruling 2026-04-23: [isnad-graph#815 comment 4301538921](https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/815#issuecomment-4301538921) (**v6**). v6 shape is identical to v5 (4301487132) / v3 (4301425114); content across all three is substantively the same option-C tag scheme.

### 1. Promotion action signatures

**Stg auto-deploy** (`deploy-stg.yml`) — triggered by:

```yaml
on:
  repository_dispatch:
    types:
      - deploy-noorinalabs-isnad-graph
      - deploy-noorinalabs-user-service
      - deploy-noorinalabs-landing-page
  workflow_dispatch:
    inputs:
      image_tag: { default: "stg-latest" }
```

Tag resolution: `stg-<sha[:7]>` from `github.event.client_payload.sha` on `repository_dispatch`, else the explicit `workflow_dispatch` input, else `stg-latest`.

**Promotion** (`promote.yml`) — triggered by:

```yaml
on:
  workflow_dispatch:
    inputs:
      source_sha: { required: false, default: "" }   # "" = resolve from stg-latest
      images:     { default: "api,frontend,user-service,landing" }
```

Non-empty `source_sha` accepts either `sha-a1b2c3d` or bare `a1b2c3d` (7-char lowercase hex). Empty input means "promote whatever `stg-latest` currently points at, per image."

**Prod rollout** (`deploy-prod.yml`) — triggered by:

```yaml
on:
  workflow_dispatch:
    inputs:
      image_tag: { default: "prod-latest" }          # MUST match prod-*
```

Fired automatically by `promote.yml`'s `trigger-prod-deploy` job with `image_tag=prod-latest` after the retag-and-approve step succeeds. Also dispatchable manually by the operator for pinning a specific `prod-<short>` rollback.

### 2. Image-tag consumption chain (pinned to Contract v6, option C)

Per-image tag shape, canonical source: https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/815#issuecomment-4301538921

| Tag | Mutability | Written by | Read by |
|---|---|---|---|
| `sha-<short>` | Immutable | service repo's `ghcr-publish.yml` | `promote.yml` (rollback path via explicit `source_sha`) |
| `latest` | Moving pointer | service repo's `ghcr-publish.yml` | legacy `deploy-isnad-graph.yml` (manual) |
| `stg-<short>` | Immutable | service repo's `ghcr-publish.yml` | `deploy-stg.yml` (default path, resolved from dispatch `sha`) |
| `stg-latest` | Moving pointer | service repo's `ghcr-publish.yml` | `promote.yml` (default source), `deploy-stg.yml` (manual fallback) |
| `prod-<short>` | **Immutable, per-promotion** | **`promote.yml` ONLY** | rollback input to `deploy-prod.yml` |
| `prod-latest` | **Moving pointer** | **`promote.yml` ONLY** | `deploy-prod.yml` (default) |

Images covered (matrix keys in `promote.yml`):

```
api           → ghcr.io/noorinalabs/noorinalabs-isnad-graph
frontend      → ghcr.io/noorinalabs/noorinalabs-isnad-graph-frontend
user-service  → ghcr.io/noorinalabs/noorinalabs-user-service
landing       → ghcr.io/noorinalabs/noorinalabs-landing-page
```

### 3. Retag mechanism — registry-side, not pull-push

```bash
docker buildx imagetools create \
  --tag "ghcr.io/<image>:prod-<short>" \
  --tag "ghcr.io/<image>:prod-latest" \
  "ghcr.io/<image>:<source-tag>"
```

Properties:
- **Same digest** on both `prod-<short>` and `prod-latest` as on the source. Multi-arch manifest-list is preserved byte-identical.
- **No layer blobs pulled or pushed** — only manifest rewrites.
- **Atomic across both output tags** for the user-facing view: a single invocation writes both. If the invocation errors mid-way, `prod-<short>` may be set without `prod-latest` being updated; a stale `prod-latest` is a known-safe state (points at previous promotion) and is resolved by re-running promote. We explicitly do NOT roll back `prod-<short>` on a `prod-latest` failure — audit-trail preservation over transactional fiction.
- **Digest parity** is verified post-retag: source/`prod-<short>`/`prod-latest` must all resolve to the same sha256 or the step fails.

### 4. Env-scope guarantee

Stg secrets scoped to GH Environment `staging`; prod secrets scoped to `production`. Scoping boundaries:

| Workflow | Env-gated job(s) | Secret set accessible |
|---|---|---|
| `deploy-stg.yml` | `deploy` | staging |
| `promote.yml` | `retag` (per-image matrix) | production (manual-approval gate here) |
| `promote.yml` | `plan`, `trigger-prod-deploy` | none (neither needs VPS secrets) |
| `deploy-prod.yml` | `deploy` | production |
| Legacy workflows | kept env=`production` | production (manual-only now) |

The `promote.yml`/`retag` job uses only `GITHUB_TOKEN` (scoped to `packages: write` via workflow `permissions:`). It does NOT pull VPS secrets — its only side effect is a GHCR manifest rewrite. `deploy-prod.yml` does the VPS rollout and owns the production secret surface.

**Contract violation:** any workflow definition that reads a `staging`-scoped secret in a `production`-gated job (or vice versa) breaks this Contract and should be flagged in review.

### 5. Ownership

- **Workflow-level promotion Contract** (this PR): **Aisha Idrissi** adjudicates.
- **Image-tag Contract** (v6 canonical, shape-equivalent v3/v5): **Nadia Boukhari** adjudicates, at `isnad-graph#815`.

Divergence requests to either Contract go to the owning party via charter-format comment; unilateral forks are Contract violations.

### 6. Legitimate divergence (downstream consumers)

- **`deploy#85`** (Lucas Ferreira, alembic pre-deploy gate) — adds an alembic pre-deploy step to the stg and prod deploy paths. Allowed to modify step ordering inside `deploy-stg.yml` / `deploy-prod.yml`; NOT allowed to alter the tag shape or retag mechanism.
- **`deploy#87`** (Aisha Idrissi, follow-up) — splits `verify-deploy.yml` into per-env variants. Allowed to fan out from this PR's `environment` scaffolding; NOT allowed to redefine promotion semantics.
- **Legacy workflows** — retained manual-only for rollback to the pre-W10 VPS. Deletion gated on `deploy#86`.

## Sequencing

1. ~~`#154` merge (integration-tests CI trigger fix)~~ — **merged**.
2. `#83` merge (Cloudflare DNS) — **pending** (in scaffolding by Weronika). Hard gate for mergeability only. Tracking at PR #157 (OPEN, CI 9/9, MERGEABLE, awaiting merge as of this push).
3. `#815` merge — soft gate; only blocks first end-to-end promotion execution, not ready-for-review or merge.
4. `#85` (alembic) and `#87` (verify-deploy split) can draft against this PR's scaffolding without waiting for this to merge.

## Acceptance criteria

- [ ] Push to main in any service repo produces four stg-side tags (`sha-<short>`, `latest`, `stg-<short>`, `stg-latest`) via that service's `ghcr-publish.yml`, then deploys to stg via `deploy-stg.yml` (needs `#815`/`#64`/`#68` to have landed).
- [ ] Same digest appears in `promote.yml` as pending approval (production environment gate on the `retag` job).
- [ ] Manual approval triggers prod rollout: `promote.yml` retags digest as `prod-<short>` + `prod-latest`, then auto-dispatches `deploy-prod.yml`. No rebuild, no layer push.
- [ ] `workflow_dispatch` on `promote.yml` with explicit `source_sha=sha-<short>` produces a new `prod-<short>` and updates `prod-latest` (rollback path).
- [ ] Stg and prod secrets verified non-overlapping via GH Environment scoping.
- [ ] **Tag-count invariant:** `image-tag-invariants.yml` passes per-image — exactly 4 publish-side tags per push digest, exactly 2 promote-side tags per promotion digest.
- [ ] CI green (manual `gh pr checks` verification — Hook 14 not synced to deploy per main#194).

## Reviewers

- **Lucas Ferreira** (SRE, Senior) — primary, CI workflows expertise
- **Weronika Zielinska** (Platform Architect, Staff) — secondary, architecture review

Charter-format reviews only: `Requestor: … / Requestee: … / RequestOrReplied: … / TechDebt: <none|#N>` on every comment including the final Approved.

## Upstream context

- Meta-issue: https://github.com/noorinalabs/noorinalabs-main/issues/141
- Bereket's kickoff comment on #84: https://github.com/noorinalabs/noorinalabs-deploy/issues/84#issuecomment-4301394155
- **Canonical image-tag Contract (v6, per Khoury ruling):** https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/815#issuecomment-4301538921
  - Shape-equivalent historical comments: v5 (4301487132), v3 (4301425114). v4 (4301445174) RETRACTED. v2 (4301408087) SUPERSEDED.
- Paired contract PR (TF foundation, MERGED): #150 / #82 (my review: #150#issuecomment-4301522950)
- Paired contract PR (Cloudflare DNS): PR #157 / issue #83 (Weronika) — OPEN, CI 9/9 green, mergeable, awaiting merge
- Paired contract PR (alembic merge): user-service#80 (my cross-review: user-service#80#issuecomment-4301523864)
- Paired CI-trigger fix (MERGED): #154 / #152 (my secondary review: #154#issuecomment-4301553259)
- Rotation-drift tracking follow-up: #158


