### PR TITLE
fix(promote): shape-aware digest parity for single-arch images (closes #239)

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -602,11 +602,37 @@ jobs:
           set -euo pipefail
           # Defense in depth: the retag is registry-side so digests MUST
           # match, but verifying catches registry bugs or accidental
-          # buildx flag drift. Use `--format '{{.Manifest.Digest}}'` to
-          # read registry-authoritative digest.
+          # buildx flag drift.
+          #
+          # Comparison is shape-aware (#239 fix). When the source is a
+          # multi-arch index/list, `imagetools create` preserves it
+          # identically and we compare top-level manifest digests directly.
+          # When the source is a single-arch v2 manifest (landing-page is
+          # currently the only one), `imagetools create` wraps it in a
+          # NEW index whose digest is necessarily different from the
+          # unwrapped source manifest. In that case we compare the source
+          # digest to the destination index's `manifests[0].digest` —
+          # which IS the wrapped source manifest, so equality means the
+          # retag preserved content even though the surface representation
+          # changed.
           src=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$IMAGE:$SOURCE_TAG")
-          ps=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$IMAGE:prod-$SHORT")
-          pl=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$IMAGE:prod-latest")
+          src_media=$(docker buildx imagetools inspect --format '{{.Manifest.MediaType}}' "$IMAGE:$SOURCE_TAG")
+
+          if echo "$src_media" | grep -qE 'index|manifest\.list'; then
+            # Multi-arch source — direct top-level comparison.
+            ps=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$IMAGE:prod-$SHORT")
+            pl=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$IMAGE:prod-latest")
+            shape="multi-arch (direct top-level digest comparison)"
+          else
+            # Single-arch source — compare against the wrapped manifest digest
+            # inside the destination index.
+            ps=$(docker buildx imagetools inspect --raw "$IMAGE:prod-$SHORT" | jq -r '.manifests[0].digest')
+            pl=$(docker buildx imagetools inspect --raw "$IMAGE:prod-latest" | jq -r '.manifests[0].digest')
+            shape="single-arch (compare source to destination's manifests[0].digest)"
+          fi
+
+          echo "Source MediaType:    $src_media"
+          echo "Comparison shape:    $shape"
           echo "source digest:       $src"
           echo "prod-<short> digest: $ps"
           echo "prod-latest digest:  $pl"


### PR DESCRIPTION
## Closes

- Closes #239

## Summary

`promote.yml`'s digest-parity check assumed all sources are multi-arch indexes. `docker buildx imagetools create` preserves multi-arch source digests identically, but for single-arch v2 manifests (landing-page) it wraps the source in a new index — destination index digest necessarily differs from the unwrapped source manifest, even though the wrapped manifest IS bit-for-bit identical to the source.

## Fix

Branch the parity check on source MediaType:

- **Multi-arch source** (`oci.image.index` or `docker.distribution.manifest.list`): compare top-level digests directly. (Unchanged.)
- **Single-arch source** (`docker.distribution.manifest.v2`): compare the source digest to the destination's `manifests[0].digest` — the wrapped source inside the new index.

Equality in either case proves the retag preserved content, which is the actual invariant the parity check wants to enforce.

## Test plan

- [ ] CI: actionlint passes
- [ ] After merge: dispatch promote.yml against current stg-latest. All 4 services pass parity check (was 3/4 before this PR, only landing-page failing).
- [ ] After merge: dispatch promote.yml on a multi-arch service: `Comparison shape: multi-arch` reported in step output.
- [ ] After merge: dispatch promote.yml landing-page: `Comparison shape: single-arch` reported, parity passes.

## Refs

- 2026-05-02 incident — landing-page parity failure surfaced post-#234/#235 fixes
- Companion to #236 (PR that closed #234, #235); after this lands, all 4 services promote without break-glass