### PR TITLE
fix(workflows): close TOCTOU + asyncpg/psycopg defects (closes #234, #235)

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -144,10 +144,17 @@ jobs:
             echo "==> Pulling ${IMAGE}..."
             docker pull "${IMAGE}"
 
-            # DATABASE_URL — psycopg driver, sync, because alembic's env.py
-            # is synchronous. user-postgres resolves on the user-backend
-            # docker network which this one-shot container joins explicitly.
-            DATABASE_URL="postgresql+psycopg://${USER_POSTGRES_USER}:${USER_POSTGRES_PASSWORD}@user-postgres:5432/${USER_POSTGRES_DB}"
+            # DATABASE_URL — asyncpg driver. user-service's alembic/env.py
+            # uses create_async_engine + asyncio.run, so the async driver is
+            # what alembic actually consumes. The image only ships asyncpg
+            # in pyproject.toml (no psycopg), and the runtime
+            # docker-compose.prod.yml DATABASE_URL also uses +asyncpg —
+            # so this aligns the gate's URL with the rest of the stack.
+            # Earlier "psycopg, sync" comment was wrong about env.py; closes
+            # #235 (was the cause of `ModuleNotFoundError: psycopg` on
+            # 2026-05-02). user-postgres resolves on the user-backend docker
+            # network which this one-shot container joins explicitly.
+            DATABASE_URL="postgresql+asyncpg://${USER_POSTGRES_USER}:${USER_POSTGRES_PASSWORD}@user-postgres:5432/${USER_POSTGRES_DB}"
 
             # -------- Belt-and-suspenders head-count assertion (Anya, 2026-04-23) --------
             echo "==> [${ENV_NAME}] alembic heads — heads-count assertion"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -549,23 +549,20 @@ jobs:
       - name: Resolve source tag
         id: src
         env:
-          # Matrix short is plan-resolved; if plan received an explicit
-          # source_sha, `short` is that SHA and source tag is `sha-<short>`.
-          # If plan walked from stg-latest, `short` is the matched sha-<short>
-          # and we still source from `stg-latest` (same digest; using the
-          # short-tag gives slightly better audit trace).
+          # Always source from sha-${SHORT}. The plan job resolved SHORT from
+          # whatever drove this run (explicit source_sha input or stg-latest
+          # digest at plan time), and sha-<short> is digest-stable per the
+          # Contract v6 invariant. Sourcing from a floating tag like
+          # stg-latest creates a TOCTOU race between plan, retag, and the
+          # digest-parity step — surfaced 2026-05-02 (#234) when a
+          # concurrent service-repo ghcr-publish caused the parity check to
+          # observe three different digests across that window. sha-<short>
+          # closes the race.
           SHORT: ${{ matrix.short }}
           IMAGE: ${{ env.REGISTRY }}/${{ matrix.image }}
-          EXPLICIT: ${{ inputs.source_sha }}
         run: |
           set -euo pipefail
-          if [ -n "$EXPLICIT" ]; then
-            # Operator-provided sha: pin to that specific sha-<short>.
-            source_tag="sha-${SHORT}"
-          else
-            # Auto-promote from stg-latest. Same digest as sha-${SHORT}.
-            source_tag="stg-latest"
-          fi
+          source_tag="sha-${SHORT}"
           echo "Using source tag: $IMAGE:$source_tag (matches short=$SHORT)"
           echo "source_tag=$source_tag" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Closes

- Closes #234 (promote.yml retag TOCTOU race on stg-latest source)
- Closes #235 (db-migrate.yml alembic uses psycopg URL — image only ships asyncpg)

Both surfaced during 2026-05-02 emergency restore. The break-glass inputs in #232 papered over both; this PR closes the underlying defects so those break-glass paths revert to DR-only use.

## Changes

### promote.yml — retag source = sha-\<short> always (#234)

Before: `source_tag` was conditionally `stg-latest` or `sha-\<short>` depending on whether `source_sha` input was provided. The `stg-latest` path opened a TOCTOU window — a concurrent `ghcr-publish` from a service repo could move `stg-latest` between plan, retag, and digest-parity check.

After: always use `sha-\<short>`. The plan job already resolved `SHORT` from whatever drove the run (explicit input or `stg-latest` digest at plan time), and `sha-\<short>` is digest-stable per Contract v6.

### db-migrate.yml — DATABASE_URL uses asyncpg (#235)

Before: `DATABASE_URL=postgresql+psycopg://...` with comment claiming user-service alembic env.py is sync. Both wrong: env.py uses `create_async_engine` + `asyncio.run`, and the image ships only asyncpg (no psycopg in pyproject.toml). Result: every `alembic upgrade head` invocation failed with `ModuleNotFoundError: No module named 'psycopg'`.

After: `DATABASE_URL=postgresql+asyncpg://...` and comment realigned with reality. Matches the runtime URL in compose.

## Verification

- [ ] CI: actionlint passes
- [ ] After merge: dispatch promote.yml without skips against current stg-latest. Retag completes, no digest-parity error. (#234 verified)
- [ ] After merge: dispatch promote.yml without `skip_alembic_gate`. Alembic gate runs heads-count + upgrade head against prod's user-postgres successfully. (#235 verified)
- [ ] After merge: end-to-end happy-path promote → deploy-prod completes without any break-glass flags

## Refs

- 2026-05-02 emergency restore: PR #232 (break-glass inputs); this PR removes the need for those break-glass uses going forward
- Run #234 (TOCTOU) caught at run `25243063822` (landing-page)
- Run #235 (psycopg) caught at runs `25242208146`, `25243033399` (alembic gate steps)