### PR TITLE
ci(verify-deploy): split by env — stg full integration, prod smoke battery

### DIFF
--- a/.github/workflows/verify-deploy.yml
+++ b/.github/workflows/verify-deploy.yml
@@ -1,58 +1,288 @@
+# Verify Deployment — split by environment.
+#
+# Two jobs, two triggers, two failure semantics:
+#
+#   verify-stg  — runs the full cross-repo integration suite (deploy#81)
+#                 on every successful stg deploy. Failure blocks any
+#                 prod-promote attempt that consumes the stg artifact
+#                 (gate enforcement is deploy#179).
+#
+#   verify-prod — runs a tight (<60s) smoke battery on every successful
+#                 prod deploy. Failure surfaces a `::error::` annotation
+#                 for owner investigation; no auto-rollback (no rollback
+#                 policy currently exists).
+#
+# Why split (vs. matrix.env):
+#   - Different upstream `workflow_run.workflows` triggers per env
+#   - Different runtime budgets (stg ~10–15min, prod <60s)
+#   - Different failure semantics (stg blocks promote, prod alerts)
+#   - Different `environment:` scopes (stg URLs vs prod URLs)
+#
+# Trigger note: the previous version watched "Deploy noorinalabs-isnad-graph"
+# which is now LEGACY (deploy-isnad-graph.yml line 1). Active deploys are
+# "Deploy to staging" and "Deploy to production" — repointed below as part
+# of deploy#87 (the split is unimplementable otherwise; trigger today fires
+# on a workflow nobody runs).
+
 name: Verify Deployment
 
 on:
   workflow_run:
-    workflows: ["Deploy noorinalabs-isnad-graph"]
+    workflows: ["Deploy to staging", "Deploy to production"]
     types: [completed]
   workflow_dispatch:
+    inputs:
+      target:
+        description: "Which env to verify (stg|prod). Required for manual dispatch."
+        required: true
+        default: "stg"
+        type: choice
+        options: [stg, prod]
 
 jobs:
-  verify:
+  # ─────────────────────────────────────────────────────────────────
+  # Stg: full cross-repo integration suite (hermetic, in-CI compose).
+  # See deploy#178 for the follow-up that adds remote-mode against
+  # the deployed stg URLs.
+  # ─────────────────────────────────────────────────────────────────
+  verify-stg:
+    name: Verify stg (full integration suite)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.name == 'Deploy to staging' &&
+       github.event.workflow_run.conclusion == 'success') ||
+      (github.event_name == 'workflow_dispatch' && inputs.target == 'stg')
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout noorinalabs-deploy
+        uses: actions/checkout@v4
+        with:
+          path: noorinalabs-deploy
 
-      - name: Wait for services to stabilize
-        run: sleep 30
-
-      - name: Run deployment verification
-        env:
-          SITE_URL: https://isnad-graph.noorinalabs.com
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Wave-aware sibling-repo ref resolution (mirrors integration-tests.yml
+      # pattern; needed so a wave-branch deploy verifies against matching
+      # wave branches of user-service + isnad-graph). See feedback memory
+      # "Cross-repo wave-aware sibling checkout" 2026-04-24.
+      - name: Resolve sibling-repo refs (wave-aware)
+        id: sibling-refs
         run: |
-          set -o pipefail
-          chmod +x scripts/verify_deployment.sh
-          ./scripts/verify_deployment.sh --skip-workflow 2>&1 | tee verify-output.txt
+          set -euo pipefail
+          # On workflow_run the head_branch of the upstream deploy is most
+          # accurate; on workflow_dispatch, fall back to ref_name of this
+          # workflow's invocation context.
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            BASE="${{ github.event.workflow_run.head_branch }}"
+          else
+            BASE="${{ github.ref_name }}"
+          fi
+          [ -n "$BASE" ] || BASE="main"
 
-      - name: Upload verification output
+          resolve_ref() {
+            local repo="$1"
+            if [[ "$BASE" == deployments/* ]] && \
+               git ls-remote --exit-code "https://github.com/noorinalabs/${repo}.git" "refs/heads/${BASE}" >/dev/null 2>&1; then
+              echo "$BASE"
+            else
+              echo "main"
+            fi
+          }
+
+          US_REF=$(resolve_ref noorinalabs-user-service)
+          IG_REF=$(resolve_ref noorinalabs-isnad-graph)
+
+          echo "user_service_ref=${US_REF}" >> "$GITHUB_OUTPUT"
+          echo "isnad_graph_ref=${IG_REF}"  >> "$GITHUB_OUTPUT"
+          {
+            echo "## Resolved sibling refs (verify-stg)"
+            echo "- upstream branch: \`${BASE}\`"
+            echo "- noorinalabs-user-service: \`${US_REF}\`"
+            echo "- noorinalabs-isnad-graph:  \`${IG_REF}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Checkout noorinalabs-user-service
+        uses: actions/checkout@v4
+        with:
+          repository: noorinalabs/noorinalabs-user-service
+          path: noorinalabs-user-service
+          ref: ${{ steps.sibling-refs.outputs.user_service_ref }}
+
+      - name: Checkout noorinalabs-isnad-graph
+        uses: actions/checkout@v4
+        with:
+          repository: noorinalabs/noorinalabs-isnad-graph
+          path: noorinalabs-isnad-graph
+          ref: ${{ steps.sibling-refs.outputs.isnad_graph_ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run full integration suite
+        working-directory: noorinalabs-deploy/integration-tests
+        run: ./run-tests.sh --junit-xml=reports/junit.xml
+
+      - name: Upload junit report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: verify-output
-          path: verify-output.txt
-          retention-days: 7
+          name: verify-stg-junit
+          path: noorinalabs-deploy/integration-tests/reports/
 
-      - name: Write verification summary
+      - name: Dump compose logs on failure
+        if: failure()
+        working-directory: noorinalabs-deploy/integration-tests
+        run: docker compose -f docker-compose.test.yml --env-file .env.test logs --no-color > reports/compose.log || true
+
+      # Artifact consumed by deploy#179 (promote.yml gate). Schema:
+      # { "result": "success"|"failure", "commit_sha": "...", "timestamp": "...", "run_id": "..." }
+      # Filename includes run_id so promote.yml can validate freshness.
+      - name: Emit verify-stg-result artifact
         if: always()
         run: |
-          if [ -f verify-output.txt ]; then
+          set -euo pipefail
+          if [ "${{ job.status }}" = "success" ]; then
+            RESULT="success"
+          else
+            RESULT="failure"
+          fi
+          # On workflow_run, prefer the upstream deploy's head_sha; otherwise
+          # fall back to this workflow's GITHUB_SHA.
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            COMMIT_SHA="${{ github.event.workflow_run.head_sha }}"
+          else
+            COMMIT_SHA="${{ github.sha }}"
+          fi
+          TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          OUT="stg-verify-result-${{ github.run_id }}.json"
+          printf '{"result":"%s","commit_sha":"%s","timestamp":"%s","run_id":"%s"}\n' \
+            "$RESULT" "$COMMIT_SHA" "$TS" "${{ github.run_id }}" > "$OUT"
+          echo "Wrote $OUT:"
+          cat "$OUT"
+
+      - name: Upload verify-stg-result artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stg-verify-result
+          path: stg-verify-result-${{ github.run_id }}.json
+          retention-days: 30
+
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo "## Verify stg — ${{ job.status }}"
+            echo ""
+            echo "Full cross-repo integration suite (hermetic Option A; deploy#178 tracks remote-mode against live stg URLs)."
+            echo ""
+            if [ -f noorinalabs-deploy/integration-tests/reports/junit.xml ]; then
+              echo "### Test counts"
+              python3 - <<'PY' || true
+          import xml.etree.ElementTree as ET
+          try:
+              t = ET.parse("noorinalabs-deploy/integration-tests/reports/junit.xml")
+              r = t.getroot()
+              tests = r.attrib.get("tests", "?")
+              fails = r.attrib.get("failures", "?")
+              errs = r.attrib.get("errors", "?")
+              skips = r.attrib.get("skipped", "?")
+              time = r.attrib.get("time", "?")
+              print("| Metric | Value |")
+              print("|--------|-------|")
+              print(f"| Tests | {tests} |")
+              print(f"| Failures | {fails} |")
+              print(f"| Errors | {errs} |")
+              print(f"| Skipped | {skips} |")
+              print(f"| Duration | {time}s |")
+          except Exception as e:
+              print(f"_Could not parse junit.xml: {e}_")
+          PY
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  notify-stg-failure:
+    name: Notify stg verify failure
+    runs-on: ubuntu-latest
+    needs: verify-stg
+    if: always() && needs.verify-stg.result == 'failure'
+    steps:
+      - name: Surface stg failure
+        run: |
+          echo "::error::Stg verify-deploy failed — prod-promote will be blocked once deploy#179 lands."
+          {
+            echo "## Stg verify FAILED"
+            echo ""
+            echo "The full integration suite did not pass against the stg deployment context."
+            echo "Investigate before promoting to prod. The promote.yml gate (deploy#179) will hard-block prod-promote on this state."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ─────────────────────────────────────────────────────────────────
+  # Prod: tight smoke battery (<60s).
+  # Health endpoints, narrator query (expect 401), auth wiring (route
+  # reachability only — no creds in prod, per Bereket sign-off).
+  # ─────────────────────────────────────────────────────────────────
+  verify-prod:
+    name: Verify prod (smoke battery)
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    environment: production
+    if: >-
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.name == 'Deploy to production' &&
+       github.event.workflow_run.conclusion == 'success') ||
+      (github.event_name == 'workflow_dispatch' && inputs.target == 'prod')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Wait briefly for services to settle
+        run: sleep 10
+
+      - name: Run prod smoke battery
+        env:
+          ISNAD_BASE_URL: https://isnad.noorinalabs.com
+          USER_SERVICE_BASE_URL: https://users.noorinalabs.com
+          LANDING_BASE_URL: https://noorinalabs.com
+          SMOKE_REPORT: smoke-report.md
+        run: |
+          set -o pipefail
+          chmod +x scripts/verify_prod_smoke.sh
+          ./scripts/verify_prod_smoke.sh 2>&1 | tee smoke-output.txt
+
+      - name: Upload smoke output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: verify-prod-smoke-output
+          path: |
+            smoke-output.txt
+            smoke-report.md
+          retention-days: 14
+
+      - name: Append smoke report to job summary
+        if: always()
+        run: |
+          if [ -f smoke-report.md ]; then
+            cat smoke-report.md >> "$GITHUB_STEP_SUMMARY"
+          else
             {
-              echo "## Deployment Verification Results"
-              echo '```'
-              cat verify-output.txt
-              echo '```'
+              echo "## Verify prod — ${{ job.status }}"
+              echo ""
+              echo "_smoke-report.md not produced; see smoke-output.txt artifact._"
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 
-  notify-failure:
+  notify-prod-failure:
+    name: Notify prod smoke failure
     runs-on: ubuntu-latest
-    needs: verify
-    if: always() && needs.verify.result == 'failure'
+    needs: verify-prod
+    if: always() && needs.verify-prod.result == 'failure'
     steps:
-      - name: Report verification failure
+      - name: Surface prod smoke failure
         run: |
-          echo "::error::Deployment verification failed — check verify job for details"
-          echo "## Deployment Verification Failed" >> "$GITHUB_STEP_SUMMARY"
+          echo "::error::Prod verify-deploy smoke battery FAILED — owner investigate immediately."
+          {
+            echo "## Prod smoke FAILED"
+            echo ""
+            echo "One or more checks in the prod smoke battery did not pass. There is no auto-rollback policy."
+            echo "Investigate via the verify-prod-smoke-output artifact and the upstream prod deploy logs."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/verify-deploy.yml
+++ b/.github/workflows/verify-deploy.yml
@@ -124,9 +124,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # run-tests.sh already passes --junit-xml=/app/reports/junit.xml to
+      # pytest internally; re-passing the flag here would duplicate it
+      # (latter-wins works by accident with WORKDIR=/app + the ./reports
+      # mount, but is brittle to refactor). Let the script own the flag.
+      # See deploy#181 review (Nurul).
       - name: Run full integration suite
         working-directory: noorinalabs-deploy/integration-tests
-        run: ./run-tests.sh --junit-xml=reports/junit.xml
+        run: ./run-tests.sh
 
       - name: Upload junit report
         if: always()
@@ -140,9 +145,15 @@ jobs:
         working-directory: noorinalabs-deploy/integration-tests
         run: docker compose -f docker-compose.test.yml --env-file .env.test logs --no-color > reports/compose.log || true
 
-      # Artifact consumed by deploy#179 (promote.yml gate). Schema:
-      # { "result": "success"|"failure", "commit_sha": "...", "timestamp": "...", "run_id": "..." }
+      # Artifact consumed by deploy#179 (promote.yml gate). Schema v1:
+      # { "schema_version": 1,
+      #   "result": "success"|"failure",
+      #   "commit_sha": "...",
+      #   "timestamp": "...",
+      #   "run_id": "..." }
       # Filename includes run_id so promote.yml can validate freshness.
+      # `schema_version` lets future #179 consumers do graceful evolution
+      # (deploy#181 review, Nurul).
       - name: Emit verify-stg-result artifact
         if: always()
         run: |
@@ -161,7 +172,7 @@ jobs:
           fi
           TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           OUT="stg-verify-result-${{ github.run_id }}.json"
-          printf '{"result":"%s","commit_sha":"%s","timestamp":"%s","run_id":"%s"}\n' \
+          printf '{"schema_version":1,"result":"%s","commit_sha":"%s","timestamp":"%s","run_id":"%s"}\n' \
             "$RESULT" "$COMMIT_SHA" "$TS" "${{ github.run_id }}" > "$OUT"
           echo "Wrote $OUT:"
           cat "$OUT"

--- a/.github/workflows/verify-deploy.yml
+++ b/.github/workflows/verify-deploy.yml
@@ -49,16 +49,23 @@ jobs:
     name: Verify stg (full integration suite)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment: staging
     if: >-
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.name == 'Deploy to staging' &&
        github.event.workflow_run.conclusion == 'success') ||
       (github.event_name == 'workflow_dispatch' && inputs.target == 'stg')
     steps:
+      # ref pin matters: workflow_run defaults checkout to the default
+      # branch (main), which would silently run a wave-branch deploy's
+      # verify against main's revision. Pin to the upstream deploy's
+      # head_sha (sha is more stable than head_branch — branch may have
+      # moved between trigger and run). See deploy#181 review (Weronika).
       - name: Checkout noorinalabs-deploy
         uses: actions/checkout@v4
         with:
           path: noorinalabs-deploy
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       # Wave-aware sibling-repo ref resolution (mirrors integration-tests.yml
       # pattern; needed so a wave-branch deploy verifies against matching
@@ -232,15 +239,27 @@ jobs:
        github.event.workflow_run.conclusion == 'success') ||
       (github.event_name == 'workflow_dispatch' && inputs.target == 'prod')
     steps:
+      # ref pin matters: workflow_run defaults checkout to the default
+      # branch (main), which would silently run a wave-branch deploy's
+      # verify against main's revision. Same fix as verify-stg above.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Wait briefly for services to settle
         run: sleep 10
 
+      # Hostname defaults reflect TODAY's prod Caddy (caddy/Caddyfile:18 —
+      # `isnad-graph.noorinalabs.com`). User-service routes are wrapped
+      # in the same site block via Caddy `handle /auth/*`, `/api/v1/users`,
+      # etc., so USER_SERVICE_BASE_URL points at the same host today.
+      # When deploy#156 lands (cutover to `isnad.noorinalabs.com` +
+      # `users.noorinalabs.com`), update these defaults in that PR's diff.
+      # See deploy#181 review (Weronika).
       - name: Run prod smoke battery
         env:
-          ISNAD_BASE_URL: https://isnad.noorinalabs.com
-          USER_SERVICE_BASE_URL: https://users.noorinalabs.com
+          ISNAD_BASE_URL: https://isnad-graph.noorinalabs.com
+          USER_SERVICE_BASE_URL: https://isnad-graph.noorinalabs.com
           LANDING_BASE_URL: https://noorinalabs.com
           SMOKE_REPORT: smoke-report.md
         run: |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -266,14 +266,16 @@ artifact (schema: `{result, commit_sha, timestamp, run_id}`) consumed by
 ### Prod verify — smoke battery (<60s)
 
 Job: `verify-prod`. Runs `scripts/verify_prod_smoke.sh` against the live
-prod URLs. Checks:
+prod URLs. Defaults reflect today's prod Caddy
+(`isnad-graph.noorinalabs.com` per `caddy/Caddyfile:18`); will be updated
+to `isnad.*` / `users.*` when the deploy#156 cutover lands. Checks:
 
-1. `isnad.noorinalabs.com/health` — HTTP 200, JSON `.status`
-2. `isnad.noorinalabs.com/api/v1/user-service/health` — HTTP 200 (Caddy rewrite)
+1. `isnad-graph.noorinalabs.com/health` — HTTP 200, JSON `.status`
+2. `isnad-graph.noorinalabs.com/api/v1/user-service/health` — HTTP 200 (Caddy rewrite)
 3. `noorinalabs.com/` — HTTP 200 (landing)
-4. `isnad.noorinalabs.com/api/v1/narrators?limit=1` — HTTP 401 + JSON-shaped body (proves user-service answers, not Caddy bypass)
-5. `isnad.noorinalabs.com/.well-known/jwks.json` — HTTP 200 with `.keys[]` populated
-6. `isnad.noorinalabs.com/auth/login` — HTTP 3xx redirect to OAuth provider (route reachability only — no creds in prod)
+4. `isnad-graph.noorinalabs.com/api/v1/narrators?limit=1` — HTTP 401 + JSON-shaped body (proves user-service answers, not Caddy bypass)
+5. `isnad-graph.noorinalabs.com/.well-known/jwks.json` — HTTP 200 with `.keys[]` populated
+6. `isnad-graph.noorinalabs.com/auth/login` — HTTP 3xx redirect to OAuth provider (route reachability only — no creds in prod)
 
 Failure semantics: emits `::error::` annotation. There is no auto-rollback
 (no rollback policy currently defined; owner investigates).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,7 +85,7 @@ All workflows support `workflow_dispatch` for manual triggering via the GitHub A
 |----------|---------|------------|
 | `deploy-isnad-graph.yml` | Deploy isnad-graph services | `image_tag` (default: `latest`) |
 | `deploy-all.yml` | Full-stack deploy (all 13 services) | `isnad_image_tag` (default: `latest`) |
-| `verify-deploy.yml` | Run verification checks | (none) |
+| `verify-deploy.yml` | Run verification checks (split: stg full integration suite + prod smoke battery) | `target` (`stg` or `prod`) |
 | `rollback.yml` | Roll back to a previous image | `image_tag` (required), `service` (all/api/frontend) |
 
 All deploy and rollback workflows share a concurrency group (`deploy-production`) that limits to one deployment at a time without cancelling in-progress runs.
@@ -242,20 +242,51 @@ Caddy automatically obtains and renews certificates via ACME (Let's Encrypt).
 
 ## Post-Deployment Verification
 
-The `verify-deploy.yml` workflow runs automatically after a successful deploy (via `workflow_run` trigger) and can also be triggered manually.
+The `verify-deploy.yml` workflow runs automatically after a successful deploy (via `workflow_run` trigger on `Deploy to staging` and `Deploy to production`) and can also be triggered manually with a `target` input (`stg` or `prod`).
 
-Verification is performed by `scripts/verify_deployment.sh`, which checks:
+Verification is **split by environment** (deploy#87):
 
-1. **Live site reachability** — HTTP 200 from the root URL
-2. **API health endpoint** — `/health` or `/api/v1/health` returns a healthy status
-3. **API status endpoint** — `/status` reports operational state
-4. **Endpoint smoke tests** — requests to `/api/v1/narrators`, `/api/v1/hadiths`, `/api/v1/collections`, `/api/v1/search`, `/api/v1/parallels`, `/api/v1/timeline` (expects 200, 401, or 403)
-5. **Security headers** — validates all six required headers are present
-6. **Caddy config verification** — confirms security headers originate from Caddy
-7. **SSL certificate** — checks validity period and subject match
-8. **Response time** — health endpoint must respond within 500ms (warning) / 2000ms (failure)
+### Stg verify — full integration suite
 
-Results are uploaded as a GitHub Actions artifact and written to the job summary.
+Job: `verify-stg`. Runs the full cross-repo integration suite in
+`integration-tests/run-tests.sh` (delivered in deploy#81). Hermetic — spins
+up its own docker-compose stack from sibling-repo checkouts of
+`noorinalabs-user-service` and `noorinalabs-isnad-graph` (wave-aware ref
+resolution). Validates auth flow, RBAC, subscriptions, sessions, 2FA,
+verification flow, network isolation, and performance baselines.
+
+Failure semantics: blocking gate. Emits a `stg-verify-result-{run_id}.json`
+artifact (schema: `{result, commit_sha, timestamp, run_id}`) consumed by
+`promote.yml`'s prod-promote gate (deploy#179, follow-up).
+
+> Limitation: today's stg verify validates "the code on the wave branch
+> passes integration", not "the bits actually running on the stg VPS pass
+> integration". Remote-mode against live stg URLs is tracked in deploy#178.
+
+### Prod verify — smoke battery (<60s)
+
+Job: `verify-prod`. Runs `scripts/verify_prod_smoke.sh` against the live
+prod URLs. Checks:
+
+1. `isnad.noorinalabs.com/health` — HTTP 200, JSON `.status`
+2. `isnad.noorinalabs.com/api/v1/user-service/health` — HTTP 200 (Caddy rewrite)
+3. `noorinalabs.com/` — HTTP 200 (landing)
+4. `isnad.noorinalabs.com/api/v1/narrators?limit=1` — HTTP 401 + JSON-shaped body (proves user-service answers, not Caddy bypass)
+5. `isnad.noorinalabs.com/.well-known/jwks.json` — HTTP 200 with `.keys[]` populated
+6. `isnad.noorinalabs.com/auth/login` — HTTP 3xx redirect to OAuth provider (route reachability only — no creds in prod)
+
+Failure semantics: emits `::error::` annotation. There is no auto-rollback
+(no rollback policy currently defined; owner investigates).
+
+### Legacy / manual verification
+
+`scripts/verify_deployment.sh` is retained for manual operator use against
+arbitrary environments (notably by `docs/runbooks/user-service-migration.md`)
+and is intentionally NOT invoked by CI anymore. It is the broader
+verification script that pre-dates the env split.
+
+Results from both jobs are uploaded as GitHub Actions artifacts and
+written to the job summary.
 
 ## Rollback
 

--- a/docs/runbooks/deploy-isnad-graph.md
+++ b/docs/runbooks/deploy-isnad-graph.md
@@ -51,18 +51,32 @@ To deploy all 13 services (including infrastructure):
 
 ## Post-Deployment Verification
 
-The `verify-deploy.yml` workflow runs automatically. To run manually:
+`verify-deploy.yml` is split by environment (deploy#87) and runs
+automatically after a successful deploy:
+
+- **Stg deploy** → `verify-stg` job runs the full cross-repo integration
+  suite (`integration-tests/run-tests.sh`). Failure blocks prod-promote
+  (gate enforcement: deploy#179, follow-up).
+- **Prod deploy** → `verify-prod` job runs `scripts/verify_prod_smoke.sh`
+  (<60s smoke battery: health 200s, narrator query, JWKS, auth wiring).
+  Failure surfaces a `::error::` annotation; no auto-rollback.
+
+To run manually:
 
 1. Go to [Actions > Verify Deployment](https://github.com/noorinalabs/noorinalabs-deploy/actions/workflows/verify-deploy.yml)
-2. Click **Run workflow**
+2. Click **Run workflow**, select `target` (`stg` or `prod`)
 
-Or run the script directly on any machine with network access:
+For broader manual verification against an arbitrary env (legacy/operator
+script, not invoked by CI anymore — used by the user-service migration
+runbook):
 
 ```bash
 SITE_URL=https://isnad-graph.noorinalabs.com ./scripts/verify_deployment.sh --skip-workflow
 ```
 
-The script checks: site reachability (HTTP 200), API health endpoint, API status, endpoint smoke tests, security headers, Caddy config, SSL certificate, and response time.
+This broader script checks: site reachability (HTTP 200), API health
+endpoint, API status, endpoint smoke tests, security headers, Caddy
+config, SSL certificate, and response time.
 
 ## Rollback
 

--- a/scripts/verify_deployment.sh
+++ b/scripts/verify_deployment.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
-# verify_deployment.sh — Production deployment verification for noorinalabs-isnad-graph
+# verify_deployment.sh — Generic deployment verification (legacy / manual).
 # Checks deploy workflow, live site, API health, security headers, and SSL.
+#
+# Note (deploy#87): Post-deploy verification in CI is now split by env:
+#   - Stg verify (full integration suite) lives in `verify-deploy.yml`'s
+#     `verify-stg` job and runs `integration-tests/run-tests.sh`.
+#   - Prod verify (smoke battery, <60s) lives in `verify-deploy.yml`'s
+#     `verify-prod` job and runs `scripts/verify_prod_smoke.sh`.
+# This script is retained for manual/operator use against arbitrary
+# environments (used by `docs/runbooks/user-service-migration.md`) and is
+# intentionally NOT invoked by `verify-deploy.yml` anymore.
 #
 # Usage:
 #   ./scripts/verify_deployment.sh [--site URL] [--skip-workflow] [--skip-ssl]

--- a/scripts/verify_prod_smoke.sh
+++ b/scripts/verify_prod_smoke.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# verify_prod_smoke.sh — Prod post-deploy smoke battery (<60s budget).
+#
+# Runs a tight set of route-reachability checks against the prod URLs.
+# By design this script does NOT mint real auth tokens (no test creds in
+# prod, per Bereket sign-off in deploy#87). The full login+refresh flow
+# is exercised by the integration suite pre-deploy (see verify-stg).
+#
+# Checks:
+#   1. isnad-graph /health    → HTTP 200, JSON .status in {healthy,degraded,ok}
+#   2. user-service /health   → HTTP 200 (via Caddy /api/v1/user-service/health)
+#   3. landing /              → HTTP 200
+#   4. /api/v1/narrators?limit=1 → HTTP 401 + JSON-shaped body (proves
+#                                  user-service auth is in the path, not
+#                                  Caddy bypass returning plaintext)
+#   5. /.well-known/jwks.json → HTTP 200 + valid JWKS shape (.keys[])
+#   6. /auth/login            → HTTP 3xx redirect to OAuth provider
+#                                (proves user-service auth wiring alive)
+#
+# Env:
+#   ISNAD_BASE_URL          (default: https://isnad.noorinalabs.com)
+#   USER_SERVICE_BASE_URL   (default: https://users.noorinalabs.com — currently
+#                            unused; user-service is reached via Caddy on
+#                            ISNAD_BASE_URL today, but kept for forward
+#                            compat with subdomain-split topology)
+#   LANDING_BASE_URL        (default: https://noorinalabs.com)
+#   SMOKE_REPORT            Path to write GH-summary-formatted markdown
+#                           (default: smoke-report.md)
+#   TIMEOUT                 Per-check curl timeout, seconds (default: 5)
+
+set -euo pipefail
+
+ISNAD_BASE_URL="${ISNAD_BASE_URL:-https://isnad.noorinalabs.com}"
+USER_SERVICE_BASE_URL="${USER_SERVICE_BASE_URL:-https://users.noorinalabs.com}"
+LANDING_BASE_URL="${LANDING_BASE_URL:-https://noorinalabs.com}"
+SMOKE_REPORT="${SMOKE_REPORT:-smoke-report.md}"
+TIMEOUT="${TIMEOUT:-5}"
+
+# Result tracking ----------------------------------------------------
+PASS=0
+FAIL=0
+ROWS=()           # markdown table rows
+START_NS="$(date +%s%N)"
+
+record() {
+  # record <name> <pass|fail> <time_ms> <detail>
+  local name="$1" status="$2" time_ms="$3" detail="$4"
+  if [ "$status" = "pass" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS [${time_ms}ms]: $name — $detail"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL [${time_ms}ms]: $name — $detail"
+  fi
+  ROWS+=("| $name | ${status^^} | ${time_ms}ms | $detail |")
+}
+
+SMOKE_BODY="/tmp/smoke_body.$$"
+trap 'rm -f "$SMOKE_BODY"' EXIT
+
+# http_check <url> → "<http_code> <time_total_seconds>" on stdout,
+# response body written to $SMOKE_BODY.
+http_check() {
+  curl -sS -o "$SMOKE_BODY" \
+       -w '%{http_code} %{time_total}' \
+       --max-time "$TIMEOUT" \
+       "$1" 2>/dev/null || echo "000 0"
+}
+
+read_body() {
+  cat "$SMOKE_BODY" 2>/dev/null || echo ""
+}
+
+ms_from_secs() {
+  awk -v t="$1" 'BEGIN { printf("%d", t * 1000) }'
+}
+
+# --- 1. isnad-graph /health -----------------------------------------
+{
+  read -r code secs <<<"$(http_check "${ISNAD_BASE_URL}/health")"
+  body="$(read_body)"
+  ms="$(ms_from_secs "$secs")"
+  if [ "$code" = "200" ]; then
+    if echo "$body" | jq -e '.status' >/dev/null 2>&1; then
+      st="$(echo "$body" | jq -r '.status')"
+      case "$st" in
+        healthy|degraded|ok) record "isnad /health" pass "$ms" "status=$st" ;;
+        *)                   record "isnad /health" fail "$ms" "unexpected status=$st" ;;
+      esac
+    else
+      # Caddy could in principle return 200 with non-JSON; treat as fail
+      # because the API is supposed to answer here.
+      record "isnad /health" fail "$ms" "HTTP 200 but body is not JSON-shaped"
+    fi
+  else
+    record "isnad /health" fail "$ms" "HTTP $code (expected 200)"
+  fi
+}
+
+# --- 2. user-service /health (via Caddy rewrite) --------------------
+{
+  read -r code secs <<<"$(http_check "${ISNAD_BASE_URL}/api/v1/user-service/health")"
+  ms="$(ms_from_secs "$secs")"
+  if [ "$code" = "200" ]; then
+    record "user-service /health" pass "$ms" "HTTP 200 via Caddy rewrite"
+  else
+    record "user-service /health" fail "$ms" "HTTP $code (expected 200)"
+  fi
+}
+
+# --- 3. landing root ------------------------------------------------
+{
+  read -r code secs <<<"$(http_check "${LANDING_BASE_URL}/")"
+  ms="$(ms_from_secs "$secs")"
+  if [ "$code" = "200" ]; then
+    record "landing /" pass "$ms" "HTTP 200"
+  else
+    record "landing /" fail "$ms" "HTTP $code (expected 200)"
+  fi
+}
+
+# --- 4. narrator query (expect 401 + JSON body) ---------------------
+# The JSON-shape check matters: a misconfigured Caddy returning plaintext
+# "401 Unauthorized" from the proxy itself would still pass an HTTP-only
+# check but means user-service is not actually responding (Bereket note).
+{
+  read -r code secs <<<"$(http_check "${ISNAD_BASE_URL}/api/v1/narrators?limit=1")"
+  body="$(read_body)"
+  ms="$(ms_from_secs "$secs")"
+  if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+    if echo "$body" | jq -e '.detail or .error or .message' >/dev/null 2>&1; then
+      record "narrator /api/v1/narrators" pass "$ms" "HTTP $code + JSON body (auth path live)"
+    else
+      record "narrator /api/v1/narrators" fail "$ms" "HTTP $code but body is not JSON — proxy may be answering instead of API"
+    fi
+  else
+    record "narrator /api/v1/narrators" fail "$ms" "HTTP $code (expected 401/403 unauth)"
+  fi
+}
+
+# --- 5. JWKS endpoint -----------------------------------------------
+{
+  read -r code secs <<<"$(http_check "${ISNAD_BASE_URL}/.well-known/jwks.json")"
+  body="$(read_body)"
+  ms="$(ms_from_secs "$secs")"
+  if [ "$code" = "200" ] && echo "$body" | jq -e '.keys | length > 0' >/dev/null 2>&1; then
+    nkeys="$(echo "$body" | jq -r '.keys | length')"
+    record "jwks.json" pass "$ms" "HTTP 200, $nkeys key(s)"
+  elif [ "$code" = "200" ]; then
+    record "jwks.json" fail "$ms" "HTTP 200 but missing/empty .keys array"
+  else
+    record "jwks.json" fail "$ms" "HTTP $code (expected 200)"
+  fi
+}
+
+# --- 6. /auth/login (expect 3xx → OAuth provider) -------------------
+# We use -o /dev/null and inspect Location via a separate -I pass to keep
+# the body tiny but still see the redirect target.
+{
+  # First: status code only (no follow)
+  read -r code secs <<<"$(http_check "${ISNAD_BASE_URL}/auth/login")"
+  ms="$(ms_from_secs "$secs")"
+  # Then: grab Location header (separate call; cheap, still under budget)
+  loc="$(curl -sSI --max-time "$TIMEOUT" "${ISNAD_BASE_URL}/auth/login" 2>/dev/null \
+          | grep -i '^location:' | head -1 | sed 's/^[Ll]ocation:[[:space:]]*//' | tr -d '\r' || true)"
+  case "$code" in
+    301|302|303|307|308)
+      if [ -n "$loc" ] && echo "$loc" | grep -qiE 'google|github|accounts\.google|github\.com/login'; then
+        # Mask the redirect target for log hygiene (state/nonce in query)
+        host="$(echo "$loc" | sed -E 's|^https?://([^/]+).*|\1|')"
+        record "/auth/login wiring" pass "$ms" "HTTP $code → OAuth provider ($host)"
+      elif [ -n "$loc" ]; then
+        record "/auth/login wiring" pass "$ms" "HTTP $code → $(echo "$loc" | sed -E 's|^(https?://[^/]+).*|\1|') (non-canonical OAuth host)"
+      else
+        record "/auth/login wiring" fail "$ms" "HTTP $code but no Location header"
+      fi
+      ;;
+    200)
+      # Some OAuth flows render an interstitial page instead of redirect.
+      # Treat as pass only if body looks HTML-ish (route is alive).
+      record "/auth/login wiring" pass "$ms" "HTTP 200 (route alive, non-redirect handler)"
+      ;;
+    *)
+      record "/auth/login wiring" fail "$ms" "HTTP $code (expected 3xx or 200)"
+      ;;
+  esac
+}
+
+# --- Summary --------------------------------------------------------
+END_NS="$(date +%s%N)"
+TOTAL_MS=$(( (END_NS - START_NS) / 1000000 ))
+TOTAL=$((PASS + FAIL))
+
+echo ""
+echo "==> Prod smoke summary: $PASS/$TOTAL passed, total ${TOTAL_MS}ms"
+
+# Markdown report for $GITHUB_STEP_SUMMARY
+{
+  echo "## Prod Smoke Results"
+  echo ""
+  echo "| Check | Result | Time | Detail |"
+  echo "|-------|--------|------|--------|"
+  for row in "${ROWS[@]}"; do
+    echo "$row"
+  done
+  echo ""
+  echo "**Totals:** ${PASS}/${TOTAL} passed — total runtime **${TOTAL_MS}ms** (budget: <60000ms)"
+  if [ "$TOTAL_MS" -gt 60000 ]; then
+    echo ""
+    echo "> WARNING: total runtime exceeded the 60s budget defined in deploy#87."
+  fi
+} > "$SMOKE_REPORT"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo "RESULT: FAILED — $FAIL/$TOTAL checks did not pass"
+  exit 1
+fi
+
+echo "RESULT: ALL SMOKE CHECKS PASSED"
+exit 0

--- a/scripts/verify_prod_smoke.sh
+++ b/scripts/verify_prod_smoke.sh
@@ -17,12 +17,14 @@
 #   6. /auth/login            → HTTP 3xx redirect to OAuth provider
 #                                (proves user-service auth wiring alive)
 #
-# Env:
-#   ISNAD_BASE_URL          (default: https://isnad.noorinalabs.com)
-#   USER_SERVICE_BASE_URL   (default: https://users.noorinalabs.com — currently
-#                            unused; user-service is reached via Caddy on
-#                            ISNAD_BASE_URL today, but kept for forward
-#                            compat with subdomain-split topology)
+# Env (defaults reflect TODAY's prod Caddy — caddy/Caddyfile:18 serves
+# `isnad-graph.noorinalabs.com` and routes user-service traffic in the
+# same site block. When deploy#156 lands, update defaults to
+# `isnad.noorinalabs.com` + `users.noorinalabs.com`):
+#   ISNAD_BASE_URL          (default: https://isnad-graph.noorinalabs.com)
+#   USER_SERVICE_BASE_URL   (default: https://isnad-graph.noorinalabs.com —
+#                            same host as ISNAD_BASE_URL today; cleaves
+#                            into a separate subdomain at #156)
 #   LANDING_BASE_URL        (default: https://noorinalabs.com)
 #   SMOKE_REPORT            Path to write GH-summary-formatted markdown
 #                           (default: smoke-report.md)
@@ -30,8 +32,8 @@
 
 set -euo pipefail
 
-ISNAD_BASE_URL="${ISNAD_BASE_URL:-https://isnad.noorinalabs.com}"
-USER_SERVICE_BASE_URL="${USER_SERVICE_BASE_URL:-https://users.noorinalabs.com}"
+ISNAD_BASE_URL="${ISNAD_BASE_URL:-https://isnad-graph.noorinalabs.com}"
+USER_SERVICE_BASE_URL="${USER_SERVICE_BASE_URL:-https://isnad-graph.noorinalabs.com}"
 LANDING_BASE_URL="${LANDING_BASE_URL:-https://noorinalabs.com}"
 SMOKE_REPORT="${SMOKE_REPORT:-smoke-report.md}"
 TIMEOUT="${TIMEOUT:-5}"


### PR DESCRIPTION
Closes #87

## Summary

Splits `verify-deploy.yml` into two jobs with different runtime budgets and failure semantics:

- **`verify-stg`** — runs the full cross-repo integration suite from `integration-tests/run-tests.sh` (deploy#81) on every successful stg deploy. Hermetic Option A per Bereket sign-off (remote-mode against live stg URLs is tracked as a follow-up in deploy#178). Emits a `stg-verify-result-{run_id}.json` artifact (schema v1) for the future promote.yml gate (deploy#179).
- **`verify-prod`** — runs the new `scripts/verify_prod_smoke.sh` (<60s budget) on every successful prod deploy. Six checks: `/health`, user-service `/health` via Caddy rewrite, landing root, narrator query (expects 401 + JSON body — proves user-service answers, not Caddy bypass), JWKS, and `/auth/login` redirect to OAuth provider. **No prod creds** in the smoke (per Bereket sign-off, 3a not 3b).

Both jobs surface results in `$GITHUB_STEP_SUMMARY` (markdown table for prod, junit-derived counts for stg) using the SC2129-clean group-command form. Stg failure runs a `notify-stg-failure` job; prod failure surfaces `::error::` (no auto-rollback policy currently exists).

## Why this is in scope (trigger repoint)

The previous `verify-deploy.yml` watched `workflows: ["Deploy noorinalabs-isnad-graph"]`, which is the **LEGACY** workflow (`deploy-isnad-graph.yml` line 1: `name: Deploy noorinalabs-isnad-graph (LEGACY — manual only)`). Active deploys are `Deploy to staging` and `Deploy to production` — repointed in this PR.

The literal split-by-env scope of #87 is unimplementable without this repoint: the trigger today fires on a workflow nobody runs in normal flow. Bereket signed off on folding the repoint into #87 rather than spinning a separate follow-up (would have created an artificial sequencing constraint and two broken intermediate states).

## Design decisions

- **Separate jobs, not `matrix.env`** — different upstream `workflow_run.workflows` triggers, different runtime budgets, different `environment:` scopes, different failure semantics; matrix would conflate them.
- **Wave-aware sibling ref resolution** — `verify-stg` mirrors the pattern from `integration-tests.yml` so a wave-branch deploy verifies against matching wave branches of `noorinalabs-user-service` and `noorinalabs-isnad-graph`. Falls back to `main` for non-wave bases.
- **JSON-shape check on the narrator 401** — Bereket flagged a Caddy-misconfig failure mode where the proxy itself returns plaintext "401 Unauthorized" while user-service is actually down. The `jq -e '.detail or .error or .message'` guard catches this.
- **Artifact filename includes run_id + schema_version** — `stg-verify-result-{run_id}.json` so deploy#179's promote.yml gate can validate freshness, not just presence; `schema_version: 1` allows graceful evolution of the JSON shape.
- **`scripts/verify_deployment.sh` retained, not deleted** — it's still referenced by `docs/runbooks/user-service-migration.md:262` for manual operator use against arbitrary envs. Header comment updated to point at the new env-split workflow.

## Review iteration

### Weronika-Rev-181 (commit `c0b65e2` → rebased to `1faacef`)

Three blockers, all verified independently before applying. Additive (no force-push, per #176 review pattern):

1. **Prod hostname defaults** — pointed at post-cutover targets (`isnad.noorinalabs.com` / `users.noorinalabs.com`) but `caddy/Caddyfile:18` still serves `isnad-graph.noorinalabs.com` (deploy#156 cutover OPEN). As shipped, every `verify-prod` run would 404. Now defaults to today's canonical host; user-service routes share the same site block via Caddy `handle /auth/*`, `/api/v1/users`, etc. Header comment notes the post-#156 update needed (one-line flip in #156's diff).
2. **`actions/checkout@v4` ref pin** — without `ref:`, defaults to the default branch on `workflow_run` triggers. Wave-branch deploys would silently verify against main's revision. Both verify-stg and verify-prod checkouts now pin to `github.event.workflow_run.head_sha` (sha is more stable than `head_branch` — branch may have moved between trigger and run).
3. **`verify-stg` missing `environment: staging`** — file's own header at line 19 cited "Different `environment:` scopes" as a split rationale, contradicting itself. Added; pre-stages future deploy#178 remote-mode work that needs env-scoped vars.

### Nurul-Rev-181 (commit `3c7ee55` → rebased to `65016af`)

Two nits, additive:

1. **Duplicate `--junit-xml` flag** — workflow passed `--junit-xml=reports/junit.xml` to `run-tests.sh`, which already passes `--junit-xml=/app/reports/junit.xml` to pytest internally (line 92). Latter-wins worked by accident with WORKDIR=/app + the ./reports mount but is brittle to refactor. Dropped from the workflow; script owns the flag.
2. **Artifact `schema_version: 1`** — added to the `stg-verify-result-{run_id}.json` JSON for forward-compat. The future deploy#179 promote-gate consumer can validate `schema_version == 1` and either reject or upgrade-handle anything else. Posted the refined schema spec on #179 (issuecomment-4332139375).

Nurul's same-class hostname corollary on `USER_SERVICE_BASE_URL` was already covered by `c0b65e2`/`1faacef`.

### Wave-10 rebase (Lucas + Nurul both Approved-v2)

`#176` (compose-validate paths + actionlint workflow lint, sha `524befd`) merged to wave-10 between v2 approval and merge. `#176` included an SC2129 fix in the old `verify-deploy.yml` (group-command coalescing of multi-`>>` writers). My full rewrite is SC2129-clean by construction — every summary writer in the new file already uses the `{ ...; } >> "$GITHUB_STEP_SUMMARY"` form (lines 101, 201, 217, 271, 288).

Conflict was textual only (#176 patched a region my rewrite removed). Resolved via `git checkout --theirs` for `verify-deploy.yml` (rebase semantics: theirs = the commit being applied = my version). No substantive change vs the v2-approved content. Branch identity preserved across rebase via per-commit `-c user.name`/`-c user.email`. New SHAs: `53781dc` / `1faacef` / `65016af`.

## Files changed

- `.github/workflows/verify-deploy.yml` — rewrite (split jobs, trigger fix) + Weronika fixes + Nurul nits; SC2129-clean
- `scripts/verify_prod_smoke.sh` — new (lean, <60s); hostname defaults updated
- `scripts/verify_deployment.sh` — header comment only
- `docs/architecture.md` — documents the split; URL examples reflect today's host
- `docs/runbooks/deploy-isnad-graph.md` — same

## Follow-ups (filed during design review)

- **deploy#178** — `feat: integration-tests remote-mode for post-deploy validation against live stg URLs` (real stg-URL validation; deferred per #87's "Out of scope: rebuilding the integration suite")
- **deploy#179** — `feat: promote.yml gates prod-promote on latest stg verify-deploy success` (consumes the schema-v1 `stg-verify-result` artifact this PR emits)
- **deploy#183** — `tech-debt(observability): add blackbox-exporter for continuous prod-route probes` (Nurul-filed; continuous monitoring, separate from #87's per-deploy verify scope)

## Test plan

- [ ] CI green on this PR's compose-validate / actionlint workflows (now active post-#176 — both gates fire on this PR)
- [ ] After merge, manually dispatch `verify-deploy.yml` with `target=prod` against current prod and confirm <60s runtime + all 6 checks pass against `isnad-graph.noorinalabs.com`
- [ ] After next stg deploy, confirm `verify-stg` job auto-fires via `workflow_run`, completes the integration suite, uploads the `stg-verify-result` artifact with schema v1, and pinned the correct `head_sha`

## Risk / blast radius

- Worst-case smoke false negative: `/auth/login` Location host check is OAuth-provider-specific (Google/GitHub). If a non-canonical OAuth host is configured, the check still passes with a "non-canonical OAuth host" note rather than failing.
- Worst-case stg false negative: hermetic suite passes against wave code but real stg VPS is broken — captured in deploy#178 follow-up.
- Hostname defaults will need a one-line flip when deploy#156 lands; that change owner is the #156 author and the post-#156 update is documented in both the workflow and the smoke script.
