### PR TITLE
infra(cf): apply CF DNS — add stg subdomain tree, retire isnad-graph legacy, all proxied (closes #192)

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -15,7 +15,7 @@ www.{$BASE_DOMAIN} {
     }
 }
 
-isnad-graph.{$BASE_DOMAIN} {
+isnad.{$BASE_DOMAIN} {
     # ── User service routes ──────────────────────────────────────────
 
     # OAuth post-login redirect target lives on the frontend (React Router

--- a/terraform/cloudflare/main.tf
+++ b/terraform/cloudflare/main.tf
@@ -19,52 +19,72 @@ resource "cloudflare_zone_settings_override" "ssl" {
 }
 
 # ===========================================================================
-# PROD records — point at `noorinalabs-prod` (VPS provisioned by
-# terraform/hetzner/envs/prod, see #82).
+# PROD records — point at the prod Hetzner VPS. Currently the hand-made
+# 1box-prod (87.99.134.161 / 2a01:4ff:f0:be57::1); cuts over to the new
+# TF-managed noorinalabs-prod via deploy#86. All proxied through Cloudflare
+# for DDoS / WAF / edge cache (per owner ruling 2026-05-02). ssl=strict
+# (set at zone level above) requires origin Caddy to present a valid LE
+# cert — works through the proxy via ACME HTTP-01 path-passthrough.
 # ===========================================================================
 
-# Root apex — noorinalabs.com → prod VPS IPv4 (DNS only, not proxied).
+# Root apex — noorinalabs.com (proxied A + AAAA to prod origin).
+# `name = var.domain` (FQDN) instead of `"@"` — Cloudflare's API normalizes
+# `@` to the FQDN on read, so using FQDN here keeps the diff clean post-import.
 resource "cloudflare_record" "prod_apex_a" {
   zone_id = var.cloudflare_zone_id
-  name    = "@"
+  name    = var.domain
   content = var.prod_vps_ipv4_address
   type    = "A"
   ttl     = 1
-  proxied = false
+  proxied = true
 }
 
-# Root apex IPv6 — optional. `prod_vps_ipv6_address = ""` disables the record.
 resource "cloudflare_record" "prod_apex_aaaa" {
   count   = var.prod_vps_ipv6_address == "" ? 0 : 1
   zone_id = var.cloudflare_zone_id
-  name    = "@"
+  name    = var.domain
   content = var.prod_vps_ipv6_address
   type    = "AAAA"
   ttl     = 1
-  proxied = false
+  proxied = true
 }
 
-# www → apex redirect (Caddy does the actual redirect; DNS just resolves).
-resource "cloudflare_record" "www_cname" {
+# www.noorinalabs.com — A/AAAA mirrors of apex (matches live; Caddy redirects
+# to apex). Was a CNAME in earlier drafts; A/AAAA matches the hand-managed
+# state in production and is the shape Cloudflare uses when imported.
+resource "cloudflare_record" "www_a" {
   zone_id = var.cloudflare_zone_id
   name    = "www"
-  content = var.domain
-  type    = "CNAME"
+  content = var.prod_vps_ipv4_address
+  type    = "A"
   ttl     = 1
-  proxied = false
+  proxied = true
 }
 
-# isnad.noorinalabs.com → prod apex (isnad-graph app in prod).
+resource "cloudflare_record" "www_aaaa" {
+  count   = var.prod_vps_ipv6_address == "" ? 0 : 1
+  zone_id = var.cloudflare_zone_id
+  name    = "www"
+  content = var.prod_vps_ipv6_address
+  type    = "AAAA"
+  ttl     = 1
+  proxied = true
+}
+
+# isnad.noorinalabs.com → apex (isnad-graph app in prod, new-shaped name).
+# Replaces the legacy isnad-graph.noorinalabs.com — Caddy binding moved to
+# isnad.{$BASE_DOMAIN} in this same PR; legacy DNS records destroyed by
+# this apply (drop-legacy-immediately per owner choice 2026-05-02).
 resource "cloudflare_record" "prod_isnad_cname" {
   zone_id = var.cloudflare_zone_id
   name    = "isnad"
   content = var.domain
   type    = "CNAME"
   ttl     = 1
-  proxied = false
+  proxied = true
 }
 
-# users.noorinalabs.com → prod apex (user-service in prod).
+# users.noorinalabs.com → apex (user-service in prod).
 # Per main#212 Q2 ruling 2026-04-25: hostname is `users.*` (matches the
 # noorinalabs-user-service repo and reflects combined auth + account-mgmt scope).
 resource "cloudflare_record" "prod_users_cname" {
@@ -73,38 +93,22 @@ resource "cloudflare_record" "prod_users_cname" {
   content = var.domain
   type    = "CNAME"
   ttl     = 1
-  proxied = false
-}
-
-# Legacy subdomains (isnad-graph.noorinalabs.com currently) — CNAME to apex.
-# Preserved by #83 to avoid traffic disruption; retired in #156 cutover.
-resource "cloudflare_record" "legacy_subdomains" {
-  for_each = var.legacy_subdomains
-
-  zone_id = var.cloudflare_zone_id
-  name    = each.key
-  content = var.domain
-  type    = "CNAME"
-  ttl     = 1
-  proxied = each.value
+  proxied = true
 }
 
 # ===========================================================================
-# STG records — point at `noorinalabs-stg` (VPS provisioned by
-# terraform/hetzner/envs/stg, see #82).
+# STG records — point at noorinalabs-stg (TF-managed Hetzner VPS).
 # ===========================================================================
 
-# Stg subdomain apex — stg.noorinalabs.com → stg VPS IPv4.
 resource "cloudflare_record" "stg_apex_a" {
   zone_id = var.cloudflare_zone_id
   name    = "stg"
   content = var.stg_vps_ipv4_address
   type    = "A"
   ttl     = 1
-  proxied = false
+  proxied = true
 }
 
-# Stg subdomain apex IPv6 — optional.
 resource "cloudflare_record" "stg_apex_aaaa" {
   count   = var.stg_vps_ipv6_address == "" ? 0 : 1
   zone_id = var.cloudflare_zone_id
@@ -112,25 +116,23 @@ resource "cloudflare_record" "stg_apex_aaaa" {
   content = var.stg_vps_ipv6_address
   type    = "AAAA"
   ttl     = 1
-  proxied = false
+  proxied = true
 }
 
-# isnad.stg.noorinalabs.com → stg subdomain apex (isnad-graph app in stg).
 resource "cloudflare_record" "stg_isnad_cname" {
   zone_id = var.cloudflare_zone_id
   name    = "isnad.stg"
   content = "stg.${var.domain}"
   type    = "CNAME"
   ttl     = 1
-  proxied = false
+  proxied = true
 }
 
-# users.stg.noorinalabs.com → stg subdomain apex (user-service in stg).
 resource "cloudflare_record" "stg_users_cname" {
   zone_id = var.cloudflare_zone_id
   name    = "users.stg"
   content = "stg.${var.domain}"
   type    = "CNAME"
   ttl     = 1
-  proxied = false
+  proxied = true
 }

--- a/terraform/cloudflare/moved.tf
+++ b/terraform/cloudflare/moved.tf
@@ -17,13 +17,11 @@ moved {
 
 moved {
   from = cloudflare_record.www
-  to   = cloudflare_record.www_cname
+  to   = cloudflare_record.www_a
 }
 
-moved {
-  from = cloudflare_record.subdomains
-  to   = cloudflare_record.legacy_subdomains
-}
+# subdomains/legacy_subdomains rename block dropped in #192 — legacy isnad-graph
+# records are destroyed by this PR's apply, so there's nothing to rename to.
 
 # auth → users rename (deploy#167, P2W10) — per main#212 Q2 owner ruling.
 # Defensive: the auth records were defined in #157 but not yet applied to the

--- a/terraform/cloudflare/outputs.tf
+++ b/terraform/cloudflare/outputs.tf
@@ -2,7 +2,7 @@ output "prod_hostnames" {
   description = "Prod hostname map — consumed by deploy#87 verify and the cutover issue #156. Keys are canonical service identifiers."
   value = {
     landing = cloudflare_record.prod_apex_a.hostname
-    www     = cloudflare_record.www_cname.hostname
+    www     = cloudflare_record.www_a.hostname
     isnad   = cloudflare_record.prod_isnad_cname.hostname
     users   = cloudflare_record.prod_users_cname.hostname
   }
@@ -17,10 +17,8 @@ output "stg_hostnames" {
   }
 }
 
-output "legacy_subdomain_hostnames" {
-  description = "Legacy subdomains (e.g., isnad-graph.noorinalabs.com) preserved during cutover. Retired via #156."
-  value       = { for k, v in cloudflare_record.legacy_subdomains : k => v.hostname }
-}
+# legacy_subdomain_hostnames output removed in #192 — legacy isnad-graph
+# records are destroyed by this PR's apply (drop-legacy-immediately).
 
 output "ssl_mode" {
   description = "Current SSL/TLS mode for the zone."

--- a/terraform/cloudflare/variables.tf
+++ b/terraform/cloudflare/variables.tf
@@ -43,16 +43,7 @@ variable "stg_vps_ipv6_address" {
   default     = ""
 }
 
-# ---------------------------------------------------------------------------
-# Legacy subdomain map (for `isnad-graph.noorinalabs.com` and any ad-hoc
-# CNAMEs that should alias to the prod apex). Preserved untouched by #83 —
-# retirement of `isnad-graph` is tracked in #156 (cutover follow-up).
-# ---------------------------------------------------------------------------
-
-variable "legacy_subdomains" {
-  description = "Map of legacy subdomain names → proxied flag. All CNAME to the prod apex. Empty the map to drop a legacy name once its cutover is complete."
-  type        = map(bool)
-  default = {
-    "isnad-graph" = false
-  }
-}
+# Legacy subdomains variable removed in #192 (drop-legacy-immediately per
+# owner ruling 2026-05-02). isnad-graph.noorinalabs.com A/AAAA records are
+# imported and then destroyed by this PR's apply; Caddy binding moved to
+# isnad.{$BASE_DOMAIN} in the same PR.


### PR DESCRIPTION
## Closes

- Closes #192

## Summary

Brings `terraform/cloudflare/` under TF management aligned with the live zone, adds the new prod + stg subdomain tree per the W10 split, retires the legacy `isnad-graph.*` records, and makes everything proxied (DDoS / WAF / edge cache, owner-ratified 2026-05-02).

The actual `terraform apply` was run **locally by SRE in this session** — TF state in B2 (`s3://noorinalabs-terraform-state/cloudflare/terraform.tfstate`) is already aligned with these code changes. The PR captures the source-of-truth code state. CI's `Terraform` workflow validates the cloudflare module on every PR but does not currently include cloudflare in the apply matrix (filing follow-up to wire that in — manual is fine for the cadence we're on).

## Live state after this PR's apply

```
$ curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
       "https://api.cloudflare.com/client/v4/zones/<id>/dns_records?per_page=100" \
  | jq -r '.result[] | "\(.name)  \(.type)  \(.content)  proxied=\(.proxied)"' \
  | sort

# Managed by this PR (TF):
isnad.noorinalabs.com           CNAME   noorinalabs.com         proxied=true
isnad.stg.noorinalabs.com       CNAME   stg.noorinalabs.com     proxied=true
noorinalabs.com                 A       87.99.134.161           proxied=true
noorinalabs.com                 AAAA    2a01:4ff:f0:be57::1     proxied=true
stg.noorinalabs.com             A       87.99.137.225           proxied=true
stg.noorinalabs.com             AAAA    2a01:4ff:f4:5e0d::1     proxied=true
users.noorinalabs.com           CNAME   noorinalabs.com         proxied=true
users.stg.noorinalabs.com       CNAME   stg.noorinalabs.com     proxied=true
www.noorinalabs.com             A       87.99.134.161           proxied=true
www.noorinalabs.com             AAAA    2a01:4ff:f0:be57::1     proxied=true

# Outside TF scope (Proton/identity):
*._domainkey.noorinalabs.com    TXT     v=DKIM1; p=
_dmarc.noorinalabs.com          TXT     v=DMARC1;...
noorinalabs.com                 MX      mailsec.protonmail.ch
noorinalabs.com                 MX      mail.protonmail.ch
noorinalabs.com                 TXT     v=spf1 include:...
noorinalabs.com                 TXT     protonmail-verification=...
protonmail._domainkey.*         CNAME   protonmail.domainkey.*
protonmail2._domainkey.*        CNAME   protonmail2.domainkey.*
protonmail3._domainkey.*        CNAME   protonmail3.domainkey.*

# Destroyed (drop-legacy-immediately):
isnad-graph.noorinalabs.com     A/AAAA  — gone (curl-deleted post-apply, IDs 07ca26019abf4e60d360707ef33324d0 + b245dbdbad8139543d04c951bfe703cc)
```

## Verification

After apply + Caddy container restart on stg:

```
$ curl -I https://stg.noorinalabs.com/
HTTP/2 200
server: cloudflare

$ docker logs noorinalabs-caddy-1 | grep "stg.noorinalabs.com.*obtained"
{"level":"info","msg":"certificate obtained successfully","identifier":"stg.noorinalabs.com","issuer":"acme-v02.api.letsencrypt.org-directory"}
```

`isnad.stg.noorinalabs.com` and `users.stg.noorinalabs.com` ACME challenges will succeed once stg redeploys with this PR's Caddyfile (currently bound to `isnad-graph.{$BASE_DOMAIN}` legacy name in the deployed Caddyfile; this PR renames to `isnad.{$BASE_DOMAIN}`).

## Apply runbook (already executed — for reference + future re-applies)

```bash
cd terraform/cloudflare/
export AWS_ACCESS_KEY_ID=$TF_STATE_B2_KEY_ID
export AWS_SECRET_ACCESS_KEY=$TF_STATE_B2_APP_KEY
export TF_VAR_cloudflare_api_token=$CLOUDFLARE_API_TOKEN
export TF_VAR_cloudflare_zone_id=ae6e445ccc0be21a61fd8d5a789137ca
export TF_VAR_prod_vps_ipv4_address=87.99.134.161
export TF_VAR_prod_vps_ipv6_address=2a01:4ff:f0:be57::1
export TF_VAR_stg_vps_ipv4_address=87.99.137.225
export TF_VAR_stg_vps_ipv6_address=2a01:4ff:f4:5e0d::1

terraform init

# One-time imports (existing live records). Skip if state already populated.
ZONE=ae6e445ccc0be21a61fd8d5a789137ca
terraform import cloudflare_record.prod_apex_a       $ZONE/f7074fb00d80fe3d16983bbda69c1135
terraform import cloudflare_record.prod_apex_aaaa[0] $ZONE/da925460c8a79f67e7c45d070db63b0c
terraform import cloudflare_record.www_a             $ZONE/d8712139b5f8a5c089fbf57d4d3344a3
terraform import cloudflare_record.www_aaaa[0]       $ZONE/98b6151fcc25b176e88ba75556a85401
# (cloudflare_zone_settings_override doesn't support import — TF will "create" with idempotent API write)

terraform plan -out=tfplan
terraform apply tfplan

# Drop-legacy-immediately: destroy the legacy isnad-graph A + AAAA records.
# Not in TF scope (intentionally — they're being removed, not managed).
for rid in 07ca26019abf4e60d360707ef33324d0 b245dbdbad8139543d04c951bfe703cc; do
  curl -X DELETE -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
       "https://api.cloudflare.com/client/v4/zones/$ZONE/dns_records/$rid"
done
```

## Apply shape (executed local)

```
Plan: 7 to add, 4 to change, 0 to destroy.
Apply complete! Resources: 7 added, 4 changed, 0 destroyed.
```

The 4 in-place changes are import-state metadata sync (`+ allow_overwrite = false`, `+ content = "..."` re-asserting the imported value into state). No live DNS record content changes for the imported records.

## Post-merge follow-up

- Trigger `deploy-stg.yml` to push the renamed Caddyfile (`isnad.{$BASE_DOMAIN}`) to the box. Caddy ACME for `isnad.stg.noorinalabs.com` will succeed once it sees the new binding.
- Phase C cutover (`deploy#86`) — when the new prod box takes over, its Caddyfile (templated, same as stg) binds `isnad.{$BASE_DOMAIN}` = `isnad.noorinalabs.com`, which is what the new CNAME points at. Wire-aligned.

## Followups to file separately

1. Wire cloudflare into terraform.yml apply matrix (cloudflare TF was applied locally for this PR; future CF changes should auto-apply on merge to main, same as hetzner). Currently each `terraform/cloudflare/**` change needs the manual runbook above.
2. Optional: `www.stg.noorinalabs.com` DNS — Caddy on stg currently binds `www.{$BASE_DOMAIN}` (= `www.stg.noorinalabs.com`) for the redirect, but no DNS exists for it. Either add the record or make the www redirect block conditional. Tech-debt; non-blocking.

## Test plan

- [ ] CI: `Format check` + `Validate (terraform/cloudflare)` pass
- [ ] After merge: `gh workflow run deploy-stg.yml` succeeds end-to-end
- [ ] After merge: `curl -I https://isnad.stg.noorinalabs.com/` returns 200 (Caddy ACME succeeds for new name)
- [ ] After merge: `curl -I https://stg.noorinalabs.com/` continues to return 200 (regression check)

## Refs

- `deploy#216`/`#217`/`#222`/`#223` — SSH-lockout work (this session)
- `deploy#218`/`#219` — Caddyfile per-env templating (this session, foundation for the `{$BASE_DOMAIN}` interpolation used in this PR's Caddy rename)
- main#212 Q2 ruling 2026-04-25 — `users.*` hostname canonical
