### PR TITLE
infra(secrets): provision BACKUP_B2_* end-to-end (closes #188)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -134,6 +134,13 @@ jobs:
           PIPELINE_B2_KEY: ${{ secrets.PIPELINE_B2_KEY }}
           PIPELINE_B2_KEY_ID: ${{ secrets.PIPELINE_B2_KEY_ID }}
           PIPELINE_B2_REGION: ${{ secrets.PIPELINE_B2_REGION }}
+          # Backup-scope B2 creds (deploy#188). Distinct from PIPELINE_B2_*
+          # (ingest scope) and TF_STATE_B2_* (terraform backend). Renamed to
+          # bare B2_* in the .env-write block below to match scripts/backup.sh
+          # consumer-side names. Cutover-gate (main#212) dependency.
+          BACKUP_B2_KEY_ID: ${{ secrets.BACKUP_B2_KEY_ID }}
+          BACKUP_B2_APP_KEY: ${{ secrets.BACKUP_B2_APP_KEY }}
+          BACKUP_B2_BUCKET: ${{ secrets.BACKUP_B2_BUCKET }}
           USER_POSTGRES_DB: ${{ secrets.USER_POSTGRES_DB }}
           USER_POSTGRES_PASSWORD: ${{ secrets.USER_POSTGRES_PASSWORD }}
           USER_POSTGRES_USER: ${{ secrets.USER_POSTGRES_USER }}
@@ -142,7 +149,7 @@ jobs:
           host: ${{ vars.VPS_HOST }}
           username: deploy
           key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
-          envs: NEO4J_PASSWORD,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,REDIS_PASSWORD,AUTH_GOOGLE_CLIENT_ID,AUTH_GOOGLE_CLIENT_SECRET,AUTH_GITHUB_CLIENT_ID,AUTH_GITHUB_CLIENT_SECRET,GRAFANA_ADMIN_PASSWORD,JWT_PRIVATE_KEY,JWT_PUBLIC_KEY,KAFKA_CLUSTER_ID,KAFKA_UI_PASSWORD,KAFKA_UI_USER,IMAGE_TAG,USER_SERVICE_IMAGE_TAG,LANDING_IMAGE_TAG,PIPELINE_B2_BUCKET,PIPELINE_B2_ENDPOINT,PIPELINE_B2_KEY,PIPELINE_B2_KEY_ID,PIPELINE_B2_REGION,USER_POSTGRES_DB,USER_POSTGRES_PASSWORD,USER_POSTGRES_USER,USER_REDIS_PASSWORD,GITHUB_TOKEN,GITHUB_ACTOR
+          envs: NEO4J_PASSWORD,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,REDIS_PASSWORD,AUTH_GOOGLE_CLIENT_ID,AUTH_GOOGLE_CLIENT_SECRET,AUTH_GITHUB_CLIENT_ID,AUTH_GITHUB_CLIENT_SECRET,GRAFANA_ADMIN_PASSWORD,JWT_PRIVATE_KEY,JWT_PUBLIC_KEY,KAFKA_CLUSTER_ID,KAFKA_UI_PASSWORD,KAFKA_UI_USER,IMAGE_TAG,USER_SERVICE_IMAGE_TAG,LANDING_IMAGE_TAG,PIPELINE_B2_BUCKET,PIPELINE_B2_ENDPOINT,PIPELINE_B2_KEY,PIPELINE_B2_KEY_ID,PIPELINE_B2_REGION,BACKUP_B2_KEY_ID,BACKUP_B2_APP_KEY,BACKUP_B2_BUCKET,USER_POSTGRES_DB,USER_POSTGRES_PASSWORD,USER_POSTGRES_USER,USER_REDIS_PASSWORD,GITHUB_TOKEN,GITHUB_ACTOR
           script: |
             set -euo pipefail
             cd /opt/noorinalabs-deploy
@@ -173,6 +180,13 @@ jobs:
             printf "%s='%s'\n" "IMAGE_TAG" "${IMAGE_TAG}" >> "$env_file"
             printf "%s='%s'\n" "USER_SERVICE_IMAGE_TAG" "${USER_SERVICE_IMAGE_TAG}" >> "$env_file"
             printf "%s='%s'\n" "LANDING_IMAGE_TAG" "${LANDING_IMAGE_TAG}" >> "$env_file"
+            # Backup B2 creds (deploy#188): rename BACKUP_B2_* secrets to the
+            # bare B2_* names that scripts/backup.sh:59-61 expects. Empty values
+            # are written as empty so backup.sh fails fast at preflight rather
+            # than partially-running with stale or wrong creds.
+            printf "%s='%s'\n" "B2_KEY_ID" "${BACKUP_B2_KEY_ID:-}" >> "$env_file"
+            printf "%s='%s'\n" "B2_APP_KEY" "${BACKUP_B2_APP_KEY:-}" >> "$env_file"
+            printf "%s='%s'\n" "B2_BUCKET" "${BACKUP_B2_BUCKET:-}" >> "$env_file"
             chmod 600 "$env_file"
 
             echo "==> Authenticating to GHCR..."

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -95,6 +95,13 @@ jobs:
           PIPELINE_B2_KEY: ${{ secrets.PIPELINE_B2_KEY }}
           PIPELINE_B2_KEY_ID: ${{ secrets.PIPELINE_B2_KEY_ID }}
           PIPELINE_B2_REGION: ${{ secrets.PIPELINE_B2_REGION }}
+          # Backup-scope B2 creds (deploy#188). Distinct from PIPELINE_B2_*
+          # (ingest scope) and TF_STATE_B2_* (terraform backend). Renamed to
+          # bare B2_* in the .env-write block below to match scripts/backup.sh
+          # consumer-side names.
+          BACKUP_B2_KEY_ID: ${{ secrets.BACKUP_B2_KEY_ID }}
+          BACKUP_B2_APP_KEY: ${{ secrets.BACKUP_B2_APP_KEY }}
+          BACKUP_B2_BUCKET: ${{ secrets.BACKUP_B2_BUCKET }}
           USER_POSTGRES_DB: ${{ secrets.USER_POSTGRES_DB }}
           USER_POSTGRES_PASSWORD: ${{ secrets.USER_POSTGRES_PASSWORD }}
           USER_POSTGRES_USER: ${{ secrets.USER_POSTGRES_USER }}
@@ -103,7 +110,7 @@ jobs:
           host: ${{ vars.VPS_HOST }}
           username: deploy
           key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
-          envs: NEO4J_PASSWORD,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,REDIS_PASSWORD,AUTH_GOOGLE_CLIENT_ID,AUTH_GOOGLE_CLIENT_SECRET,AUTH_GITHUB_CLIENT_ID,AUTH_GITHUB_CLIENT_SECRET,GRAFANA_ADMIN_PASSWORD,JWT_PRIVATE_KEY,JWT_PUBLIC_KEY,KAFKA_CLUSTER_ID,KAFKA_UI_PASSWORD,KAFKA_UI_USER,IMAGE_TAG,PIPELINE_B2_BUCKET,PIPELINE_B2_ENDPOINT,PIPELINE_B2_KEY,PIPELINE_B2_KEY_ID,PIPELINE_B2_REGION,USER_POSTGRES_DB,USER_POSTGRES_PASSWORD,USER_POSTGRES_USER,USER_REDIS_PASSWORD,GITHUB_TOKEN,GITHUB_ACTOR
+          envs: NEO4J_PASSWORD,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,REDIS_PASSWORD,AUTH_GOOGLE_CLIENT_ID,AUTH_GOOGLE_CLIENT_SECRET,AUTH_GITHUB_CLIENT_ID,AUTH_GITHUB_CLIENT_SECRET,GRAFANA_ADMIN_PASSWORD,JWT_PRIVATE_KEY,JWT_PUBLIC_KEY,KAFKA_CLUSTER_ID,KAFKA_UI_PASSWORD,KAFKA_UI_USER,IMAGE_TAG,PIPELINE_B2_BUCKET,PIPELINE_B2_ENDPOINT,PIPELINE_B2_KEY,PIPELINE_B2_KEY_ID,PIPELINE_B2_REGION,BACKUP_B2_KEY_ID,BACKUP_B2_APP_KEY,BACKUP_B2_BUCKET,USER_POSTGRES_DB,USER_POSTGRES_PASSWORD,USER_POSTGRES_USER,USER_REDIS_PASSWORD,GITHUB_TOKEN,GITHUB_ACTOR
           script: |
             set -euo pipefail
             cd /opt/noorinalabs-deploy
@@ -129,6 +136,13 @@ jobs:
               printf "%s='%s'\n" "$var" "$val" >> "$env_file"
             done
             printf "%s='%s'\n" "IMAGE_TAG" "${IMAGE_TAG}" >> "$env_file"
+            # Backup B2 creds (deploy#188): rename BACKUP_B2_* secrets to the
+            # bare B2_* names that scripts/backup.sh:59-61 expects. Empty values
+            # are written as empty so backup.sh fails fast at preflight rather
+            # than partially-running with stale or wrong creds.
+            printf "%s='%s'\n" "B2_KEY_ID" "${BACKUP_B2_KEY_ID:-}" >> "$env_file"
+            printf "%s='%s'\n" "B2_APP_KEY" "${BACKUP_B2_APP_KEY:-}" >> "$env_file"
+            printf "%s='%s'\n" "B2_BUCKET" "${BACKUP_B2_BUCKET:-}" >> "$env_file"
             chmod 600 "$env_file"
 
             echo "==> Authenticating to GHCR..."

--- a/scripts/bootstrap-vps.sh
+++ b/scripts/bootstrap-vps.sh
@@ -153,6 +153,16 @@ RATE_LIMIT_WINDOW_SECONDS=60
 DATA_RAW_DIR=./data/raw
 DATA_STAGING_DIR=./data/staging
 DATA_CURATED_DIR=./data/curated
+
+# Backblaze B2 — backup credentials [REQUIRED for backup timer]
+# Consumed by scripts/backup.sh:59-61. Scope: read+write+delete on the
+# isnad-graph-backups bucket only (separate from PIPELINE_B2_* ingest scope
+# and TF_STATE_B2_* terraform backend scope). The deploy-{stg,prod}.yml
+# workflows populate these from BACKUP_B2_* GH secrets; manual operators
+# bootstrapping a new VPS must fill these in by hand. See deploy#188.
+B2_KEY_ID=CHANGE-ME
+B2_APP_KEY=CHANGE-ME
+B2_BUCKET=isnad-graph-backups
 ENVEOF
   chmod 600 "$ENV_FILE"
   chown $DEPLOY_USER:$DEPLOY_USER "$ENV_FILE"


### PR DESCRIPTION
## Summary

`scripts/backup.sh:59-61` hard-requires `B2_KEY_ID`, `B2_APP_KEY`, `B2_BUCKET` from `/opt/noorinalabs-deploy/.env`, but these are **not provisioned anywhere** in the deploy pipeline (verified by Bereket + me across repo-level + env-scoped GH secrets, deploy-{stg,prod}.yml, and bootstrap-vps.sh — the only B2 secrets present are `PIPELINE_B2_*` (ingest scope) and `TF_STATE_B2_*` (terraform backend scope), both wrong scope).

With #187 (deploy#121 unit-mechanic layer) **now merged**, the backup unit will run cleanly on bootstrap — but it dies at `backup.sh:59` preflight on the first cutover-gate fire because no `B2_KEY_ID` is in `.env`. This defeats the [main#212 cutover-gate](https://github.com/noorinalabs/noorinalabs-main/issues/212) ("one successful end-to-end backup within 24h of first compose-up before DNS-flip").

This PR is the **secret-provisioning layer** of the same root-cause that #187 addressed at the unit-mechanic layer. Per `feedback_multi_layer_gap_filing.md`, related-but-orthogonal layers ship as separate issues — surfaced from PR #187's stg validation, filed as deploy#188 by Bereket.

## Changes (Option A from #188)

* **`.github/workflows/deploy-stg.yml`** + **`deploy-prod.yml`**:
  * Add `BACKUP_B2_KEY_ID`, `BACKUP_B2_APP_KEY`, `BACKUP_B2_BUCKET` to the appleboy/ssh-action `env:` block.
  * Append the same three names to the `envs:` whitelist line so the action passes them through SSH.
  * In the `.env`-write shell snippet, **rename** `BACKUP_B2_*` → bare `B2_*` (matching `scripts/backup.sh:59-61` consumer-side names). Empty values are written as empty so `backup.sh` fails loud at preflight rather than partially-running with stale or wrong creds.

* **`scripts/bootstrap-vps.sh`** Step 5 `.env` template heredoc:
  * Adds `B2_KEY_ID=CHANGE-ME`, `B2_APP_KEY=CHANGE-ME`, `B2_BUCKET=isnad-graph-backups`. Manual operators bootstrapping a new VPS now see a placeholder block to fill in. The "skip existing .env" branch above the heredoc is unchanged, so re-bootstrap on a populated box doesn't clobber operator edits. **No conflict with #187's Step 7 systemd-install changes** (rebased cleanly onto `fb8ce80`).

Diff is `+40 / −2` across the three files.

## Critical scope boundary — owner action required

This PR does **NOT** mint the B2 application key or set the GH secrets. That is owner-action (Steven, B2 console + `gh secret set BACKUP_B2_KEY_ID/APP_KEY/BUCKET`). Steven has been notified separately.

End-to-end backup validation (acceptance-criteria items 5 + 6 in #188) is **deferred to post-Steven-secret-mint** per the main#212 cutover-gate sequencing. This PR makes the consumption-side correct so the gating dependency is now exclusively the secret-mint action. Once Steven's `gh secret set` lands, the next deploy-stg run will populate `.env` with real values and `systemctl start isnad-backup.service` will validate the chain end-to-end.

## Sequencing

1. ~~**#187 merges first** (unit-mechanic — `A.Idrissi/0121-backup-service-rewrite`)~~ ✅ merged at `fb8ce80`
2. **#188 merges next** (this PR — secret-provisioning shape) ← here
3. **Steven owner-action**: mint B2 app key scoped to `isnad-graph-backups` bucket; `gh secret set BACKUP_B2_KEY_ID/APP_KEY/BUCKET` at repo level (or env-scoped — owner judgment)
4. **Next stg deploy** populates `.env` correctly; `systemctl start isnad-backup.service` validates upload to B2
5. **Cutover-gate fires successfully** (main#212), DNS-flip greenlit, deploy#86 (decommission hand-made prod VPS) unblocks

## Test plan

- [x] Local YAML validation (`python3 -c "import yaml; yaml.safe_load(...)"`) passes on both workflows
- [x] Local `bash -n scripts/bootstrap-vps.sh` passes
- [x] Clean rebase onto post-#187 wave-10 (no conflicts in `bootstrap-vps.sh` despite both PRs touching it — disjoint regions confirmed)
- [ ] CI: `compose-validate` (paths-filter triggers on `.github/workflows/*` per #176)
- [ ] CI: `actionlint` workflow lint passes
- [ ] CI: shellcheck on `scripts/bootstrap-vps.sh` passes
- [ ] **Post-Steven-secret-mint** (separate session): manual stg test — `systemctl start isnad-backup.service` after compose-up → `b2 ls isnad-graph-backups` shows the test-upload object → comment evidence on this issue or #86 cutover thread

## Closes / refs

- Closes #188
- Paired with #187 (deploy#121 unit-mechanic layer — merged)
- Cutover-gate dependency: noorinalabs-main#212
- Env-split meta: noorinalabs-main#141
- Unblocks: #86 (decommission hand-made prod VPS — depends on cutover-gate firing)
