### PR TITLE
refactor(tf): remove hcloud_ssh_key resource — cloud-init is sole authorized_keys path (closes #222)

### DIFF
--- a/terraform/hetzner/envs/stg/main.tf
+++ b/terraform/hetzner/envs/stg/main.tf
@@ -6,7 +6,7 @@ module "vps" {
   source = "../../modules/hetzner-vps"
 
   env         = "stg"
-  server_type = "cpx21"
+  server_type = "cpx41"
   location    = "ash"
 
   ssh_public_key_path = var.ssh_public_key_path

--- a/terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl
+++ b/terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl
@@ -41,6 +41,16 @@ users:
 # Write configuration files
 # ---------------------------------------------------------------------------
 write_files:
+  # Root authorized_keys — the canonical operator/CI deploy key. Replaces the
+  # role previously played by Hetzner's `ssh_keys` server argument (removed
+  # in #222 because per-env resources couldn't share one pubkey). Operators
+  # who want their personal id_ed25519 on root can append it post-provision.
+  - path: /root/.ssh/authorized_keys
+    owner: root:root
+    permissions: '0600'
+    content: |
+      ${ssh_public_key}
+
   # fail2ban jail for SSH brute force
   - path: /etc/fail2ban/jail.local
     content: |

--- a/terraform/hetzner/modules/hetzner-vps/main.tf
+++ b/terraform/hetzner/modules/hetzner-vps/main.tf
@@ -6,11 +6,11 @@ locals {
   }
 }
 
-resource "hcloud_ssh_key" "deploy" {
-  name       = "${local.name_prefix}-deploy"
-  public_key = sensitive(chomp(file(var.ssh_public_key_path)))
-  labels     = local.labels
-}
+# hcloud_ssh_key.deploy was removed in #222 — Hetzner enforces SSH-key content
+# uniqueness across the project, so per-env resources sharing one canonical
+# pubkey hit `uniqueness_error 409`. cloud-init's user_data is now the sole
+# path for injecting authorized_keys (writes both /home/deploy/.ssh/authorized_keys
+# and /root/.ssh/authorized_keys with var.ssh_public_key_path content).
 
 resource "hcloud_firewall" "web" {
   name   = "${local.name_prefix}-firewall"
@@ -49,7 +49,6 @@ resource "hcloud_server" "app" {
   location    = var.location
   image       = var.image
 
-  ssh_keys     = [hcloud_ssh_key.deploy.id]
   firewall_ids = [hcloud_firewall.web.id]
 
   user_data = templatefile("${path.module}/cloud-init.yaml.tpl", {
@@ -62,13 +61,13 @@ resource "hcloud_server" "app" {
 
   labels = local.labels
 
-  # ssh_keys + user_data are creation-time-only on Hetzner. Once the server is
-  # running, changes to either don't affect the live box (cloud-init has long
-  # since finished). Without ignore_changes, Terraform plans a destructive
-  # replace whenever the deploy pubkey or cloud-init template content changes
-  # — e.g., when this PR (#216) lands and replaces the runner-ephemeral pubkey
-  # with the canonical checked-in one. Out-of-band rotations on the live box's
-  # /home/deploy/.ssh/authorized_keys are the operator's job, not Terraform's.
+  # ssh_keys + user_data are creation-time-only on Hetzner. The ssh_keys arg
+  # was removed in #222 (cloud-init handles authorized_keys for both root and
+  # deploy users via user_data — see cloud-init.yaml.tpl). The ignore_changes
+  # entry is retained so the existing live-state ssh_keys reference (a now-
+  # deleted hcloud_ssh_key.deploy id from #217's apply) doesn't cause
+  # spurious reconciliation. user_data is ignored so cloud-init template
+  # edits don't trigger destructive server replace on already-provisioned VPSes.
   lifecycle {
     ignore_changes = [ssh_keys, user_data]
   }


### PR DESCRIPTION
## Closes

- Closes #222

## Summary

`hcloud_ssh_key` per-env resources can't coexist when sharing one canonical pubkey content (Hetzner project-scoped uniqueness — `uniqueness_error 409`). #217's apply hit this on prod (stg created the new key first; prod's create failed after the destroy succeeded). Cloud-init's `user_data` already does the actual authorization work for the deploy user; this PR extends that to root so the Hetzner-side resource becomes fully redundant and gets removed.

## Changes

| File | Change |
|------|--------|
| `terraform/hetzner/modules/hetzner-vps/main.tf` | Drop `resource "hcloud_ssh_key" "deploy"`. Drop the `ssh_keys = [hcloud_ssh_key.deploy.id]` arg on `hcloud_server.app`. Keep `lifecycle { ignore_changes = [ssh_keys, user_data] }` — protects existing live-state values from spurious reconciliation. |
| `terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl` | New `write_files` entry for `/root/.ssh/authorized_keys` (mode 0600, owner root:root) containing `${ssh_public_key}` — mirrors the existing deploy-user injection. |
| `terraform/hetzner/envs/stg/main.tf` | `server_type = "cpx21"` → `"cpx41"`. Captures the live state from the 2026-05-01 manual `hcloud server change-type` (sizing fix during the SSH-recovery session). Without this, next plan attempts a cpx41 → cpx21 downgrade and fails with disk-doesn't-fit. |

## Apply shape after this PR

| Env | Plan |
|-----|------|
| stg | 1 to destroy: `hcloud_ssh_key.deploy` (orphan id `111684917`). 0 server changes (cpx41 = cpx41; lifecycle covers ssh_keys reference). |
| prod | 0 changes. `hcloud_ssh_key.deploy` already absent in state from #217's partial-apply failure. Server has lifecycle ignore_changes for the stale ssh_keys reference. |

## Operator-facing impact

Future-provisioned VPSes will have `/root/.ssh/authorized_keys` containing **only the canonical `noorinalabs_deploy.pub`** — same pubkey as `/home/deploy/.ssh/authorized_keys`. Operators wanting their personal `~/.ssh/id_ed25519.pub` on root for a fresh box need to manually append it post-provision (matches the existing post-cloud-init paste pattern documented in `reference_ssh_topology` memory).

Currently-running stg + new-prod boxes have the manually-pasted authorized_keys files from earlier in the 2026-05-01 session and are unaffected by this PR.

## Test plan

- [ ] CI: `Format check` + 5 `Validate` jobs + `Plan (stg)` + `Plan (prod)` all pass
- [ ] `Plan (stg)` output matches the expected shape (1 destroy, 0 server changes)
- [ ] `Plan (prod)` output is empty (0 changes)
- [ ] On merge: `Apply (stg)` succeeds, `Apply (prod)` succeeds (clean), both running VPSes still alive
- [ ] After merge: `hcloud ssh-key list` is empty
- [ ] After merge: `gh workflow run deploy-stg.yml` succeeds end-to-end (cloud-init authorization path is unchanged for live boxes)
- [ ] After merge: when Phase C cutover later provisions a fresh prod box, root SSH works using `noorinalabs_deploy` and deploy SSH works the same — both via cloud-init injection

## Refs

- `deploy#216` — original SSH-lockout bug
- `deploy#217` — first-pass fix; this PR closes the structural gap that fix exposed
- `deploy#218` / PR #219 — Caddyfile per-env templating (companion, can land in any order vs this PR)
