### PR TITLE
ci(verify-deploy): multi-trigger + landing/user-service script checks (closes #73)

### DIFF
--- a/.github/workflows/verify-deploy.yml
+++ b/.github/workflows/verify-deploy.yml
@@ -23,12 +23,33 @@
 # "Deploy to staging" and "Deploy to production" — repointed below as part
 # of deploy#87 (the split is unimplementable otherwise; trigger today fires
 # on a workflow nobody runs).
+#
+# Trigger expansion (deploy#73, P3W1 Round 2):
+#   - "Deploy All Services" — manual-dispatch full-stack prod deploy. Same
+#     environment: production as deploy-prod.yml; benefits from the same
+#     post-deploy smoke battery.
+#   - "Rollback" — manual-dispatch prod tag rollback. A rollback IS a deploy
+#     for verification purposes; the prod stack just changed so smoke-test it.
+#
+# Why NOT add legacy/manual workflows:
+#   - "Deploy noorinalabs-isnad-graph (LEGACY — manual only)" and
+#     "Deploy noorinalabs-landing-page (LEGACY — manual only)" target the
+#     legacy single-VPS box that deploy#86 will decommission. Auto-verify
+#     against legacy-VPS endpoints would smoke against URLs that no longer
+#     resolve once #86 lands. Operators running the legacy paths invoke
+#     scripts/verify_deployment.sh manually if they want post-deploy checks
+#     against the legacy host (the script grew landing + user-service checks
+#     in this same PR for that purpose).
 
 name: Verify Deployment
 
 on:
   workflow_run:
-    workflows: ["Deploy to staging", "Deploy to production"]
+    workflows:
+      - "Deploy to staging"
+      - "Deploy to production"
+      - "Deploy All Services"
+      - "Rollback"
     types: [completed]
   workflow_dispatch:
     inputs:
@@ -244,9 +265,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     environment: production
+    # Multi-trigger acceptance (deploy#73): three prod-touching upstream
+    # workflows now share verify-prod. All produce the same post-state
+    # invariant (prod stack just got rolled forward or back), so the same
+    # smoke battery is the right post-condition for all three. The
+    # workflow_run.name check enumerates them rather than allow-everything
+    # so a future stg-targeting workflow accidentally hitting this trigger
+    # list does not run prod smoke against itself.
     if: >-
       (github.event_name == 'workflow_run' &&
-       github.event.workflow_run.name == 'Deploy to production' &&
+       (github.event.workflow_run.name == 'Deploy to production' ||
+        github.event.workflow_run.name == 'Deploy All Services' ||
+        github.event.workflow_run.name == 'Rollback') &&
        github.event.workflow_run.conclusion == 'success') ||
       (github.event_name == 'workflow_dispatch' && inputs.target == 'prod')
     steps:

--- a/scripts/verify_deployment.sh
+++ b/scripts/verify_deployment.sh
@@ -15,15 +15,35 @@
 #   ./scripts/verify_deployment.sh [--site URL] [--skip-workflow] [--skip-ssl]
 #
 # Environment:
-#   SITE_URL      Override the default site URL (default: https://isnad-graph.noorinalabs.com)
-#   GH_REPO       Override the GitHub repo for workflow checks (default: noorinalabs/noorinalabs-deploy)
-#   ROLLBACK_TAG  If set, tag the current deployment for rollback reference
+#   SITE_URL              Override the default API host URL
+#                         (default: https://isnad-graph.noorinalabs.com)
+#   LANDING_URL           Landing-page URL to check. Empty disables the
+#                         landing reachability check.
+#                         (default: https://noorinalabs.com)
+#   USER_SERVICE_URL      Base URL whose `/health` is hit for the
+#                         user-service auth-plane check. Empty disables.
+#                         (default: $SITE_URL — caddy/Caddyfile routes
+#                         user-service via the same host today; the
+#                         deploy#156 cutover will move it to its own
+#                         subdomain.)
+#   GH_REPO               Override the GitHub repo for workflow checks
+#                         (default: noorinalabs/noorinalabs-deploy)
+#   ROLLBACK_TAG          If set, tag the current deployment for rollback
+#                         reference
 
 set -euo pipefail
 
 # ---------- Configuration ----------
 
 SITE_URL="${SITE_URL:-https://isnad-graph.noorinalabs.com}"
+# Landing-page reachability check (deploy#73). Empty = skip.
+LANDING_URL="${LANDING_URL:-https://noorinalabs.com}"
+# user-service auth-plane health (deploy#73). Empty = skip. Defaults to
+# SITE_URL because today Caddy routes user-service traffic via the same
+# host as the API (caddy/Caddyfile site block); the deploy#156 cutover
+# will move it to https://users.noorinalabs.com — at that point operators
+# pass USER_SERVICE_URL=https://users.noorinalabs.com explicitly.
+USER_SERVICE_URL="${USER_SERVICE_URL:-$SITE_URL}"
 GH_REPO="${GH_REPO:-noorinalabs/noorinalabs-deploy}"
 SKIP_WORKFLOW="${SKIP_WORKFLOW:-false}"
 SKIP_SSL="${SKIP_SSL:-false}"
@@ -34,10 +54,12 @@ TIMEOUT=10
 for arg in "$@"; do
   case "$arg" in
     --site=*) SITE_URL="${arg#*=}" ;;
+    --landing=*) LANDING_URL="${arg#*=}" ;;
+    --user-service=*) USER_SERVICE_URL="${arg#*=}" ;;
     --skip-workflow) SKIP_WORKFLOW=true ;;
     --skip-ssl) SKIP_SSL=true ;;
     --help|-h)
-      head -12 "$0" | tail -10
+      head -22 "$0" | tail -20
       exit 0
       ;;
   esac
@@ -116,6 +138,45 @@ if [ "$health_resolved" = "false" ]; then
     pass "Health endpoint returned HTTP 200 (non-JSON response)"
   else
     fail "Health endpoint unreachable or invalid (HTTP $health_code)"
+  fi
+fi
+
+# ---------- 3a. Landing-Page Reachability (deploy#73) ----------
+
+if [ -n "$LANDING_URL" ]; then
+  section "Landing-Page Reachability"
+  landing_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time "$TIMEOUT" "$LANDING_URL" 2>/dev/null || echo "000")
+  if [ "$landing_code" = "200" ]; then
+    pass "Landing returns HTTP 200 at $LANDING_URL"
+  elif [ "$landing_code" = "000" ]; then
+    fail "Landing unreachable (timeout/connection error) at $LANDING_URL"
+  else
+    fail "Landing returned HTTP $landing_code at $LANDING_URL"
+  fi
+fi
+
+# ---------- 3b. User-Service Health (deploy#73) ----------
+
+# Two routes are tried in order, mirroring the prod-smoke script:
+#   1. ${USER_SERVICE_URL}/api/v1/user-service/health  (Caddy rewrite path,
+#      used today while user-service traffic shares the API host)
+#   2. ${USER_SERVICE_URL}/health                       (direct subdomain
+#      path that becomes canonical post-deploy#156 cutover)
+# Whichever returns HTTP 200 first wins. If neither responds, fail loud.
+if [ -n "$USER_SERVICE_URL" ]; then
+  section "User-Service Health Check"
+  us_resolved=false
+  for us_path in "/api/v1/user-service/health" "/health"; do
+    us_url="${USER_SERVICE_URL}${us_path}"
+    us_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time "$TIMEOUT" "$us_url" 2>/dev/null || echo "000")
+    if [ "$us_code" = "200" ]; then
+      pass "User-service health endpoint (${us_path}) returned HTTP 200"
+      us_resolved=true
+      break
+    fi
+  done
+  if [ "$us_resolved" = "false" ]; then
+    fail "User-service health unreachable at $USER_SERVICE_URL (tried /api/v1/user-service/health and /health)"
   fi
 fi
 

--- a/scripts/verify_deployment.sh
+++ b/scripts/verify_deployment.sh
@@ -12,7 +12,9 @@
 # intentionally NOT invoked by `verify-deploy.yml` anymore.
 #
 # Usage:
-#   ./scripts/verify_deployment.sh [--site URL] [--skip-workflow] [--skip-ssl]
+#   ./scripts/verify_deployment.sh [--site=URL] [--landing=URL]
+#                                  [--user-service=URL] [--skip-workflow]
+#                                  [--skip-ssl]
 #
 # Environment:
 #   SITE_URL              Override the default API host URL
@@ -59,7 +61,9 @@ for arg in "$@"; do
     --skip-workflow) SKIP_WORKFLOW=true ;;
     --skip-ssl) SKIP_SSL=true ;;
     --help|-h)
-      head -22 "$0" | tail -20
+      # Print the leading comment block (Usage + Environment sections).
+      # Stops at the first non-comment, non-blank line.
+      awk '/^#!/ {next} /^#/ {print substr($0,3); next} {exit}' "$0"
       exit 0
       ;;
   esac
@@ -157,16 +161,30 @@ fi
 
 # ---------- 3b. User-Service Health (deploy#73) ----------
 
-# Two routes are tried in order, mirroring the prod-smoke script:
-#   1. ${USER_SERVICE_URL}/api/v1/user-service/health  (Caddy rewrite path,
-#      used today while user-service traffic shares the API host)
-#   2. ${USER_SERVICE_URL}/health                       (direct subdomain
-#      path that becomes canonical post-deploy#156 cutover)
-# Whichever returns HTTP 200 first wins. If neither responds, fail loud.
+# Two routes exist depending on the deploy#156 cutover state:
+#   1. /api/v1/user-service/health — Caddy rewrite at caddy/Caddyfile:88-89
+#      that proxies to user-service:8000. Used today while user-service
+#      traffic shares the API host with isnad-graph.
+#   2. /health — direct path on the user-service subdomain after the #156
+#      cutover lands `users.noorinalabs.com` as a separate site block.
+#
+# IMPORTANT: pre-#156, /health on the SHARED host hits **isnad-graph's**
+# /health (caddy/Caddyfile:101 — `handle /health { reverse_proxy api:8000 }`),
+# NOT user-service. So the second-route fallback is only correct when an
+# explicit subdomain URL was passed via --user-service= or the
+# USER_SERVICE_URL env var; if USER_SERVICE_URL == SITE_URL, that fallback
+# would falsely report user-service healthy when only isnad-graph is up
+# (Aisha review on PR #206, hot spot 4 — flagged 2026-04-30).
 if [ -n "$USER_SERVICE_URL" ]; then
   section "User-Service Health Check"
   us_resolved=false
   for us_path in "/api/v1/user-service/health" "/health"; do
+    # Skip the /health fallback on the shared host — it routes to
+    # isnad-graph, not user-service. Only safe to probe /health when an
+    # explicit user-service subdomain (post-#156) was passed.
+    if [ "$us_path" = "/health" ] && [ "$USER_SERVICE_URL" = "$SITE_URL" ]; then
+      continue
+    fi
     us_url="${USER_SERVICE_URL}${us_path}"
     us_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time "$TIMEOUT" "$us_url" 2>/dev/null || echo "000")
     if [ "$us_code" = "200" ]; then
@@ -176,7 +194,11 @@ if [ -n "$USER_SERVICE_URL" ]; then
     fi
   done
   if [ "$us_resolved" = "false" ]; then
-    fail "User-service health unreachable at $USER_SERVICE_URL (tried /api/v1/user-service/health and /health)"
+    if [ "$USER_SERVICE_URL" = "$SITE_URL" ]; then
+      fail "User-service health unreachable at ${USER_SERVICE_URL}/api/v1/user-service/health (Caddy rewrite path; the /health fallback only applies post-#156 with a separate user-service subdomain)"
+    else
+      fail "User-service health unreachable at $USER_SERVICE_URL (tried /api/v1/user-service/health and /health)"
+    fi
   fi
 fi
 


### PR DESCRIPTION
Closes #73.

## Summary

Two narrow changes that match the spirit of #73 against the **current** post-deploy#87 architecture. The issue body predates #87's `verify-deploy.yml` split + workflow_run repoint and is partially obsolete; this PR body documents the substitutions explicitly.

## What changed in #73's intent (issue body vs. reality)

| Issue body says | Reality post-#87 | This PR's choice |
|---|---|---|
| Add `"Deploy noorinalabs-isnad-graph"` to triggers | LEGACY workflow (header line 1: `(LEGACY — manual only)`); targets the legacy single-VPS box `deploy#86` will decommission. | **Skip.** Auto-verifying against a host that won't resolve post-#86 is wasted work. |
| Add `"Deploy noorinalabs-landing-page"` to triggers | LEGACY workflow, same reasoning. Active landing-page deploys fan into `deploy-stg.yml` / `promote.yml` → `deploy-prod.yml`, both already covered. | **Skip.** Same. |
| Add `"Deploy All Services"` to triggers | Manual-dispatch full-stack prod deploy. `environment: production`. | **Add.** ✓ |
| Add `"Rollback"` to triggers | Manual-dispatch prod tag rollback. `environment: production`. A rollback IS a deploy for verification purposes. | **Add.** ✓ |
| Extend `verify_deployment.sh` to check `noorinalabs.com` (landing) + user-service `/health` | Script is no longer invoked by `verify-deploy.yml` (per its line-12 comment, post-#87). The CI-side prod smoke (`verify_prod_smoke.sh`) **already covers** landing root + user-service `/health` + isnad-graph `/health` (steps 1-3, since #87). | **Extend the script anyway** — it's still used by operators via the `user-service-migration` runbook. Both new checks are env-driven (`LANDING_URL=""`/`USER_SERVICE_URL=""` disables) so the script remains useful for arbitrary envs. |

## Changes

### `verify-deploy.yml`

- `on.workflow_run.workflows:` — list expanded from 2 to 4 entries:
  ```yaml
  workflows:
    - "Deploy to staging"
    - "Deploy to production"
    - "Deploy All Services"   # added
    - "Rollback"              # added
  ```
- `verify-prod.if:` predicate — extended to match any of the three prod-touching upstream workflow names:
  ```yaml
  if: >-
    (github.event_name == 'workflow_run' &&
     (github.event.workflow_run.name == 'Deploy to production' ||
      github.event.workflow_run.name == 'Deploy All Services' ||
      github.event.workflow_run.name == 'Rollback') &&
     github.event.workflow_run.conclusion == 'success') ||
    (github.event_name == 'workflow_dispatch' && inputs.target == 'prod')
  ```
- `verify-stg.if:` UNCHANGED (still gated on `Deploy to staging` only — no new stg-touching upstream).
- Top-of-file comment updated with a "Why NOT add legacy workflows" note so a future reader doesn't redo the analysis.

### `scripts/verify_deployment.sh`

- New section **3a — Landing-Page Reachability**: `curl` against `LANDING_URL` (default `https://noorinalabs.com`); HTTP 200 = pass. `LANDING_URL=""` disables.
- New section **3b — User-Service Health**: tries `${USER_SERVICE_URL}/api/v1/user-service/health` (Caddy rewrite; today's path) then `${USER_SERVICE_URL}/health` (subdomain path; post-#156 cutover). Either HTTP 200 wins. `USER_SERVICE_URL=""` disables.
- `USER_SERVICE_URL` defaults to `SITE_URL` because Caddy currently routes user-service via the same host as the API; the #156 cutover will move it to its own subdomain and operators pass `--user-service https://users.noorinalabs.com` explicitly then.
- Two new CLI flags: `--landing=URL`, `--user-service=URL`.
- Help text updated.

## Out of scope

- **`verify_prod_smoke.sh`** — already covers landing + user-service /health (#87 delivery, steps 1-3). No changes needed.
- **`verify-deploy.yml`'s `verify-stg` mode flip** — that's deploy#205 (Round 3). Aisha owns that.
- **Auto-verify of legacy single-VPS workflows** — won't outlive `deploy#86` decommission; not worth wiring up.

## Sequencing note for #205

This PR touches `verify-deploy.yml` at the top (trigger list) and at `verify-prod.if:` (lines ~248-260 in the post-PR file). Aisha's #205 will touch `verify-stg`'s pytest invocation step (lines ~127-138 today). **No textual overlap expected.** Flagging here because both PRs are in P3W1 Round 2/3 against the same wave branch — first to land sets the rebase context. Either order works.

## Acceptance (verified locally)

- [x] `actionlint -color` clean on `.github/workflows/verify-deploy.yml` (with shellcheck v0.10.0 + actionlint v1.7.12 on PATH per the actionlint-needs-shellcheck discipline).
- [x] `shellcheck scripts/verify_deployment.sh` clean.
- [x] `bash -n scripts/verify_deployment.sh` clean.
- [x] YAML parse clean.

## Test plan (post-merge, runtime-gate-scoping)

- [ ] CI green on this PR.
- [ ] First post-merge `Deploy All Services` dispatch → `verify-deploy.yml` `verify-prod` job auto-fires after upstream completes → smoke battery runs → `stg-verify-result` artifact NOT emitted (correct — that's stg-only). Live-trace acceptance for the `Deploy All Services` trigger.
- [ ] First post-merge `Rollback` dispatch (against a real rollback test in stg-equivalent if one exists, otherwise against prod with operator approval) → `verify-prod` auto-fires → smoke battery runs.
- [ ] Manual operator run of `scripts/verify_deployment.sh` with default flags → all sections pass including new 3a/3b.
- [ ] Manual operator run with `LANDING_URL=""` → 3a section is silently skipped.
- [ ] Manual operator run with `USER_SERVICE_URL=""` → 3b section is silently skipped.

## References

- #73 — this issue.
- #87 / PR #181 — `verify-deploy.yml` split + `workflow_run` repoint that made the issue body partially stale.
- #205 — `verify-stg` mode flip (Round 3, Aisha's).
- `verify_prod_smoke.sh` (in repo) — already covers landing + user-service /health on the CI prod path.
- `docs/runbooks/user-service-migration.md` — operator runbook that calls `verify_deployment.sh` manually.
