### PR TITLE
fix(cf): stg records proxied=false — Universal SSL doesn't cover *.stg.* (followup to #192)

### DIFF
--- a/terraform/cloudflare/main.tf
+++ b/terraform/cloudflare/main.tf
@@ -98,6 +98,15 @@ resource "cloudflare_record" "prod_users_cname" {
 
 # ===========================================================================
 # STG records — point at noorinalabs-stg (TF-managed Hetzner VPS).
+#
+# All stg records are gray-cloud (proxied=false). Cloudflare Universal SSL
+# only covers `*.noorinalabs.com` (one level deep), so 3rd-level subdomains
+# like `isnad.stg.noorinalabs.com` get a TLS handshake failure at the CF
+# edge. Until/unless we enable Cloudflare Advanced Certificate Manager (paid,
+# wildcard at any depth), stg lives outside the CF proxy. Origin Caddy has
+# valid LE certs for the stg hostnames and serves directly. Stg loses the
+# CF DDoS / WAF / cache benefits — acceptable for non-prod. Tracked as a
+# tech-debt followup if owner ever wants to revisit ACM.
 # ===========================================================================
 
 resource "cloudflare_record" "stg_apex_a" {
@@ -106,7 +115,7 @@ resource "cloudflare_record" "stg_apex_a" {
   content = var.stg_vps_ipv4_address
   type    = "A"
   ttl     = 1
-  proxied = true
+  proxied = false
 }
 
 resource "cloudflare_record" "stg_apex_aaaa" {
@@ -116,7 +125,7 @@ resource "cloudflare_record" "stg_apex_aaaa" {
   content = var.stg_vps_ipv6_address
   type    = "AAAA"
   ttl     = 1
-  proxied = true
+  proxied = false
 }
 
 resource "cloudflare_record" "stg_isnad_cname" {
@@ -125,7 +134,7 @@ resource "cloudflare_record" "stg_isnad_cname" {
   content = "stg.${var.domain}"
   type    = "CNAME"
   ttl     = 1
-  proxied = true
+  proxied = false
 }
 
 resource "cloudflare_record" "stg_users_cname" {
@@ -134,5 +143,5 @@ resource "cloudflare_record" "stg_users_cname" {
   content = "stg.${var.domain}"
   type    = "CNAME"
   ttl     = 1
-  proxied = true
+  proxied = false
 }


### PR DESCRIPTION
## Summary

Followup to #192 (now-merged #226). After applying `*.stg.*` records as proxied=true, TLS handshake at the CF edge fails for 3rd-level subdomains because **Cloudflare Universal SSL only covers `*.noorinalabs.com` (one level deep) and the apex** — not `*.stg.noorinalabs.com`.

```
$ curl -I https://isnad.stg.noorinalabs.com/
* TLSv1.3 (IN), TLS alert, handshake failure (552):
* OpenSSL/3.0.13: error:0A000410:SSL routines::sslv3 alert handshake failure
```

Fix: gray-cloud all stg records (proxied=false). Origin Caddy already has valid LE certs for the stg hostnames (verified — `isnad.stg.noorinalabs.com` cert: `subject CN=isnad.stg.noorinalabs.com, issuer Let's Encrypt E8`). Stg loses CF DDoS / WAF / cache; acceptable for non-prod.

## Verification post-apply (already executed locally)

```
$ curl -I https://stg.noorinalabs.com/         → 200
$ curl -I https://isnad.stg.noorinalabs.com/   → 200  (was 000 with TLS handshake failure)
$ curl -I https://users.stg.noorinalabs.com/   → 000  (separate issue: deploy#220, no users.* vhost in Caddy yet)
$ curl https://isnad.stg.noorinalabs.com/health → {"status":"healthy","services":{"neo4j":"up","postgres":"up","redis":"up"}}
```

## Apply shape

`Plan: 0 to add, 4 to change, 0 to destroy.` Just the 4 stg records flipped.

## Followup (optional, separate)

If we ever want "everything proxied" uniformity for stg too, enable Cloudflare Advanced Certificate Manager (~$10/mo recurring) — gives wildcard cert at any depth. One-toggle dashboard change. Not filing as a tech-debt issue unless requested; it's a paid-feature decision, not a defect.

## Test plan

- [ ] CI: Format + Validate pass
- [ ] Plan output matches `Plan: 0 to add, 4 to change, 0 to destroy` (already verified locally)
- [ ] After merge: stg subdomains continue to resolve direct-to-origin and return 200