### PR TITLE
chore(integration-tests): revert alembic upgrade heads → head (US #63)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,19 +22,52 @@ jobs:
         with:
           path: noorinalabs-deploy
 
+      # Resolve sibling-repo refs so wave-branch PRs in this repo pull the
+      # matching wave branch from user-service + isnad-graph when it exists,
+      # falling back to main otherwise. Fixes the cross-repo contract skew
+      # where (e.g.) a US migration lands on `deployments/phase-2/wave-N` but
+      # this workflow would have checked out US@main and missed it.
+      - name: Resolve sibling-repo refs (wave-aware)
+        id: sibling-refs
+        run: |
+          BASE="${{ github.base_ref }}"
+          if [ -z "$BASE" ]; then BASE="${{ github.ref_name }}"; fi
+
+          resolve_ref() {
+            local repo="$1"
+            if [[ "$BASE" == deployments/* ]] && \
+               git ls-remote --exit-code "https://github.com/noorinalabs/${repo}.git" "refs/heads/${BASE}" >/dev/null 2>&1; then
+              echo "$BASE"
+            else
+              echo "main"
+            fi
+          }
+
+          US_REF=$(resolve_ref noorinalabs-user-service)
+          IG_REF=$(resolve_ref noorinalabs-isnad-graph)
+
+          echo "user_service_ref=${US_REF}" >> "$GITHUB_OUTPUT"
+          echo "isnad_graph_ref=${IG_REF}"  >> "$GITHUB_OUTPUT"
+          {
+            echo "## Resolved sibling refs"
+            echo "- base branch: \`${BASE}\`"
+            echo "- noorinalabs-user-service: \`${US_REF}\`"
+            echo "- noorinalabs-isnad-graph:  \`${IG_REF}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Checkout noorinalabs-user-service
         uses: actions/checkout@v4
         with:
           repository: noorinalabs/noorinalabs-user-service
           path: noorinalabs-user-service
-          ref: main
+          ref: ${{ steps.sibling-refs.outputs.user_service_ref }}
 
       - name: Checkout noorinalabs-isnad-graph
         uses: actions/checkout@v4
         with:
           repository: noorinalabs/noorinalabs-isnad-graph
           path: noorinalabs-isnad-graph
-          ref: main
+          ref: ${{ steps.sibling-refs.outputs.isnad_graph_ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -31,12 +31,6 @@ Part of [noorinalabs-main#49](https://github.com/noorinalabs/noorinalabs-main/is
 | Real OAuth provider code-exchange | Hardcoded provider URLs in `src/app/services/oauth.py`; needs a `OAUTH_PROVIDER_BASE_URL` override before a fake-provider container can sit in front | noorinalabs-main#135 |
 | Pipeline worker scenarios | Pipeline (#105–#108) not yet live on wave-9 at the time this harness was written | noorinalabs-main#136 |
 
-### Known work-arounds (revert once upstream fix lands)
-
-| Work-around | Reason | Revert-path |
-|-------------|--------|-------------|
-| `alembic upgrade heads` (plural) in the user-service command | user-service has three unmerged migration heads (0003, 0020, 0030 off 0001); `upgrade head` refuses with "Multiple head revisions" | `noorinalabs/noorinalabs-user-service#63` — once a merge migration lands, revert to `head` (singular) |
-
 ## Running locally
 
 ```bash

--- a/integration-tests/docker-compose.test.yml
+++ b/integration-tests/docker-compose.test.yml
@@ -64,14 +64,9 @@ services:
         condition: service_healthy
       fake_oauth:
         condition: service_healthy
-    # NOTE: `alembic upgrade heads` (plural) is a temporary work-around —
-    # user-service's migration history has three unmerged heads (0003, 0020, 0030
-    # all off 0001) so `upgrade head` refuses. Tracked in
-    # noorinalabs/noorinalabs-user-service#63; revert to `head` (singular) once
-    # that merge migration lands.
     command: >
       sh -c "
-      /app/.venv/bin/alembic upgrade heads &&
+      /app/.venv/bin/alembic upgrade head &&
       /app/.venv/bin/uvicorn src.app.main:create_app --factory --host 0.0.0.0 --port 8000
       "
     networks:


### PR DESCRIPTION
Reverts the temporary `alembic upgrade heads` (plural) workaround in the deploy integration-test harness back to `alembic upgrade head` (singular) now that the upstream merge migration has landed, and fixes the sibling-checkout coordination that was masking the revert's effect in CI.

## Why now

[`noorinalabs/noorinalabs-user-service#80`](https://github.com/noorinalabs/noorinalabs-user-service/pull/80) merged 2026-04-23 with migration `0040_merge_multi_heads.py`, which collapses the three unmerged heads (0003, 0020, 0030 — all off 0001) into a single head. With a single head, `alembic upgrade head` now succeeds, so the `heads` plural workaround introduced when US#63 was still open is no longer needed.

- Closes the workaround tracked in [`noorinalabs/noorinalabs-user-service#63`](https://github.com/noorinalabs/noorinalabs-user-service/issues/63).
- Unblocks gate 2 of [`deploy#153`](https://github.com/noorinalabs/noorinalabs-deploy/pull/153) (Lucas's alembic pre-deploy gate with heads-count assertion) — that gate asserts exactly one head and therefore depends on this revert landing.

## Scope (two commits)

### Commit 1 — the revert (two files, no logic touched)

- `integration-tests/docker-compose.test.yml` — remove the 5-line NOTE comment block and swap `heads` → `head` in the `sh -c` command.
- `integration-tests/README.md` — remove the `### Known work-arounds (revert once upstream fix lands)` section (the only row was the alembic entry, so the section is now empty and the header goes with it).

### Commit 2 — CI sibling-checkout fix (surfaced by the first commit's CI failure)

- `.github/workflows/integration-tests.yml` — resolve sibling-repo refs per-PR. When the workflow runs on a wave-branch PR (base = `deployments/...`), check out `noorinalabs-user-service` + `noorinalabs-isnad-graph` at the **same wave branch** if it exists on those repos, falling back to `main` otherwise.

**Why commit 2 exists:** commit 1's CI failed because the workflow hardcoded `ref: main` for sibling checkouts. US #80's merge migration landed on US's `deployments/phase-2/wave-10` branch — not main — so `alembic upgrade head` (singular, the whole point of the revert) kept hitting "Multiple head revisions" because the test was pulling US@main, which still lacked 0040. Structural fix, not a workaround.

**Fallback chain covers all trigger types:**
- `pull_request` (wave-branch base) → wave branch on sibling if exists, else `main`
- `pull_request` (non-wave base) → falls through to `main`
- `push` to main / `workflow_dispatch` → `github.ref_name` doesn't start with `deployments/`, falls through to `main`

Uses `git ls-remote --exit-code` to verify the wave branch exists on each sibling before selecting it. Writes resolved refs to `$GITHUB_STEP_SUMMARY` for reviewer visibility.

Follow-up issue filed: pattern likely belongs in a reusable composite action if more cross-repo wave PRs accumulate.

## Test plan

- [x] CI on the revert-only commit: failed as expected (US@main still lacked 0040 → `alembic upgrade head` refused).
- [ ] CI on the revert + workflow-fix commit: should go green — US's `deployments/phase-2/wave-10` branch has 0040, so `alembic upgrade head` will succeed.
- [ ] Reviewer: confirm no other callers of `upgrade heads` (plural) remain in this repo.
- [ ] Reviewer: confirm the fallback chain behaves correctly for all four trigger types (PR wave / PR non-wave / push main / dispatch).
- [ ] Post-merge: `deploy#153` can move forward on its heads-count assertion.

Part of Wave 10 cascade (cloudflare PR #157 and promotion workflow #155 already merged).
