### PR TITLE
fix(caddy): users.{base} default → frontend, fixes blank AuthCallbackPage

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -224,10 +224,14 @@ users.{$BASE_DOMAIN} {
         reverse_proxy user-service:8000
     }
 
-    # Default — catch-all to user-service for any unmapped path on this
-    # vhost. user-service returns 404 cleanly.
+    # Default — catch-all to frontend for SPA assets (/assets/*, /theme-init.js,
+    # favicon, fonts, etc.) needed when /auth/callback/{provider} loads the
+    # React AuthCallbackPage on this vhost. The user-service explicit handlers
+    # above match first; only unmapped paths fall here. Was originally routed
+    # to user-service, but that broke the post-OAuth callback page (blank
+    # page — bundle assets returned user-service 404 JSON instead of the JS).
     handle {
-        reverse_proxy user-service:8000
+        reverse_proxy frontend:80
     }
 
     # Security headers


### PR DESCRIPTION
Hotfix continued from #246. After enabling OAuth login, the callback URL `https://users.{base}/auth/callback/{provider}?token=...` loaded index.html but the SPA's `/assets/*.js` and `/theme-init.js` requests fell through to user-service:8000 and 404'd, leaving a blank page.

Default catch-all on `users.{\$BASE_DOMAIN}` flipped from user-service:8000 → frontend:80. User-service explicit handlers still match first. Surfaced 2026-05-02 browser test.