### PR TITLE
Phase 3 Wave 1 → main (deploy)

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -216,6 +216,91 @@ jobs:
             exit 1
           fi
 
+      # Textfile-collector emission (deploy#161). Writes a .prom file on the
+      # VPS host that node-exporter scrapes via its textfile collector. Both
+      # success AND failure paths emit (`if: always()`); the heads-count
+      # assertion failure and the `alembic upgrade head` failure both result
+      # in `steps.record.outputs.migrated == 'false'`, which we map to
+      # `_success=0`. Prometheus alert `UserServiceAlembicGateFailure` reads
+      # the `_success` gauge with a `_timestamp` freshness filter so a
+      # promotion-less hour doesn't fire.
+      #
+      # Atomic write discipline: writes go to a `.prom.$$` temp path in the
+      # same directory and `mv` (atomic on the same filesystem) into place.
+      # node-exporter's textfile collector reads files lazily; without atomic
+      # rename it could read a half-written file and parse-fail.
+      #
+      # Schema (mode 0644, env label matches `inputs.env`):
+      #   user_service_alembic_gate_last_run_success{env="..."} <0|1>
+      #   user_service_alembic_gate_last_run_timestamp_seconds{env="..."} <unix-ts>
+      - name: Emit textfile-collector metrics on VPS
+        if: always()
+        uses: appleboy/ssh-action@v1
+        env:
+          ENV_NAME: ${{ inputs.env }}
+          MIGRATED: ${{ steps.record.outputs.migrated }}
+        with:
+          host: ${{ vars.VPS_HOST }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          envs: ENV_NAME,MIGRATED
+          script: |
+            set -euo pipefail
+            TEXTFILE_DIR="/var/lib/node_exporter/textfile_collector"
+            FINAL="${TEXTFILE_DIR}/user_service_alembic_gate.prom"
+            TMP="${FINAL}.$$"
+
+            # Bootstrap-permissions check (Bereket #210 manager-direct
+            # review, 2026-04-30). The host dir is provisioned by
+            # cloud-init for fresh VPSes (terraform/hetzner/modules/
+            # hetzner-vps/cloud-init.yaml.tpl) — but if cloud-init didn't
+            # fire (DR-restore that bypassed TF, blue-green VPS swap with
+            # an older snapshot), Docker's default-create-on-bind behavior
+            # creates the dir as root:root 0755. A simple `if [ ! -d ... ]`
+            # would see the dir as "present" and fall through to a
+            # permission-denied `mv` later — silent metric loss.
+            #
+            # Check write access explicitly. Fail loud rather than silent
+            # fall-through so on-call notices via the failed SSH step
+            # rather than silently-stale `_success=1` from yesterday.
+            if ! [ -w "${TEXTFILE_DIR}" ]; then
+              echo "ERROR: ${TEXTFILE_DIR} is not writable by deploy user." >&2
+              echo "       This usually means cloud-init did not fire (fresh VPS" >&2
+              echo "       provisioning issue, or DR-restored VPS that bypassed TF)." >&2
+              echo "       Investigate via 'cloud-init status --long' on the VPS;" >&2
+              echo "       fix per docs/runbooks/user-service-alembic.md#observability" >&2
+              echo "       (recovery section)." >&2
+              exit 1
+            fi
+
+            # Map the runner-side `migrated` boolean to a 0|1 gauge value.
+            # Anything other than the literal string "true" → 0 (failure),
+            # which covers both the heads-count assertion failure path and
+            # the `alembic upgrade head` failure path (record step sets
+            # migrated=false in both cases). An empty MIGRATED (e.g., the
+            # record step itself crashed) also maps to 0 — fail-loud default.
+            if [ "${MIGRATED}" = "true" ]; then
+              SUCCESS=1
+            else
+              SUCCESS=0
+            fi
+            NOW="$(date -u +%s)"
+
+            {
+              echo "# HELP user_service_alembic_gate_last_run_success 1 if the most recent alembic pre-deploy gate run succeeded for the labeled env, else 0."
+              echo "# TYPE user_service_alembic_gate_last_run_success gauge"
+              echo "user_service_alembic_gate_last_run_success{env=\"${ENV_NAME}\"} ${SUCCESS}"
+              echo "# HELP user_service_alembic_gate_last_run_timestamp_seconds Unix timestamp of the most recent alembic pre-deploy gate run for the labeled env."
+              echo "# TYPE user_service_alembic_gate_last_run_timestamp_seconds gauge"
+              echo "user_service_alembic_gate_last_run_timestamp_seconds{env=\"${ENV_NAME}\"} ${NOW}"
+            } > "${TMP}"
+            chmod 0644 "${TMP}"
+            # Atomic rename — safe against node-exporter read race. Same fs
+            # by construction (both paths under TEXTFILE_DIR).
+            mv -f "${TMP}" "${FINAL}"
+            echo "Wrote ${FINAL}: success=${SUCCESS} timestamp=${NOW} env=${ENV_NAME}"
+            cat "${FINAL}"
+
       - name: Report migration result
         if: always()
         run: |

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -40,7 +40,40 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Pre-deploy alembic gate (deploy#160). Only fires for the user-service
+  # dispatch path so isnad-graph / landing fan-ins don't pay alembic latency
+  # or contend on the user-postgres advisory lock. Discrimination: the
+  # repository_dispatch `event.action` carries the dispatched repo name (one
+  # of the three `deploy-noorinalabs-<service>` types declared in `on:`).
+  #
+  # workflow_dispatch path is intentionally excluded — the manual operator
+  # tag may target any image; running alembic against an arbitrary stg-latest
+  # would be confusing. Operators wanting a manual stg migrate run dispatch
+  # db-migrate.yml directly with env=stg.
+  migrate:
+    name: alembic upgrade head (stg, user-service only)
+    if: ${{ github.event_name == 'repository_dispatch' && github.event.action == 'deploy-noorinalabs-user-service' }}
+    # Reusable workflow accepts an empty string and falls back to `<env>-latest`
+    # (db-migrate.yml § Resolve image tag). Passing empty here is safer than
+    # synthesising a tag client-side: if the dispatch payload's `sha` is
+    # missing or malformed the gate still runs against stg-latest, which is
+    # what the user-service push fan-in already pointed at by the time its
+    # ghcr-publish.yml fired this repository_dispatch.
+    uses: ./.github/workflows/db-migrate.yml
+    with:
+      env: stg
+      image_tag: ""
+    secrets: inherit
+
   deploy:
+    # Gate the existing deploy job on the alembic outcome — but ONLY when
+    # the migrate job actually ran (success). For non-user-service dispatches
+    # and workflow_dispatch the migrate job is skipped via its `if:` and we
+    # still want deploy to proceed; GH Actions treats `needs: [migrate]` with
+    # a skipped dependency as not-satisfied by default, so we re-allow via the
+    # explicit `if:` below.
+    needs: [migrate]
+    if: ${{ always() && (needs.migrate.result == 'success' || needs.migrate.result == 'skipped') }}
     runs-on: ubuntu-latest
     environment: staging
     permissions:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -52,6 +52,21 @@ on:
         description: "Comma-separated image set to promote (default: all)."
         required: false
         default: "api,frontend,user-service,landing"
+      skip_stg_verify:
+        description: >-
+          BREAK-GLASS: skip the stg-verify gate. Only set true when the
+          gate is broken and you need an emergency promotion. A warning
+          annotation + job-summary entry are emitted on use.
+        required: false
+        default: false
+        type: boolean
+      stg_verify_max_age_hours:
+        description: >-
+          Maximum age (hours) of the stg-verify-result artifact. Older
+          artifacts cause the gate to fail with "stg verify is stale".
+        required: false
+        default: "24"
+        type: string
 
 concurrency:
   # All promotions serialize globally — we never want two promotions racing
@@ -214,9 +229,235 @@ jobs:
           print("[plan] matrix:", json.dumps(data, indent=2))
           PY3
 
+  # ─────────────────────────────────────────────────────────────────
+  # Stg-verify gate (deploy#179).
+  #
+  # Hard-blocks promotion unless the most recent `verify-deploy.yml`
+  # run triggered by "Deploy to staging" concluded success AND its
+  # emitted artifact is fresh (default: <24h old).
+  #
+  # Why "most recent" instead of "per image SHA":
+  #   verify-deploy.yml emits its artifact's `commit_sha` from the
+  #   triggering deploy-stg run's `head_sha`, which for a
+  #   repository_dispatch is the deploy-repo HEAD, NOT the service
+  #   image's SHA. The plan job resolves per-service image short SHAs
+  #   from each service's GHCR `stg-latest` digest — these two
+  #   identifiers do not share a namespace, so per-image SHA equality
+  #   isn't achievable without modifying verify-deploy.yml's schema
+  #   (out of scope for this issue per the issue body).
+  #
+  #   Operationally, the unit of stg verification IS the compose stack
+  #   as a whole at a moment in time. One successful verify-stg run
+  #   validates the cumulative state of every `stg-latest` pointer at
+  #   trigger time. If `stg-latest` hasn't moved since, that verify
+  #   covers what plan resolved. The freshness window enforces the
+  #   "hasn't moved" assumption probabilistically.
+  #
+  # Override: `inputs.skip_stg_verify: true` skips the gate. A warning
+  # annotation + job-summary entry surface the break-glass use.
+  # ─────────────────────────────────────────────────────────────────
+  gate-stg-verify:
+    name: Gate — stg verify-deploy success
+    needs: plan
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      gate_result: ${{ steps.gate.outputs.gate_result }}
+    steps:
+      - name: Break-glass override (skip_stg_verify)
+        if: ${{ inputs.skip_stg_verify }}
+        env:
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          echo "::warning::stg-verify gate SKIPPED via break-glass input by $ACTOR"
+          {
+            echo "## ⚠ stg-verify gate SKIPPED (break-glass)"
+            echo ""
+            echo "- **Actor:** $ACTOR"
+            echo "- **Input:** \`skip_stg_verify=true\`"
+            echo ""
+            echo "This promotion proceeded WITHOUT confirming the latest stg verify-deploy succeeded."
+            echo "Use only when the gate itself is broken; otherwise investigate the gate failure first."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Locate recent verify-deploy runs
+        if: ${{ !inputs.skip_stg_verify }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Heuristic: the verify-stg job is the only path that emits the
+          # `stg-verify-result` artifact, so we scan up to 50 most recent
+          # `verify-deploy.yml` runs newest-first and stop at the first
+          # one carrying that artifact (gate step picks it up below).
+          # We don't pre-filter by upstream workflow name because gh's
+          # workflow_runs payload doesn't surface the triggering workflow
+          # title at this level reliably; the artifact's existence is the
+          # clean signal.
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${REPO}/actions/workflows/verify-deploy.yml/runs?per_page=50" \
+            --jq '.workflow_runs[] | [.id, .event] | @tsv' \
+            > /tmp/verify_runs.tsv
+          echo "Found $(wc -l < /tmp/verify_runs.tsv) recent verify-deploy runs."
+
+      - name: Validate stg-verify artifact (gate)
+        id: gate
+        if: ${{ !inputs.skip_stg_verify }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          MAX_AGE_HOURS: ${{ inputs.stg_verify_max_age_hours }}
+          API_SHORT:          ${{ needs.plan.outputs.api_short }}
+          FRONTEND_SHORT:     ${{ needs.plan.outputs.frontend_short }}
+          USER_SERVICE_SHORT: ${{ needs.plan.outputs.user_service_short }}
+          LANDING_SHORT:      ${{ needs.plan.outputs.landing_short }}
+        run: |
+          set -euo pipefail
+
+          # Validate freshness window input is a positive integer.
+          if ! printf '%s' "${MAX_AGE_HOURS}" | grep -qE '^[1-9][0-9]*$'; then
+            echo "::error::stg_verify_max_age_hours must be a positive integer. Got: ${MAX_AGE_HOURS}"
+            exit 1
+          fi
+
+          # Walk recent verify-deploy runs newest-first; for each one,
+          # try to download the `stg-verify-result` artifact and parse it.
+          # Stop at the first artifact that parses cleanly — that is the
+          # most recent stg-verify outcome. Then evaluate result + age.
+          mkdir -p /tmp/verify_artifacts
+          chosen_run_id=""
+          chosen_artifact=""
+          while IFS=$'\t' read -r run_id event; do
+            # Only workflow_run-triggered verify runs matter (those are
+            # auto-fired post-deploy). workflow_dispatch runs may target
+            # prod or have no stg artifact at all.
+            if [ "$event" != "workflow_run" ]; then
+              continue
+            fi
+            # List artifacts for this run; look for `stg-verify-result`.
+            artifacts_json=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/${REPO}/actions/runs/${run_id}/artifacts" \
+              --jq '.artifacts[] | select(.name=="stg-verify-result") | .id' \
+              2>/dev/null || true)
+            if [ -z "$artifacts_json" ]; then
+              continue
+            fi
+            artifact_id=$(printf '%s\n' "$artifacts_json" | head -n1)
+            dl_dir="/tmp/verify_artifacts/${run_id}"
+            mkdir -p "$dl_dir"
+            # Use gh api to download the zip, then unzip.
+            if ! gh api \
+                -H "Accept: application/vnd.github+json" \
+                "/repos/${REPO}/actions/artifacts/${artifact_id}/zip" \
+                > "${dl_dir}/artifact.zip" 2>/dev/null; then
+              continue
+            fi
+            if ! unzip -q -o "${dl_dir}/artifact.zip" -d "$dl_dir" 2>/dev/null; then
+              continue
+            fi
+            # Filename is `stg-verify-result-<run_id>.json` per
+            # verify-deploy.yml. Use a glob to be tolerant.
+            json_file=$(find "$dl_dir" -maxdepth 1 -name 'stg-verify-result-*.json' | head -n1)
+            if [ -z "$json_file" ] || [ ! -f "$json_file" ]; then
+              continue
+            fi
+            # Sanity-check schema_version. Fail loud on unknown schema —
+            # do NOT silently treat unrecognized as success.
+            schema_version=$(python3 -c "import json,sys;print(json.load(open(sys.argv[1])).get('schema_version',''))" "$json_file" 2>/dev/null || echo "")
+            if [ "$schema_version" != "1" ]; then
+              echo "::error::stg-verify-result artifact for run ${run_id} has unknown schema_version=${schema_version}; refusing to gate."
+              echo "::error::This gate understands only schema_version=1. Update the gate before publishing schema v2."
+              exit 1
+            fi
+            chosen_run_id="$run_id"
+            chosen_artifact="$json_file"
+            break
+          done < /tmp/verify_runs.tsv
+
+          if [ -z "$chosen_run_id" ]; then
+            echo "::error::No verify-deploy.yml run with a stg-verify-result artifact was found in the last 50 runs."
+            echo "::error::Cannot gate prod-promote without a recent stg-verify outcome. Investigate verify-deploy.yml or run it manually before retrying promotion."
+            {
+              echo "## stg-verify gate FAILED — no artifact"
+              echo ""
+              echo "Searched 50 most-recent runs of \`verify-deploy.yml\`; none produced a \`stg-verify-result\` artifact."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          echo "Using stg-verify-result from run ${chosen_run_id}"
+          echo "Artifact: ${chosen_artifact}"
+          cat "$chosen_artifact"
+          echo ""
+
+          # Parse fields.
+          result=$(python3 -c "import json,sys;print(json.load(open(sys.argv[1])).get('result',''))" "$chosen_artifact")
+          commit_sha=$(python3 -c "import json,sys;print(json.load(open(sys.argv[1])).get('commit_sha',''))" "$chosen_artifact")
+          timestamp=$(python3 -c "import json,sys;print(json.load(open(sys.argv[1])).get('timestamp',''))" "$chosen_artifact")
+
+          # Freshness check.
+          age_seconds=$(python3 - "$timestamp" <<'PY'
+          import sys, datetime
+          ts = sys.argv[1]
+          try:
+              when = datetime.datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=datetime.timezone.utc)
+          except ValueError:
+              print(-1)
+              sys.exit(0)
+          now = datetime.datetime.now(datetime.timezone.utc)
+          print(int((now - when).total_seconds()))
+          PY
+          )
+          if [ "$age_seconds" = "-1" ]; then
+            echo "::error::stg-verify-result timestamp could not be parsed: ${timestamp}"
+            exit 1
+          fi
+          max_age_seconds=$(( MAX_AGE_HOURS * 3600 ))
+          age_hours=$(python3 -c "print(round(${age_seconds}/3600.0, 2))")
+
+          # Decision.
+          {
+            echo "## stg-verify gate"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Source verify-deploy run | [${chosen_run_id}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${chosen_run_id}) |"
+            echo "| Artifact result | \`${result}\` |"
+            echo "| Artifact commit_sha | \`${commit_sha}\` |"
+            echo "| Artifact timestamp | \`${timestamp}\` (age ${age_hours}h, max ${MAX_AGE_HOURS}h) |"
+            echo ""
+            echo "### Plan-resolved per-service shorts (for audit)"
+            echo "- api:          \`${API_SHORT:-<not in promotion set>}\`"
+            echo "- frontend:     \`${FRONTEND_SHORT:-<not in promotion set>}\`"
+            echo "- user-service: \`${USER_SERVICE_SHORT:-<not in promotion set>}\`"
+            echo "- landing:      \`${LANDING_SHORT:-<not in promotion set>}\`"
+            echo ""
+            echo "_Note: per-service shorts and \`commit_sha\` come from different namespaces (image SHA vs deploy-repo HEAD). Identity match is informational only — the gate semantics are 'latest stg verify succeeded within freshness window'._"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$result" != "success" ]; then
+            echo "::error::Latest stg-verify-result is \`${result}\` (not success). Blocking prod-promote."
+            echo "gate_result=blocked-failed-verify" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          if [ "$age_seconds" -gt "$max_age_seconds" ]; then
+            echo "::error::stg verify is stale: artifact age=${age_hours}h exceeds max ${MAX_AGE_HOURS}h. Re-run verify-deploy.yml against current stg state, or raise stg_verify_max_age_hours if accepting risk."
+            echo "gate_result=blocked-stale" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          echo "stg-verify gate PASSED."
+          echo "gate_result=passed" >> "$GITHUB_OUTPUT"
+
   retag:
     name: Retag ${{ matrix.key }} (stg → prod)
-    needs: plan
+    needs: [plan, gate-stg-verify]
     runs-on: ubuntu-latest
     # The production GH Environment carries the manual-approval reviewer rule.
     # This job does NOT touch a VPS — it only rewrites tags at GHCR. The

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -455,9 +455,53 @@ jobs:
           echo "stg-verify gate PASSED."
           echo "gate_result=passed" >> "$GITHUB_OUTPUT"
 
+  # ─────────────────────────────────────────────────────────────────
+  # Pre-retag alembic gate (deploy#160).
+  #
+  # Runs `alembic upgrade head` on prod's user-postgres BEFORE retag
+  # writes `prod-<short>` and `prod-latest`. Sequencing rationale
+  # (Bereket spec, P3W1 Round 2):
+  #
+  #   plan → gate-stg-verify → migrate-prod → retag → trigger-prod-deploy
+  #
+  # `retag` is the irreversible commit-to-prod step. A migration
+  # failure AFTER retag would leave prod with a forward-pinned image
+  # but a half-migrated DB — recoverable only via manual rollback of
+  # both image and schema. Running migrate-prod BEFORE retag keeps
+  # failure recovery to "fix the migration, re-promote".
+  #
+  # Image tag passed: `stg-<short>` resolved by `plan` from the
+  # promotion source. The `prod-<short>` tag does NOT yet exist at
+  # this stage (retag is what writes it). The `stg-<short>` tag
+  # points at the same digest the retag will promote, so alembic
+  # runs against the exact image about to be made the prod pointer.
+  #
+  # Skip semantics: this job is gated on user-service being in the
+  # promotion set (plan emits `user_service_short=""` when not). When
+  # user-service is excluded the job is skipped and `retag` proceeds
+  # via the explicit `if:` below allowing skipped-or-success.
+  # ─────────────────────────────────────────────────────────────────
+  migrate-prod:
+    name: alembic upgrade head (prod, user-service only)
+    needs: [plan, gate-stg-verify]
+    # Skip if user-service is not in this promotion's image set.
+    if: ${{ needs.plan.outputs.user_service_short != '' }}
+    uses: ./.github/workflows/db-migrate.yml
+    with:
+      env: prod
+      # plan emits the bare 7-char short; alembic runs from the stg-tagged
+      # image (prod-<short> doesn't exist until retag below).
+      image_tag: stg-${{ needs.plan.outputs.user_service_short }}
+    secrets: inherit
+
   retag:
     name: Retag ${{ matrix.key }} (stg → prod)
-    needs: [plan, gate-stg-verify]
+    needs: [plan, gate-stg-verify, migrate-prod]
+    # `migrate-prod` is gated on user-service being in the promotion set; for
+    # promotions that exclude user-service it is skipped, and retag must still
+    # proceed. GH Actions defaults a `needs:` to satisfied only on `success`,
+    # so the explicit allow-skipped predicate is required.
+    if: ${{ always() && needs.gate-stg-verify.result == 'success' && (needs.migrate-prod.result == 'success' || needs.migrate-prod.result == 'skipped') }}
     runs-on: ubuntu-latest
     # The production GH Environment carries the manual-approval reviewer rule.
     # This job does NOT touch a VPS — it only rewrites tags at GHCR. The

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       image_tag:
-        description: 'Image tag to roll back to (e.g., sha-a1b2c3d, phase12-wave1)'
+        description: 'Image tag to roll back to (e.g., sha-a1b2c3d, phase12-wave1). Drives api+frontend (which share IMAGE_TAG) and is the default for user-service / landing if their per-service override is left blank.'
         required: true
       service:
         description: 'Service to roll back'
@@ -13,7 +13,17 @@ on:
           - all
           - api
           - frontend
+          - user-service
+          - landing
         default: 'all'
+      user_service_image_tag:
+        description: 'Override tag for user-service (optional, defaults to image_tag). user-service is independently tagged via USER_SERVICE_IMAGE_TAG.'
+        required: false
+        default: ''
+      landing_image_tag:
+        description: 'Override tag for landing (optional, defaults to image_tag). landing is independently tagged via LANDING_IMAGE_TAG.'
+        required: false
+        default: ''
 
 concurrency:
   group: deploy-production
@@ -31,31 +41,68 @@ jobs:
         env:
           IMAGE_TAG: ${{ inputs.image_tag }}
           ROLLBACK_SERVICE: ${{ inputs.service }}
+          USER_SERVICE_IMAGE_TAG_OVERRIDE: ${{ inputs.user_service_image_tag }}
+          LANDING_IMAGE_TAG_OVERRIDE: ${{ inputs.landing_image_tag }}
         with:
           host: ${{ vars.VPS_HOST }}
           username: deploy
           key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
-          envs: IMAGE_TAG,ROLLBACK_SERVICE
+          envs: IMAGE_TAG,ROLLBACK_SERVICE,USER_SERVICE_IMAGE_TAG_OVERRIDE,LANDING_IMAGE_TAG_OVERRIDE
           script: |
             set -euo pipefail
             cd /opt/noorinalabs-deploy
 
             echo "==> Rolling back ${ROLLBACK_SERVICE} to image tag: ${IMAGE_TAG}"
 
-            # Update IMAGE_TAG in .env
-            sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=\"${IMAGE_TAG}\"/" .env
-
             if [ "$ROLLBACK_SERVICE" = "all" ]; then
-              docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env pull api frontend 2>/dev/null || true
-              docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env up -d --force-recreate api frontend
+              SERVICES=(api frontend user-service landing)
             else
-              docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env pull "$ROLLBACK_SERVICE" 2>/dev/null || true
-              docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env up -d --force-recreate "$ROLLBACK_SERVICE"
+              SERVICES=("$ROLLBACK_SERVICE")
             fi
+
+            # Resolve which env vars in .env need updating, given that:
+            #   - api + frontend share IMAGE_TAG (compose: ${IMAGE_TAG:-latest})
+            #   - user-service uses USER_SERVICE_IMAGE_TAG
+            #   - landing uses LANDING_IMAGE_TAG
+            US_TAG="${USER_SERVICE_IMAGE_TAG_OVERRIDE:-$IMAGE_TAG}"
+            LD_TAG="${LANDING_IMAGE_TAG_OVERRIDE:-$IMAGE_TAG}"
+
+            update_env_var() {
+              local var="$1" val="$2"
+              if grep -qE "^${var}=" .env; then
+                sed -i "s/^${var}=.*/${var}=\"${val}\"/" .env
+              else
+                printf '%s="%s"\n' "$var" "$val" >> .env
+              fi
+            }
+
+            for svc in "${SERVICES[@]}"; do
+              case "$svc" in
+                api|frontend)
+                  update_env_var IMAGE_TAG "$IMAGE_TAG"
+                  echo "  ${svc} -> ${IMAGE_TAG} (via IMAGE_TAG)"
+                  ;;
+                user-service)
+                  update_env_var USER_SERVICE_IMAGE_TAG "$US_TAG"
+                  echo "  ${svc} -> ${US_TAG} (via USER_SERVICE_IMAGE_TAG)"
+                  ;;
+                landing)
+                  update_env_var LANDING_IMAGE_TAG "$LD_TAG"
+                  echo "  ${svc} -> ${LD_TAG} (via LANDING_IMAGE_TAG)"
+                  ;;
+              esac
+            done
+
+            for svc in "${SERVICES[@]}"; do
+              docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env pull "$svc" 2>/dev/null || true
+              docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env up -d --force-recreate "$svc"
+            done
 
             sleep 15
             echo "==> Rollback complete. Verifying health..."
-            docker compose -p noorinalabs -f compose/docker-compose.prod.yml ps --format '{{.Name}}\t{{.Status}}'
+            docker compose -p noorinalabs -f compose/docker-compose.prod.yml ps \
+              --format '{{.Name}}\t{{.Status}}' \
+              api frontend user-service landing
 
       - name: Report rollback status
         if: always()
@@ -64,4 +111,10 @@ jobs:
             echo "## Rollback: ${{ job.status }}"
             echo "- **Service:** ${{ inputs.service }}"
             echo "- **Target tag:** ${{ inputs.image_tag }}"
+            if [ -n "${{ inputs.user_service_image_tag }}" ]; then
+              echo "- **user-service override:** ${{ inputs.user_service_image_tag }}"
+            fi
+            if [ -n "${{ inputs.landing_image_tag }}" ]; then
+              echo "- **landing override:** ${{ inputs.landing_image_tag }}"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/verify-deploy.yml
+++ b/.github/workflows/verify-deploy.yml
@@ -46,10 +46,28 @@ jobs:
   # the deployed stg URLs.
   # ─────────────────────────────────────────────────────────────────
   verify-stg:
-    name: Verify stg (full integration suite)
+    name: Verify stg (remote-mode integration suite)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: staging
+    # Belt-and-suspenders: run-tests.sh's remote branch already hard-refuses
+    # on ENVIRONMENT in {prod, production} (#178 / PR #202). Setting it
+    # explicitly at the workflow level makes verify-stg impossible to
+    # mis-point at prod even if someone manually edits the job-level env
+    # block. Cheap redundancy for a load-bearing safety check.
+    env:
+      ENVIRONMENT: stg
+      RUN_MODE: remote
+      # Public stg URLs — these are the same hostnames operators hit in a
+      # browser. Caddy auto-provisions LE TLS for them; per #157 the
+      # `users.stg.noorinalabs.com` cutover lives in the wave's Caddyfile.
+      ISNAD_BASE_URL: https://isnad.stg.noorinalabs.com
+      USER_SERVICE_BASE_URL: https://users.stg.noorinalabs.com
+      # Stg test-user creds. No-op for the 3 health tests that currently
+      # run remote-mode (those don't authenticate); #204 expands coverage
+      # by populating these as the per-test refactor lands.
+      STG_TEST_USER_EMAIL: ${{ secrets.STG_TEST_USER_EMAIL }}
+      STG_TEST_USER_PASSWORD: ${{ secrets.STG_TEST_USER_PASSWORD }}
     if: >-
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.name == 'Deploy to staging' &&
@@ -61,75 +79,28 @@ jobs:
       # verify against main's revision. Pin to the upstream deploy's
       # head_sha (sha is more stable than head_branch — branch may have
       # moved between trigger and run). See deploy#181 review (Weronika).
+      #
+      # Sibling-repo checkouts (user-service + isnad-graph) and Buildx
+      # setup were dropped in #205 — remote mode runs against deployed
+      # stg URLs, doesn't build images locally. The wave-aware sibling
+      # ref resolution is therefore unused here. If hermetic local
+      # verification is ever revived, restore that sequence from
+      # `git show 6e8f450:.github/workflows/verify-deploy.yml`.
       - name: Checkout noorinalabs-deploy
         uses: actions/checkout@v4
         with:
           path: noorinalabs-deploy
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
-      # Wave-aware sibling-repo ref resolution (mirrors integration-tests.yml
-      # pattern; needed so a wave-branch deploy verifies against matching
-      # wave branches of user-service + isnad-graph). See feedback memory
-      # "Cross-repo wave-aware sibling checkout" 2026-04-24.
-      - name: Resolve sibling-repo refs (wave-aware)
-        id: sibling-refs
-        run: |
-          set -euo pipefail
-          # On workflow_run the head_branch of the upstream deploy is most
-          # accurate; on workflow_dispatch, fall back to ref_name of this
-          # workflow's invocation context.
-          if [ "${{ github.event_name }}" = "workflow_run" ]; then
-            BASE="${{ github.event.workflow_run.head_branch }}"
-          else
-            BASE="${{ github.ref_name }}"
-          fi
-          [ -n "$BASE" ] || BASE="main"
-
-          resolve_ref() {
-            local repo="$1"
-            if [[ "$BASE" == deployments/* ]] && \
-               git ls-remote --exit-code "https://github.com/noorinalabs/${repo}.git" "refs/heads/${BASE}" >/dev/null 2>&1; then
-              echo "$BASE"
-            else
-              echo "main"
-            fi
-          }
-
-          US_REF=$(resolve_ref noorinalabs-user-service)
-          IG_REF=$(resolve_ref noorinalabs-isnad-graph)
-
-          echo "user_service_ref=${US_REF}" >> "$GITHUB_OUTPUT"
-          echo "isnad_graph_ref=${IG_REF}"  >> "$GITHUB_OUTPUT"
-          {
-            echo "## Resolved sibling refs (verify-stg)"
-            echo "- upstream branch: \`${BASE}\`"
-            echo "- noorinalabs-user-service: \`${US_REF}\`"
-            echo "- noorinalabs-isnad-graph:  \`${IG_REF}\`"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Checkout noorinalabs-user-service
-        uses: actions/checkout@v4
-        with:
-          repository: noorinalabs/noorinalabs-user-service
-          path: noorinalabs-user-service
-          ref: ${{ steps.sibling-refs.outputs.user_service_ref }}
-
-      - name: Checkout noorinalabs-isnad-graph
-        uses: actions/checkout@v4
-        with:
-          repository: noorinalabs/noorinalabs-isnad-graph
-          path: noorinalabs-isnad-graph
-          ref: ${{ steps.sibling-refs.outputs.isnad_graph_ref }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      # run-tests.sh already passes --junit-xml=/app/reports/junit.xml to
-      # pytest internally; re-passing the flag here would duplicate it
-      # (latter-wins works by accident with WORKDIR=/app + the ./reports
-      # mount, but is brittle to refactor). Let the script own the flag.
-      # See deploy#181 review (Nurul).
-      - name: Run full integration suite
+      # run-tests.sh in RUN_MODE=remote (#178 / PR #202) skips compose
+      # stack-up entirely, builds the runner image from Dockerfile.runner,
+      # and `docker run`s it against the env-supplied stg URLs. The
+      # Dockerfile.runner build is pure-pip and doesn't need Buildx, so
+      # there's no `setup-buildx-action` step here. Job env exports
+      # USER_SERVICE_BASE_URL / ISNAD_BASE_URL above; the script sets
+      # USER_SERVICE_URL / ISNAD_GRAPH_URL inside the runner container
+      # for conftest.py compatibility.
+      - name: Run integration suite (remote mode)
         working-directory: noorinalabs-deploy/integration-tests
         run: ./run-tests.sh
 
@@ -140,10 +111,10 @@ jobs:
           name: verify-stg-junit
           path: noorinalabs-deploy/integration-tests/reports/
 
-      - name: Dump compose logs on failure
-        if: failure()
-        working-directory: noorinalabs-deploy/integration-tests
-        run: docker compose -f docker-compose.test.yml --env-file .env.test logs --no-color > reports/compose.log || true
+      # Compose-logs-on-failure dump was dropped with the hermetic stack
+      # — there is no docker-compose stack to query in remote mode. Test
+      # failure surfaces via the junit artifact above and via run-tests.sh
+      # stdout in the job's run-log.
 
       # Artifact consumed by deploy#179 (promote.yml gate). Schema v1:
       # { "schema_version": 1,
@@ -191,7 +162,7 @@ jobs:
           {
             echo "## Verify stg — ${{ job.status }}"
             echo ""
-            echo "Full cross-repo integration suite (hermetic Option A; deploy#178 tracks remote-mode against live stg URLs)."
+            echo "Remote-mode integration suite (#205) against deployed stg URLs (\`$USER_SERVICE_BASE_URL\` / \`$ISNAD_BASE_URL\`)."
             echo ""
             if [ -f noorinalabs-deploy/integration-tests/reports/junit.xml ]; then
               echo "### Test counts"

--- a/.github/workflows/verify-deploy.yml
+++ b/.github/workflows/verify-deploy.yml
@@ -23,12 +23,33 @@
 # "Deploy to staging" and "Deploy to production" — repointed below as part
 # of deploy#87 (the split is unimplementable otherwise; trigger today fires
 # on a workflow nobody runs).
+#
+# Trigger expansion (deploy#73, P3W1 Round 2):
+#   - "Deploy All Services" — manual-dispatch full-stack prod deploy. Same
+#     environment: production as deploy-prod.yml; benefits from the same
+#     post-deploy smoke battery.
+#   - "Rollback" — manual-dispatch prod tag rollback. A rollback IS a deploy
+#     for verification purposes; the prod stack just changed so smoke-test it.
+#
+# Why NOT add legacy/manual workflows:
+#   - "Deploy noorinalabs-isnad-graph (LEGACY — manual only)" and
+#     "Deploy noorinalabs-landing-page (LEGACY — manual only)" target the
+#     legacy single-VPS box that deploy#86 will decommission. Auto-verify
+#     against legacy-VPS endpoints would smoke against URLs that no longer
+#     resolve once #86 lands. Operators running the legacy paths invoke
+#     scripts/verify_deployment.sh manually if they want post-deploy checks
+#     against the legacy host (the script grew landing + user-service checks
+#     in this same PR for that purpose).
 
 name: Verify Deployment
 
 on:
   workflow_run:
-    workflows: ["Deploy to staging", "Deploy to production"]
+    workflows:
+      - "Deploy to staging"
+      - "Deploy to production"
+      - "Deploy All Services"
+      - "Rollback"
     types: [completed]
   workflow_dispatch:
     inputs:
@@ -215,9 +236,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     environment: production
+    # Multi-trigger acceptance (deploy#73): three prod-touching upstream
+    # workflows now share verify-prod. All produce the same post-state
+    # invariant (prod stack just got rolled forward or back), so the same
+    # smoke battery is the right post-condition for all three. The
+    # workflow_run.name check enumerates them rather than allow-everything
+    # so a future stg-targeting workflow accidentally hitting this trigger
+    # list does not run prod smoke against itself.
     if: >-
       (github.event_name == 'workflow_run' &&
-       github.event.workflow_run.name == 'Deploy to production' &&
+       (github.event.workflow_run.name == 'Deploy to production' ||
+        github.event.workflow_run.name == 'Deploy All Services' ||
+        github.event.workflow_run.name == 'Rollback') &&
        github.event.workflow_run.conclusion == 'success') ||
       (github.event_name == 'workflow_dispatch' && inputs.target == 'prod')
     steps:

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -653,6 +653,43 @@ services:
           memory: 128M
           cpus: "0.25"
 
+  # blackbox-exporter — continuous external probing of prod public routes
+  # (companion to scripts/verify_prod_smoke.sh post-deploy battery, see deploy#183).
+  # Two-network topology:
+  #   - frontend: real-DNS / real-TLS path to the public Caddy endpoints
+  #     (`internal: false`, so the container has egress to the public internet).
+  #   - backend:  Prometheus scrapes /probe + /metrics on this internal network.
+  blackbox-exporter:
+    image: prom/blackbox-exporter:v0.25.0
+    volumes:
+      - ../infra/blackbox-exporter/blackbox.yml:/etc/blackbox_exporter/config.yml:ro
+    command:
+      - "--config.file=/etc/blackbox_exporter/config.yml"
+    expose:
+      - "9115"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:9115/-/healthy || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    networks:
+      - backend
+      - frontend
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+          cpus: "0.25"
+        reservations:
+          memory: 32M
+          cpus: "0.05"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
   # --- Pipeline messaging (Kafka KRaft, single-node) ---
   #
   # Single-broker Kafka in KRaft mode (no ZooKeeper). Used by the data

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -611,11 +611,25 @@ services:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
       - /:/rootfs:ro
+      # Textfile collector input directory (deploy#161). The host path is
+      # owned by the `deploy` user (mode 0775) and populated by the alembic
+      # pre-deploy gate in db-migrate.yml on every run via `if: always()`.
+      # Read-only mount so a compromised node-exporter cannot clobber the
+      # written .prom files. Provisioning of the host directory is a runbook
+      # step today (`mkdir -p /var/lib/node_exporter/textfile_collector &&
+      # chown deploy:deploy && chmod 0775`); cloud-init bake-in is tracked as
+      # a follow-up if Nurul prefers it move to TF.
+      - /var/lib/node_exporter/textfile_collector:/var/lib/node_exporter/textfile_collector:ro
     command:
       - "--path.procfs=/host/proc"
       - "--path.rootfs=/rootfs"
       - "--path.sysfs=/host/sys"
       - "--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)"
+      # Enable the textfile collector with the directory mounted above.
+      # Files matching `*.prom` are scraped at the interval set by Prometheus
+      # for the node-exporter job. Atomic writes (temp + rename) on the
+      # producer side prevent half-written reads.
+      - "--collector.textfile.directory=/var/lib/node_exporter/textfile_collector"
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:9100/metrics || exit 1"]
       interval: 10s

--- a/docs/runbooks/blackbox-probes.md
+++ b/docs/runbooks/blackbox-probes.md
@@ -1,0 +1,124 @@
+# Runbook — Blackbox prod probes
+
+The blackbox-exporter (`prom/blackbox-exporter:v0.25.0`, container
+`blackbox-exporter`) continuously probes the same 6 prod public routes
+that `scripts/verify_prod_smoke.sh` validates post-deploy. Smoke is the
+deploy-time gate; blackbox is the steady-state monitor between deploys.
+
+Source of truth for the route list: `infra/prometheus/prometheus.yml`
+(scrape_config `blackbox`). Modules and HTTP-status expectations live in
+`infra/blackbox-exporter/blackbox.yml`.
+
+| Route label             | URL                                                                       | Module          | Expected |
+|-------------------------|---------------------------------------------------------------------------|-----------------|----------|
+| `isnad-health`          | `https://isnad-graph.noorinalabs.com/health`                              | `http_2xx_json` | 200, JSON body |
+| `user-service-health`   | `https://isnad-graph.noorinalabs.com/api/v1/user-service/health`          | `http_2xx`      | 200 |
+| `landing-root`          | `https://noorinalabs.com/`                                                | `http_2xx`      | 200 |
+| `narrator-401`          | `https://isnad-graph.noorinalabs.com/api/v1/narrators?limit=1`            | `http_401_json` | 401/403 + JSON body |
+| `jwks`                  | `https://isnad-graph.noorinalabs.com/.well-known/jwks.json`               | `http_2xx_json` | 200, JSON `.keys[]` |
+| `auth-login-redirect`   | `https://isnad-graph.noorinalabs.com/auth/login`                          | `http_3xx`      | 3xx (or 200 for interstitial) |
+
+When deploy#156 cleaves user-service onto its own subdomain
+(`users.noorinalabs.com`) and isnad onto `isnad.noorinalabs.com`,
+update the URLs in `infra/prometheus/prometheus.yml` and the smoke
+battery defaults in lockstep.
+
+## Alerts
+
+### probe-failing
+
+Fires when `probe_success == 0` for any route for >2m.
+
+Investigation steps:
+
+1. Reproduce the probe locally:
+   `curl -sSI https://<route-url>` from a non-VPS host.
+2. If the route is healthy from outside but blackbox shows it down:
+   - SSH to prod and run `docker compose logs --tail 200 blackbox-exporter`.
+   - Check for DNS-resolution errors (the container is on `frontend` +
+     `backend`; only `frontend` has internet egress).
+   - **Suspect hairpin-NAT** if logs show no DNS errors and the host
+     itself can reach the route (`curl -sSI https://<route>` from the
+     prod shell). blackbox runs on the same prod box that Caddy serves,
+     so it probes its own public FQDN — egress works on Ubuntu 24.04
+     via standard MASQUERADE today, but a future kernel / netfilter /
+     docker-network change can break self-targeted SNAT. Reproduce from
+     inside the container with `docker compose exec blackbox-exporter wget -qO- -S https://<route>`.
+     If hairpin is the cause, do NOT pre-emptively re-shape the
+     topology — file an issue and we'll revisit.
+3. If the route is genuinely down:
+   - For `isnad-health` / `user-service-health`: pivot to the
+     `ServiceDown` / `ContainerUnhealthy` runbooks — those alerts
+     should already be firing.
+   - For `narrator-401` shape regression: this is the "Caddy answering
+     in plaintext while user-service is down" failure mode. Check that
+     `user-service` container is responding on its internal network
+     (`docker compose exec caddy wget -qO- http://user-service:8000/health`).
+   - For `auth-login-redirect`: confirm the `/auth/login` site block in
+     `caddy/Caddyfile` is still wired and that user-service has the
+     OAuth client credentials in `.env`.
+
+### unexpected-status
+
+Fires when a route returns an HTTP code outside the expected set for >5m
+(e.g. narrator-401 returning 200, or jwks returning 500). The alert is a
+weaker-but-louder signal than `probe-failing`; it tells you *what code*
+is being returned. Most often this points at a Caddy mis-route or a
+service answering in degraded mode.
+
+### cert-expiring-soon
+
+Fires when the TLS cert for any probed route expires in <7 days. Caddy
+auto-renews ~30 days before expiry, so reaching this threshold means
+renewal is failing. Check:
+
+- `docker compose logs --tail 500 caddy | grep -i 'acme\|certificate'`
+- `/data` volume disk usage (Let's Encrypt renewal needs scratch space).
+- Let's Encrypt rate-limit status (was the cert reissued repeatedly?).
+
+## Silencing during planned maintenance
+
+When you are about to do something that will deliberately cause one or
+more probes to fail (e.g. a known-disruptive deploy, a Caddy config
+shuffle, taking the box down for a Hetzner snapshot), silence the
+relevant alerts in alertmanager *before* the disruption rather than
+acknowledging pages after the fact.
+
+Current alertmanager runs on the prod box, bound to `127.0.0.1:9093`.
+Reach it via SSH tunnel:
+
+```bash
+ssh -L 9093:127.0.0.1:9093 deploy@<prod-host>
+# leave the session open while you work
+```
+
+Then create a silence with `amtool` (installed on the prod box) or via
+the alertmanager web UI at `http://localhost:9093`:
+
+```bash
+# Silence ALL blackbox alerts for 30 minutes
+amtool silence add \
+  --alertmanager.url=http://127.0.0.1:9093 \
+  --comment "Planned maintenance — deploy#NNN" \
+  --duration 30m \
+  alertname=~"Blackbox.*"
+
+# Silence one specific route (e.g. just /auth/login while reshuffling Caddy)
+amtool silence add \
+  --alertmanager.url=http://127.0.0.1:9093 \
+  --comment "Reshuffling Caddy auth carve-out — deploy#NNN" \
+  --duration 15m \
+  alertname=~"Blackbox.*" route="auth-login-redirect"
+```
+
+Always include a comment with the issue or PR number — it's the only
+breadcrumb to whoever is on-call after you. To list/expire silences:
+
+```bash
+amtool silence query   --alertmanager.url=http://127.0.0.1:9093
+amtool silence expire <silence-id> --alertmanager.url=http://127.0.0.1:9093
+```
+
+Silences auto-expire at the end of their duration; prefer a tight
+duration over an open-ended one. If a maintenance window over-runs,
+extend the silence rather than letting it lapse and then re-creating.

--- a/docs/runbooks/user-service-alembic.md
+++ b/docs/runbooks/user-service-alembic.md
@@ -156,22 +156,57 @@ If a migration needs to land urgently (e.g., a prod outage fix):
 
 ## Observability
 
-**Status: aspirational — deferred to W11 follow-up [`deploy#161`](https://github.com/noorinalabs/noorinalabs-deploy/issues/161).**
+**Status: implemented — [`deploy#161`](https://github.com/noorinalabs/noorinalabs-deploy/issues/161) (P3W1) wired the textfile-collector plumbing and landed the Prometheus alert.**
 
-The intended end state is a Prometheus alert `UserServiceAlembicGateFailure` that fires when the gate fails — short `for:` interval because the gate is one-shot and a miss is always actionable. The infrastructure to support this (textfile-collector writeout in `db-migrate.yml`, `--collector.textfile.directory=` flag + volume mount on `node-exporter` in `compose/docker-compose.prod.yml`) is **not** in place today. That plumbing is tracked in `deploy#161`.
+Gate runs emit two gauges to node-exporter's textfile collector via an `if: always()` SSH step in `db-migrate.yml`. The metric file lives at `/var/lib/node_exporter/textfile_collector/user_service_alembic_gate.prom` on the VPS (mode 0644, written by the `deploy` user via temp + atomic rename). The host directory is provisioned as a one-time runbook step on each VPS (`mkdir -p /var/lib/node_exporter/textfile_collector && chown deploy:deploy && chmod 0775`); the `node-exporter` service in `compose/docker-compose.prod.yml` mounts that directory read-only and reads the file on each scrape.
 
-Until #161 lands, gate failures surface via:
+Metric schema:
 
-1. **GitHub Actions UI** — the `Report migration result` step in `db-migrate.yml` writes a structured summary to `$GITHUB_STEP_SUMMARY` for every run (success or failure) including env, image tag, expected head, and the `migrated` boolean. The runbook link is included on failure.
-2. **Caller workflow signal** — the reusable workflow's `migrated` output is `false` (and the job result is `failure`) on any gate failure, which the promotion workflow (#155 → `promote.yml`) gates on. A failed stg gate hard-stops before prod manual-approval is even offered.
-3. **On-call escalation** — the table above (§ Escalation) lists primary/secondary owners per failure class. Until the Prometheus alert exists, the on-call engineer learns of a failure when the promotion workflow surfaces a failed run.
+```
+user_service_alembic_gate_last_run_success{env="..."} <0|1>
+user_service_alembic_gate_last_run_timestamp_seconds{env="..."} <unix-ts>
+```
+
+Alerts (`infra/prometheus/alerts.yml` group `db_migrate`) — two distinct rules so on-call can discriminate failure modes at first sight:
+
+| Alert | Expression | Fires when | Operator action |
+|-------|-----------|-----------|------------------|
+| `UserServiceAlembicGateFailure` | `_success == 0` | The most recent gate run returned `_success=0` (and has not been replaced by a successful run since) | Walk § Failure Modes above to discriminate heads-count vs `alembic upgrade head` failure; fix upstream and re-promote. |
+| `UserServiceAlembicGateStale` | `(time() - _timestamp) > 86400` | The most recent gate timestamp is older than 24h | Check `Deploy to staging` / `Promote to production` workflow runs first. If they ran but the metric didn't move, the textfile emission step or node-exporter scrape is broken. If they didn't run, the upstream pipeline (notify-deploy / repository_dispatch / ghcr-publish) is broken. |
+
+Both severities are `critical` and `for: 0m` — the gate is one-shot and every signal is operator-actionable; flap suppression isn't needed at this layer. Severity matches the § Escalation table above.
+
+Gate failures surface via:
+
+1. **Prometheus alert** (above) — routed through Alertmanager per `infra/alertmanager/alertmanager.yml` warning-severity rules.
+2. **GitHub Actions UI** — the `Report migration result` step in `db-migrate.yml` writes a structured summary to `$GITHUB_STEP_SUMMARY` for every run (success or failure) including env, image tag, expected head, and the `migrated` boolean. The runbook link is included on failure.
+3. **Caller workflow signal** — the reusable workflow's `migrated` output is `false` (and the job result is `failure`) on any gate failure, which the promotion workflow (#155 → `promote.yml`) gates on. A failed stg gate hard-stops before prod manual-approval is even offered.
+4. **On-call escalation** — the table above (§ Escalation) lists primary/secondary owners per failure class.
+
+### Operator: recovering the textfile_collector directory
+
+The host directory is provisioned automatically by Terraform cloud-init on every VPS — see `terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl` (the `runcmd:` block creates `/var/lib/node_exporter/textfile_collector` at first boot, owned `deploy:deploy` mode `0755`). **This recipe is for recovery only**, not bootstrap. Reach for it if:
+
+- The directory is missing or has wrong perms on a long-lived VPS (someone manually deleted it, partial restore from backup, etc.).
+- The cloud-init template was changed in a way that didn't run on existing VPSes (cloud-init only fires once on first boot).
+- An ad-hoc rebuild of the alert plumbing without re-running terraform.
+
+The most common observable symptom is the `Emit textfile-collector metrics on VPS` step in `db-migrate.yml` failing with `ERROR: /var/lib/node_exporter/textfile_collector is not writable by deploy user.` — this means cloud-init didn't fire (or its provisioning was overwritten). On the affected VPS, check `cloud-init status --long` first to confirm the diagnosis, then apply the recovery recipe:
+
+```bash
+sudo mkdir -p /var/lib/node_exporter/textfile_collector
+sudo chown deploy:deploy /var/lib/node_exporter/textfile_collector
+sudo chmod 0755 /var/lib/node_exporter/textfile_collector
+```
+
+Note: as of #210 the `Emit` step **fails loud** rather than silently auto-creating a wrong-perm directory. If the directory is missing OR exists but is not writable by `deploy`, the SSH step exits non-zero and the gate run is marked failed. This catches Docker's default-create-on-bind behavior (root:root 0755) on a fresh VPS where cloud-init didn't run — without fail-loud, the metric would silently never land and the alert would be silently dark.
 
 ## Related issues
 
-- **deploy#85** — this PR.
-- **deploy#155** — promotion workflow that will call this gate (merged 2026-04-23, produced `promote.yml` + `deploy-stg.yml` + `deploy-prod.yml`). Issue #84.
-- **deploy#160** — wires `promote.yml` to `uses: ./.github/workflows/db-migrate.yml`. Follow-up.
-- **deploy#161** — textfile-collector plumbing for the deferred `UserServiceAlembicGateFailure` Prometheus alert. P2W11.
+- **deploy#85** — original gate PR (this runbook authored alongside).
+- **deploy#155** — promotion workflow that calls this gate (merged 2026-04-23, produced `promote.yml` + `deploy-stg.yml` + `deploy-prod.yml`). Issue #84.
+- **deploy#160** — wired `promote.yml` to `uses: ./.github/workflows/db-migrate.yml` (P3W1, merged).
+- **deploy#161** — this section's textfile-collector plumbing + `UserServiceAlembicGate{Failure,Stale}` alerts (P3W1).
 - **user-service#80** — alembic merge migration producing revision `0040`. Upstream unblock.
 - **user-service#63** — original alembic merge migration issue (closed by #80).
 - **deploy#141** — fresh-volume alembic-in-compose-up init container. Out of scope here.

--- a/infra/blackbox-exporter/blackbox.yml
+++ b/infra/blackbox-exporter/blackbox.yml
@@ -1,0 +1,70 @@
+# blackbox-exporter modules — continuous prod-route probing (deploy#183).
+#
+# Module naming convention: <protocol>_<expected-status>[_<flavour>].
+# Each route in infra/prometheus/prometheus.yml chooses the module that
+# matches its smoke-battery expectation in scripts/verify_prod_smoke.sh.
+#
+# Probes are intentionally narrow: HTTP-status + (where useful) regex on
+# response body shape. Auth-flow synthetic probes are explicitly out of
+# scope (no prod creds — Bereket sign-off, deploy#87).
+modules:
+  # 200 + JSON body. Used by isnad /health (.status field) and JWKS
+  # (.keys[] array). The fail_if_body_not_matches_regexp keeps the
+  # plaintext-from-Caddy failure mode out of the green-state set.
+  http_2xx_json:
+    prober: http
+    timeout: 5s
+    http:
+      method: GET
+      preferred_ip_protocol: ip4
+      valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+      valid_status_codes: [200]
+      fail_if_body_not_matches_regexp:
+        - '[{\[]'  # response begins with '{' or '[' — JSON shape
+      tls_config:
+        insecure_skip_verify: false
+      follow_redirects: true
+
+  # Plain 200 (no body shape assertion). Used by landing /.
+  http_2xx:
+    prober: http
+    timeout: 5s
+    http:
+      method: GET
+      preferred_ip_protocol: ip4
+      valid_status_codes: [200]
+      tls_config:
+        insecure_skip_verify: false
+
+  # 401 + JSON body. Used by /api/v1/narrators?limit=1 — the JSON-shape
+  # check is the load-bearing assertion (Caddy returning plaintext "401
+  # Unauthorized" while user-service is silently down would otherwise
+  # pass — same trap the smoke battery is designed around).
+  http_401_json:
+    prober: http
+    timeout: 5s
+    http:
+      method: GET
+      preferred_ip_protocol: ip4
+      valid_status_codes: [401, 403]
+      fail_if_body_not_matches_regexp:
+        - '[{\[]'  # JSON-shaped error envelope (.detail / .error / .message)
+      tls_config:
+        insecure_skip_verify: false
+
+  # 3xx redirect. Used by /auth/login. We do NOT follow the redirect —
+  # we just want to confirm the user-service auth wiring still hands off
+  # to an OAuth provider. The smoke battery inspects the Location
+  # header itself for OAuth-host substring; here we settle for the
+  # weaker "any 3xx is acceptable" assertion (200 also acceptable for
+  # interstitial-page handlers, mirroring smoke #6).
+  http_3xx:
+    prober: http
+    timeout: 5s
+    http:
+      method: GET
+      preferred_ip_protocol: ip4
+      valid_status_codes: [200, 301, 302, 303, 307, 308]
+      follow_redirects: false
+      tls_config:
+        insecure_skip_verify: false

--- a/infra/grafana/dashboards/blackbox-probes.json
+++ b/infra/grafana/dashboards/blackbox-probes.json
@@ -1,0 +1,133 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "uid": "blackbox-probes",
+  "title": "Blackbox Prod Probes",
+  "tags": ["observability", "blackbox", "prod"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "1m",
+  "time": { "from": "now-24h", "to": "now" },
+  "links": [],
+  "panels": [
+    {
+      "title": "Probe success by route (last 24h)",
+      "type": "timeseries",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "probe_success{job=\"blackbox\"}",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 1,
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "fillOpacity": 25,
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    },
+    {
+      "title": "Current probe state",
+      "type": "stat",
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 10 },
+      "targets": [
+        {
+          "expr": "probe_success{job=\"blackbox\"}",
+          "legendFormat": "{{route}}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "value_and_name",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      }
+    },
+    {
+      "title": "Probe duration p95 (5m)",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 10 },
+      "targets": [
+        {
+          "expr": "probe_duration_seconds{job=\"blackbox\"}",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s", "decimals": 3 },
+        "overrides": []
+      }
+    },
+    {
+      "title": "TLS cert: days until expiry",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 16 },
+      "targets": [
+        {
+          "expr": "(probe_ssl_earliest_cert_expiry{job=\"blackbox\"} - time()) / 86400",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "d",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 7 },
+              { "color": "green", "value": 14 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/infra/prometheus/alerts.yml
+++ b/infra/prometheus/alerts.yml
@@ -108,3 +108,80 @@ groups:
           description: >-
             The last successful backup was more than 24 hours ago.
           runbook: "docs/deployment/alerting.md#backupfailure"
+
+  - name: blackbox_probes
+    rules:
+      # Any of the 6 prod-route probes failing for >2m. Companion to the
+      # post-deploy smoke battery — smoke validates the deploy worked,
+      # this alerts when it stops working between deploys (deploy#183).
+      - alert: BlackboxProbeFailing
+        expr: probe_success == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Blackbox probe failing for {{ $labels.route }}"
+          description: >-
+            The blackbox probe for {{ $labels.route }} ({{ $labels.instance }})
+            has reported probe_success=0 for more than 2 minutes. Smoke
+            battery covers this route post-deploy; this alert catches
+            mid-deploy-window regressions.
+          runbook: "docs/runbooks/blackbox-probes.md#probe-failing"
+
+      # Routes where the smoke battery enforces a specific HTTP status
+      # (e.g. 401 on the narrator check, 3xx on /auth/login). The
+      # blackbox modules already encode "valid" status sets, so a
+      # mismatch surfaces as probe_success=0 — but we still alert
+      # explicitly on the status-code metric so the description tells
+      # operators *what* code came back rather than just "probe failed".
+      - alert: BlackboxUnexpectedStatus
+        expr: |
+          (
+            probe_http_status_code{route="isnad-health"}        != 200
+          ) or (
+            probe_http_status_code{route="user-service-health"} != 200
+          ) or (
+            probe_http_status_code{route="landing-root"}        != 200
+          ) or (
+            probe_http_status_code{route="jwks"}                != 200
+          ) or (
+            probe_http_status_code{route="narrator-401"}        != 401
+            and
+            probe_http_status_code{route="narrator-401"}        != 403
+          )
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Unexpected HTTP status on {{ $labels.route }}"
+          description: >-
+            Route {{ $labels.route }} returned HTTP {{ $value }}, which is
+            outside the expected set defined in the smoke battery
+            (scripts/verify_prod_smoke.sh).
+          runbook: "docs/runbooks/blackbox-probes.md#unexpected-status"
+
+      # Defense-in-depth cert-expiry warning. Caddy auto-renews via
+      # Let's Encrypt, but a renewal failure (rate-limit, ACME outage,
+      # disk-full on /data) would silently approach expiry — we want
+      # ~7d of warning before the cert dies in prod.
+      #
+      # The `> 0` guard skips probes where the metric is unset (HTTP
+      # targets, or HTTPS probes that never reached TLS handshake) —
+      # without it, the alert fires forever on any non-HTTPS target if
+      # one is ever added to this scrape job.
+      - alert: BlackboxCertExpiringSoon
+        expr: |
+          probe_ssl_earliest_cert_expiry > 0
+          and
+          (probe_ssl_earliest_cert_expiry - time()) < 7 * 86400
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "TLS cert for {{ $labels.route }} expires in <7 days"
+          description: >-
+            The TLS certificate served at {{ $labels.instance }} expires in
+            {{ $value | humanizeDuration }}. Caddy normally auto-renews
+            ~30 days before expiry, so reaching this threshold indicates
+            renewal is failing.
+          runbook: "docs/runbooks/blackbox-probes.md#cert-expiring-soon"

--- a/infra/prometheus/alerts.yml
+++ b/infra/prometheus/alerts.yml
@@ -109,6 +109,81 @@ groups:
             The last successful backup was more than 24 hours ago.
           runbook: "docs/deployment/alerting.md#backupfailure"
 
+  # Alerts for the alembic pre-deploy gate (deploy#161). Two distinct
+  # failure modes share the same metric source but warrant separate alerts
+  # so on-call can disambiguate at first sight (Bereket's manager-direct
+  # review call):
+  #
+  #   - Failure: gate ran, returned _success=0. Promotion blocked at the
+  #     pre-deploy step. Severity critical, for: 0m — the gate is one-shot
+  #     and every miss is operator-actionable.
+  #
+  #   - Stale: gate hasn't run in 24h. Could mean a broken promotion
+  #     pipeline upstream (e.g., notify-deploy.yml not firing, GHCR auth
+  #     drift), or simply a quiet 24h with no user-service pushes. On-call
+  #     should check the upstream signal before assuming a fault.
+  #
+  # The metrics are emitted to the host-side textfile collector at
+  # /var/lib/node_exporter/textfile_collector/user_service_alembic_gate.prom
+  # by db-migrate.yml's `Emit textfile-collector metrics on VPS` step
+  # (`if: always()`, atomic temp+rename, mode 0644). Both heads-count and
+  # `alembic upgrade head` failure paths produce _success=0.
+  #
+  # These alerts were originally drafted in deploy#153 but deferred during
+  # review (commit 76d7d7f) pending textfile plumbing; this group lands
+  # alongside the plumbing in #161 as one atomic delivery.
+  - name: db_migrate
+    rules:
+      - alert: UserServiceAlembicGateFailure
+        # Bare equality on _success — no freshness filter. Bereket's
+        # truth-table on the manager-direct review (PR #210 review,
+        # 2026-04-30) showed an `< 3600` AND clause silenced exactly the
+        # failures we want to catch: a stuck `_success=0` after the
+        # deduplication window aged out (e.g., a gate that failed hours
+        # ago and nothing has re-run it since) would silently clear, even
+        # though promotion is still blocked. Staleness doesn't make
+        # `_success=0` less true. The orthogonal "nothing has run"
+        # concern is captured by `UserServiceAlembicGateStale` below.
+        expr: |
+          user_service_alembic_gate_last_run_success == 0
+        for: 0m
+        labels:
+          severity: critical
+          service: user-service
+        annotations:
+          summary: "user-service alembic gate FAILED in {{ $labels.env }}"
+          description: >-
+            The most recent db-migrate run for user-service in {{ $labels.env }}
+            reported _success=0. Promotion is blocked at the pre-deploy gate
+            until a successful run replaces this metric. Both the heads-count
+            assertion failure path and the `alembic upgrade head` failure
+            path land here — see the runbook's Failure Modes section to
+            discriminate.
+          runbook: "docs/runbooks/user-service-alembic.md#observability"
+
+      - alert: UserServiceAlembicGateStale
+        # Distinct from Failure: the gate hasn't even run in 24h. Either the
+        # promotion pipeline upstream is broken (notify-deploy not firing,
+        # GHCR auth drift, etc.) or there have been no user-service pushes
+        # for a day. On-call should check upstream first before assuming a
+        # fault. `> 86400` flags silence beyond a day.
+        expr: |
+          (time() - user_service_alembic_gate_last_run_timestamp_seconds) > 86400
+        for: 0m
+        labels:
+          severity: critical
+          service: user-service
+        annotations:
+          summary: "user-service alembic gate has not run in {{ $labels.env }} for >24h"
+          description: >-
+            The pre-deploy gate metric for {{ $labels.env }} is older than
+            24 hours. Either no user-service push has triggered a promotion
+            in the last day (benign — confirm via the recent PR list and
+            ghcr-publish runs), or the promotion pipeline upstream is
+            broken. Check the latest `Deploy to staging` and `Promote to
+            production` runs before assuming the gate itself is at fault.
+          runbook: "docs/runbooks/user-service-alembic.md#observability"
+
   - name: blackbox_probes
     rules:
       # Any of the 6 prod-route probes failing for >2m. Companion to the

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -23,3 +23,40 @@ scrape_configs:
   - job_name: "postgres-exporter"
     static_configs:
       - targets: ["postgres-exporter:9187"]
+
+  # blackbox-exporter — continuous external probe of the same 6 prod
+  # routes covered by the post-deploy smoke battery
+  # (scripts/verify_prod_smoke.sh). Each target carries a `route` label
+  # so alerts and dashboards can identify the probed endpoint without
+  # having to URL-decode the __param_target.
+  #
+  # The relabel pipeline is the standard blackbox pattern:
+  #   1. instance label = the URL itself (visible in alerts)
+  #   2. __param_target = URL passed to /probe?target=…
+  #   3. __address__   = blackbox-exporter:9115 (the actual scrape target)
+  - job_name: "blackbox"
+    metrics_path: /probe
+    scrape_interval: 60s
+    scrape_timeout: 10s
+    static_configs:
+      - targets: ["https://isnad-graph.noorinalabs.com/health"]
+        labels: { route: "isnad-health", module: "http_2xx_json" }
+      - targets: ["https://isnad-graph.noorinalabs.com/api/v1/user-service/health"]
+        labels: { route: "user-service-health", module: "http_2xx" }
+      - targets: ["https://noorinalabs.com/"]
+        labels: { route: "landing-root", module: "http_2xx" }
+      - targets: ["https://isnad-graph.noorinalabs.com/api/v1/narrators?limit=1"]
+        labels: { route: "narrator-401", module: "http_401_json" }
+      - targets: ["https://isnad-graph.noorinalabs.com/.well-known/jwks.json"]
+        labels: { route: "jwks", module: "http_2xx_json" }
+      - targets: ["https://isnad-graph.noorinalabs.com/auth/login"]
+        labels: { route: "auth-login-redirect", module: "http_3xx" }
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [module]
+        target_label: __param_module
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox-exporter:9115

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -31,10 +31,18 @@ Part of [noorinalabs-main#49](https://github.com/noorinalabs/noorinalabs-main/is
 | Real OAuth provider code-exchange | Hardcoded provider URLs in `src/app/services/oauth.py`; needs a `OAUTH_PROVIDER_BASE_URL` override before a fake-provider container can sit in front | noorinalabs-main#135 |
 | Pipeline worker scenarios | Pipeline (#105–#108) not yet live on wave-9 at the time this harness was written | noorinalabs-main#136 |
 
-## Running locally
+## Run modes
+
+The harness supports two run modes via `RUN_MODE`:
+
+| Mode | Default? | What it does |
+|------|----------|--------------|
+| `hermetic` | yes | Local docker-compose stack, builds from sibling checkouts, full DB+Redis seeding via `seeded_user_factory`. Used by PR CI. |
+| `remote` | no | Skip stack-up; run pytest against env-supplied stg URLs. DB/Redis-direct fixtures auto-skip — effective remote-runnable set today is health + JWKS. |
+
+### Running locally — hermetic (PR-CI default)
 
 ```bash
-# One command
 cd integration-tests
 ./run-tests.sh
 ```
@@ -47,6 +55,31 @@ The script will:
 2. Wait for all health checks to pass
 3. Run the pytest suite inside the `test-runner` container
 4. Tear down the stack on exit (pass `KEEP_STACK=1` to leave it up for debugging)
+
+### Running remotely against stg
+
+```bash
+cd integration-tests
+RUN_MODE=remote \
+  ISNAD_BASE_URL=https://isnad.stg.noorinalabs.com \
+  USER_SERVICE_BASE_URL=https://auth.stg.noorinalabs.com \
+  ./run-tests.sh
+```
+
+Remote mode:
+- Refuses to run against `ENVIRONMENT=prod` (hard guardrail — refuses with
+  exit code 3). Defaults `ENVIRONMENT=stg` if unset.
+- Requires `ISNAD_BASE_URL` and `USER_SERVICE_BASE_URL` (both validated up
+  front via /health probes).
+- Builds the runner image and `docker run`s it directly — no compose
+  stack-up, no sibling-repo checkouts needed.
+- Auto-skips tests that depend on `user_pg`, `user_redis`, or
+  `seeded_user_factory` because direct stg DB/Redis access is not
+  available from outside the VPS. The current effective remote set is
+  `test_health.py` (health endpoints + JWKS publication).
+- Per-test refactors to use stg test-user creds delivered via secrets
+  (so RBAC / sessions / 2FA / subscription flows can run remotely too)
+  are downstream follow-up work — see deploy#178 body.
 
 ## Architecture
 

--- a/integration-tests/run-tests.sh
+++ b/integration-tests/run-tests.sh
@@ -138,6 +138,57 @@ export TOTP_ENCRYPTION_KEY="$(cat secrets/totp.key)"
 
 mkdir -p reports
 
+# Pull images with per-image retry-with-backoff (closes #214).
+# `docker compose up -d --build` pulls images implicitly, but a single-image
+# Docker Hub registry timeout (e.g., neo4j:5-community on 2026-05-01 P3W1
+# wave-merge run 25196318721) hard-fails the entire run with no retry.
+# Pulling explicitly first with bounded retry absorbs single-image transient
+# Docker Hub jitter without changing the test suite or compose layout.
+echo "--- Pulling images (with retry-with-backoff) ---"
+pull_with_retry() {
+    local image="$1"
+    local delay=1
+    for attempt in 1 2 3; do
+        if docker pull "$image" >/dev/null 2>&1; then
+            return 0
+        fi
+        if [[ $attempt -lt 3 ]]; then
+            echo "  retry $attempt failed for $image — backing off ${delay}s" >&2
+            sleep "$delay"
+            delay=$((delay * 2))
+        fi
+    done
+    echo "  ERROR: docker pull $image failed after 3 attempts" >&2
+    return 1
+}
+# Identify pull targets via structured compose-config parse: a pull target
+# is a service with `image:` and NO `build:`. Services with `build:` are
+# locally built by the `up --build` step below — pulling them would hit
+# Docker Hub for a non-existent tag.
+#
+# Why not `docker compose config --images` + a glob filter? Compose emits
+# short-form Docker Hub references (`neo4j:5-community`, `postgres:16-alpine`)
+# without a registry-path slash; a `*/*` filter silently skips them.
+# JSON-parse-by-shape avoids that whole class of false-positive miss.
+mapfile -t PULL_IMAGES < <(
+    $COMPOSE config --format json 2>/dev/null | python3 -c "
+import json, sys
+config = json.load(sys.stdin)
+seen = set()
+for name, svc in config.get('services', {}).items():
+    if 'image' in svc and 'build' not in svc:
+        img = svc['image']
+        if img not in seen:
+            seen.add(img)
+            print(img)
+"
+)
+for image in "${PULL_IMAGES[@]}"; do
+    [[ -z "$image" ]] && continue
+    echo "  pull: $image"
+    pull_with_retry "$image"
+done
+
 echo "--- Building and starting stack ---"
 $COMPOSE up -d --build \
     user-postgres user-redis user-service \

--- a/integration-tests/run-tests.sh
+++ b/integration-tests/run-tests.sh
@@ -1,13 +1,107 @@
 #!/usr/bin/env bash
 # Single-command integration test runner.
-# Usage: ./run-tests.sh [pytest args]
-# Env:
+#
+# Modes (set via RUN_MODE; default `hermetic`):
+#
+#   hermetic  — Full local docker-compose stack, builds user-service and
+#               isnad-graph-api from sibling checkouts, seeds DB+Redis
+#               directly. PR-CI default; what `integration-tests.yml` runs.
+#
+#   remote    — Skip stack-up. Point HTTP fixtures at env-supplied stg URLs
+#               (ISNAD_BASE_URL, USER_SERVICE_BASE_URL). DB/Redis-direct
+#               fixtures auto-skip in remote (no direct stg DB access from
+#               outside the VPS), so the effective remote-runnable set today
+#               is health + JWKS. Per-test refactors to use stg test-user
+#               creds via secrets are downstream follow-up work — see #178.
+#
+# Usage:
+#   ./run-tests.sh [pytest args]
+#
+# Env (hermetic):
 #   KEEP_STACK=1  — leave stack up after tests for debugging.
+#
+# Env (remote — required):
+#   ISNAD_BASE_URL          — e.g. https://isnad.stg.noorinalabs.com
+#   USER_SERVICE_BASE_URL   — e.g. https://auth.stg.noorinalabs.com
+#
+# Env (remote — guardrail):
+#   ENVIRONMENT             — must NOT equal "prod"; refused at startup.
+#                             Defaults to "stg" if unset.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
+
+RUN_MODE="${RUN_MODE:-hermetic}"
+
+case "$RUN_MODE" in
+    hermetic|remote) ;;
+    *)
+        echo "ERROR: RUN_MODE must be one of: hermetic, remote (got: $RUN_MODE)" >&2
+        exit 2
+        ;;
+esac
+
+if [[ "$RUN_MODE" == "remote" ]]; then
+    # Hard refusal: never run integration tests against prod, even by accident.
+    # The suite seeds and mutates state via /auth endpoints; running against
+    # prod could create test users in the live user-postgres or trip
+    # rate-limiters that page oncall.
+    : "${ENVIRONMENT:=stg}"
+    if [[ "$ENVIRONMENT" == "prod" || "$ENVIRONMENT" == "production" ]]; then
+        echo "ERROR: refusing to run integration suite against ENVIRONMENT=$ENVIRONMENT." >&2
+        echo "       Remote mode is stg-only. Unset ENVIRONMENT or set ENVIRONMENT=stg." >&2
+        exit 3
+    fi
+
+    : "${ISNAD_BASE_URL:?ISNAD_BASE_URL is required in remote mode}"
+    : "${USER_SERVICE_BASE_URL:?USER_SERVICE_BASE_URL is required in remote mode}"
+
+    # Sanity-check both URLs respond before pytest spends real time. We use
+    # /health on each — same probe verify-prod's smoke battery uses. Failure
+    # here means the runner is fundamentally pointed at the wrong place;
+    # bail before pytest emits a wall of timeouts.
+    echo "--- Probing remote URLs ---"
+    echo "  USER_SERVICE_BASE_URL=$USER_SERVICE_BASE_URL"
+    echo "  ISNAD_BASE_URL=$ISNAD_BASE_URL"
+    echo "  ENVIRONMENT=$ENVIRONMENT"
+
+    mkdir -p reports
+
+    echo "--- Building runner image ---"
+    # docker compose `build` reads docker-compose.test.yml's test-runner
+    # service and produces the image without bringing up depends_on (we
+    # don't `up` anything in remote mode). The image gets a stable repo
+    # tag we can `docker run` directly afterward without resurrecting
+    # any compose state.
+    docker build -f Dockerfile.runner -t noorinalabs-integration-test-runner:remote .
+
+    echo "--- Running integration tests (remote mode) ---"
+    # Run pytest in the same image we use hermetically, but pass URLs +
+    # RUN_MODE through env. Mount tests + reports just like compose does.
+    # No --network arg — runner container reaches the public stg URLs over
+    # the host's default bridge.
+    set +e
+    docker run --rm \
+        -e RUN_MODE=remote \
+        -e ENVIRONMENT="$ENVIRONMENT" \
+        -e ISNAD_BASE_URL="$ISNAD_BASE_URL" \
+        -e USER_SERVICE_BASE_URL="$USER_SERVICE_BASE_URL" \
+        -e USER_SERVICE_URL="$USER_SERVICE_BASE_URL" \
+        -e ISNAD_GRAPH_URL="$ISNAD_BASE_URL" \
+        -v "$SCRIPT_DIR/tests:/app/tests:ro" \
+        -v "$SCRIPT_DIR/reports:/app/reports" \
+        noorinalabs-integration-test-runner:remote \
+        pytest -v --tb=short --junit-xml=/app/reports/junit.xml "$@"
+    ec=$?
+    set -e
+    exit "$ec"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# Hermetic path (default; unchanged behavior).
+# ─────────────────────────────────────────────────────────────────
 
 COMPOSE="docker compose -f docker-compose.test.yml --env-file .env.test"
 

--- a/integration-tests/tests/conftest.py
+++ b/integration-tests/tests/conftest.py
@@ -1,9 +1,21 @@
 """Shared fixtures for the cross-repo integration suite.
 
-These fixtures talk to the *running* services over the docker Compose network.
-Each fixture that creates state also cleans it up.
+These fixtures talk to the *running* services. Two run modes are supported
+(see `run-tests.sh` for the orchestration):
 
-Two auth-flow paths are exercised against the same stack:
+  * hermetic (default) — services run on the local docker-compose network
+    built from sibling checkouts. DB+Redis are reachable from the runner
+    container; `seeded_user_factory` writes directly into them.
+
+  * remote — services run on stg; HTTP fixtures point at env-supplied URLs
+    (USER_SERVICE_BASE_URL, ISNAD_BASE_URL). Direct DB/Redis access is NOT
+    available from outside the VPS, so `user_pg`, `user_redis`, and
+    `seeded_user_factory` auto-skip in remote mode. Tests that depend on
+    them are therefore hermetic-only today; per-test refactors to use
+    pre-provisioned stg test-user creds delivered via secrets are
+    downstream follow-up work (see deploy#178 body).
+
+Two auth-flow paths are exercised against the same stack (hermetic only):
   * Real-callback path — `test_oauth_callback_to_token_issue` exercises
     `/auth/oauth/google/callback` end-to-end against the `fake_oauth`
     container, reaching user-service via OAUTH_PROVIDER_BASE_URL_OVERRIDE
@@ -28,18 +40,49 @@ import httpx
 import pytest
 import redis.asyncio as aioredis
 
-USER_SERVICE_URL = os.environ["USER_SERVICE_URL"]
-ISNAD_GRAPH_URL = os.environ["ISNAD_GRAPH_URL"]
-
-
-
-USER_POSTGRES_DSN = (
-    f"postgresql://{os.environ['USER_POSTGRES_USER']}"
-    f":{os.environ['USER_POSTGRES_PASSWORD']}"
-    f"@{os.environ['USER_POSTGRES_HOST']}:{os.environ['USER_POSTGRES_PORT']}"
-    f"/{os.environ['USER_POSTGRES_DB']}"
+# RUN_MODE is set by run-tests.sh; default to hermetic so direct invocation
+# of pytest (e.g. `pytest tests/test_health.py`) inside the runner container
+# still works the same way it always has.
+RUN_MODE = os.environ.get("RUN_MODE", "hermetic")
+HERMETIC_ONLY_REASON = (
+    "hermetic-only fixture: direct DB/Redis access is not available in "
+    "remote mode (stg DBs are not reachable from outside the VPS). Run "
+    "this test with RUN_MODE=hermetic, or refactor it to drive the "
+    "user-service via stg test-user credentials (deploy#178 follow-up)."
 )
-USER_REDIS_URL = os.environ["USER_REDIS_URL"]
+
+# In remote mode, the *_BASE_URL env vars are the canonical stg targets;
+# the legacy USER_SERVICE_URL / ISNAD_GRAPH_URL names are the hermetic
+# compose-internal hostnames. run-tests.sh exports both shapes in remote
+# mode so this lookup works either way.
+USER_SERVICE_URL = os.environ.get(
+    "USER_SERVICE_URL", os.environ.get("USER_SERVICE_BASE_URL", "")
+)
+ISNAD_GRAPH_URL = os.environ.get(
+    "ISNAD_GRAPH_URL", os.environ.get("ISNAD_BASE_URL", "")
+)
+if not USER_SERVICE_URL or not ISNAD_GRAPH_URL:
+    raise RuntimeError(
+        "USER_SERVICE_URL/USER_SERVICE_BASE_URL and "
+        "ISNAD_GRAPH_URL/ISNAD_BASE_URL are required. "
+        "run-tests.sh sets these; if you're running pytest directly, "
+        "export them yourself."
+    )
+
+# DB/Redis DSN construction is hermetic-only — these env vars are not
+# defined in remote mode, and a plain `os.environ[...]` lookup would crash
+# at import time before any pytest skip could fire. Guard the lookups.
+if RUN_MODE == "hermetic":
+    USER_POSTGRES_DSN = (
+        f"postgresql://{os.environ['USER_POSTGRES_USER']}"
+        f":{os.environ['USER_POSTGRES_PASSWORD']}"
+        f"@{os.environ['USER_POSTGRES_HOST']}:{os.environ['USER_POSTGRES_PORT']}"
+        f"/{os.environ['USER_POSTGRES_DB']}"
+    )
+    USER_REDIS_URL = os.environ["USER_REDIS_URL"]
+else:
+    USER_POSTGRES_DSN = ""
+    USER_REDIS_URL = ""
 
 
 @dataclass
@@ -52,6 +95,8 @@ class SeededUser:
 
 @pytest.fixture
 async def user_pg() -> AsyncIterator[asyncpg.Connection]:
+    if RUN_MODE != "hermetic":
+        pytest.skip(HERMETIC_ONLY_REASON)
     conn = await asyncpg.connect(USER_POSTGRES_DSN)
     try:
         yield conn
@@ -61,6 +106,8 @@ async def user_pg() -> AsyncIterator[asyncpg.Connection]:
 
 @pytest.fixture
 async def user_redis() -> AsyncIterator[aioredis.Redis]:
+    if RUN_MODE != "hermetic":
+        pytest.skip(HERMETIC_ONLY_REASON)
     client = aioredis.from_url(USER_REDIS_URL, decode_responses=True)
     try:
         yield client

--- a/integration-tests/tests/test_network_isolation.py
+++ b/integration-tests/tests/test_network_isolation.py
@@ -20,6 +20,14 @@ import pytest
 
 @pytest.mark.isolation
 def test_isnad_graph_cannot_reach_user_postgres() -> None:
+    # Topology assertion — only meaningful in hermetic mode where we
+    # control the docker-compose network layout. In remote mode the
+    # equivalent invariant is enforced at the VPS firewall + docker
+    # network layer in compose/docker-compose.prod.yml; this in-cluster
+    # probe has no remote analogue.
+    if os.environ.get("RUN_MODE", "hermetic") != "hermetic":
+        pytest.skip("network isolation is a hermetic-only topology assertion")
+
     result = os.environ.get("ISOLATION_CHECK_RESULT", "unknown")
     assert result == "pass", (
         f"Isolation probe result = {result!r}. "

--- a/scripts/verify_deployment.sh
+++ b/scripts/verify_deployment.sh
@@ -12,18 +12,40 @@
 # intentionally NOT invoked by `verify-deploy.yml` anymore.
 #
 # Usage:
-#   ./scripts/verify_deployment.sh [--site URL] [--skip-workflow] [--skip-ssl]
+#   ./scripts/verify_deployment.sh [--site=URL] [--landing=URL]
+#                                  [--user-service=URL] [--skip-workflow]
+#                                  [--skip-ssl]
 #
 # Environment:
-#   SITE_URL      Override the default site URL (default: https://isnad-graph.noorinalabs.com)
-#   GH_REPO       Override the GitHub repo for workflow checks (default: noorinalabs/noorinalabs-deploy)
-#   ROLLBACK_TAG  If set, tag the current deployment for rollback reference
+#   SITE_URL              Override the default API host URL
+#                         (default: https://isnad-graph.noorinalabs.com)
+#   LANDING_URL           Landing-page URL to check. Empty disables the
+#                         landing reachability check.
+#                         (default: https://noorinalabs.com)
+#   USER_SERVICE_URL      Base URL whose `/health` is hit for the
+#                         user-service auth-plane check. Empty disables.
+#                         (default: $SITE_URL — caddy/Caddyfile routes
+#                         user-service via the same host today; the
+#                         deploy#156 cutover will move it to its own
+#                         subdomain.)
+#   GH_REPO               Override the GitHub repo for workflow checks
+#                         (default: noorinalabs/noorinalabs-deploy)
+#   ROLLBACK_TAG          If set, tag the current deployment for rollback
+#                         reference
 
 set -euo pipefail
 
 # ---------- Configuration ----------
 
 SITE_URL="${SITE_URL:-https://isnad-graph.noorinalabs.com}"
+# Landing-page reachability check (deploy#73). Empty = skip.
+LANDING_URL="${LANDING_URL:-https://noorinalabs.com}"
+# user-service auth-plane health (deploy#73). Empty = skip. Defaults to
+# SITE_URL because today Caddy routes user-service traffic via the same
+# host as the API (caddy/Caddyfile site block); the deploy#156 cutover
+# will move it to https://users.noorinalabs.com — at that point operators
+# pass USER_SERVICE_URL=https://users.noorinalabs.com explicitly.
+USER_SERVICE_URL="${USER_SERVICE_URL:-$SITE_URL}"
 GH_REPO="${GH_REPO:-noorinalabs/noorinalabs-deploy}"
 SKIP_WORKFLOW="${SKIP_WORKFLOW:-false}"
 SKIP_SSL="${SKIP_SSL:-false}"
@@ -34,10 +56,14 @@ TIMEOUT=10
 for arg in "$@"; do
   case "$arg" in
     --site=*) SITE_URL="${arg#*=}" ;;
+    --landing=*) LANDING_URL="${arg#*=}" ;;
+    --user-service=*) USER_SERVICE_URL="${arg#*=}" ;;
     --skip-workflow) SKIP_WORKFLOW=true ;;
     --skip-ssl) SKIP_SSL=true ;;
     --help|-h)
-      head -12 "$0" | tail -10
+      # Print the leading comment block (Usage + Environment sections).
+      # Stops at the first non-comment, non-blank line.
+      awk '/^#!/ {next} /^#/ {print substr($0,3); next} {exit}' "$0"
       exit 0
       ;;
   esac
@@ -116,6 +142,63 @@ if [ "$health_resolved" = "false" ]; then
     pass "Health endpoint returned HTTP 200 (non-JSON response)"
   else
     fail "Health endpoint unreachable or invalid (HTTP $health_code)"
+  fi
+fi
+
+# ---------- 3a. Landing-Page Reachability (deploy#73) ----------
+
+if [ -n "$LANDING_URL" ]; then
+  section "Landing-Page Reachability"
+  landing_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time "$TIMEOUT" "$LANDING_URL" 2>/dev/null || echo "000")
+  if [ "$landing_code" = "200" ]; then
+    pass "Landing returns HTTP 200 at $LANDING_URL"
+  elif [ "$landing_code" = "000" ]; then
+    fail "Landing unreachable (timeout/connection error) at $LANDING_URL"
+  else
+    fail "Landing returned HTTP $landing_code at $LANDING_URL"
+  fi
+fi
+
+# ---------- 3b. User-Service Health (deploy#73) ----------
+
+# Two routes exist depending on the deploy#156 cutover state:
+#   1. /api/v1/user-service/health — Caddy rewrite at caddy/Caddyfile:88-89
+#      that proxies to user-service:8000. Used today while user-service
+#      traffic shares the API host with isnad-graph.
+#   2. /health — direct path on the user-service subdomain after the #156
+#      cutover lands `users.noorinalabs.com` as a separate site block.
+#
+# IMPORTANT: pre-#156, /health on the SHARED host hits **isnad-graph's**
+# /health (caddy/Caddyfile:101 — `handle /health { reverse_proxy api:8000 }`),
+# NOT user-service. So the second-route fallback is only correct when an
+# explicit subdomain URL was passed via --user-service= or the
+# USER_SERVICE_URL env var; if USER_SERVICE_URL == SITE_URL, that fallback
+# would falsely report user-service healthy when only isnad-graph is up
+# (Aisha review on PR #206, hot spot 4 — flagged 2026-04-30).
+if [ -n "$USER_SERVICE_URL" ]; then
+  section "User-Service Health Check"
+  us_resolved=false
+  for us_path in "/api/v1/user-service/health" "/health"; do
+    # Skip the /health fallback on the shared host — it routes to
+    # isnad-graph, not user-service. Only safe to probe /health when an
+    # explicit user-service subdomain (post-#156) was passed.
+    if [ "$us_path" = "/health" ] && [ "$USER_SERVICE_URL" = "$SITE_URL" ]; then
+      continue
+    fi
+    us_url="${USER_SERVICE_URL}${us_path}"
+    us_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time "$TIMEOUT" "$us_url" 2>/dev/null || echo "000")
+    if [ "$us_code" = "200" ]; then
+      pass "User-service health endpoint (${us_path}) returned HTTP 200"
+      us_resolved=true
+      break
+    fi
+  done
+  if [ "$us_resolved" = "false" ]; then
+    if [ "$USER_SERVICE_URL" = "$SITE_URL" ]; then
+      fail "User-service health unreachable at ${USER_SERVICE_URL}/api/v1/user-service/health (Caddy rewrite path; the /health fallback only applies post-#156 with a separate user-service subdomain)"
+    else
+      fail "User-service health unreachable at $USER_SERVICE_URL (tried /api/v1/user-service/health and /health)"
+    fi
   fi
 fi
 

--- a/terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl
+++ b/terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl
@@ -131,6 +131,20 @@ runcmd:
   - docker volume create user-postgres-data
   - docker volume create user-redis-data
 
+  # node-exporter textfile_collector input directory (deploy#161).
+  # Owned by deploy:deploy because the alembic pre-deploy gate's SSH step
+  # (.github/workflows/db-migrate.yml) writes .prom files here as the
+  # `deploy` user. Mode 0755 so the node-exporter container — which runs
+  # as image-default uid (nobody) inside its container — can read the
+  # files via its read-only bind mount in compose/docker-compose.prod.yml.
+  # No host-side `node_exporter` system user is required: node-exporter
+  # is a container, not a system service. Provisioning this here (TF
+  # cloud-init) rather than as a runbook step prevents silent drift on
+  # fresh VPSes — a missed mkdir would leave the alert silently dark.
+  - mkdir -p /var/lib/node_exporter/textfile_collector
+  - chown deploy:deploy /var/lib/node_exporter/textfile_collector
+  - chmod 0755 /var/lib/node_exporter/textfile_collector
+
   # Install Caddy via official apt repo
   - curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
   - echo "deb [signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg] https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main" > /etc/apt/sources.list.d/caddy-stable.list


### PR DESCRIPTION
## Phase 3 Wave 1 → main (deploy)

Final wave-merge for P3W1 (theme: promotion pipeline goes prod). 8 squash-merged feature PRs landing the actual promotion-pathway code; sister parent-repo wave-merge at `noorinalabs/noorinalabs-main` carries the coordination state, charter deltas, retro entries, and ontology updates.

### Wave PRs (in merge order)

| Sha | PR | Issue | Theme |
|-----|----|----|-------|
| `b40e532` | #197 | #67 | rollback workflow expand to user-service + landing (with bundled per-service env-var routing fix) |
| `25ca72a` | #198 | #179 | promote.yml `gate-stg-verify` job — gates prod retag on latest fresh stg verify-deploy success |
| `4aa2444` | #201 | #160 | db-migrate.yml wiring — `migrate` job in deploy-stg.yml (user-service repo_dispatch only) + `migrate-prod` between gate-stg-verify and retag in promote.yml |
| `6e8f450` | #202 | #178 | integration-tests RUN_MODE=remote scaffolding (default hermetic preserves PR-CI; remote points fixtures at deployed stg URLs) |
| `372b0e1` | #207 | #205 | verify-deploy.yml `verify-stg` job → RUN_MODE=remote with stg URLs + secret-sourced test-user creds + ENVIRONMENT=stg belt-and-suspenders |
| `6006f2c` | #206 | #73 | verify-deploy.yml multi-trigger expansion (Deploy All Services + Rollback added) + `verify_deployment.sh` extended with landing + user-service health probes |
| `f4c5a85` | #208 | #183 | blackbox-exporter for continuous prod-route probing (compose service + 4 modules + scrape config + 3 alert rules + Grafana dashboard + amtool runbook) |
| `851bd71` | #210 | #161 | alembic gate textfile metrics — 3-part atomic delivery: node-exporter textfile collector + db-migrate.yml SSH emit + alerts.yml UserServiceAlembicGateFailure + UserServiceAlembicGateStale + cloud-init.yaml.tpl pre-creation + runbook flipped from aspirational to implemented |

Plus the empty kickoff commit at `3e7a96d` opening the wave branch.

### Tier coverage

- **Tier 1 (5/5):** #67 #179 #160 #178 #73
- **Tier 2 (2/2):** #161 #183
- **Followup-of-spec (1):** #205 (#178-followup verify-stg flip)

**3 Tier-3 carry-forwards** (operationally gated):

- #86 — Phase C VPS decom (async routine `trig_01Bif8T51pdaYFjkbM5bERyL`)
- #151 — manual SRE B2 tfstate-key migration
- (sibling) `noorinalabs-user-service#84` — DEPLOY_REPO_PAT secret provisioning

### Followups filed during wave

7 deploy-repo follow-ups for next-wave planning round:

- #199 — gate-stg-verify schema v2 with per-service digests
- #200 — durable break-glass audit trail
- #203 — conftest-load prod-environment guard
- #204 — remote-mode coverage expansion to non-health tests
- #209 — `BlackboxUnexpectedStatus` double-pager guard
- #211 — runbook L161 + compose L614-621 drift cleanup (post-#210 manager-pass-failure cleanup)
- #212 — promtool check rules CI gate on alerts.yml

### Owner directive delivery

**Materially met.** Pipeline is now at "running seamlessly" state across 6 promotion-pathway primitives:

- Stg → prod promote with three layers of gating (verify-deploy success, db-migrate success, optional break-glass with audit)
- Continuous prod-route monitoring via blackbox + smoke battery (disjoint layer coverage)
- Rollback covers all four prod services (api + frontend + user-service + landing)
- Integration tests work in remote mode against deployed stg
- Alembic gate has textfile metrics + alert + runbook + recovery procedure
- verify-deploy multi-trigger + extended health checks expand auto-verification to all active deploy paths

### Sister merge

This PR is a coordinated merge with `noorinalabs/noorinalabs-main` Phase 3 Wave 1 → main parent PR. Both must merge for the wave to land cleanly; the parent carries charter deltas (Patterns A, B, C, D) + retro entries + trust matrix updates that document the coordination context for this delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
