### PR TITLE
infra(tf): cloudflare stg + per-service subdomains across both envs (#83)

### DIFF
--- a/terraform/cloudflare/main.tf
+++ b/terraform/cloudflare/main.tf
@@ -3,9 +3,9 @@ provider "cloudflare" {
 }
 
 # ---------------------------------------------------------------------------
-# SSL/TLS configuration
+# SSL/TLS configuration — applies to every record in the zone.
 # Full (Strict) — Cloudflare verifies the origin certificate.
-# Caddy on the VPS provides a valid Let's Encrypt certificate, so strict works.
+# Caddy on each VPS provides a valid Let's Encrypt cert, so strict works.
 # ---------------------------------------------------------------------------
 resource "cloudflare_zone_settings_override" "ssl" {
   zone_id = var.cloudflare_zone_id
@@ -18,24 +18,34 @@ resource "cloudflare_zone_settings_override" "ssl" {
   }
 }
 
-# ---------------------------------------------------------------------------
-# Root domain A record — points directly to VPS IP (DNS only, not proxied)
-# DNS-only because Caddy handles TLS termination and we don't need
-# Cloudflare's proxy layer in front of it.
-# ---------------------------------------------------------------------------
-resource "cloudflare_record" "root_a" {
+# ===========================================================================
+# PROD records — point at `noorinalabs-prod` (VPS provisioned by
+# terraform/hetzner/envs/prod, see #82).
+# ===========================================================================
+
+# Root apex — noorinalabs.com → prod VPS IPv4 (DNS only, not proxied).
+resource "cloudflare_record" "prod_apex_a" {
   zone_id = var.cloudflare_zone_id
   name    = "@"
-  content = var.vps_ipv4_address
+  content = var.prod_vps_ipv4_address
   type    = "A"
-  ttl     = 1 # Auto TTL
+  ttl     = 1
   proxied = false
 }
 
-# ---------------------------------------------------------------------------
-# www CNAME — redirects to root domain
-# ---------------------------------------------------------------------------
-resource "cloudflare_record" "www" {
+# Root apex IPv6 — optional. `prod_vps_ipv6_address = ""` disables the record.
+resource "cloudflare_record" "prod_apex_aaaa" {
+  count   = var.prod_vps_ipv6_address == "" ? 0 : 1
+  zone_id = var.cloudflare_zone_id
+  name    = "@"
+  content = var.prod_vps_ipv6_address
+  type    = "AAAA"
+  ttl     = 1
+  proxied = false
+}
+
+# www → apex redirect (Caddy does the actual redirect; DNS just resolves).
+resource "cloudflare_record" "www_cname" {
   zone_id = var.cloudflare_zone_id
   name    = "www"
   content = var.domain
@@ -44,11 +54,30 @@ resource "cloudflare_record" "www" {
   proxied = false
 }
 
-# ---------------------------------------------------------------------------
-# Subdomain CNAME records — each points to the root domain
-# ---------------------------------------------------------------------------
-resource "cloudflare_record" "subdomains" {
-  for_each = var.subdomains
+# isnad.noorinalabs.com → prod apex (isnad-graph app in prod).
+resource "cloudflare_record" "prod_isnad_cname" {
+  zone_id = var.cloudflare_zone_id
+  name    = "isnad"
+  content = var.domain
+  type    = "CNAME"
+  ttl     = 1
+  proxied = false
+}
+
+# auth.noorinalabs.com → prod apex (user-service in prod).
+resource "cloudflare_record" "prod_auth_cname" {
+  zone_id = var.cloudflare_zone_id
+  name    = "auth"
+  content = var.domain
+  type    = "CNAME"
+  ttl     = 1
+  proxied = false
+}
+
+# Legacy subdomains (isnad-graph.noorinalabs.com currently) — CNAME to apex.
+# Preserved by #83 to avoid traffic disruption; retired in #156 cutover.
+resource "cloudflare_record" "legacy_subdomains" {
+  for_each = var.legacy_subdomains
 
   zone_id = var.cloudflare_zone_id
   name    = each.key
@@ -56,4 +85,50 @@ resource "cloudflare_record" "subdomains" {
   type    = "CNAME"
   ttl     = 1
   proxied = each.value
+}
+
+# ===========================================================================
+# STG records — point at `noorinalabs-stg` (VPS provisioned by
+# terraform/hetzner/envs/stg, see #82).
+# ===========================================================================
+
+# Stg subdomain apex — stg.noorinalabs.com → stg VPS IPv4.
+resource "cloudflare_record" "stg_apex_a" {
+  zone_id = var.cloudflare_zone_id
+  name    = "stg"
+  content = var.stg_vps_ipv4_address
+  type    = "A"
+  ttl     = 1
+  proxied = false
+}
+
+# Stg subdomain apex IPv6 — optional.
+resource "cloudflare_record" "stg_apex_aaaa" {
+  count   = var.stg_vps_ipv6_address == "" ? 0 : 1
+  zone_id = var.cloudflare_zone_id
+  name    = "stg"
+  content = var.stg_vps_ipv6_address
+  type    = "AAAA"
+  ttl     = 1
+  proxied = false
+}
+
+# isnad.stg.noorinalabs.com → stg subdomain apex (isnad-graph app in stg).
+resource "cloudflare_record" "stg_isnad_cname" {
+  zone_id = var.cloudflare_zone_id
+  name    = "isnad.stg"
+  content = "stg.${var.domain}"
+  type    = "CNAME"
+  ttl     = 1
+  proxied = false
+}
+
+# auth.stg.noorinalabs.com → stg subdomain apex (user-service in stg).
+resource "cloudflare_record" "stg_auth_cname" {
+  zone_id = var.cloudflare_zone_id
+  name    = "auth.stg"
+  content = "stg.${var.domain}"
+  type    = "CNAME"
+  ttl     = 1
+  proxied = false
 }

--- a/terraform/cloudflare/moved.tf
+++ b/terraform/cloudflare/moved.tf
@@ -1,0 +1,26 @@
+# Terraform `moved` blocks — state-preserving renames from the pre-#83
+# Cloudflare module. Without these, the first `terraform apply` after #83
+# merges would destroy + recreate the three existing records (apex A, www
+# CNAME, and the isnad-graph subdomain), causing DNS flicker on production.
+#
+# `moved` blocks instruct Terraform to treat the rename as a state-move
+# rather than a destroy-create. No resource changes at the Cloudflare API
+# level.
+#
+# These blocks can be removed in a follow-up PR after the next apply
+# completes cleanly and everyone is on post-#83 state.
+
+moved {
+  from = cloudflare_record.root_a
+  to   = cloudflare_record.prod_apex_a
+}
+
+moved {
+  from = cloudflare_record.www
+  to   = cloudflare_record.www_cname
+}
+
+moved {
+  from = cloudflare_record.subdomains
+  to   = cloudflare_record.legacy_subdomains
+}

--- a/terraform/cloudflare/outputs.tf
+++ b/terraform/cloudflare/outputs.tf
@@ -1,14 +1,28 @@
-output "root_record_hostname" {
-  description = "Hostname of the root A record"
-  value       = cloudflare_record.root_a.hostname
+output "prod_hostnames" {
+  description = "Prod hostname map — consumed by deploy#87 verify and the cutover issue #156. Keys are canonical service identifiers."
+  value = {
+    landing = cloudflare_record.prod_apex_a.hostname
+    www     = cloudflare_record.www_cname.hostname
+    isnad   = cloudflare_record.prod_isnad_cname.hostname
+    auth    = cloudflare_record.prod_auth_cname.hostname
+  }
 }
 
-output "subdomain_hostnames" {
-  description = "Map of subdomain names to their full hostnames"
-  value       = { for k, v in cloudflare_record.subdomains : k => v.hostname }
+output "stg_hostnames" {
+  description = "Stg hostname map — consumed by deploy#87 verify and the stg deploy workflow (deploy#155)."
+  value = {
+    landing = cloudflare_record.stg_apex_a.hostname
+    isnad   = cloudflare_record.stg_isnad_cname.hostname
+    auth    = cloudflare_record.stg_auth_cname.hostname
+  }
+}
+
+output "legacy_subdomain_hostnames" {
+  description = "Legacy subdomains (e.g., isnad-graph.noorinalabs.com) preserved during cutover. Retired via #156."
+  value       = { for k, v in cloudflare_record.legacy_subdomains : k => v.hostname }
 }
 
 output "ssl_mode" {
-  description = "Current SSL/TLS mode for the zone"
+  description = "Current SSL/TLS mode for the zone."
   value       = cloudflare_zone_settings_override.ssl.settings[0].ssl
 }

--- a/terraform/cloudflare/terraform.tfvars.example
+++ b/terraform/cloudflare/terraform.tfvars.example
@@ -5,5 +5,11 @@ cloudflare_api_token = "CHANGE-ME"
 # Zone ID — found on the Cloudflare dashboard overview page for noorinalabs.com
 cloudflare_zone_id = "CHANGE-ME"
 
-# VPS public IPv4 — from `terraform output -raw server_ip` in the hetzner/ module
-vps_ipv4_address = "CHANGE-ME"
+# Prod VPS IPs — from `terraform output -raw server_ip` (and `server_ipv6`)
+# in terraform/hetzner/envs/prod. See #82.
+prod_vps_ipv4_address = "CHANGE-ME"
+prod_vps_ipv6_address = "" # optional; empty string disables AAAA
+
+# Stg VPS IPs — from terraform/hetzner/envs/stg outputs.
+stg_vps_ipv4_address = "CHANGE-ME"
+stg_vps_ipv6_address = "" # optional; empty string disables AAAA

--- a/terraform/cloudflare/variables.tf
+++ b/terraform/cloudflare/variables.tf
@@ -1,27 +1,56 @@
 variable "cloudflare_api_token" {
-  description = "Cloudflare API token with Zone:DNS:Edit and Zone:Zone:Read permissions"
+  description = "Cloudflare API token with Zone:DNS:Edit, Zone:Zone Settings:Edit, Zone:Zone:Read."
   type        = string
   sensitive   = true
 }
 
 variable "cloudflare_zone_id" {
-  description = "Cloudflare Zone ID for noorinalabs.com"
-  type        = string
-}
-
-variable "vps_ipv4_address" {
-  description = "Public IPv4 address of the Hetzner VPS"
+  description = "Cloudflare Zone ID for noorinalabs.com."
   type        = string
 }
 
 variable "domain" {
-  description = "Root domain name"
+  description = "Root domain name."
   type        = string
   default     = "noorinalabs.com"
 }
 
-variable "subdomains" {
-  description = "Map of subdomain names to their proxy status (false = DNS only, true = proxied)"
+# ---------------------------------------------------------------------------
+# Per-env Hetzner VPS IPs — consumed from terraform/hetzner/envs/{prod,stg}
+# outputs (`server_ip`, `server_ipv6`). Passed in at plan/apply time as
+# -var flags in CI, or via terraform.tfvars locally.
+# ---------------------------------------------------------------------------
+
+variable "prod_vps_ipv4_address" {
+  description = "Public IPv4 of the prod Hetzner VPS (from terraform/hetzner/envs/prod output server_ip)."
+  type        = string
+}
+
+variable "prod_vps_ipv6_address" {
+  description = "Public IPv6 of the prod Hetzner VPS (from terraform/hetzner/envs/prod output server_ipv6). Empty string disables the AAAA record."
+  type        = string
+  default     = ""
+}
+
+variable "stg_vps_ipv4_address" {
+  description = "Public IPv4 of the stg Hetzner VPS (from terraform/hetzner/envs/stg output server_ip)."
+  type        = string
+}
+
+variable "stg_vps_ipv6_address" {
+  description = "Public IPv6 of the stg Hetzner VPS (from terraform/hetzner/envs/stg output server_ipv6). Empty string disables the AAAA record."
+  type        = string
+  default     = ""
+}
+
+# ---------------------------------------------------------------------------
+# Legacy subdomain map (for `isnad-graph.noorinalabs.com` and any ad-hoc
+# CNAMEs that should alias to the prod apex). Preserved untouched by #83 —
+# retirement of `isnad-graph` is tracked in #156 (cutover follow-up).
+# ---------------------------------------------------------------------------
+
+variable "legacy_subdomains" {
+  description = "Map of legacy subdomain names → proxied flag. All CNAME to the prod apex. Empty the map to drop a legacy name once its cutover is complete."
   type        = map(bool)
   default = {
     "isnad-graph" = false


### PR DESCRIPTION
Closes #83. Consumes the per-env Contract from [#82 / PR#150](https://github.com/noorinalabs/noorinalabs-deploy/pull/150) (merged). Part of Wave 10 meta-issue noorinalabs-main#141 (section A, TF foundation pair #2). Follow-up cutover tracked in [#156](https://github.com/noorinalabs/noorinalabs-deploy/issues/156).

## Summary

Extend `terraform/cloudflare/` to manage both `stg` and `prod` DNS per the meta-issue #141 topology. Flat in prod, `.stg.` prefix in staging — verbatim from the issue body:

| Purpose | Prod | Staging |
|---|---|---|
| Landing | `noorinalabs.com` | `stg.noorinalabs.com` |
| Isnad app | `isnad.noorinalabs.com` | `isnad.stg.noorinalabs.com` |
| User service | `auth.noorinalabs.com` | `auth.stg.noorinalabs.com` |

**Scope is DNS-only and additive.** No existing records are removed or repointed. `isnad-graph.noorinalabs.com` stays bound to the prod apex for the cutover transition window — its retirement is tracked in #156.

## Contract

This PR is a **consumer** of the #82 Contract (`server_ip`, `server_ipv6`, `server_name`, `env` outputs per env) and a **producer** of the hostname map that downstream consumers (`#87` verify, `#155`/`#84` promotion workflow, `#156` cutover) will target.

### 1. Input shape — consumed from #82

Four scalar inputs, one per env × protocol. Today wired via GitHub-secrets + `TF_VAR_` env vars; tomorrow can be wired via `terraform_remote_state` against the `hetzner/{stg,prod}.tfstate` B2 keys if we want strict IaC coupling.

| Variable | Source | Required |
|---|---|---|
| `prod_vps_ipv4_address` | `terraform/hetzner/envs/prod` output `server_ip` | yes |
| `prod_vps_ipv6_address` | `terraform/hetzner/envs/prod` output `server_ipv6` | no (empty disables AAAA) |
| `stg_vps_ipv4_address` | `terraform/hetzner/envs/stg` output `server_ip` | yes |
| `stg_vps_ipv6_address` | `terraform/hetzner/envs/stg` output `server_ipv6` | no (empty disables AAAA) |

### 2. State layout — single root module (deliberate divergence from #82)

**This module keeps a single Terraform state** at `cloudflare/terraform.tfstate` on the existing B2 backend. No `envs/{stg,prod}/` split.

Rationale for the divergence from #82's layout:

- The Cloudflare zone is a **single object** (`noorinalabs.com`). Records for both envs live in the same zone.
- Splitting state would require either (a) two `cloudflare_zone_settings_override` resources racing on the same zone, or (b) factoring zone settings into a third shared module. Both add complexity to defend against a problem that doesn't exist — Hetzner's per-env state isolation was justified because the *resources* are per-env; DNS records aren't.
- Per-env IPs are already an input-shape concern (variables prefixed `prod_*` / `stg_*`), not a state-isolation concern.

"What happens when this fails?" per failure mode:

| Scenario | Guarantee |
|---|---|
| `terraform apply` fails mid-run | Partial state in the single `cloudflare/terraform.tfstate`. Idempotent re-apply resolves. |
| Cloudflare API rate limit | All records in one plan → one backoff window. Acceptable vs. two plans racing each other against the same zone. |
| Stg-only change applied in error | Plan diff is explicit per-record; reviewer sees exactly which hostnames change before `apply`. |
| Prod apex record accidentally repointed | Reviewer gate + `moved` block discipline. Not possible by renaming a resource alone — see §3. |

### 3. Resource-name refactor + `moved` blocks — no DNS flicker on first apply

Three resources are renamed in this PR for clarity:

| Before | After |
|---|---|
| `cloudflare_record.root_a` | `cloudflare_record.prod_apex_a` |
| `cloudflare_record.www` | `cloudflare_record.www_cname` |
| `cloudflare_record.subdomains` | `cloudflare_record.legacy_subdomains` |

Without mitigation, renaming a resource causes Terraform to destroy the old address and create the new one — here that would mean DNS flicker on the live apex + www + isnad-graph records. **`terraform/cloudflare/moved.tf`** declares three `moved` blocks that tell Terraform to treat each rename as a state-move, not destroy-create. First apply after merge is a no-op at the Cloudflare API level.

The `moved` blocks can be removed in a tiny follow-up PR once everyone is on post-#83 state (low priority; they're harmless as-is).

### 4. Output shape — authoritative for downstream

```hcl
output "prod_hostnames" = {
  landing = "noorinalabs.com"
  www     = "www.noorinalabs.com"
  isnad   = "isnad.noorinalabs.com"
  auth    = "auth.noorinalabs.com"
}

output "stg_hostnames" = {
  landing = "stg.noorinalabs.com"
  isnad   = "isnad.stg.noorinalabs.com"
  auth    = "auth.stg.noorinalabs.com"
}

output "legacy_subdomain_hostnames" = {
  "isnad-graph" = "isnad-graph.noorinalabs.com"
}
```

**Downstream consumers:**

- **#87 (verify-deploy split)** — reads `prod_hostnames` and `stg_hostnames` maps for per-env health-endpoint URLs. MUST NOT hard-code hostnames as literal strings.
- **#84 / #155 (promotion workflow)** — reads `stg_hostnames` for post-deploy verification targets.
- **#156 (cutover)** — reads `prod_hostnames.isnad`/`.auth` to know the new hostnames; reads `legacy_subdomain_hostnames` to know what to retire.

### 5. Ownership

- **Contract owner (this PR):** Weronika Zielinska.
- **Adjudicator for disputes:** Bereket Tadesse.
- **Topology source of truth:** issue #83 body (flat prod / `.stg.` prefix). Bereket adjudicated 2026-04-23 that the issue body is authoritative when prior coordinator messages used a contradictory `{env}` template.

### 6. Legitimate divergence for downstream

- **#87 verify** — is free to add synthetic health endpoints per hostname (e.g., `https://isnad.noorinalabs.com/api/v1/health`) that this module doesn't know about. No Contract change needed.
- **#156 cutover** — is free to swap `isnad-graph.noorinalabs.com` out of the `legacy_subdomains` map once Caddy/compose are updated. That's the contract between #83 and #156 — when the cutover PR lands, it empties or reduces the legacy map; this PR does not.
- **Future envs** — if a `qa` env is added, that's a new pair of variables (`qa_vps_ipv4_address` etc.) + a matching record set. Not a state-layout change.

### 7. Zone-level settings unchanged

Strict SSL, `min_tls_version = 1.2`, `always_use_https = on`, `automatic_https_rewrites = on`. Same posture as before. New records inherit these.

## Scope boundary — what is NOT in this PR

Per Bereket's 2026-04-23 adjudication (option (c) of the DNS-only vs DNS+cutover decision):

- Caddyfile hostname swap (`isnad-graph.noorinalabs.com` → `isnad.noorinalabs.com` / `auth.noorinalabs.com`) → #156.
- `compose/docker-compose.prod.yml` env var updates (`AUTH_OAUTH_REDIRECT_BASE_URL`, `CORS_ORIGINS`, `GF_SERVER_ROOT_URL`) → #156.
- `compose/.env.example`, `scripts/verify_deployment.sh`, `scripts/bootstrap-vps.sh` hostname updates → #156.
- OAuth provider console redirect-URI update (human action) → #156.
- stg-side runtime config (stg's own `CORS_ORIGINS` etc.) → part of the #155 promotion workflow scope, not here.

## Test plan

- [x] `terraform fmt -check -recursive terraform/` clean locally
- [x] `terraform init -backend=false && terraform validate` passes for `terraform/cloudflare/`
- [ ] CI: Format check pass
- [ ] CI: `Validate (terraform/cloudflare)` pass
- [ ] CI: `Plan (cloudflare)` — note there is no per-env matrix for Cloudflare today; the plan job for Cloudflare was removed when #150 restructured the terraform workflow to Hetzner envs. See the "Follow-up CI consideration" note below.
- [ ] Reviewer: confirm the `moved` blocks are correctly addressed (Terraform `moved {}` syntax, addresses match the pre-#83 state)
- [ ] Reviewer: confirm additive-only scope — no existing record is removed or repointed
- [ ] Post-merge (manual, by SRE): first `terraform apply` on `terraform/cloudflare/` should show only adds (new records) and no destroy/create — the `moved` blocks verify as state-moves

### Follow-up CI consideration (not in this PR)

The current `.github/workflows/terraform.yml` (from #150) validates `terraform/cloudflare/` but has no `plan`/`apply` job for Cloudflare — the Hetzner matrix is the only plan/apply path. That was intentional in #150 (scope discipline) but `#83`'s changes deserve a `plan` comment on PRs for review visibility. I propose adding a small Cloudflare-specific plan/apply path to the workflow as a separate tiny follow-up PR (not in #83 to keep scope to DNS + HCL).

## Reviewers

- **Primary:** Aisha.Idrissi (SRE, DNS/TLS expertise) — please verify the `moved` blocks correctly rename without destroy-create, confirm strict SSL posture + DNS-only parity, and spot-check additive-only scope
- **Secondary:** Lucas.Ferreira (SRE) — please confirm the output shape will work as input for #87 verify

---

Requestor: Weronika.Zielinska
Requestee: Aisha.Idrissi, Lucas.Ferreira
RequestOrReplied: Request
TechDebt: none
