### PR TITLE
fix(hetzner-tf): chomp() ssh pubkey to eliminate provider read-back permadrift (#173)

### DIFF
--- a/terraform/hetzner/modules/hetzner-vps/main.tf
+++ b/terraform/hetzner/modules/hetzner-vps/main.tf
@@ -8,7 +8,7 @@ locals {
 
 resource "hcloud_ssh_key" "deploy" {
   name       = "${local.name_prefix}-deploy"
-  public_key = file(var.ssh_public_key_path)
+  public_key = chomp(file(var.ssh_public_key_path))
   labels     = local.labels
 }
 
@@ -53,7 +53,7 @@ resource "hcloud_server" "app" {
   firewall_ids = [hcloud_firewall.web.id]
 
   user_data = templatefile("${path.module}/cloud-init.yaml.tpl", {
-    ssh_public_key          = file(var.ssh_public_key_path)
+    ssh_public_key          = chomp(file(var.ssh_public_key_path))
     ghcr_auth_b64           = var.ghcr_auth_b64
     user_postgres_password  = var.user_postgres_password
     user_redis_password     = var.user_redis_password


### PR DESCRIPTION
## Summary

`file(var.ssh_public_key_path)` in the hetzner-vps module returns the file
content with its trailing newline. The Hetzner provider strips the newline
server-side and fails its read-back validation after every apply with:

```
Error: Provider produced inconsistent result after apply
  .public_key: was cty.StringVal("ssh-ed25519 ...com\n"),
  but now cty.StringVal("ssh-ed25519 ...com").
```

On subsequent plans the same mismatch surfaces as a forced replacement,
so the resource never reaches steady state. Wrap both call sites in
`chomp()` to align the TF-tracked value with what Hetzner stores.

Two-character fix; the diff is minimal:

```diff
-  public_key = file(var.ssh_public_key_path)
+  public_key = chomp(file(var.ssh_public_key_path))
```

repeated at the cloud-init templatefile call so the cloud-init
`ssh_authorized_keys:` entry doesn't pick up an extra blank line either.

## Why this is showing up now

`deploy#82` parameterized the module by env but the resulting state was
never successfully applied end-to-end against B2 — the live stg/prod
boxes were tracked in the legacy single-state-key `hetzner/terraform.tfstate`,
not the new `hetzner/{stg,prod}.tfstate`. The Phase B fresh-start rebuild
of stg (2026-04-26) was the first real apply against the new module
structure, which is when this provider-strict behaviour became visible.

## Validation

- Replanned stg locally with the fix applied → `Plan: 1 to add, 0 to
  change, 0 to destroy.` (no resource replacement, no permadrift)
- Applied → `module.vps.hcloud_server.app: Creation complete after 20s
  [id=128100194]`. `Apply complete! Resources: 1 added, 0 changed,
  0 destroyed.`
- Re-planned → no drift detected (clean steady state)

The new stg server (`noorinalabs-stg`, 87.99.137.225) is currently
running with this code path; remove the fix and the next apply
permadrifts again.

## Related work — sibling fixes filed separately

This is gap A of the `#173` post-Phase-B carry-forward. The remaining gaps
(B–E: write_files-vs-users ordering, sshd→ssh service rename, debconf
interactivity, CI ephemeral-key lockout) are tracked in `#173` and do
not block this PR. They land in follow-up PRs that target the
cloud-init template and the terraform.yml CI workflow respectively.

Sister scope at `#165` (single-pubkey injection / multi-key support) is
unaffected by this change.

## Test plan

- [x] `terraform plan` against `terraform/hetzner/envs/stg/` shows no
      diff for `module.vps.hcloud_ssh_key.deploy` after a clean apply
- [x] `terraform apply` against `envs/stg/` succeeds end-to-end without
      `Provider produced inconsistent result` error
- [ ] Reviewer to verify same behaviour will obtain in `envs/prod/`
      (the module is shared; behaviour should be identical)
- [ ] CI: `terraform fmt -check` + `terraform validate` for the
      module + both env roots remain green

Refs `#173` (gap A).
