### PR TITLE
ci(verify-deploy): flip verify-stg to RUN_MODE=remote (closes #205)

### DIFF
--- a/.github/workflows/verify-deploy.yml
+++ b/.github/workflows/verify-deploy.yml
@@ -46,10 +46,28 @@ jobs:
   # the deployed stg URLs.
   # ─────────────────────────────────────────────────────────────────
   verify-stg:
-    name: Verify stg (full integration suite)
+    name: Verify stg (remote-mode integration suite)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: staging
+    # Belt-and-suspenders: run-tests.sh's remote branch already hard-refuses
+    # on ENVIRONMENT in {prod, production} (#178 / PR #202). Setting it
+    # explicitly at the workflow level makes verify-stg impossible to
+    # mis-point at prod even if someone manually edits the job-level env
+    # block. Cheap redundancy for a load-bearing safety check.
+    env:
+      ENVIRONMENT: stg
+      RUN_MODE: remote
+      # Public stg URLs — these are the same hostnames operators hit in a
+      # browser. Caddy auto-provisions LE TLS for them; per #157 the
+      # `users.stg.noorinalabs.com` cutover lives in the wave's Caddyfile.
+      ISNAD_BASE_URL: https://isnad.stg.noorinalabs.com
+      USER_SERVICE_BASE_URL: https://users.stg.noorinalabs.com
+      # Stg test-user creds. No-op for the 3 health tests that currently
+      # run remote-mode (those don't authenticate); #204 expands coverage
+      # by populating these as the per-test refactor lands.
+      STG_TEST_USER_EMAIL: ${{ secrets.STG_TEST_USER_EMAIL }}
+      STG_TEST_USER_PASSWORD: ${{ secrets.STG_TEST_USER_PASSWORD }}
     if: >-
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.name == 'Deploy to staging' &&
@@ -61,75 +79,28 @@ jobs:
       # verify against main's revision. Pin to the upstream deploy's
       # head_sha (sha is more stable than head_branch — branch may have
       # moved between trigger and run). See deploy#181 review (Weronika).
+      #
+      # Sibling-repo checkouts (user-service + isnad-graph) and Buildx
+      # setup were dropped in #205 — remote mode runs against deployed
+      # stg URLs, doesn't build images locally. The wave-aware sibling
+      # ref resolution is therefore unused here. If hermetic local
+      # verification is ever revived, restore that sequence from
+      # `git show 6e8f450:.github/workflows/verify-deploy.yml`.
       - name: Checkout noorinalabs-deploy
         uses: actions/checkout@v4
         with:
           path: noorinalabs-deploy
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
-      # Wave-aware sibling-repo ref resolution (mirrors integration-tests.yml
-      # pattern; needed so a wave-branch deploy verifies against matching
-      # wave branches of user-service + isnad-graph). See feedback memory
-      # "Cross-repo wave-aware sibling checkout" 2026-04-24.
-      - name: Resolve sibling-repo refs (wave-aware)
-        id: sibling-refs
-        run: |
-          set -euo pipefail
-          # On workflow_run the head_branch of the upstream deploy is most
-          # accurate; on workflow_dispatch, fall back to ref_name of this
-          # workflow's invocation context.
-          if [ "${{ github.event_name }}" = "workflow_run" ]; then
-            BASE="${{ github.event.workflow_run.head_branch }}"
-          else
-            BASE="${{ github.ref_name }}"
-          fi
-          [ -n "$BASE" ] || BASE="main"
-
-          resolve_ref() {
-            local repo="$1"
-            if [[ "$BASE" == deployments/* ]] && \
-               git ls-remote --exit-code "https://github.com/noorinalabs/${repo}.git" "refs/heads/${BASE}" >/dev/null 2>&1; then
-              echo "$BASE"
-            else
-              echo "main"
-            fi
-          }
-
-          US_REF=$(resolve_ref noorinalabs-user-service)
-          IG_REF=$(resolve_ref noorinalabs-isnad-graph)
-
-          echo "user_service_ref=${US_REF}" >> "$GITHUB_OUTPUT"
-          echo "isnad_graph_ref=${IG_REF}"  >> "$GITHUB_OUTPUT"
-          {
-            echo "## Resolved sibling refs (verify-stg)"
-            echo "- upstream branch: \`${BASE}\`"
-            echo "- noorinalabs-user-service: \`${US_REF}\`"
-            echo "- noorinalabs-isnad-graph:  \`${IG_REF}\`"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Checkout noorinalabs-user-service
-        uses: actions/checkout@v4
-        with:
-          repository: noorinalabs/noorinalabs-user-service
-          path: noorinalabs-user-service
-          ref: ${{ steps.sibling-refs.outputs.user_service_ref }}
-
-      - name: Checkout noorinalabs-isnad-graph
-        uses: actions/checkout@v4
-        with:
-          repository: noorinalabs/noorinalabs-isnad-graph
-          path: noorinalabs-isnad-graph
-          ref: ${{ steps.sibling-refs.outputs.isnad_graph_ref }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      # run-tests.sh already passes --junit-xml=/app/reports/junit.xml to
-      # pytest internally; re-passing the flag here would duplicate it
-      # (latter-wins works by accident with WORKDIR=/app + the ./reports
-      # mount, but is brittle to refactor). Let the script own the flag.
-      # See deploy#181 review (Nurul).
-      - name: Run full integration suite
+      # run-tests.sh in RUN_MODE=remote (#178 / PR #202) skips compose
+      # stack-up entirely, builds the runner image from Dockerfile.runner,
+      # and `docker run`s it against the env-supplied stg URLs. The
+      # Dockerfile.runner build is pure-pip and doesn't need Buildx, so
+      # there's no `setup-buildx-action` step here. Job env exports
+      # USER_SERVICE_BASE_URL / ISNAD_BASE_URL above; the script sets
+      # USER_SERVICE_URL / ISNAD_GRAPH_URL inside the runner container
+      # for conftest.py compatibility.
+      - name: Run integration suite (remote mode)
         working-directory: noorinalabs-deploy/integration-tests
         run: ./run-tests.sh
 
@@ -140,10 +111,10 @@ jobs:
           name: verify-stg-junit
           path: noorinalabs-deploy/integration-tests/reports/
 
-      - name: Dump compose logs on failure
-        if: failure()
-        working-directory: noorinalabs-deploy/integration-tests
-        run: docker compose -f docker-compose.test.yml --env-file .env.test logs --no-color > reports/compose.log || true
+      # Compose-logs-on-failure dump was dropped with the hermetic stack
+      # — there is no docker-compose stack to query in remote mode. Test
+      # failure surfaces via the junit artifact above and via run-tests.sh
+      # stdout in the job's run-log.
 
       # Artifact consumed by deploy#179 (promote.yml gate). Schema v1:
       # { "schema_version": 1,
@@ -191,7 +162,7 @@ jobs:
           {
             echo "## Verify stg — ${{ job.status }}"
             echo ""
-            echo "Full cross-repo integration suite (hermetic Option A; deploy#178 tracks remote-mode against live stg URLs)."
+            echo "Remote-mode integration suite (#205) against deployed stg URLs (\`$USER_SERVICE_BASE_URL\` / \`$ISNAD_BASE_URL\`)."
             echo ""
             if [ -f noorinalabs-deploy/integration-tests/reports/junit.xml ]; then
               echo "### Test counts"


### PR DESCRIPTION
## Summary

Activates the remote-mode harness landed in #178 (PR #202) for the post-deploy `verify-stg` job in `.github/workflows/verify-deploy.yml`. The flip is its own discrete change so the cutover is atomic and easy to revert if the live-trace post-merge surfaces any issues that didn't show in PR-CI hermetic tests.

## Related Issues

Closes #205

## What changed

### Job-level env additions

- `ENVIRONMENT: stg` — belt-and-suspenders alongside run-tests.sh's internal hard-refusal on `prod`/`production` (#178 / PR #202).
- `RUN_MODE: remote` — flips the harness mode.
- `ISNAD_BASE_URL: https://isnad.stg.noorinalabs.com`
- `USER_SERVICE_BASE_URL: https://users.stg.noorinalabs.com`
- `STG_TEST_USER_EMAIL` / `STG_TEST_USER_PASSWORD` from secrets — no-ops for the 3 health tests that currently run remote-mode; #204 expands coverage by populating these as the per-test refactor lands.

### Step removals (sanctioned by issue body's "Drop the docker-compose stack-up bits")

- `Resolve sibling-repo refs (wave-aware)` — remote mode doesn't build images from sibling checkouts.
- `Checkout noorinalabs-user-service` / `Checkout noorinalabs-isnad-graph` — same rationale.
- `Set up Docker Buildx` — `Dockerfile.runner` is pure-pip, no Buildx needed.
- `Dump compose logs on failure` — there is no docker-compose stack in remote mode; failures surface via the junit artifact and the job's run-log of run-tests.sh stdout.

If hermetic local verification is ever revived here, the dropped sequence is recoverable via `git show 6e8f450:.github/workflows/verify-deploy.yml`.

### Untouched per spec

- `Emit verify-stg-result artifact` step — schema_version=1, owned by promote.yml's `gate-stg-verify` gate via #179 / PR #198. Byte-identical.
- `Upload verify-stg-result artifact` step — byte-identical.
- All `verify-prod` job steps.
- `on.workflow_run.workflows:` trigger list — that's #73 scope, Lucas rebases his #73 PR onto this merge.
- `verify_deployment.sh` — also #73 scope.

## Test Plan

Verified locally (mechanic correctness — not live-trace):

- [x] `actionlint -color .github/workflows/verify-deploy.yml` clean (shellcheck v0.10.0 + actionlint v1.7.7 on PATH).
- [x] `actionlint -color` over all workflows clean.
- [x] YAML parse clean. Job structure inspected: `verify-stg` env block has all 6 expected vars; steps reduced from 12 → 6 (drops listed above); artifact emission steps untouched; `verify-prod` job untouched.
- [x] Diff bounded as spec requested: 1 file, 40 insertions, 69 deletions.

Live verification post-merge (one-shot, on first deploy-stg after merge):

- [ ] First post-merge `Deploy to staging` workflow_run completion → `verify-stg` triggers in remote mode.
- [ ] 3 health tests (`test_health.py::*`) pass against deployed stg URLs.
- [ ] 16 fixture-skipped tests skip cleanly with the conftest-defined skip messages.
- [ ] `stg-verify-result-{run_id}.json` artifact emits with the same schema_version=1 shape promote.yml's `gate-stg-verify` already consumes.
- [ ] On a manual `workflow_dispatch` with `target: stg`, same outcome.

## Review Checklist

- [ ] Peer reviewed by another engineer (Lucas Ferreira)
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Aisha Idrissi <parametrization+Aisha.Idrissi@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
