### PR TITLE
fix(verify-deploy): swap destroyed isnad-graph hostname → isnad/users (#252)

### DIFF
--- a/.github/workflows/verify-deploy.yml
+++ b/.github/workflows/verify-deploy.yml
@@ -261,17 +261,17 @@ jobs:
       - name: Wait briefly for services to settle
         run: sleep 10
 
-      # Hostname defaults reflect TODAY's prod Caddy (caddy/Caddyfile:18 —
-      # `isnad-graph.noorinalabs.com`). User-service routes are wrapped
-      # in the same site block via Caddy `handle /auth/*`, `/api/v1/users`,
-      # etc., so USER_SERVICE_BASE_URL points at the same host today.
-      # When deploy#156 lands (cutover to `isnad.noorinalabs.com` +
-      # `users.noorinalabs.com`), update these defaults in that PR's diff.
-      # See deploy#181 review (Weronika).
+      # Post-cutover topology (#226 / emergency 2026-05-02 + #245 phase 2):
+      # frontend + isnad-graph API on isnad.{base}; pure user-service API
+      # surface on users.{base}. The legacy isnad-graph.{base} hostname was
+      # retired during the emergency CF DNS reconciliation. Both vhosts are
+      # currently dual-bound for /auth/* and JWKS during the absolute-URL
+      # frontend cutover; user-service smoke-targets resolve cleanly via
+      # either, but USER_SERVICE_BASE_URL is the canonical pure surface.
       - name: Run prod smoke battery
         env:
-          ISNAD_BASE_URL: https://isnad-graph.noorinalabs.com
-          USER_SERVICE_BASE_URL: https://isnad-graph.noorinalabs.com
+          ISNAD_BASE_URL: https://isnad.noorinalabs.com
+          USER_SERVICE_BASE_URL: https://users.noorinalabs.com
           LANDING_BASE_URL: https://noorinalabs.com
           SMOKE_REPORT: smoke-report.md
         run: |

--- a/scripts/bootstrap-vps.sh
+++ b/scripts/bootstrap-vps.sh
@@ -3,7 +3,7 @@
 # bootstrap-vps.sh — First-time VPS setup for Noorina Labs
 #
 # Run as root on a fresh Hetzner VPS:
-#   ssh -i ~/.ssh/isnad_deploy root@isnad-graph.noorinalabs.com
+#   ssh -i ~/.ssh/isnad_deploy root@isnad.noorinalabs.com
 #   curl -sL https://raw.githubusercontent.com/noorinalabs/noorinalabs-deploy/main/scripts/bootstrap-vps.sh | bash
 #
 # Or copy this script to the VPS and run:
@@ -136,10 +136,10 @@ REDIS_PASSWORD=CHANGE-ME
 # Grafana [REQUIRED]
 GRAFANA_ADMIN_USER=admin
 GRAFANA_ADMIN_PASSWORD=CHANGE-ME
-GRAFANA_ROOT_URL=https://isnad-graph.noorinalabs.com/grafana
+GRAFANA_ROOT_URL=https://isnad.noorinalabs.com/grafana
 
 # CORS
-CORS_ORIGINS=["https://isnad-graph.noorinalabs.com"]
+CORS_ORIGINS=["https://isnad.noorinalabs.com"]
 
 # Logging
 LOG_LEVEL=INFO
@@ -236,7 +236,7 @@ echo "  3. Verify:"
 echo "     curl http://localhost:8000/health"
 echo ""
 echo "  4. Add VPS_HOST variable in GitHub repo settings:"
-echo "     Settings → Variables → New: VPS_HOST = isnad-graph.noorinalabs.com"
+echo "     Settings → Variables → New: VPS_HOST = isnad.noorinalabs.com"
 echo ""
 echo "  5. Start the backup timer:"
 echo "     systemctl start isnad-backup.timer"

--- a/scripts/verify_deployment.sh
+++ b/scripts/verify_deployment.sh
@@ -18,16 +18,17 @@
 #
 # Environment:
 #   SITE_URL              Override the default API host URL
-#                         (default: https://isnad-graph.noorinalabs.com)
+#                         (default: https://isnad.noorinalabs.com)
 #   LANDING_URL           Landing-page URL to check. Empty disables the
 #                         landing reachability check.
 #                         (default: https://noorinalabs.com)
 #   USER_SERVICE_URL      Base URL whose `/health` is hit for the
 #                         user-service auth-plane check. Empty disables.
-#                         (default: $SITE_URL — caddy/Caddyfile routes
-#                         user-service via the same host today; the
-#                         deploy#156 cutover will move it to its own
-#                         subdomain.)
+#                         (default: $SITE_URL — auth-plane routes are
+#                         dual-bound on isnad.* and users.* during the
+#                         #245 absolute-URL frontend cutover; pass
+#                         USER_SERVICE_URL=https://users.noorinalabs.com
+#                         to hit the pure user-service surface directly.)
 #   GH_REPO               Override the GitHub repo for workflow checks
 #                         (default: noorinalabs/noorinalabs-deploy)
 #   ROLLBACK_TAG          If set, tag the current deployment for rollback
@@ -37,14 +38,15 @@ set -euo pipefail
 
 # ---------- Configuration ----------
 
-SITE_URL="${SITE_URL:-https://isnad-graph.noorinalabs.com}"
+SITE_URL="${SITE_URL:-https://isnad.noorinalabs.com}"
 # Landing-page reachability check (deploy#73). Empty = skip.
 LANDING_URL="${LANDING_URL:-https://noorinalabs.com}"
 # user-service auth-plane health (deploy#73). Empty = skip. Defaults to
-# SITE_URL because today Caddy routes user-service traffic via the same
-# host as the API (caddy/Caddyfile site block); the deploy#156 cutover
-# will move it to https://users.noorinalabs.com — at that point operators
-# pass USER_SERVICE_URL=https://users.noorinalabs.com explicitly.
+# SITE_URL because the auth-plane routes are currently dual-bound on
+# isnad.* and users.* during the #245 absolute-URL frontend cutover, so
+# /api/v1/user-service/health resolves via either. Operators wanting to
+# hit the pure user-service surface pass
+# USER_SERVICE_URL=https://users.noorinalabs.com explicitly.
 USER_SERVICE_URL="${USER_SERVICE_URL:-$SITE_URL}"
 GH_REPO="${GH_REPO:-noorinalabs/noorinalabs-deploy}"
 SKIP_WORKFLOW="${SKIP_WORKFLOW:-false}"

--- a/scripts/verify_prod_smoke.sh
+++ b/scripts/verify_prod_smoke.sh
@@ -17,14 +17,15 @@
 #   6. /auth/login            → HTTP 3xx redirect to OAuth provider
 #                                (proves user-service auth wiring alive)
 #
-# Env (defaults reflect TODAY's prod Caddy — caddy/Caddyfile:18 serves
-# `isnad-graph.noorinalabs.com` and routes user-service traffic in the
-# same site block. When deploy#156 lands, update defaults to
-# `isnad.noorinalabs.com` + `users.noorinalabs.com`):
-#   ISNAD_BASE_URL          (default: https://isnad-graph.noorinalabs.com)
-#   USER_SERVICE_BASE_URL   (default: https://isnad-graph.noorinalabs.com —
-#                            same host as ISNAD_BASE_URL today; cleaves
-#                            into a separate subdomain at #156)
+# Env (post-cutover topology, #226 + emergency 2026-05-02): frontend +
+# isnad-graph API live on `isnad.noorinalabs.com`; the pure user-service
+# API surface lives on `users.noorinalabs.com`. The auth-plane routes
+# (/auth/*, /.well-known/jwks.json) are dual-bound on both vhosts during
+# the absolute-URL frontend cutover (#245 phase 2), so the script's
+# auth-plane checks currently route via ISNAD_BASE_URL — see check 6:
+#   ISNAD_BASE_URL          (default: https://isnad.noorinalabs.com)
+#   USER_SERVICE_BASE_URL   (default: https://users.noorinalabs.com —
+#                            canonical pure user-service API surface)
 #   LANDING_BASE_URL        (default: https://noorinalabs.com)
 #   SMOKE_REPORT            Path to write GH-summary-formatted markdown
 #                           (default: smoke-report.md)
@@ -32,8 +33,8 @@
 
 set -euo pipefail
 
-ISNAD_BASE_URL="${ISNAD_BASE_URL:-https://isnad-graph.noorinalabs.com}"
-USER_SERVICE_BASE_URL="${USER_SERVICE_BASE_URL:-https://isnad-graph.noorinalabs.com}"
+ISNAD_BASE_URL="${ISNAD_BASE_URL:-https://isnad.noorinalabs.com}"
+USER_SERVICE_BASE_URL="${USER_SERVICE_BASE_URL:-https://users.noorinalabs.com}"
 LANDING_BASE_URL="${LANDING_BASE_URL:-https://noorinalabs.com}"
 SMOKE_REPORT="${SMOKE_REPORT:-smoke-report.md}"
 TIMEOUT="${TIMEOUT:-5}"


### PR DESCRIPTION
## Summary

Swap the destroyed `isnad-graph.noorinalabs.com` hostname to the post-cutover topology in the `Verify Deployment` workflow + 3 ops scripts. CI prod-smoke battery has been red on every push since 2026-05-02T05:13Z (HTTP 000 = NXDOMAIN).

Resolves the smoke-test failure mode without expanding scope. 5 of the 6 smoke checks pass against live infra after this swap; check 6 (`/auth/login` wiring) is a separate route-correctness issue tracked in a sibling.

## Topology applied

Per #226 (emergency CF DNS reconciliation 2026-05-02) + #245 phase-2:

| Surface | Hostname (prod) |
|---|---|
| isnad SPA + isnad-graph API + dual-bound /auth + JWKS | `isnad.noorinalabs.com` |
| Pure user-service API surface | `users.noorinalabs.com` |
| Landing | `noorinalabs.com` |

Stg-mode env block (`verify-deploy.yml:85-86`) was correctly updated during the emergency and is unchanged here.

## Files

| File | Change |
|---|---|
| `.github/workflows/verify-deploy.yml` | Prod env block: `ISNAD_BASE_URL` → `isnad.noorinalabs.com`, `USER_SERVICE_BASE_URL` → `users.noorinalabs.com`. Comment block above (L264-L270) replaced with post-cutover-topology rationale. |
| `scripts/verify_prod_smoke.sh` | Defaults swapped + L20-L31 comment block updated. |
| `scripts/verify_deployment.sh` | `SITE_URL` default + L17-L30 comment block updated. |
| `scripts/bootstrap-vps.sh` | SSH-usage comment, `GRAFANA_ROOT_URL`, `CORS_ORIGINS`, VPS_HOST hint. |

## Verification

Live probe of new hostnames against current prod:

| Smoke check | Expected | Live response |
|---|---|---|
| `isnad /health` | 200 | 200 ✓ |
| `user-service /health` (via Caddy rewrite at `/api/v1/user-service/health`) | 200 | 200 ✓ |
| `landing /` | 200 | 200 ✓ |
| `narrator /api/v1/narrators?limit=1` | 401/403 + JSON | 401 ✓ |
| `jwks.json` | 200 + `.keys[]` | 200 ✓ |
| `/auth/login wiring` | 3xx or 200 | 404 ✗ — **see sibling issue (filed)** |

The previous failed run [25244530406](https://github.com/noorinalabs/noorinalabs-deploy/actions/runs/25244530406) showed all 5 fails as HTTP 000 (NXDOMAIN). Post-merge, the next prod-deploy verify run should report 5/6 passing — and the auth/login route fix (sibling) cleans up the last one.

Bash + YAML syntax validated locally (`bash -n` on each script + `yaml.safe_load` on the workflow). `.github/workflows/` and `scripts/` no longer contain any `isnad-graph.noorinalabs.com` references.

## Out-of-scope findings (filed as siblings, not bundled here)

Per scope-discipline / multi-layer-gap discipline:

1. **`infra/prometheus/prometheus.yml` blackbox-exporter targets** — 5 stale `isnad-graph.noorinalabs.com` URLs on the steady-state monitor. Same root cause, different lifecycle (continuous monitor vs. one-shot smoke). Sibling issue filed.
2. **`scripts/verify_prod_smoke.sh` check 6** — hits a phantom `/auth/login`. user-service exposes `/auth/oauth/{provider}/login` instead. Smoke-script-correctness, not hostname. Sibling issue filed.
3. **`docs/runbooks/blackbox-probes.md`, `docs/runbooks/user-service-migration.md`, `docs/troubleshooting.md`, `terraform/cloudflare/variables.tf`** — retain `isnad-graph.noorinalabs.com` references. Per the issue's exclusion clause, "archive-tagged comments documenting the migration history" are deferred. The blackbox-probes runbook update is part of sibling #1 above.

## Acceptance criteria

- [x] Workflow + 3 in-scope scripts no longer reference the destroyed hostname.
- [x] New hostnames match the convention: frontend = `isnad.${BASE_DOMAIN}`, user-service API = `users.${BASE_DOMAIN}` (BASE_DOMAIN = `noorinalabs.com` for prod).
- [x] Stg-mode block preserved.
- [x] PR opens against `deployments/phase-3/wave-3`, labelled `p3-wave-3` + `bug` + `priority-high`.
- [ ] Prod-smoke 5/6 passes on next `Verify Deployment` workflow run (auth/login = sibling); validated post-merge by next prod deploy.

## Branch / scope

- **Branch:** `A.Idrissi/0252-smoke-fix`
- **Base:** `deployments/phase-3/wave-3`
- **Wave:** P3W3 Tier 1
- **Issue:** Closes #252
- **Reviewer:** Bereket Tadesse

🤖 Generated with [Claude Code](https://claude.com/claude-code)
