### PR TITLE
fix(caddy): restore user-service routes on isnad.{${BASE_DOMAIN}} (hotfix — frontend uses relative URLs)

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -16,13 +16,93 @@ www.{$BASE_DOMAIN} {
 }
 
 isnad.{$BASE_DOMAIN} {
-    # User-service routes carved out to users.{$BASE_DOMAIN} in #220 — see
-    # the dedicated vhost block below. Anything user-related (auth, accounts,
-    # sessions, subscriptions, JWKS, 2FA, etc.) is served from there.
+    # User-service routes are ALSO served from this vhost (in addition to
+    # the dedicated users.{$BASE_DOMAIN} block below). The frontend hard-
+    # codes relative URLs (`/auth/oauth/{provider}/login`, `/api/v1/users`,
+    # etc.) — see frontend/src/{hooks/useAuth.ts,pages/LoginPage.tsx} —
+    # so removing these entirely from isnad.* breaks login. Restored
+    # 2026-05-02 mid-emergency-restore as the pragmatic two-phase
+    # migration completion: phase 1 is dual-binding both vhosts (this
+    # state); phase 2 is updating frontend to absolute URLs targeting
+    # users.{$BASE_DOMAIN}, then dropping the user-service routes from
+    # isnad.* (filed as deploy#NNN).
+
+    # ── User service routes (transitional — see comment above) ──────
+
+    # OAuth post-login redirect target lives on the frontend (React Router
+    # AuthCallbackPage), NOT user-service. Carve out before /auth/* which
+    # goes to user-service. See deploy#133, user-service#67.
+    handle /auth/callback/* {
+        reverse_proxy frontend:80
+    }
+
+    # User service — auth endpoints
+    handle /auth/* {
+        reverse_proxy user-service:8000
+    }
+
+    # User service — JWKS public keys (IETF well-known)
+    handle /.well-known/jwks.json {
+        reverse_proxy user-service:8000
+    }
+
+    # User service — user management API
+    handle /api/v1/users {
+        reverse_proxy user-service:8000
+    }
+    handle /api/v1/users/* {
+        reverse_proxy user-service:8000
+    }
+
+    # User service — session management
+    handle /api/v1/sessions {
+        reverse_proxy user-service:8000
+    }
+    handle /api/v1/sessions/* {
+        reverse_proxy user-service:8000
+    }
+
+    # User service — subscription management
+    handle /api/v1/subscriptions {
+        reverse_proxy user-service:8000
+    }
+    handle /api/v1/subscriptions/* {
+        reverse_proxy user-service:8000
+    }
+
+    # User service — email verification
+    handle /api/v1/verification {
+        reverse_proxy user-service:8000
+    }
+    handle /api/v1/verification/* {
+        reverse_proxy user-service:8000
+    }
+
+    # User service — roles
+    handle /api/v1/roles {
+        reverse_proxy user-service:8000
+    }
+    handle /api/v1/roles/* {
+        reverse_proxy user-service:8000
+    }
+
+    # User service — 2FA (TOTP)
+    handle /api/v1/2fa {
+        reverse_proxy user-service:8000
+    }
+    handle /api/v1/2fa/* {
+        reverse_proxy user-service:8000
+    }
+
+    # User service — health check (rewrite to /health)
+    handle /api/v1/user-service/health {
+        rewrite * /health
+        reverse_proxy user-service:8000
+    }
 
     # ── isnad-graph API routes ───────────────────────────────────────
 
-    # API routes (versioned) — catch-all for isnad-graph
+    # API routes (versioned) — catch-all for non-user-service paths
     handle /api/* {
         reverse_proxy api:8000
     }


### PR DESCRIPTION
## Summary

Hotfix for OAuth login. Frontend (noorinalabs-isnad-graph) hardcodes relative URLs:

```ts
const AUTH_BASE = '/auth'
const USER_BASE = '/api/v1/users'
const SESSIONS_BASE = '/api/v1/sessions'
fetch(`${AUTH_BASE}/oauth/google/login`)  // → isnad.{base}/auth/oauth/google/login
```

After #241 carved those routes off `isnad.{\$BASE_DOMAIN}` to `users.{\$BASE_DOMAIN}`, the same-origin fetches fell through Caddy's catch-all to nginx SPA fallback (HTML), and JSON.parse blew up at `unexpected character at line 1 column 1` on the leading `<`.

## Fix

Restore user-service routes on `isnad.{\$BASE_DOMAIN}` (dual-binding alongside the new `users.{\$BASE_DOMAIN}` vhost). Both vhosts proxy to the same user-service container; both serve correctly. Phase-2 frontend update tracked in #245.

`users.{\$BASE_DOMAIN}` block unchanged — it remains valid for direct API consumers and the post-OAuth-callback flow (which lands on `users.*` origin first per `AUTH_OAUTH_REDIRECT_BASE_URL`).

## Test plan

- [ ] After merge + redeploy: `curl -I https://isnad.${BASE_DOMAIN}/auth/oauth/google/login` returns 200 (not nginx SPA HTML)
- [ ] Browser login flow: click "Login with Google" on `https://isnad.{base}/login`, no JSON.parse error, redirects to Google's OAuth consent page
- [ ] Same on stg
- [ ] Existing `https://users.{base}/auth/oauth/google/login` still returns 200 (no regression)

## Refs

- #220 (original carve-out)
- #241 (PR that did the partial server-side move)
- #245 (phase-2 followup: frontend → absolute URLs, then drop dual-binding)
- 2026-05-02 OAuth flow test — surfaced via owner browser console error