### PR TITLE
ci(db-migrate): wire reusable gate into deploy-stg + promote (closes #160)

### DIFF
--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -40,7 +40,40 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Pre-deploy alembic gate (deploy#160). Only fires for the user-service
+  # dispatch path so isnad-graph / landing fan-ins don't pay alembic latency
+  # or contend on the user-postgres advisory lock. Discrimination: the
+  # repository_dispatch `event.action` carries the dispatched repo name (one
+  # of the three `deploy-noorinalabs-<service>` types declared in `on:`).
+  #
+  # workflow_dispatch path is intentionally excluded — the manual operator
+  # tag may target any image; running alembic against an arbitrary stg-latest
+  # would be confusing. Operators wanting a manual stg migrate run dispatch
+  # db-migrate.yml directly with env=stg.
+  migrate:
+    name: alembic upgrade head (stg, user-service only)
+    if: ${{ github.event_name == 'repository_dispatch' && github.event.action == 'deploy-noorinalabs-user-service' }}
+    # Reusable workflow accepts an empty string and falls back to `<env>-latest`
+    # (db-migrate.yml § Resolve image tag). Passing empty here is safer than
+    # synthesising a tag client-side: if the dispatch payload's `sha` is
+    # missing or malformed the gate still runs against stg-latest, which is
+    # what the user-service push fan-in already pointed at by the time its
+    # ghcr-publish.yml fired this repository_dispatch.
+    uses: ./.github/workflows/db-migrate.yml
+    with:
+      env: stg
+      image_tag: ""
+    secrets: inherit
+
   deploy:
+    # Gate the existing deploy job on the alembic outcome — but ONLY when
+    # the migrate job actually ran (success). For non-user-service dispatches
+    # and workflow_dispatch the migrate job is skipped via its `if:` and we
+    # still want deploy to proceed; GH Actions treats `needs: [migrate]` with
+    # a skipped dependency as not-satisfied by default, so we re-allow via the
+    # explicit `if:` below.
+    needs: [migrate]
+    if: ${{ always() && (needs.migrate.result == 'success' || needs.migrate.result == 'skipped') }}
     runs-on: ubuntu-latest
     environment: staging
     permissions:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -455,9 +455,53 @@ jobs:
           echo "stg-verify gate PASSED."
           echo "gate_result=passed" >> "$GITHUB_OUTPUT"
 
+  # ─────────────────────────────────────────────────────────────────
+  # Pre-retag alembic gate (deploy#160).
+  #
+  # Runs `alembic upgrade head` on prod's user-postgres BEFORE retag
+  # writes `prod-<short>` and `prod-latest`. Sequencing rationale
+  # (Bereket spec, P3W1 Round 2):
+  #
+  #   plan → gate-stg-verify → migrate-prod → retag → trigger-prod-deploy
+  #
+  # `retag` is the irreversible commit-to-prod step. A migration
+  # failure AFTER retag would leave prod with a forward-pinned image
+  # but a half-migrated DB — recoverable only via manual rollback of
+  # both image and schema. Running migrate-prod BEFORE retag keeps
+  # failure recovery to "fix the migration, re-promote".
+  #
+  # Image tag passed: `stg-<short>` resolved by `plan` from the
+  # promotion source. The `prod-<short>` tag does NOT yet exist at
+  # this stage (retag is what writes it). The `stg-<short>` tag
+  # points at the same digest the retag will promote, so alembic
+  # runs against the exact image about to be made the prod pointer.
+  #
+  # Skip semantics: this job is gated on user-service being in the
+  # promotion set (plan emits `user_service_short=""` when not). When
+  # user-service is excluded the job is skipped and `retag` proceeds
+  # via the explicit `if:` below allowing skipped-or-success.
+  # ─────────────────────────────────────────────────────────────────
+  migrate-prod:
+    name: alembic upgrade head (prod, user-service only)
+    needs: [plan, gate-stg-verify]
+    # Skip if user-service is not in this promotion's image set.
+    if: ${{ needs.plan.outputs.user_service_short != '' }}
+    uses: ./.github/workflows/db-migrate.yml
+    with:
+      env: prod
+      # plan emits the bare 7-char short; alembic runs from the stg-tagged
+      # image (prod-<short> doesn't exist until retag below).
+      image_tag: stg-${{ needs.plan.outputs.user_service_short }}
+    secrets: inherit
+
   retag:
     name: Retag ${{ matrix.key }} (stg → prod)
-    needs: [plan, gate-stg-verify]
+    needs: [plan, gate-stg-verify, migrate-prod]
+    # `migrate-prod` is gated on user-service being in the promotion set; for
+    # promotions that exclude user-service it is skipped, and retag must still
+    # proceed. GH Actions defaults a `needs:` to satisfied only on `success`,
+    # so the explicit allow-skipped predicate is required.
+    if: ${{ always() && needs.gate-stg-verify.result == 'success' && (needs.migrate-prod.result == 'success' || needs.migrate-prod.result == 'skipped') }}
     runs-on: ubuntu-latest
     # The production GH Environment carries the manual-approval reviewer rule.
     # This job does NOT touch a VPS — it only rewrites tags at GHCR. The


### PR DESCRIPTION
Closes #160.

## Summary

Wires the reusable `db-migrate.yml` (workflow_call shape, ready per #153 — NOT modified here) into the deploy caller graph so the alembic pre-deploy gate actually runs.

## Changes

### `deploy-stg.yml` — stg path

- New `migrate` job: `uses: ./.github/workflows/db-migrate.yml` with `env: stg`.
- **Discrimination by trigger event** (Bereket spec): gates only on the user-service `repository_dispatch` path:

  ```yaml
  if: ${{ github.event_name == 'repository_dispatch' && github.event.action == 'deploy-noorinalabs-user-service' }}
  ```

  isnad-graph and landing fan-ins are unaffected — they don't pay alembic latency or contend on the user-postgres advisory lock.

- **`workflow_dispatch` path intentionally excluded.** The operator-driven dispatch may target any image; running alembic against an arbitrary stg-latest would be confusing. Operators wanting a manual stg migrate dispatch `db-migrate.yml` directly with `env: stg`.

- `image_tag: ""` — db-migrate falls back to `stg-latest` per its workflow body. That pointer was just moved by the dispatching service repo's `ghcr-publish.yml`, so it's the right target.

- Existing `deploy` job gated via `needs: [migrate]` plus explicit allow-skipped predicate, so non-user-service dispatches still proceed:

  ```yaml
  needs: [migrate]
  if: ${{ always() && (needs.migrate.result == 'success' || needs.migrate.result == 'skipped') }}
  ```

### `promote.yml` — prod path

- New `migrate-prod` job inserted between `gate-stg-verify` (#179, PR #198) and `retag`. Final DAG:

  ```
  plan → gate-stg-verify → migrate-prod → retag → trigger-prod-deploy
  ```

- **Critical sequencing**: `migrate-prod` runs BEFORE `retag` because retag is the irreversible commit-to-prod step (writes `prod-<short>` and `prod-latest` at the registry). A migration failure AFTER retag would leave prod with a forward-pinned image and a half-migrated DB — recoverable only via manual rollback of both image and schema. With migrate-prod first, failure recovery is "fix the migration, re-promote".

- **Gated on user-service inclusion**: `if: ${{ needs.plan.outputs.user_service_short != '' }}`. Non-user-service promotions skip cleanly.

- **`image_tag: stg-${{ needs.plan.outputs.user_service_short }}`** — `prod-<short>` does NOT exist at this stage (retag hasn't run yet). The `stg-<short>` tag points at the same digest the retag is about to promote, so alembic runs against the exact image about to become the prod pointer.

- `retag.needs` extended to include `migrate-prod`, with explicit `if:` allowing skipped-or-success:

  ```yaml
  needs: [plan, gate-stg-verify, migrate-prod]
  if: ${{ always() && needs.gate-stg-verify.result == 'success' && (needs.migrate-prod.result == 'success' || needs.migrate-prod.result == 'skipped') }}
  ```

## Out of scope

- **`deploy-prod.yml`** does NOT need a migrate job. Migrate runs at the promote layer before retag, so by the time deploy-prod fires the schema is current. The issue body's "promote.yml OR deploy-prod.yml" TBD is **settled in favor of promote.yml** per Bereket P3W1 R2 spec — confirmed against issue body which lists both as candidates.
- **`db-migrate.yml` itself** — it's #153's deliverable and ready as-is. NOT modified.

## DAG verification

I walked the five outcome paths for promote.yml's gate-stg-verify x migrate-prod x retag chain:

| gate-stg-verify | migrate-prod | retag if eval | retag fires? | Correct? |
|---|---|---|---|---|
| success | skipped (no user-service) | `success && (success∨skipped)` | yes | ✓ |
| success | success (user-service in set) | `success && success` | yes | ✓ |
| success | failure | `success && false` | no | ✓ (don't retag if migrate broke) |
| failure | (skipped) | `false && …` | no | ✓ |
| skipped (skip_stg_verify=true) | (skipped) | `success` clause | yes\* | ✓ (skip path: gate-stg-verify result is `success` because all its steps are skipped — runs without erroring) |

\*Skip path: when `skip_stg_verify=true`, every step in `gate-stg-verify` has its own `if: !inputs.skip_stg_verify`, so all are skipped. A job with all steps skipped concludes `success`. So break-glass passes through migrate-prod (which still runs if user-service is in the set — alembic is too cheap to skip on the same break-glass).

## Acceptance (verified locally)

- [x] `actionlint -color` clean on both files (shellcheck v0.10.0 + actionlint v1.7.12 on PATH per the actionlint-needs-shellcheck discipline).
- [x] YAML parse clean.
- [x] Job DAG inspected via `grep -E '^  [a-z-]+:$|needs:'` — chain is linear plan → gate-stg-verify → migrate-prod → retag → trigger-prod-deploy.
- [x] Plan output `user_service_short` is already a flat string output (line 95 of promote.yml at base) — no plan-job changes needed.

## Test plan (post-merge runtime acceptance, per runtime-gate-scoping)

- [ ] CI green on this PR.
- [ ] First post-merge `user-service` push to its main → fans `deploy-noorinalabs-user-service` → deploy-stg.yml runs migrate (alembic upgrade head, heads-count assertion) BEFORE deploy step → live-trace acceptance for the stg path.
- [ ] First post-merge prod promote that includes `user-service` in the image set → promote.yml runs migrate-prod BEFORE retag → live-trace acceptance for the prod path.
- [ ] Verify a non-user-service-only dispatch (isnad-graph push to stg, or a frontend-only manual prod promote) skips migrate cleanly without latency overhead.
- [ ] Migration failure injection (post-merge, in a maintenance window): force a bad migration on stg, verify deploy-stg's `deploy` job is gated off and prod-promote of the same SHA refuses to retag.

## References

- #153 — reusable `db-migrate.yml` (this PR's upstream).
- #155 — promote.yml / deploy-stg.yml / deploy-prod.yml landings.
- #179 / PR #198 — `gate-stg-verify` job that this PR sequences with.
- `docs/runbooks/user-service-alembic.md` — operator runbook for migration failures.
