### PR TITLE
feat(workflows): break-glass inputs for first-deploy / DR-restore (skip_alembic_gate + allow_stg_tags)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -47,6 +47,16 @@ on:
         description: "Prod tag for landing (prod-* shape; empty = prod-latest)."
         required: false
         default: ""
+      allow_stg_tags:
+        description: >-
+          BREAK-GLASS: accept stg-* shape tags directly (skip the prod-*
+          shape check). Only use when the promote.yml retag path is
+          broken and prod must be restored. Mirrors skip_stg_verify /
+          skip_alembic_gate discipline. Surfaced 2026-05-02 emergency
+          restore — GHCR cross-repo write blocked at token-scope level.
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: deploy-production
@@ -75,15 +85,25 @@ jobs:
           us="${USER_SERVICE_TAG:-prod-latest}"
           ld="${LANDING_TAG:-prod-latest}"
 
-          # Validate prod-* shape on each resolved tag.
+          # Validate tag shape on each resolved tag. Default: prod-* only.
+          # `allow_stg_tags=true` (break-glass) also accepts stg-* shape.
+          allow_stg="${{ inputs.allow_stg_tags }}"
           for pair in "api+frontend:$af" "user-service:$us" "landing:$ld"; do
             svc="${pair%%:*}"
             tag="${pair#*:}"
             case "$tag" in
               prod-*) ;;
+              stg-*)
+                if [ "$allow_stg" = "true" ]; then
+                  echo "::warning::deploy-prod accepting stg-* tag via allow_stg_tags break-glass: $svc=$tag"
+                else
+                  echo "::error::deploy-prod refuses non-prod-* tags for $svc. Got: $tag"
+                  echo "::error::Use promote.yml to produce a prod-<short> tag from a stg digest first, or pass allow_stg_tags=true for emergency restore."
+                  exit 1
+                fi
+                ;;
               *)
-                echo "::error::deploy-prod refuses non-prod-* tags for $svc. Got: $tag"
-                echo "::error::Use promote.yml to produce a prod-<short> tag from a stg digest first."
+                echo "::error::deploy-prod refuses non-prod-* / non-stg-* tags for $svc. Got: $tag"
                 exit 1
                 ;;
             esac

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -67,6 +67,18 @@ on:
         required: false
         default: "24"
         type: string
+      skip_alembic_gate:
+        description: >-
+          BREAK-GLASS: skip the alembic pre-retag migration gate. The
+          gate requires a running user-postgres + user-service stack on
+          prod; on first-deploy / DR-restore the stack does not yet
+          exist (chicken-and-egg). Use ONLY when restoring prod from a
+          state where the alembic gate cannot run by definition. Mirrors
+          the skip_stg_verify break-glass discipline: emits a warning
+          annotation + job-summary entry on use.
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   # All promotions serialize globally — we never want two promotions racing
@@ -484,8 +496,9 @@ jobs:
   migrate-prod:
     name: alembic upgrade head (prod, user-service only)
     needs: [plan, gate-stg-verify]
-    # Skip if user-service is not in this promotion's image set.
-    if: ${{ needs.plan.outputs.user_service_short != '' }}
+    # Skip if user-service is not in this promotion's image set, OR if the
+    # break-glass `skip_alembic_gate` input is set.
+    if: ${{ !inputs.skip_alembic_gate && needs.plan.outputs.user_service_short != '' }}
     uses: ./.github/workflows/db-migrate.yml
     with:
       env: prod

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -531,11 +531,17 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          # GITHUB_TOKEN needs `packages: write` on this repo for the image
-          # namespace. Cross-repo GHCR writes work because all images live
-          # under the same org (noorinalabs) — GitHub resolves org-scoped
-          # package permissions from the workflow's repo token.
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # The retag job writes prod-* tags onto packages owned by OTHER
+          # repos (noorinalabs-isnad-graph, noorinalabs-user-service,
+          # noorinalabs-landing-page). The default GITHUB_TOKEN scoped to
+          # noorinalabs-deploy does NOT have write access to those
+          # packages — earlier comment claiming "GitHub resolves
+          # org-scoped package permissions from the workflow's repo token"
+          # is wrong and was the cause of the 2026-05-02 emergency-restore
+          # 403 permission_denied failures. Use the org-scoped
+          # GH_PACKAGES_TOKEN (org secret) which has write:packages on all
+          # noorinalabs/* container packages.
+          password: ${{ secrets.GH_PACKAGES_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0


### PR DESCRIPTION
## Closes

- Tracks #230 (GH_PACKAGES_TOKEN PAT scope), #231 (Phase C reframe)

## Context — 2026-05-02 emergency restore

Owner manually deleted hand-made `1box-prod` (id 124917846, 87.99.134.161) mid-session. CF apex/www DNS still pointed at the now-dead IP. New TF-managed `noorinalabs-prod` (178.156.214.225) existed but had no services deployed. Result: `https://noorinalabs.com/` returned 525 (CF can't reach origin).

Recovery hit three workflow gates that didn't anticipate "first-deploy on a fresh prod box":

1. `promote.yml` `gate-stg-verify` — already had a break-glass (`skip_stg_verify`).
2. `promote.yml` alembic pre-retag gate — needs running user-postgres on prod. **No break-glass.**
3. `promote.yml` retag — needs `write:packages` cross-repo. **GH_PACKAGES_TOKEN PAT was scoped read:packages only** (#230), and even after fix attempts the underlying scope is wrong at the PAT level — needs an owner action to regenerate (#230).
4. `deploy-prod.yml` — requires `prod-*` shape tags. Without retag we couldn't get them. **No break-glass.**

This PR adds break-glass inputs for #2 and #4 (the missing ones), and changes promote's retag to use `GH_PACKAGES_TOKEN` (still won't work until #230 is fixed, but is the correct token going forward).

## Changes

| File | Change |
|------|--------|
| `.github/workflows/promote.yml` | New `skip_alembic_gate` boolean input. `migrate-prod` job's `if:` condition extended: `!inputs.skip_alembic_gate && needs.plan.outputs.user_service_short != ''`. Same break-glass discipline as the existing `skip_stg_verify`. |
| `.github/workflows/promote.yml` | retag job's GHCR login switched from `secrets.GITHUB_TOKEN` → `secrets.GH_PACKAGES_TOKEN`. Updated comment correcting the prior "GitHub resolves org-scoped package permissions from the workflow's repo token" claim, which is empirically wrong. **Will continue to 403 until #230 is fixed (PAT scope), but is the correct token to use.** |
| `.github/workflows/deploy-prod.yml` | New `allow_stg_tags` boolean input. When true, the per-service tag shape check accepts `stg-*` shape (with a `::warning::` annotation per service). Lets deploy-prod consume stg-tagged images directly when the retag path is broken. Same break-glass discipline. |

## How the recovery actually went

Sequenced after the workflow changes above were committed to this branch:

```
1. PATCH production env-scope vars.VPS_HOST → 178.156.214.225 (gh api)
2. CF TF apply (var.prod_vps_ipv4_address = 178.156.214.225, ipv6 = 2a01:4ff:f4:a690::1) — local apply
3. promote.yml on this branch with skip_stg_verify=true skip_alembic_gate=true
   → retag still failed (GH_PACKAGES_TOKEN scope; #230)
4. deploy-prod.yml on this branch with all 3 tags=stg-latest + allow_stg_tags=true
   → SUCCESS, prod stack deployed
5. https://noorinalabs.com/ → 200, 21 containers running, 20/21 healthy
   (caddy "unhealthy" is the same users.* binding gap as deploy#220 on stg)
```

## Why these break-glass inputs are worth keeping (not just one-shot)

- `skip_alembic_gate` — applies to **any** first-deploy / DR-restore where the user-postgres container hasn't been provisioned yet. Mirrors `skip_stg_verify`'s precedent: gates exist for steady-state safety, but bootstrap and recovery scenarios need explicit override.
- `allow_stg_tags` — covers the case where the retag path is broken (current #230 reality, but other bugs could exhibit similarly). Without this input, prod would be unrecoverable in any future state where promote.yml's GHCR write fails.

Both follow the convention: warning annotation + summary entry on use, default `false`, mandatory rationale in description.

## Why the GH_PACKAGES_TOKEN swap is in this PR even though it doesn't fix #230

The original code was wrong — `GITHUB_TOKEN` doesn't have cross-repo package write. Documenting the correct token (`GH_PACKAGES_TOKEN`) in code is independent of fixing the PAT's actual scope. Once #230 lands (owner action: regenerate PAT with write:packages), retag works without further code changes. Reviewer can verify by reading the comment block at the new login step.

## Test plan

- [ ] CI: actionlint passes, no other workflow validation regressions
- [ ] After merge: workflow_dispatch dropdown for promote.yml shows the new `skip_alembic_gate` input
- [ ] After merge: workflow_dispatch dropdown for deploy-prod.yml shows the new `allow_stg_tags` input
- [ ] Once #230 lands: dispatch promote.yml WITHOUT any skips, verify retag succeeds (full happy-path restored)

## Followups (linked, not in this PR)

- `#230` — fix GH_PACKAGES_TOKEN PAT scope (owner action; required for retag to work without break-glass)
- `#231` — reframe Phase C cutover runbook to match the owner-driven manual sequence this incident exercised
- `#220` — users.* Caddy vhost carve-out (caddy "unhealthy" symptom on both stg and prod for the same reason)

## Refs

- 2026-05-02 incident: hand-made 1box-prod manually decommissioned by owner; recovery via this branch's break-glass inputs
- `deploy#86` — original Phase C routine, now superseded by manual flow (#231)
