### PR TITLE
refactor(caddy): per-env hostname templating via BASE_DOMAIN (closes #218)

### DIFF
--- a/.github/workflows/compose-validate.yml
+++ b/.github/workflows/compose-validate.yml
@@ -39,6 +39,9 @@ jobs:
             echo "JWT_PUBLIC_KEY=ci-placeholder"
             # Kafka KRaft cluster id must look like a base64-encoded UUID (22 chars).
             echo "KAFKA_CLUSTER_ID=MkU3OEVCNTcwNTJENDM2Qk"
+            # Caddy per-env hostname root (deploy#218). Real value written by
+            # deploy-{stg,prod}.yml — `noorinalabs.com` for prod, `stg.noorinalabs.com` for stg.
+            echo "BASE_DOMAIN=ci.example"
           } >> .env
       - name: Validate compose config
         working-directory: compose

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -180,6 +180,9 @@ jobs:
             printf "%s='%s'\n" "IMAGE_TAG" "${IMAGE_TAG}" >> "$env_file"
             printf "%s='%s'\n" "USER_SERVICE_IMAGE_TAG" "${USER_SERVICE_IMAGE_TAG}" >> "$env_file"
             printf "%s='%s'\n" "LANDING_IMAGE_TAG" "${LANDING_IMAGE_TAG}" >> "$env_file"
+            # Per-env Caddyfile hostname root (deploy#218). Caddy interpolates
+            # {$BASE_DOMAIN} for the apex/www/isnad-graph virtual hosts.
+            printf "%s='%s'\n" "BASE_DOMAIN" "noorinalabs.com" >> "$env_file"
             # Backup B2 creds (deploy#188): rename BACKUP_B2_* secrets to the
             # bare B2_* names that scripts/backup.sh:59-61 expects. Empty values
             # are written as empty so backup.sh fails fast at preflight rather

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -169,6 +169,9 @@ jobs:
               printf "%s='%s'\n" "$var" "$val" >> "$env_file"
             done
             printf "%s='%s'\n" "IMAGE_TAG" "${IMAGE_TAG}" >> "$env_file"
+            # Per-env Caddyfile hostname root (deploy#218). Caddy interpolates
+            # {$BASE_DOMAIN} for the apex/www/isnad-graph virtual hosts.
+            printf "%s='%s'\n" "BASE_DOMAIN" "stg.noorinalabs.com" >> "$env_file"
             # Backup B2 creds (deploy#188): rename BACKUP_B2_* secrets to the
             # bare B2_* names that scripts/backup.sh:59-61 expects. Empty values
             # are written as empty so backup.sh fails fast at preflight rather

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,8 +1,8 @@
-www.noorinalabs.com {
-    redir https://noorinalabs.com{uri} permanent
+www.{$BASE_DOMAIN} {
+    redir https://{$BASE_DOMAIN}{uri} permanent
 }
 
-noorinalabs.com {
+{$BASE_DOMAIN} {
     reverse_proxy landing:80
 
     header {
@@ -15,7 +15,7 @@ noorinalabs.com {
     }
 }
 
-isnad-graph.noorinalabs.com {
+isnad-graph.{$BASE_DOMAIN} {
     # ── User service routes ──────────────────────────────────────────
 
     # OAuth post-login redirect target lives on the frontend (React Router

--- a/compose/.env.example
+++ b/compose/.env.example
@@ -1,3 +1,7 @@
+# Caddy per-env hostname root (set by deploy-{stg,prod}.yml — see deploy#218).
+# stg: stg.noorinalabs.com   prod: noorinalabs.com
+BASE_DOMAIN=
+
 # Database credentials
 NEO4J_PASSWORD=changeme
 POSTGRES_USER=isnad

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -264,6 +264,8 @@ services:
     ports:
       - "80:80"
       - "443:443"
+    environment:
+      BASE_DOMAIN: "${BASE_DOMAIN:?BASE_DOMAIN must be set — env-templated Caddyfile expects {$BASE_DOMAIN}}"
     volumes:
       - ../caddy/Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data


### PR DESCRIPTION
## Closes

- Closes #218

## Summary

`caddy/Caddyfile` hardcoded `noorinalabs.com`, `www.noorinalabs.com`, and `isnad-graph.noorinalabs.com`. When the same compose stack deployed to stg (first time at 2026-05-01T22:51Z, post-#216 SSH lockout recovery), Caddy bound the prod hostnames and tried to acquire LE certs via ACME HTTP-01 challenges that can't reach the stg origin (DNS for those names points to Cloudflare proxy IPs, not stg). Result: `noorinalabs-caddy-1` permanently unhealthy on stg.

## Approach

Per-env templating via `{$BASE_DOMAIN}` env-var interpolation. Caddy reads `BASE_DOMAIN` at parse time; the compose service declares it; the deploy workflows write the per-env literal value into `.env` on the box.

## Changes

| File | Change |
|------|--------|
| `caddy/Caddyfile` | `noorinalabs.com` → `{$BASE_DOMAIN}`, `www.noorinalabs.com` → `www.{$BASE_DOMAIN}`, `isnad-graph.noorinalabs.com` → `isnad-graph.{$BASE_DOMAIN}` |
| `compose/docker-compose.prod.yml` | Caddy service declares `BASE_DOMAIN` env (fail-fast `:?` if unset) |
| `.github/workflows/deploy-stg.yml` | Writes `BASE_DOMAIN=stg.noorinalabs.com` to `.env` |
| `.github/workflows/deploy-prod.yml` | Writes `BASE_DOMAIN=noorinalabs.com` to `.env` |

## Resulting hostname matrix

| Env | `BASE_DOMAIN` | Bound hostnames |
|-----|---------------|------------------|
| stg | `stg.noorinalabs.com` | `stg.noorinalabs.com`, `www.stg.noorinalabs.com`, `isnad-graph.stg.noorinalabs.com` |
| prod | `noorinalabs.com` | `noorinalabs.com`, `www.noorinalabs.com`, `isnad-graph.noorinalabs.com` |

## What this PR does NOT do

- **Does not enable end-to-end stg public reachability.** That requires `deploy#192` (Cloudflare DNS apply for stg subdomains) to land. Until then, ACME challenges for the stg hostnames still fail and Caddy stays unhealthy on stg — but at least it's failing for the **right** hostnames.
- **Does not carve out `users.{$BASE_DOMAIN}`.** Current Caddyfile embeds user-service routes under the `isnad-graph.*` virtual host; that's preserved here. Carving out a separate `users.*` vhost is a future refactor.

## Test plan

- [ ] `Compose & Infra Validate` CI job passes
- [ ] After merge + redeploy stg: `docker exec noorinalabs-caddy-1 caddy adapt --config /etc/caddy/Caddyfile --adapter caddyfile` shows the templated hostnames resolved (e.g. `stg.noorinalabs.com`, `isnad-graph.stg.noorinalabs.com`)
- [ ] After `deploy#192` lands: `curl -I https://stg.noorinalabs.com/` returns 200 and Caddy reports healthy
- [ ] Prod cutover (post-Phase C): same Caddyfile binds `noorinalabs.com` etc., served from new prod VPS

## Refs

- `deploy#216` — companion PR (#217), terraform.yml ephemeral SSH key fix
- `deploy#192` — gating dependency for end-to-end stg reachability
