### PR TITLE
infra(observability): add blackbox-exporter for continuous prod-route probing (closes #183)

### DIFF
--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -653,6 +653,43 @@ services:
           memory: 128M
           cpus: "0.25"
 
+  # blackbox-exporter — continuous external probing of prod public routes
+  # (companion to scripts/verify_prod_smoke.sh post-deploy battery, see deploy#183).
+  # Two-network topology:
+  #   - frontend: real-DNS / real-TLS path to the public Caddy endpoints
+  #     (`internal: false`, so the container has egress to the public internet).
+  #   - backend:  Prometheus scrapes /probe + /metrics on this internal network.
+  blackbox-exporter:
+    image: prom/blackbox-exporter:v0.25.0
+    volumes:
+      - ../infra/blackbox-exporter/blackbox.yml:/etc/blackbox_exporter/config.yml:ro
+    command:
+      - "--config.file=/etc/blackbox_exporter/config.yml"
+    expose:
+      - "9115"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:9115/-/healthy || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    networks:
+      - backend
+      - frontend
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+          cpus: "0.25"
+        reservations:
+          memory: 32M
+          cpus: "0.05"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
   # --- Pipeline messaging (Kafka KRaft, single-node) ---
   #
   # Single-broker Kafka in KRaft mode (no ZooKeeper). Used by the data

--- a/docs/runbooks/blackbox-probes.md
+++ b/docs/runbooks/blackbox-probes.md
@@ -37,6 +37,15 @@ Investigation steps:
    - SSH to prod and run `docker compose logs --tail 200 blackbox-exporter`.
    - Check for DNS-resolution errors (the container is on `frontend` +
      `backend`; only `frontend` has internet egress).
+   - **Suspect hairpin-NAT** if logs show no DNS errors and the host
+     itself can reach the route (`curl -sSI https://<route>` from the
+     prod shell). blackbox runs on the same prod box that Caddy serves,
+     so it probes its own public FQDN — egress works on Ubuntu 24.04
+     via standard MASQUERADE today, but a future kernel / netfilter /
+     docker-network change can break self-targeted SNAT. Reproduce from
+     inside the container with `docker compose exec blackbox-exporter wget -qO- -S https://<route>`.
+     If hairpin is the cause, do NOT pre-emptively re-shape the
+     topology — file an issue and we'll revisit.
 3. If the route is genuinely down:
    - For `isnad-health` / `user-service-health`: pivot to the
      `ServiceDown` / `ContainerUnhealthy` runbooks — those alerts

--- a/docs/runbooks/blackbox-probes.md
+++ b/docs/runbooks/blackbox-probes.md
@@ -1,0 +1,115 @@
+# Runbook — Blackbox prod probes
+
+The blackbox-exporter (`prom/blackbox-exporter:v0.25.0`, container
+`blackbox-exporter`) continuously probes the same 6 prod public routes
+that `scripts/verify_prod_smoke.sh` validates post-deploy. Smoke is the
+deploy-time gate; blackbox is the steady-state monitor between deploys.
+
+Source of truth for the route list: `infra/prometheus/prometheus.yml`
+(scrape_config `blackbox`). Modules and HTTP-status expectations live in
+`infra/blackbox-exporter/blackbox.yml`.
+
+| Route label             | URL                                                                       | Module          | Expected |
+|-------------------------|---------------------------------------------------------------------------|-----------------|----------|
+| `isnad-health`          | `https://isnad-graph.noorinalabs.com/health`                              | `http_2xx_json` | 200, JSON body |
+| `user-service-health`   | `https://isnad-graph.noorinalabs.com/api/v1/user-service/health`          | `http_2xx`      | 200 |
+| `landing-root`          | `https://noorinalabs.com/`                                                | `http_2xx`      | 200 |
+| `narrator-401`          | `https://isnad-graph.noorinalabs.com/api/v1/narrators?limit=1`            | `http_401_json` | 401/403 + JSON body |
+| `jwks`                  | `https://isnad-graph.noorinalabs.com/.well-known/jwks.json`               | `http_2xx_json` | 200, JSON `.keys[]` |
+| `auth-login-redirect`   | `https://isnad-graph.noorinalabs.com/auth/login`                          | `http_3xx`      | 3xx (or 200 for interstitial) |
+
+When deploy#156 cleaves user-service onto its own subdomain
+(`users.noorinalabs.com`) and isnad onto `isnad.noorinalabs.com`,
+update the URLs in `infra/prometheus/prometheus.yml` and the smoke
+battery defaults in lockstep.
+
+## Alerts
+
+### probe-failing
+
+Fires when `probe_success == 0` for any route for >2m.
+
+Investigation steps:
+
+1. Reproduce the probe locally:
+   `curl -sSI https://<route-url>` from a non-VPS host.
+2. If the route is healthy from outside but blackbox shows it down:
+   - SSH to prod and run `docker compose logs --tail 200 blackbox-exporter`.
+   - Check for DNS-resolution errors (the container is on `frontend` +
+     `backend`; only `frontend` has internet egress).
+3. If the route is genuinely down:
+   - For `isnad-health` / `user-service-health`: pivot to the
+     `ServiceDown` / `ContainerUnhealthy` runbooks — those alerts
+     should already be firing.
+   - For `narrator-401` shape regression: this is the "Caddy answering
+     in plaintext while user-service is down" failure mode. Check that
+     `user-service` container is responding on its internal network
+     (`docker compose exec caddy wget -qO- http://user-service:8000/health`).
+   - For `auth-login-redirect`: confirm the `/auth/login` site block in
+     `caddy/Caddyfile` is still wired and that user-service has the
+     OAuth client credentials in `.env`.
+
+### unexpected-status
+
+Fires when a route returns an HTTP code outside the expected set for >5m
+(e.g. narrator-401 returning 200, or jwks returning 500). The alert is a
+weaker-but-louder signal than `probe-failing`; it tells you *what code*
+is being returned. Most often this points at a Caddy mis-route or a
+service answering in degraded mode.
+
+### cert-expiring-soon
+
+Fires when the TLS cert for any probed route expires in <7 days. Caddy
+auto-renews ~30 days before expiry, so reaching this threshold means
+renewal is failing. Check:
+
+- `docker compose logs --tail 500 caddy | grep -i 'acme\|certificate'`
+- `/data` volume disk usage (Let's Encrypt renewal needs scratch space).
+- Let's Encrypt rate-limit status (was the cert reissued repeatedly?).
+
+## Silencing during planned maintenance
+
+When you are about to do something that will deliberately cause one or
+more probes to fail (e.g. a known-disruptive deploy, a Caddy config
+shuffle, taking the box down for a Hetzner snapshot), silence the
+relevant alerts in alertmanager *before* the disruption rather than
+acknowledging pages after the fact.
+
+Current alertmanager runs on the prod box, bound to `127.0.0.1:9093`.
+Reach it via SSH tunnel:
+
+```bash
+ssh -L 9093:127.0.0.1:9093 deploy@<prod-host>
+# leave the session open while you work
+```
+
+Then create a silence with `amtool` (installed on the prod box) or via
+the alertmanager web UI at `http://localhost:9093`:
+
+```bash
+# Silence ALL blackbox alerts for 30 minutes
+amtool silence add \
+  --alertmanager.url=http://127.0.0.1:9093 \
+  --comment "Planned maintenance — deploy#NNN" \
+  --duration 30m \
+  alertname=~"Blackbox.*"
+
+# Silence one specific route (e.g. just /auth/login while reshuffling Caddy)
+amtool silence add \
+  --alertmanager.url=http://127.0.0.1:9093 \
+  --comment "Reshuffling Caddy auth carve-out — deploy#NNN" \
+  --duration 15m \
+  alertname=~"Blackbox.*" route="auth-login-redirect"
+```
+
+Always include a comment with the issue or PR number — it's the only
+breadcrumb to whoever is on-call after you. To list/expire silences:
+
+```bash
+amtool silence query   --alertmanager.url=http://127.0.0.1:9093
+amtool silence expire <silence-id> --alertmanager.url=http://127.0.0.1:9093
+```
+
+Silences auto-expire at the end of their duration; prefer a tight
+duration over an open-ended one. If a maintenance window over-runs,
+extend the silence rather than letting it lapse and then re-creating.

--- a/infra/blackbox-exporter/blackbox.yml
+++ b/infra/blackbox-exporter/blackbox.yml
@@ -1,0 +1,70 @@
+# blackbox-exporter modules — continuous prod-route probing (deploy#183).
+#
+# Module naming convention: <protocol>_<expected-status>[_<flavour>].
+# Each route in infra/prometheus/prometheus.yml chooses the module that
+# matches its smoke-battery expectation in scripts/verify_prod_smoke.sh.
+#
+# Probes are intentionally narrow: HTTP-status + (where useful) regex on
+# response body shape. Auth-flow synthetic probes are explicitly out of
+# scope (no prod creds — Bereket sign-off, deploy#87).
+modules:
+  # 200 + JSON body. Used by isnad /health (.status field) and JWKS
+  # (.keys[] array). The fail_if_body_not_matches_regexp keeps the
+  # plaintext-from-Caddy failure mode out of the green-state set.
+  http_2xx_json:
+    prober: http
+    timeout: 5s
+    http:
+      method: GET
+      preferred_ip_protocol: ip4
+      valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+      valid_status_codes: [200]
+      fail_if_body_not_matches_regexp:
+        - '[{\[]'  # response begins with '{' or '[' — JSON shape
+      tls_config:
+        insecure_skip_verify: false
+      follow_redirects: true
+
+  # Plain 200 (no body shape assertion). Used by landing /.
+  http_2xx:
+    prober: http
+    timeout: 5s
+    http:
+      method: GET
+      preferred_ip_protocol: ip4
+      valid_status_codes: [200]
+      tls_config:
+        insecure_skip_verify: false
+
+  # 401 + JSON body. Used by /api/v1/narrators?limit=1 — the JSON-shape
+  # check is the load-bearing assertion (Caddy returning plaintext "401
+  # Unauthorized" while user-service is silently down would otherwise
+  # pass — same trap the smoke battery is designed around).
+  http_401_json:
+    prober: http
+    timeout: 5s
+    http:
+      method: GET
+      preferred_ip_protocol: ip4
+      valid_status_codes: [401, 403]
+      fail_if_body_not_matches_regexp:
+        - '[{\[]'  # JSON-shaped error envelope (.detail / .error / .message)
+      tls_config:
+        insecure_skip_verify: false
+
+  # 3xx redirect. Used by /auth/login. We do NOT follow the redirect —
+  # we just want to confirm the user-service auth wiring still hands off
+  # to an OAuth provider. The smoke battery inspects the Location
+  # header itself for OAuth-host substring; here we settle for the
+  # weaker "any 3xx is acceptable" assertion (200 also acceptable for
+  # interstitial-page handlers, mirroring smoke #6).
+  http_3xx:
+    prober: http
+    timeout: 5s
+    http:
+      method: GET
+      preferred_ip_protocol: ip4
+      valid_status_codes: [200, 301, 302, 303, 307, 308]
+      follow_redirects: false
+      tls_config:
+        insecure_skip_verify: false

--- a/infra/grafana/dashboards/blackbox-probes.json
+++ b/infra/grafana/dashboards/blackbox-probes.json
@@ -1,0 +1,133 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "uid": "blackbox-probes",
+  "title": "Blackbox Prod Probes",
+  "tags": ["observability", "blackbox", "prod"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "1m",
+  "time": { "from": "now-24h", "to": "now" },
+  "links": [],
+  "panels": [
+    {
+      "title": "Probe success by route (last 24h)",
+      "type": "timeseries",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "probe_success{job=\"blackbox\"}",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 1,
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "fillOpacity": 25,
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    },
+    {
+      "title": "Current probe state",
+      "type": "stat",
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 10 },
+      "targets": [
+        {
+          "expr": "probe_success{job=\"blackbox\"}",
+          "legendFormat": "{{route}}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "value_and_name",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      }
+    },
+    {
+      "title": "Probe duration p95 (5m)",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 10 },
+      "targets": [
+        {
+          "expr": "probe_duration_seconds{job=\"blackbox\"}",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s", "decimals": 3 },
+        "overrides": []
+      }
+    },
+    {
+      "title": "TLS cert: days until expiry",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 16 },
+      "targets": [
+        {
+          "expr": "(probe_ssl_earliest_cert_expiry{job=\"blackbox\"} - time()) / 86400",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "d",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 7 },
+              { "color": "green", "value": 14 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/infra/prometheus/alerts.yml
+++ b/infra/prometheus/alerts.yml
@@ -164,8 +164,16 @@ groups:
       # Let's Encrypt, but a renewal failure (rate-limit, ACME outage,
       # disk-full on /data) would silently approach expiry — we want
       # ~7d of warning before the cert dies in prod.
+      #
+      # The `> 0` guard skips probes where the metric is unset (HTTP
+      # targets, or HTTPS probes that never reached TLS handshake) —
+      # without it, the alert fires forever on any non-HTTPS target if
+      # one is ever added to this scrape job.
       - alert: BlackboxCertExpiringSoon
-        expr: probe_ssl_earliest_cert_expiry - time() < 7 * 86400
+        expr: |
+          probe_ssl_earliest_cert_expiry > 0
+          and
+          (probe_ssl_earliest_cert_expiry - time()) < 7 * 86400
         for: 1h
         labels:
           severity: warning

--- a/infra/prometheus/alerts.yml
+++ b/infra/prometheus/alerts.yml
@@ -108,3 +108,72 @@ groups:
           description: >-
             The last successful backup was more than 24 hours ago.
           runbook: "docs/deployment/alerting.md#backupfailure"
+
+  - name: blackbox_probes
+    rules:
+      # Any of the 6 prod-route probes failing for >2m. Companion to the
+      # post-deploy smoke battery — smoke validates the deploy worked,
+      # this alerts when it stops working between deploys (deploy#183).
+      - alert: BlackboxProbeFailing
+        expr: probe_success == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Blackbox probe failing for {{ $labels.route }}"
+          description: >-
+            The blackbox probe for {{ $labels.route }} ({{ $labels.instance }})
+            has reported probe_success=0 for more than 2 minutes. Smoke
+            battery covers this route post-deploy; this alert catches
+            mid-deploy-window regressions.
+          runbook: "docs/runbooks/blackbox-probes.md#probe-failing"
+
+      # Routes where the smoke battery enforces a specific HTTP status
+      # (e.g. 401 on the narrator check, 3xx on /auth/login). The
+      # blackbox modules already encode "valid" status sets, so a
+      # mismatch surfaces as probe_success=0 — but we still alert
+      # explicitly on the status-code metric so the description tells
+      # operators *what* code came back rather than just "probe failed".
+      - alert: BlackboxUnexpectedStatus
+        expr: |
+          (
+            probe_http_status_code{route="isnad-health"}        != 200
+          ) or (
+            probe_http_status_code{route="user-service-health"} != 200
+          ) or (
+            probe_http_status_code{route="landing-root"}        != 200
+          ) or (
+            probe_http_status_code{route="jwks"}                != 200
+          ) or (
+            probe_http_status_code{route="narrator-401"}        != 401
+            and
+            probe_http_status_code{route="narrator-401"}        != 403
+          )
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Unexpected HTTP status on {{ $labels.route }}"
+          description: >-
+            Route {{ $labels.route }} returned HTTP {{ $value }}, which is
+            outside the expected set defined in the smoke battery
+            (scripts/verify_prod_smoke.sh).
+          runbook: "docs/runbooks/blackbox-probes.md#unexpected-status"
+
+      # Defense-in-depth cert-expiry warning. Caddy auto-renews via
+      # Let's Encrypt, but a renewal failure (rate-limit, ACME outage,
+      # disk-full on /data) would silently approach expiry — we want
+      # ~7d of warning before the cert dies in prod.
+      - alert: BlackboxCertExpiringSoon
+        expr: probe_ssl_earliest_cert_expiry - time() < 7 * 86400
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "TLS cert for {{ $labels.route }} expires in <7 days"
+          description: >-
+            The TLS certificate served at {{ $labels.instance }} expires in
+            {{ $value | humanizeDuration }}. Caddy normally auto-renews
+            ~30 days before expiry, so reaching this threshold indicates
+            renewal is failing.
+          runbook: "docs/runbooks/blackbox-probes.md#cert-expiring-soon"

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -23,3 +23,40 @@ scrape_configs:
   - job_name: "postgres-exporter"
     static_configs:
       - targets: ["postgres-exporter:9187"]
+
+  # blackbox-exporter — continuous external probe of the same 6 prod
+  # routes covered by the post-deploy smoke battery
+  # (scripts/verify_prod_smoke.sh). Each target carries a `route` label
+  # so alerts and dashboards can identify the probed endpoint without
+  # having to URL-decode the __param_target.
+  #
+  # The relabel pipeline is the standard blackbox pattern:
+  #   1. instance label = the URL itself (visible in alerts)
+  #   2. __param_target = URL passed to /probe?target=…
+  #   3. __address__   = blackbox-exporter:9115 (the actual scrape target)
+  - job_name: "blackbox"
+    metrics_path: /probe
+    scrape_interval: 60s
+    scrape_timeout: 10s
+    static_configs:
+      - targets: ["https://isnad-graph.noorinalabs.com/health"]
+        labels: { route: "isnad-health", module: "http_2xx_json" }
+      - targets: ["https://isnad-graph.noorinalabs.com/api/v1/user-service/health"]
+        labels: { route: "user-service-health", module: "http_2xx" }
+      - targets: ["https://noorinalabs.com/"]
+        labels: { route: "landing-root", module: "http_2xx" }
+      - targets: ["https://isnad-graph.noorinalabs.com/api/v1/narrators?limit=1"]
+        labels: { route: "narrator-401", module: "http_401_json" }
+      - targets: ["https://isnad-graph.noorinalabs.com/.well-known/jwks.json"]
+        labels: { route: "jwks", module: "http_2xx_json" }
+      - targets: ["https://isnad-graph.noorinalabs.com/auth/login"]
+        labels: { route: "auth-login-redirect", module: "http_3xx" }
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [module]
+        target_label: __param_module
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox-exporter:9115


### PR DESCRIPTION
## Summary

Adds `prom/blackbox-exporter:v0.25.0` to the prod observability stack as a continuous-monitor companion to `scripts/verify_prod_smoke.sh` (deploy#181). Smoke is the post-deploy gate; blackbox watches the same six routes between deploys so layer-7 regressions surface in <2m instead of waiting for the next deploy or a user complaint.

## Artifacts (all four acceptance bullets)

- **`compose/docker-compose.prod.yml`** — new `blackbox-exporter` service on `frontend` (egress for real-DNS / real-TLS) **+** `backend` (so Prometheus can scrape it). 128M / 0.25 cpu, healthcheck on `/-/healthy`, json-file logging matching the rest of the observability cluster.
- **`infra/blackbox-exporter/blackbox.yml`** — four modules covering the six smoke-equivalent shapes:
  - `http_2xx_json` — 200 + JSON body (isnad `/health`, JWKS)
  - `http_2xx` — 200 (user-service `/health`, landing `/`)
  - `http_401_json` — 401/403 + JSON body (narrator `/api/v1/narrators?limit=1` — the load-bearing assertion that catches Caddy answering in plaintext while user-service is silently down)
  - `http_3xx` — 3xx (or 200 for interstitial) on `/auth/login`
- **`infra/prometheus/prometheus.yml`** — new `blackbox` scrape job, 60s interval, six static targets each carrying a `route` label (`isnad-health`, `user-service-health`, `landing-root`, `narrator-401`, `jwks`, `auth-login-redirect`).
- **`infra/prometheus/alerts.yml`** — three rules:
  - `BlackboxProbeFailing` — `probe_success == 0` for >2m (critical)
  - `BlackboxUnexpectedStatus` — per-route HTTP-status mismatch for >5m (warning)
  - `BlackboxCertExpiringSoon` — `<7d` (warning, defense-in-depth even though Caddy auto-renews)
- **`infra/grafana/dashboards/blackbox-probes.json`** — auto-loaded via the existing dashboards.yml provisioning. Panels:
  - Probe success per route, last 24h (stepAfter timeseries)
  - Current state (UP/DOWN stat, color-coded)
  - Probe duration p95
  - TLS days-until-expiry (per route, with red/orange/green thresholds at 7/14d)
- **`docs/runbooks/blackbox-probes.md`** — investigation steps per alert + how to silence flapping alerts via `amtool` during planned maintenance (with route-scoped silence example).

## Out of scope

Preserved from the issue body and Bereket's deploy#87 sign-off:

- Replacing the smoke battery (companion, not replacement)
- Stg blackbox monitoring (prod only — stg is exercised by integration suite per deploy)
- Auth-flow synthetic probes (would require prod creds — explicitly excluded)

## Local validation

| Check | Result |
|-------|--------|
| `docker compose -f docker-compose.prod.yml --env-file .env config --quiet` | clean |
| `promtool check config /etc/prometheus/prometheus.yml` | SUCCESS |
| `promtool check rules /etc/prometheus/alerts.yml` | SUCCESS — 10 rules |
| `blackbox-exporter --config.check` on `blackbox.yml` | OK, no deprecation warnings |
| `python -m json.tool` on Grafana dashboard JSON | clean |
| shellcheck / actionlint installed? | yes (no shell or workflow changes in this PR, so no surface to lint) |

## Test plan (post-merge, in prod)

- [ ] After merge → wave merge → prod promote, confirm `blackbox-exporter` container is healthy on the prod box.
- [ ] Open Grafana → "Blackbox Prod Probes" dashboard, confirm all six routes show `probe_success=1` and TLS-days panel populates.
- [ ] Trigger a synthetic flap (e.g. silence one route via `amtool` per the runbook) and confirm the silence prevents a fire while still showing on the dashboard.

## Linked issue

closes #183
