### PR TITLE
feat(caddy): carve out users.${BASE_DOMAIN} vhost — fixes OAuth + verify-deploy gate (closes #220)

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -16,17 +16,71 @@ www.{$BASE_DOMAIN} {
 }
 
 isnad.{$BASE_DOMAIN} {
-    # ── User service routes ──────────────────────────────────────────
+    # User-service routes carved out to users.{$BASE_DOMAIN} in #220 — see
+    # the dedicated vhost block below. Anything user-related (auth, accounts,
+    # sessions, subscriptions, JWKS, 2FA, etc.) is served from there.
 
-    # OAuth post-login redirect target lives on the frontend (React Router
-    # AuthCallbackPage), NOT user-service. Carve out before /auth/* which
-    # goes to user-service. See deploy#133, user-service#67.
+    # ── isnad-graph API routes ───────────────────────────────────────
+
+    # API routes (versioned) — catch-all for isnad-graph
+    handle /api/* {
+        reverse_proxy api:8000
+    }
+
+    # API routes (top-level health/status — no /api prefix)
+    handle /health {
+        reverse_proxy api:8000
+    }
+    handle /status {
+        reverse_proxy api:8000
+    }
+
+    # Metrics — not publicly proxied; Prometheus scrapes api:8000
+    # directly via the Docker backend network (see prometheus.yml).
+    handle /metrics {
+        respond 403
+    }
+
+    # ── Other services ───────────────────────────────────────────────
+
+    # Grafana
+    handle /grafana/* {
+        reverse_proxy grafana:3000
+    }
+
+    # Frontend (default)
+    handle {
+        reverse_proxy frontend:80
+    }
+
+    # Security headers
+    header {
+        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+        X-Content-Type-Options "nosniff"
+        X-Frame-Options "DENY"
+        X-XSS-Protection "0"
+        Referrer-Policy "strict-origin-when-cross-origin"
+        Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'"
+        -Server
+    }
+}
+
+# users.{$BASE_DOMAIN} — auth + account management surface (user-service).
+# Carved out from isnad.{$BASE_DOMAIN} in #220. The OAuth flow's
+# `redirect_uri` (set via AUTH_OAUTH_REDIRECT_BASE_URL on user-service)
+# and the post-login frontend callback path both live here.
+users.{$BASE_DOMAIN} {
+    # OAuth post-login frontend page (React Router AuthCallbackPage). The
+    # browser is sent here by user-service after a successful OAuth
+    # exchange — see user-service config.AUTH_OAUTH_POST_LOGIN_URL.
+    # Carve out before /auth/* which goes to user-service. See deploy#133,
+    # user-service#67.
     handle /auth/callback/* {
         reverse_proxy frontend:80
     }
 
-    # User service — auth endpoints
-    # NOTE: rate limiting on /auth/* should be enforced at the app layer
+    # User service — auth endpoints (login, OAuth, logout, refresh, etc.)
+    # NOTE: rate limiting on /auth/* should be enforced at the app layer.
     handle /auth/* {
         reverse_proxy user-service:8000
     }
@@ -90,37 +144,10 @@ isnad.{$BASE_DOMAIN} {
         reverse_proxy user-service:8000
     }
 
-    # ── isnad-graph API routes ───────────────────────────────────────
-
-    # API routes (versioned) — catch-all for non-user-service paths
-    handle /api/* {
-        reverse_proxy api:8000
-    }
-
-    # API routes (top-level health/status — no /api prefix)
-    handle /health {
-        reverse_proxy api:8000
-    }
-    handle /status {
-        reverse_proxy api:8000
-    }
-
-    # Metrics — not publicly proxied; Prometheus scrapes api:8000
-    # directly via the Docker backend network (see prometheus.yml).
-    handle /metrics {
-        respond 403
-    }
-
-    # ── Other services ───────────────────────────────────────────────
-
-    # Grafana
-    handle /grafana/* {
-        reverse_proxy grafana:3000
-    }
-
-    # Frontend (default)
+    # Default — catch-all to user-service for any unmapped path on this
+    # vhost. user-service returns 404 cleanly.
     handle {
-        reverse_proxy frontend:80
+        reverse_proxy user-service:8000
     }
 
     # Security headers
@@ -130,7 +157,6 @@ isnad.{$BASE_DOMAIN} {
         X-Frame-Options "DENY"
         X-XSS-Protection "0"
         Referrer-Policy "strict-origin-when-cross-origin"
-        Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'"
         -Server
     }
 }

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -140,7 +140,7 @@ services:
       - AUTH_GOOGLE_CLIENT_SECRET=${AUTH_GOOGLE_CLIENT_SECRET:-}
       - AUTH_GITHUB_CLIENT_ID=${AUTH_GITHUB_CLIENT_ID:-}
       - AUTH_GITHUB_CLIENT_SECRET=${AUTH_GITHUB_CLIENT_SECRET:-}
-      - AUTH_OAUTH_REDIRECT_BASE_URL=https://isnad-graph.noorinalabs.com
+      - AUTH_OAUTH_REDIRECT_BASE_URL=https://users.${BASE_DOMAIN}
       - AUTH_USER_SERVICE_URL=http://user-service:8000
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/health')\" || exit 1"]
@@ -325,7 +325,7 @@ services:
       - AUTH_GOOGLE_CLIENT_SECRET=${AUTH_GOOGLE_CLIENT_SECRET:-}
       - AUTH_GITHUB_CLIENT_ID=${AUTH_GITHUB_CLIENT_ID:-}
       - AUTH_GITHUB_CLIENT_SECRET=${AUTH_GITHUB_CLIENT_SECRET:-}
-      - AUTH_OAUTH_REDIRECT_BASE_URL=https://isnad-graph.noorinalabs.com
+      - AUTH_OAUTH_REDIRECT_BASE_URL=https://users.${BASE_DOMAIN}
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/health')\" || exit 1"]
       interval: 15s


### PR DESCRIPTION
## Closes

- Closes #220

## Summary

User-service routes move from `isnad.${BASE_DOMAIN}` to a dedicated `users.${BASE_DOMAIN}` virtual host in Caddy, matching the DNS records #192 already provisions for both envs. Plus a side-effect fix: prod user-service had `AUTH_OAUTH_REDIRECT_BASE_URL` pinned to the legacy `isnad-graph.noorinalabs.com` (destroyed in #192) — pointing at `users.${BASE_DOMAIN}` now.

## Routes moved

From `isnad.${BASE_DOMAIN}` to `users.${BASE_DOMAIN}`:

- `/auth/callback/*` → frontend:80 (OAuth post-login React Router page)
- `/auth/*` → user-service:8000 (login, OAuth, refresh, logout)
- `/.well-known/jwks.json` → user-service:8000
- `/api/v1/users`, `/api/v1/users/*` → user-service
- `/api/v1/sessions`, `/api/v1/sessions/*` → user-service
- `/api/v1/subscriptions`, `/api/v1/subscriptions/*` → user-service
- `/api/v1/verification`, `/api/v1/verification/*` → user-service
- `/api/v1/roles`, `/api/v1/roles/*` → user-service
- `/api/v1/2fa`, `/api/v1/2fa/*` → user-service
- `/api/v1/user-service/health` (rewrite to /health) → user-service

The new `users.${BASE_DOMAIN}` block has a `handle { reverse_proxy user-service:8000 }` default catch-all, so any unmapped path on the vhost gets a clean user-service 404.

## Compose env update

`AUTH_OAUTH_REDIRECT_BASE_URL` was hardcoded to `https://isnad-graph.noorinalabs.com` (legacy, destroyed in #192). Updated to `https://users.${BASE_DOMAIN}` so it interpolates per-env at compose-up time:

| Env | AUTH_OAUTH_REDIRECT_BASE_URL |
|-----|-------------------------------|
| prod | `https://users.noorinalabs.com` |
| stg | `https://users.stg.noorinalabs.com` |

This means user-service tells OAuth providers "redirect users to https://users.${BASE_DOMAIN}/auth/oauth/{provider}/callback" — which Caddy now routes to user-service via the carved-out vhost.

## ⚠️ Owner action required after merge

OAuth provider client config (Google Cloud Console + GitHub Developer Settings) must have the new redirect URIs added to the allowed list:

**prod (Google):** https://users.noorinalabs.com/auth/oauth/google/callback
**prod (GitHub):** https://users.noorinalabs.com/auth/oauth/github/callback
**stg (Google):** https://users.stg.noorinalabs.com/auth/oauth/google/callback
**stg (GitHub):** https://users.stg.noorinalabs.com/auth/oauth/github/callback

Without this, OAuth flows will fail with `redirect_uri_mismatch` even though Caddy + DNS are correct.

## Side benefits — what this PR also resolves

- **stg verify-deploy gate** (#178 root cause): tests `test_user_service_health` and `test_user_service_jwks` probe `https://users.stg.noorinalabs.com/...` — those URLs now have a Caddy vhost, ACME succeeds (DNS already exists), and the tests pass. Once this lands, `promote.yml` can run without `skip_stg_verify` break-glass.
- **Caddy unhealthy** (current state on both stg and prod): Caddy's healthcheck attempts `http://localhost:80/` which falls through to no-vhost-match because `users.${BASE_DOMAIN}` isn't bound. With this fix, Caddy reports healthy.

## Test plan

- [ ] CI: docker compose config + actionlint pass
- [ ] After merge + redeploy stg: `docker exec noorinalabs-caddy-1 caddy adapt` shows the new `users.stg.noorinalabs.com` vhost block
- [ ] After merge + redeploy stg: `curl -I https://users.stg.noorinalabs.com/.well-known/jwks.json` returns 200 (Caddy ACME succeeds, user-service serves the route)
- [ ] After OAuth-provider-config update: full login flow works end-to-end on stg
- [ ] After merge + verify-deploy run: test_user_service_health + test_user_service_jwks pass in remote-mode integration suite
- [ ] After merge + redeploy prod: same checks on `https://users.noorinalabs.com/`

## Refs

- DNS records already provisioned in #192 (apex `users.{stg.,}noorinalabs.com` CNAMEs proxied=true on prod, proxied=false on stg per #228)
- Existing test failure root cause traced in #178 cross-reference
- Bereket-filed during #226 review as #220

## Followups

Outside this PR's scope:
- Consider whether `users.{}` should also have CSP / security headers tuned for the API surface (the current isnad.* CSP is frontend-tuned, may not fit user-service API responses 1:1). File issue if so.