### PR TITLE
ci: extend compose-validate paths + add actionlint workflow lint

### DIFF
--- a/.github/workflows/compose-validate.yml
+++ b/.github/workflows/compose-validate.yml
@@ -4,12 +4,14 @@ on:
     paths:
       - 'compose/**'
       - 'infra/**'
+      - 'scripts/**'
       - '.github/workflows/**'
   push:
     branches: [main]
     paths:
       - 'compose/**'
       - 'infra/**'
+      - 'scripts/**'
       - '.github/workflows/**'
 
 permissions:

--- a/.github/workflows/compose-validate.yml
+++ b/.github/workflows/compose-validate.yml
@@ -4,13 +4,13 @@ on:
     paths:
       - 'compose/**'
       - 'infra/**'
-      - '.github/workflows/compose-validate.yml'
+      - '.github/workflows/**'
   push:
     branches: [main]
     paths:
       - 'compose/**'
       - 'infra/**'
-      - '.github/workflows/compose-validate.yml'
+      - '.github/workflows/**'
 
 permissions:
   contents: read

--- a/.github/workflows/deploy-isnad-graph.yml
+++ b/.github/workflows/deploy-isnad-graph.yml
@@ -163,12 +163,14 @@ jobs:
       - name: Report deployment status
         if: always()
         run: |
-          echo "## Deploy noorinalabs-isnad-graph: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-            echo "- **Source repo:** ${{ github.event.client_payload.repo }}" >> "$GITHUB_STEP_SUMMARY"
-            echo "- **Source SHA:** ${{ github.event.client_payload.sha }}" >> "$GITHUB_STEP_SUMMARY"
-            echo "- **Source ref:** ${{ github.event.client_payload.ref }}" >> "$GITHUB_STEP_SUMMARY"
-          fi
-          echo "- **Image tag:** ${{ steps.tag.outputs.tag }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Triggered by:** ${{ github.actor }}" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Deploy noorinalabs-isnad-graph: ${{ job.status }}"
+            echo ""
+            if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+              echo "- **Source repo:** ${{ github.event.client_payload.repo }}"
+              echo "- **Source SHA:** ${{ github.event.client_payload.sha }}"
+              echo "- **Source ref:** ${{ github.event.client_payload.ref }}"
+            fi
+            echo "- **Image tag:** ${{ steps.tag.outputs.tag }}"
+            echo "- **Triggered by:** ${{ github.actor }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-landing-page.yml
+++ b/.github/workflows/deploy-landing-page.yml
@@ -57,7 +57,9 @@ jobs:
       - name: Report deployment status
         if: always()
         run: |
-          echo "## Deploy noorinalabs-landing-page: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Image tag:** ${{ inputs.image_tag }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Triggered by:** ${{ github.actor }}" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Deploy noorinalabs-landing-page: ${{ job.status }}"
+            echo ""
+            echo "- **Image tag:** ${{ inputs.image_tag }}"
+            echo "- **Triggered by:** ${{ github.actor }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,35 @@
+name: Lint Workflows
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Download actionlint
+        env:
+          # Pinned to actionlint v1.7.12 release tag SHA. The downloader script
+          # verifies the binary's SHA256 against the official release manifest.
+          ACTIONLINT_REF: 914e7df21a07ef503a81201c76d2b11c789d3fca
+          ACTIONLINT_VERSION: 1.7.12
+        run: |
+          curl --fail --silent --show-error --location \
+            "https://raw.githubusercontent.com/rhysd/actionlint/${ACTIONLINT_REF}/scripts/download-actionlint.bash" \
+            -o /tmp/download-actionlint.bash
+          bash /tmp/download-actionlint.bash "${ACTIONLINT_VERSION}" /usr/local/bin
+          actionlint -version
+      - name: Lint workflows
+        run: actionlint -color

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -19,17 +19,23 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install shellcheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
-      - name: Download actionlint
+      - name: Download and verify actionlint
         env:
-          # Pinned to actionlint v1.7.12 release tag SHA. The downloader script
-          # verifies the binary's SHA256 against the official release manifest.
-          ACTIONLINT_REF: 914e7df21a07ef503a81201c76d2b11c789d3fca
+          # Pinned: version + linux_amd64 tarball SHA256 from upstream's
+          # signed release manifest (actionlint_1.7.12_checksums.txt at
+          # https://github.com/rhysd/actionlint/releases/tag/v1.7.12).
+          # `sha256sum -c` aborts the job on mismatch — bytes-on-runner are
+          # exactly what was published at release time.
           ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
         run: |
+          cd "$RUNNER_TEMP"
           curl --fail --silent --show-error --location \
-            "https://raw.githubusercontent.com/rhysd/actionlint/${ACTIONLINT_REF}/scripts/download-actionlint.bash" \
-            -o /tmp/download-actionlint.bash
-          bash /tmp/download-actionlint.bash "${ACTIONLINT_VERSION}" /usr/local/bin
+            -o "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" | sha256sum -c -
+          tar -xzf "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" actionlint
+          install -m 0755 actionlint /usr/local/bin/actionlint
           actionlint -version
       - name: Lint workflows
         run: actionlint -color

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -60,6 +60,8 @@ jobs:
       - name: Report rollback status
         if: always()
         run: |
-          echo "## Rollback: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Service:** ${{ inputs.service }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Target tag:** ${{ inputs.image_tag }}" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Rollback: ${{ job.status }}"
+            echo "- **Service:** ${{ inputs.service }}"
+            echo "- **Target tag:** ${{ inputs.image_tag }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/verify-deploy.yml
+++ b/.github/workflows/verify-deploy.yml
@@ -39,10 +39,12 @@ jobs:
         if: always()
         run: |
           if [ -f verify-output.txt ]; then
-            echo "## Deployment Verification Results" >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
-            cat verify-output.txt >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            {
+              echo "## Deployment Verification Results"
+              echo '```'
+              cat verify-output.txt
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
 
   notify-failure:


### PR DESCRIPTION
## Summary

Closes #96.

PR #95 shipped with **zero CI checks** because `compose-validate.yml`'s `paths` filter only watched `compose/**`, `infra/**`, and itself. Workflow-only edits (`deploy-*.yml`, `terraform.yml`, etc.) had no automated signal — a fix for a quoting bug could regress with no warning.

This PR implements **option 3** from the issue (both fixes), plus a **bonus paths extension** for scripts/, plus a **baseline cleanup** discovered when the new gate ran on itself, plus a **checksum-pinning correction** caught at review.

## Changes

### Commit 1 — gate addition (8a0e29e)

1. **`compose-validate.yml`** — broaden `paths` to `.github/workflows/**` so any workflow edit at minimum exercises `docker compose config` + the existing `shellcheck` job. Cheap stack-loadable check.
2. **`lint-workflows.yml`** *(new)* — runs `actionlint` on every PR/push touching `.github/workflows/**`. Catches the canonical class of workflow bugs: unknown contexts, undefined `secrets.X`, unreachable steps, and `shellcheck` on `run:` blocks.

### Commit 2 — baseline + scripts/** (1d2c1ec)

3. **SC2129 baseline cleanup (4 files)** — when the new actionlint job ran on its own PR, it caught 4 pre-existing `SC2129:style` violations from shellcheck-on-`run:`-blocks. Coalesced each `echo ... >> "$GITHUB_STEP_SUMMARY"` chain into the group-command form `{ ...; } >> "$GITHUB_STEP_SUMMARY"`. Identical behavior, single open-write-close instead of N. Files: `deploy-isnad-graph.yml`, `deploy-landing-page.yml`, `rollback.yml`, `verify-deploy.yml`. **The gate must land green; this is the precondition.**
4. **`compose-validate.yml`** — extend `paths` to also include `scripts/**`. Aisha's PR #175 (deploy#122 fix in `scripts/bootstrap-vps.sh`) just shipped with `no checks reported on the branch` — same root-cause class as #96 but for shell scripts instead of workflow YAML. The existing `shellcheck infra & scripts` job already greps `scripts/`, only the trigger was missing.

### Commit 3 — actionlint integrity-pin correction (081e1c6)

5. **Replace upstream-downloader-script call with inline `curl + sha256sum -c`** in `lint-workflows.yml`. Weronika-Rev-176 (issuecomment-4332116162) caught that the previous "pinned chain" was misleading: pinning `download-actionlint.bash` to a tag SHA only freezes which script runs, not what binary it pulls. Verified upstream — that script is plain `curl -L | tar xvz` with **zero** integrity checks (no sha256, no gpg, no signature). The earlier PR-body claim was wrong.

   New pin chain (workflow-file → version + binary SHA256 → exact bytes on the runner):

   ```yaml
   ACTIONLINT_VERSION: 1.7.12
   ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
   ```

   SHA256 is the upstream-published value from `actionlint_1.7.12_checksums.txt` at the v1.7.12 release page. **Verified two-source**: matches the hash I computed locally on the freshly-downloaded tarball. `sha256sum -c -` aborts the job non-zero on mismatch. Drops the upstream downloader script entirely — strictly fewer moving parts than commit 1.

## Self-validation

Both gate-addition files match `.github/workflows/**`, so this PR's own changes fire:
- `Lint Workflows / actionlint` (the new job — proves it loads, downloads-with-checksum, and runs)
- `Compose & Infra Validate / docker compose config` + `shellcheck infra & scripts`

**Local re-verification (with shellcheck on PATH this time, and a from-scratch download chain):**
- `curl + sha256sum -c` of `actionlint_1.7.12_linux_amd64.tar.gz`: `OK`
- `actionlint -version`: `1.7.12 ... built with go1.26.1`
- `actionlint v1.7.12 -color` against all 13 workflows: clean, exit 0
- `shellcheck v0.10.0` on `infra/`+`scripts/` (5 .sh files): clean, exit 0

## Test plan

- [ ] `Lint Workflows / actionlint` job succeeds on this PR (was failing before commit 2)
- [ ] `Compose & Infra Validate / docker compose config` job triggers (broadened paths)
- [ ] `Compose & Infra Validate / shellcheck infra & scripts` job triggers
- [ ] Confirm `Download and verify actionlint` step shows `actionlint_1.7.12_linux_amd64.tar.gz: OK` and version `1.7.12`
- [ ] After merge, next PR touching any workflow file (e.g. `deploy-stg.yml`) fires both jobs
- [ ] After merge, next PR touching any file under `scripts/**` fires the `shellcheck infra & scripts` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)
