### PR TITLE
fix(oauth): post-login cross-origin redirect to isnad.{base}, users.* now pure API

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -145,20 +145,15 @@ isnad.{$BASE_DOMAIN} {
     }
 }
 
-# users.{$BASE_DOMAIN} — auth + account management surface (user-service).
-# Carved out from isnad.{$BASE_DOMAIN} in #220. The OAuth flow's
-# `redirect_uri` (set via AUTH_OAUTH_REDIRECT_BASE_URL on user-service)
-# and the post-login frontend callback path both live here.
+# users.{$BASE_DOMAIN} — pure user-service API surface.
+# Carved out from isnad.{$BASE_DOMAIN} in #220. user-service receives the
+# OAuth provider redirect at /auth/oauth/{provider}/callback (set via
+# AUTH_OAUTH_REDIRECT_BASE_URL on user-service) and after token exchange
+# redirects the browser CROSS-ORIGIN to isnad.{$BASE_DOMAIN}/auth/callback/
+# {provider} (set via AUTH_OAUTH_POST_LOGIN_URL on user-service). The
+# AuthCallbackPage and all other frontend rendering happen on isnad.* —
+# users.* is purely an API surface.
 users.{$BASE_DOMAIN} {
-    # OAuth post-login frontend page (React Router AuthCallbackPage). The
-    # browser is sent here by user-service after a successful OAuth
-    # exchange — see user-service config.AUTH_OAUTH_POST_LOGIN_URL.
-    # Carve out before /auth/* which goes to user-service. See deploy#133,
-    # user-service#67.
-    handle /auth/callback/* {
-        reverse_proxy frontend:80
-    }
-
     # User service — auth endpoints (login, OAuth, logout, refresh, etc.)
     # NOTE: rate limiting on /auth/* should be enforced at the app layer.
     handle /auth/* {
@@ -224,14 +219,14 @@ users.{$BASE_DOMAIN} {
         reverse_proxy user-service:8000
     }
 
-    # Default — catch-all to frontend for SPA assets (/assets/*, /theme-init.js,
-    # favicon, fonts, etc.) needed when /auth/callback/{provider} loads the
-    # React AuthCallbackPage on this vhost. The user-service explicit handlers
-    # above match first; only unmapped paths fall here. Was originally routed
-    # to user-service, but that broke the post-OAuth callback page (blank
-    # page — bundle assets returned user-service 404 JSON instead of the JS).
+    # Default — catch-all to user-service for any unmapped path on this
+    # vhost. The vhost is purely an API surface post-#247 (OAuth callback
+    # redirects cross-origin to isnad.{$BASE_DOMAIN}/auth/callback rather
+    # than rendering the AuthCallbackPage here), so SPA-asset fallthrough
+    # is no longer needed. Direct hits to users.{base}/foo (no explicit
+    # handler) get a clean user-service 404 JSON.
     handle {
-        reverse_proxy frontend:80
+        reverse_proxy user-service:8000
     }
 
     # Security headers

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -141,6 +141,7 @@ services:
       - AUTH_GITHUB_CLIENT_ID=${AUTH_GITHUB_CLIENT_ID:-}
       - AUTH_GITHUB_CLIENT_SECRET=${AUTH_GITHUB_CLIENT_SECRET:-}
       - AUTH_OAUTH_REDIRECT_BASE_URL=https://users.${BASE_DOMAIN}
+      - AUTH_OAUTH_POST_LOGIN_URL=https://isnad.${BASE_DOMAIN}/auth/callback
       - AUTH_USER_SERVICE_URL=http://user-service:8000
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/health')\" || exit 1"]
@@ -326,6 +327,7 @@ services:
       - AUTH_GITHUB_CLIENT_ID=${AUTH_GITHUB_CLIENT_ID:-}
       - AUTH_GITHUB_CLIENT_SECRET=${AUTH_GITHUB_CLIENT_SECRET:-}
       - AUTH_OAUTH_REDIRECT_BASE_URL=https://users.${BASE_DOMAIN}
+      - AUTH_OAUTH_POST_LOGIN_URL=https://isnad.${BASE_DOMAIN}/auth/callback
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/health')\" || exit 1"]
       interval: 15s


### PR DESCRIPTION
Hotfix — OAuth callback rendering on users.* origin caused cascading JSON.parse errors on the SPA homepage (no isnad-graph /api/* routes there).

Architectural fix: `AUTH_OAUTH_POST_LOGIN_URL` now absolute (`https://isnad.\${BASE_DOMAIN}/auth/callback`). user-service redirects browser cross-origin to isnad.* after OAuth exchange. AuthCallbackPage runs on isnad.* where SPA is fully functional.

Caddyfile users.*: remove /auth/callback/* handler, revert default → user-service. users.* is now purely an API surface; isnad.* is the app.

Surfaced 2026-05-02 OAuth flow test.