### PR TITLE
fix(ci): commit canonical deploy pubkey, drop runner-ephemeral keypair (closes #216)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -72,10 +72,6 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "~> 1.6"
-      - name: Generate CI SSH key
-        run: |
-          ssh-keygen -t ed25519 -f /tmp/ci_key -N ""
-          echo "TF_VAR_ssh_public_key_path=/tmp/ci_key.pub" >> "$GITHUB_ENV"
       - name: Init
         run: terraform init
       - name: Plan
@@ -128,10 +124,6 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "~> 1.6"
-      - name: Generate CI SSH key
-        run: |
-          ssh-keygen -t ed25519 -f /tmp/ci_key -N ""
-          echo "TF_VAR_ssh_public_key_path=/tmp/ci_key.pub" >> "$GITHUB_ENV"
       - name: Init
         run: terraform init
       - name: Apply

--- a/terraform/hetzner/envs/prod/variables.tf
+++ b/terraform/hetzner/envs/prod/variables.tf
@@ -5,9 +5,9 @@ variable "hcloud_token" {
 }
 
 variable "ssh_public_key_path" {
-  description = "Path to SSH public key file."
+  description = "Path to SSH public key file. Default points at the canonical CI/operator deploy pubkey checked into modules/hetzner-vps/deploy.pub (matches DEPLOY_SSH_PRIVATE_KEY org-secret + workstation ~/.ssh/noorinalabs_deploy)."
   type        = string
-  default     = "~/.ssh/id_ed25519.pub"
+  default     = "../../modules/hetzner-vps/deploy.pub"
 }
 
 variable "ssh_source_ips" {

--- a/terraform/hetzner/envs/stg/variables.tf
+++ b/terraform/hetzner/envs/stg/variables.tf
@@ -5,9 +5,9 @@ variable "hcloud_token" {
 }
 
 variable "ssh_public_key_path" {
-  description = "Path to SSH public key file."
+  description = "Path to SSH public key file. Default points at the canonical CI/operator deploy pubkey checked into modules/hetzner-vps/deploy.pub (matches DEPLOY_SSH_PRIVATE_KEY org-secret + workstation ~/.ssh/noorinalabs_deploy)."
   type        = string
-  default     = "~/.ssh/id_ed25519.pub"
+  default     = "../../modules/hetzner-vps/deploy.pub"
 }
 
 variable "ssh_source_ips" {

--- a/terraform/hetzner/modules/hetzner-vps/deploy.pub
+++ b/terraform/hetzner/modules/hetzner-vps/deploy.pub
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPNeq9U2bb0W8aoFPv1Ch5h4g9VrC0cpn0BumkW1Tfrx deploy@isnad-graph

--- a/terraform/hetzner/modules/hetzner-vps/main.tf
+++ b/terraform/hetzner/modules/hetzner-vps/main.tf
@@ -61,4 +61,15 @@ resource "hcloud_server" "app" {
   })
 
   labels = local.labels
+
+  # ssh_keys + user_data are creation-time-only on Hetzner. Once the server is
+  # running, changes to either don't affect the live box (cloud-init has long
+  # since finished). Without ignore_changes, Terraform plans a destructive
+  # replace whenever the deploy pubkey or cloud-init template content changes
+  # — e.g., when this PR (#216) lands and replaces the runner-ephemeral pubkey
+  # with the canonical checked-in one. Out-of-band rotations on the live box's
+  # /home/deploy/.ssh/authorized_keys are the operator's job, not Terraform's.
+  lifecycle {
+    ignore_changes = [ssh_keys, user_data]
+  }
 }

--- a/terraform/hetzner/modules/hetzner-vps/variables.tf
+++ b/terraform/hetzner/modules/hetzner-vps/variables.tf
@@ -26,9 +26,9 @@ variable "image" {
 }
 
 variable "ssh_public_key_path" {
-  description = "Path to SSH public key file uploaded to Hetzner and authorized for the deploy user."
+  description = "Path to SSH public key file uploaded to Hetzner and authorized for the deploy user. Resolved relative to the env root module's working directory (envs always pass `../../modules/hetzner-vps/deploy.pub`); the module-local default is for module-only `terraform validate` runs."
   type        = string
-  default     = "~/.ssh/id_ed25519.pub"
+  default     = "./deploy.pub"
 }
 
 variable "ssh_source_ips" {


### PR DESCRIPTION
## Closes

- Closes #216

## Summary

The `Apply` (and `Plan`) jobs in `.github/workflows/terraform.yml` ran `ssh-keygen -t ed25519 -f /tmp/ci_key -N ""` on the runner, passed the public half to Terraform as `TF_VAR_ssh_public_key_path`, and let the private half vaporize when the runner shut down. Every VPS provisioned by this workflow was authorized for an SSH keypair whose private half existed for ~30 seconds on a destroyed runner — locking out the box for every key humans control (workstation `~/.ssh/id_ed25519`, workstation `~/.ssh/noorinalabs_deploy`, and the `DEPLOY_SSH_PRIVATE_KEY` org-secret).

This bug was masked until the P3W1 wave-merge to main on 2026-05-01T01:49:41Z auto-triggered `Apply (stg)` + `Apply (prod)`, replacing the Phase B stg VPS (id 128100194 → 128728699) and creating the new prod VPS (id 128728719). Both immediately locked out. Recovery required `hcloud server reset-password` + Hetzner web-console root login + manual key paste — see `noorinalabs-deploy#216` body for the full incident timeline.

## Changes

| File | Change |
|------|--------|
| `terraform/hetzner/modules/hetzner-vps/deploy.pub` (new) | Canonical CI/operator deploy pubkey, checked in (non-secret — matches `DEPLOY_SSH_PRIVATE_KEY` org-secret + workstation `~/.ssh/noorinalabs_deploy`) |
| `terraform/hetzner/envs/{stg,prod}/variables.tf` | `ssh_public_key_path` default → `"../../modules/hetzner-vps/deploy.pub"` (resolves relative to env-root working dir at apply time) |
| `terraform/hetzner/modules/hetzner-vps/variables.tf` | Module-local default → `"./deploy.pub"` (only used for module-only `terraform validate`; envs always pass through) |
| `terraform/hetzner/modules/hetzner-vps/main.tf` | `lifecycle { ignore_changes = [ssh_keys, user_data] }` added to `hcloud_server.app` — prevents this PR's pubkey-content change from triggering a destructive replace of the currently-running stg/prod VPSes |
| `.github/workflows/terraform.yml` | `Generate CI SSH key` step removed from both `plan` and `apply` jobs |

## Why the lifecycle block matters

`hcloud_ssh_key.deploy.public_key` is `ForceNew` on the Hetzner provider — changing the pubkey content (which this PR does) replaces the SSH-key resource. Without `ignore_changes = [ssh_keys, user_data]` on `hcloud_server.app`, Terraform would also plan to replace the server (because its `ssh_keys = [hcloud_ssh_key.deploy.id]` reference changes). That would destroy the currently-running stg + prod VPSes, including the freshly-restored authorized_keys files we just hand-pasted via Hetzner console.

With the lifecycle block in place, the next apply does:

```
hcloud_ssh_key.deploy: must be replaced (pubkey content changed)
hcloud_server.app:     no changes (lifecycle ignore_changes [ssh_keys, user_data])
```

…which is exactly the desired shape — registry gets the canonical pubkey, running boxes are untouched.

## Layering note

This is distinct from `#165` / `#173` (cloud-init only injects one key). The narrative those issues describe ("manual paste required for first access because cloud-init only ships one pubkey") becomes moot once this lands — the one pubkey cloud-init injects will be the right one. Marking those for retest after merge; if they're now redundant, they can close.

## Test plan

- [ ] CI: `Format check` job passes
- [ ] CI: `Validate` matrix passes for `modules/hetzner-vps` + `envs/stg` + `envs/prod`
- [ ] CI: `Plan (stg)` + `Plan (prod)` jobs comment plans showing **only** `hcloud_ssh_key.deploy` replace + no other changes (in particular, NOT `hcloud_server.app` replace)
- [ ] On merge: `Apply (stg)` + `Apply (prod)` succeed with the same shape
- [ ] After merge: `gh api orgs/noorinalabs/actions/secrets/DEPLOY_SSH_PRIVATE_KEY` matches the new `noorinalabs-{env}-deploy` SSH key's pubkey content (read via `hcloud ssh-key describe noorinalabs-stg-deploy`)
- [ ] After merge: `ssh deploy@noorinalabs-stg` and `ssh deploy@noorinalabs-prod` work from the operator workstation using `~/.ssh/noorinalabs_deploy`
- [ ] After merge: `deploy-stg.yml` workflow succeeds end-to-end on next dispatch (cleanup of `noorinalabs-{stg,prod}-deploy` orphan SSH-key entries can land as a follow-up)

## Followups

- Delete orphan Hetzner SSH-key registry entries `noorinalabs-stg-deploy` (id 111637771) + `noorinalabs-prod-deploy` (id 111637802) once the new key resources have stable IDs (one-time cleanup, post-merge)
- Caddyfile per-env hostname templating — separate PR (companion to this one for end-to-end stg.noorinalabs.com reachability)
