### PR TITLE
ci(terraform): wire cloudflare + backblaze into plan/apply matrix (closes #250)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -51,7 +51,7 @@ jobs:
         run: terraform validate
 
   plan:
-    name: Plan (${{ matrix.env }})
+    name: Plan (hetzner/${{ matrix.env }})
     needs: validate
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -98,8 +98,100 @@ jobs:
         if: steps.plan.outcome == 'failure'
         run: exit 1
 
+  plan-cloudflare:
+    name: Plan (cloudflare)
+    needs: validate
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    environment: production
+    defaults:
+      run:
+        working-directory: terraform/cloudflare
+    env:
+      TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      TF_VAR_cloudflare_zone_id: ${{ vars.CLOUDFLARE_ZONE_ID }}
+      TF_VAR_prod_vps_ipv4_address: ${{ vars.PROD_VPS_IPV4_ADDRESS }}
+      TF_VAR_prod_vps_ipv6_address: ${{ vars.PROD_VPS_IPV6_ADDRESS }}
+      TF_VAR_stg_vps_ipv4_address: ${{ vars.STG_VPS_IPV4_ADDRESS }}
+      TF_VAR_stg_vps_ipv6_address: ${{ vars.STG_VPS_IPV6_ADDRESS }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.TF_STATE_B2_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_B2_APP_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~> 1.6"
+      - name: Init
+        run: terraform init
+      - name: Plan
+        id: plan
+        run: terraform plan -no-color -out=tfplan
+        continue-on-error: true
+      - name: Comment PR with plan
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const output = `#### Terraform Plan (cloudflare)
+            \`\`\`
+            ${{ steps.plan.outputs.stdout }}
+            \`\`\`
+            *Triggered by @${{ github.actor }}*`;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+      - name: Fail if plan failed
+        if: steps.plan.outcome == 'failure'
+        run: exit 1
+
+  plan-backblaze:
+    name: Plan (backblaze)
+    needs: validate
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    environment: production
+    defaults:
+      run:
+        working-directory: terraform/backblaze
+    env:
+      TF_VAR_b2_application_key_id: ${{ secrets.B2_MASTER_KEY_ID }}
+      TF_VAR_b2_application_key: ${{ secrets.B2_MASTER_APP_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.TF_STATE_B2_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_B2_APP_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~> 1.6"
+      - name: Init
+        run: terraform init
+      - name: Plan
+        id: plan
+        run: terraform plan -no-color -out=tfplan
+        continue-on-error: true
+      - name: Comment PR with plan
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const output = `#### Terraform Plan (backblaze)
+            \`\`\`
+            ${{ steps.plan.outputs.stdout }}
+            \`\`\`
+            *Triggered by @${{ github.actor }}*`;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+      - name: Fail if plan failed
+        if: steps.plan.outcome == 'failure'
+        run: exit 1
+
   apply:
-    name: Apply (${{ matrix.env }})
+    name: Apply (hetzner/${{ matrix.env }})
     needs: validate
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
@@ -117,6 +209,63 @@ jobs:
         working-directory: terraform/hetzner/envs/${{ matrix.env }}
     env:
       TF_VAR_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.TF_STATE_B2_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_B2_APP_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~> 1.6"
+      - name: Init
+        run: terraform init
+      - name: Apply
+        run: terraform apply -auto-approve
+
+  # Cloudflare apply runs after hetzner apply — ensures DNS records always
+  # point at IPs from a freshly-converged hetzner state. If the hetzner apply
+  # changes a VPS IP, the cloudflare apply that follows picks up the new
+  # vars.{PROD,STG}_VPS_IPV4_ADDRESS values (which the owner updates
+  # alongside any IP-changing hetzner change).
+  apply-cloudflare:
+    name: Apply (cloudflare)
+    needs: [validate, apply]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment: production
+    defaults:
+      run:
+        working-directory: terraform/cloudflare
+    env:
+      TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      TF_VAR_cloudflare_zone_id: ${{ vars.CLOUDFLARE_ZONE_ID }}
+      TF_VAR_prod_vps_ipv4_address: ${{ vars.PROD_VPS_IPV4_ADDRESS }}
+      TF_VAR_prod_vps_ipv6_address: ${{ vars.PROD_VPS_IPV6_ADDRESS }}
+      TF_VAR_stg_vps_ipv4_address: ${{ vars.STG_VPS_IPV4_ADDRESS }}
+      TF_VAR_stg_vps_ipv6_address: ${{ vars.STG_VPS_IPV6_ADDRESS }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.TF_STATE_B2_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_B2_APP_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~> 1.6"
+      - name: Init
+        run: terraform init
+      - name: Apply
+        run: terraform apply -auto-approve
+
+  apply-backblaze:
+    name: Apply (backblaze)
+    needs: validate
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment: production
+    defaults:
+      run:
+        working-directory: terraform/backblaze
+    env:
+      TF_VAR_b2_application_key_id: ${{ secrets.B2_MASTER_KEY_ID }}
+      TF_VAR_b2_application_key: ${{ secrets.B2_MASTER_APP_KEY }}
       AWS_ACCESS_KEY_ID: ${{ secrets.TF_STATE_B2_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_B2_APP_KEY }}
     steps:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -110,10 +110,9 @@ jobs:
     env:
       TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       TF_VAR_cloudflare_zone_id: ${{ vars.CLOUDFLARE_ZONE_ID }}
-      TF_VAR_prod_vps_ipv4_address: ${{ vars.PROD_VPS_IPV4_ADDRESS }}
-      TF_VAR_prod_vps_ipv6_address: ${{ vars.PROD_VPS_IPV6_ADDRESS }}
-      TF_VAR_stg_vps_ipv4_address: ${{ vars.STG_VPS_IPV4_ADDRESS }}
-      TF_VAR_stg_vps_ipv6_address: ${{ vars.STG_VPS_IPV6_ADDRESS }}
+      # AWS_* env vars serve double duty: cloudflare's own B2 backend AND the
+      # `terraform_remote_state` data sources that read the hetzner tfstates
+      # (same bucket, same auth — see terraform/cloudflare/main.tf).
       AWS_ACCESS_KEY_ID: ${{ secrets.TF_STATE_B2_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_B2_APP_KEY }}
     steps:
@@ -221,11 +220,11 @@ jobs:
       - name: Apply
         run: terraform apply -auto-approve
 
-  # Cloudflare apply runs after hetzner apply — ensures DNS records always
-  # point at IPs from a freshly-converged hetzner state. If the hetzner apply
-  # changes a VPS IP, the cloudflare apply that follows picks up the new
-  # vars.{PROD,STG}_VPS_IPV4_ADDRESS values (which the owner updates
-  # alongside any IP-changing hetzner change).
+  # Cloudflare apply runs after hetzner apply — load-bearing because the
+  # cloudflare module reads VPS IPs from the hetzner env tfstates via
+  # `data "terraform_remote_state"`. Hetzner must converge first so the IPs
+  # we read are fresh; otherwise an IP-changing hetzner apply would leave
+  # cloudflare DNS pointing at the prior IP until the *next* push.
   apply-cloudflare:
     name: Apply (cloudflare)
     needs: [validate, apply]
@@ -238,10 +237,9 @@ jobs:
     env:
       TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       TF_VAR_cloudflare_zone_id: ${{ vars.CLOUDFLARE_ZONE_ID }}
-      TF_VAR_prod_vps_ipv4_address: ${{ vars.PROD_VPS_IPV4_ADDRESS }}
-      TF_VAR_prod_vps_ipv6_address: ${{ vars.PROD_VPS_IPV6_ADDRESS }}
-      TF_VAR_stg_vps_ipv4_address: ${{ vars.STG_VPS_IPV4_ADDRESS }}
-      TF_VAR_stg_vps_ipv6_address: ${{ vars.STG_VPS_IPV6_ADDRESS }}
+      # AWS_* env vars serve double duty: cloudflare's own B2 backend AND the
+      # `terraform_remote_state` data sources that read the hetzner tfstates
+      # (same bucket, same auth — see terraform/cloudflare/main.tf).
       AWS_ACCESS_KEY_ID: ${{ secrets.TF_STATE_B2_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_B2_APP_KEY }}
     steps:

--- a/terraform/cloudflare/main.tf
+++ b/terraform/cloudflare/main.tf
@@ -3,6 +3,58 @@ provider "cloudflare" {
 }
 
 # ---------------------------------------------------------------------------
+# Per-env Hetzner VPS IPs — read from the hetzner env-root tfstates instead of
+# input variables. Eliminates the manual var-passing footgun (cloudflare apply
+# would otherwise drift whenever a hetzner apply changed an IP). The CI apply
+# job orders `apply-cloudflare needs: apply` so the hetzner state we read here
+# is always freshly converged.
+#
+# Backend config mirrors `terraform/hetzner/envs/{prod,stg}/versions.tf` —
+# same B2 bucket, same S3-compat skip flags. Reader auth uses the same
+# `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars (mapped from
+# `TF_STATE_B2_KEY_ID` / `TF_STATE_B2_APP_KEY`) that the cloudflare module's
+# own backend already needs.
+# ---------------------------------------------------------------------------
+data "terraform_remote_state" "hetzner_prod" {
+  backend = "s3"
+  config = {
+    bucket = "noorinalabs-terraform-state"
+    key    = "hetzner/prod.tfstate"
+    region = "us-east-005"
+    endpoints = {
+      s3 = "https://s3.us-east-005.backblazeb2.com"
+    }
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+  }
+}
+
+data "terraform_remote_state" "hetzner_stg" {
+  backend = "s3"
+  config = {
+    bucket = "noorinalabs-terraform-state"
+    key    = "hetzner/stg.tfstate"
+    region = "us-east-005"
+    endpoints = {
+      s3 = "https://s3.us-east-005.backblazeb2.com"
+    }
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+  }
+}
+
+locals {
+  prod_vps_ipv4 = data.terraform_remote_state.hetzner_prod.outputs.server_ip
+  prod_vps_ipv6 = data.terraform_remote_state.hetzner_prod.outputs.server_ipv6
+  stg_vps_ipv4  = data.terraform_remote_state.hetzner_stg.outputs.server_ip
+  stg_vps_ipv6  = data.terraform_remote_state.hetzner_stg.outputs.server_ipv6
+}
+
+# ---------------------------------------------------------------------------
 # SSL/TLS configuration — applies to every record in the zone.
 # Full (Strict) — Cloudflare verifies the origin certificate.
 # Caddy on each VPS provides a valid Let's Encrypt cert, so strict works.
@@ -33,17 +85,17 @@ resource "cloudflare_zone_settings_override" "ssl" {
 resource "cloudflare_record" "prod_apex_a" {
   zone_id = var.cloudflare_zone_id
   name    = var.domain
-  content = var.prod_vps_ipv4_address
+  content = local.prod_vps_ipv4
   type    = "A"
   ttl     = 1
   proxied = true
 }
 
 resource "cloudflare_record" "prod_apex_aaaa" {
-  count   = var.prod_vps_ipv6_address == "" ? 0 : 1
+  count   = local.prod_vps_ipv6 == "" ? 0 : 1
   zone_id = var.cloudflare_zone_id
   name    = var.domain
-  content = var.prod_vps_ipv6_address
+  content = local.prod_vps_ipv6
   type    = "AAAA"
   ttl     = 1
   proxied = true
@@ -55,17 +107,17 @@ resource "cloudflare_record" "prod_apex_aaaa" {
 resource "cloudflare_record" "www_a" {
   zone_id = var.cloudflare_zone_id
   name    = "www"
-  content = var.prod_vps_ipv4_address
+  content = local.prod_vps_ipv4
   type    = "A"
   ttl     = 1
   proxied = true
 }
 
 resource "cloudflare_record" "www_aaaa" {
-  count   = var.prod_vps_ipv6_address == "" ? 0 : 1
+  count   = local.prod_vps_ipv6 == "" ? 0 : 1
   zone_id = var.cloudflare_zone_id
   name    = "www"
-  content = var.prod_vps_ipv6_address
+  content = local.prod_vps_ipv6
   type    = "AAAA"
   ttl     = 1
   proxied = true
@@ -112,17 +164,17 @@ resource "cloudflare_record" "prod_users_cname" {
 resource "cloudflare_record" "stg_apex_a" {
   zone_id = var.cloudflare_zone_id
   name    = "stg"
-  content = var.stg_vps_ipv4_address
+  content = local.stg_vps_ipv4
   type    = "A"
   ttl     = 1
   proxied = false
 }
 
 resource "cloudflare_record" "stg_apex_aaaa" {
-  count   = var.stg_vps_ipv6_address == "" ? 0 : 1
+  count   = local.stg_vps_ipv6 == "" ? 0 : 1
   zone_id = var.cloudflare_zone_id
   name    = "stg"
-  content = var.stg_vps_ipv6_address
+  content = local.stg_vps_ipv6
   type    = "AAAA"
   ttl     = 1
   proxied = false

--- a/terraform/cloudflare/terraform.tfvars.example
+++ b/terraform/cloudflare/terraform.tfvars.example
@@ -5,11 +5,11 @@ cloudflare_api_token = "CHANGE-ME"
 # Zone ID — found on the Cloudflare dashboard overview page for noorinalabs.com
 cloudflare_zone_id = "CHANGE-ME"
 
-# Prod VPS IPs — from `terraform output -raw server_ip` (and `server_ipv6`)
-# in terraform/hetzner/envs/prod. See #82.
-prod_vps_ipv4_address = "CHANGE-ME"
-prod_vps_ipv6_address = "" # optional; empty string disables AAAA
-
-# Stg VPS IPs — from terraform/hetzner/envs/stg outputs.
-stg_vps_ipv4_address = "CHANGE-ME"
-stg_vps_ipv6_address = "" # optional; empty string disables AAAA
+# Per-env VPS IPs are NOT input variables — they're read from the hetzner
+# env-root tfstates via `data "terraform_remote_state"` in main.tf. To run
+# this module locally you need read access to the hetzner state in B2:
+#
+#   export AWS_ACCESS_KEY_ID=<TF_STATE_B2_KEY_ID>
+#   export AWS_SECRET_ACCESS_KEY=<TF_STATE_B2_APP_KEY>
+#
+# (Same env vars the cloudflare module's own backend already needs.)

--- a/terraform/cloudflare/variables.tf
+++ b/terraform/cloudflare/variables.tf
@@ -15,34 +15,11 @@ variable "domain" {
   default     = "noorinalabs.com"
 }
 
-# ---------------------------------------------------------------------------
-# Per-env Hetzner VPS IPs — consumed from terraform/hetzner/envs/{prod,stg}
-# outputs (`server_ip`, `server_ipv6`). Passed in at plan/apply time as
-# -var flags in CI, or via terraform.tfvars locally.
-# ---------------------------------------------------------------------------
-
-variable "prod_vps_ipv4_address" {
-  description = "Public IPv4 of the prod Hetzner VPS (from terraform/hetzner/envs/prod output server_ip)."
-  type        = string
-}
-
-variable "prod_vps_ipv6_address" {
-  description = "Public IPv6 of the prod Hetzner VPS (from terraform/hetzner/envs/prod output server_ipv6). Empty string disables the AAAA record."
-  type        = string
-  default     = ""
-}
-
-variable "stg_vps_ipv4_address" {
-  description = "Public IPv4 of the stg Hetzner VPS (from terraform/hetzner/envs/stg output server_ip)."
-  type        = string
-}
-
-variable "stg_vps_ipv6_address" {
-  description = "Public IPv6 of the stg Hetzner VPS (from terraform/hetzner/envs/stg output server_ipv6). Empty string disables the AAAA record."
-  type        = string
-  default     = ""
-}
-
+# Per-env Hetzner VPS IPs are read from the hetzner env-root tfstates via
+# `data "terraform_remote_state"` in main.tf — no input vars. Eliminates
+# the manual var-passing footgun where cloudflare DNS could drift from a
+# hetzner IP change. See main.tf locals block.
+#
 # Legacy subdomains variable removed in #192 (drop-legacy-immediately per
 # owner ruling 2026-05-02). isnad-graph.noorinalabs.com A/AAAA records are
 # imported and then destroyed by this PR's apply; Caddy binding moved to


### PR DESCRIPTION
## Closes

- Closes #250

## Source

P3W2 emergency-thread post-emergency catchup pass. PR #226 brought
`terraform/cloudflare/` under TF management but had to apply locally (the
existing `terraform.yml` only validated non-hetzner modules; plan/apply
matrices were hetzner-only). Same gap existed for `terraform/backblaze/`.

## Summary

Extends `.github/workflows/terraform.yml` to plan + apply
`terraform/cloudflare/` and `terraform/backblaze/` from CI, eliminating the
local-apply requirement and closing the local-vs-CI parity gap.

Three new jobs added (per-module rather than overloading the hetzner matrix
because cloudflare and backblaze are single-stack while hetzner is
env-split):

| Job | Trigger | Module | Notes |
|-----|---------|--------|-------|
| `plan-cloudflare` | `pull_request` | `terraform/cloudflare/` | Comments plan diff on PR |
| `plan-backblaze` | `pull_request` | `terraform/backblaze/` | Comments plan diff on PR |
| `apply-cloudflare` | `push` to `main` | `terraform/cloudflare/` | `needs: [validate, apply]` — load-bearing (see below) |
| `apply-backblaze` | `push` to `main` | `terraform/backblaze/` | parallel with hetzner apply (no IP coupling) |

`environment: production` on both apply jobs gives the existing manual
approval gate. PR-time runs *plan only* (never apply), matching the
existing hetzner pattern.

## Design pivot — `terraform_remote_state` for hetzner→cloudflare IPs (commit `a02cf43`)

Initial shape passed VPS IPs as input variables sourced from CI repo
Variables. Owner read the cloudflare/variables.tf doc-comment ("consumed
from terraform/hetzner/envs/{prod,stg} outputs") and called the manual-var
design out as the wrong end state — the IPs are *already* known to
terraform via the hetzner env-root tfstates. Refactored to data-source
pattern:

```hcl
# terraform/cloudflare/main.tf
data "terraform_remote_state" "hetzner_prod" { backend = "s3"; key = "hetzner/prod.tfstate"; ... }
data "terraform_remote_state" "hetzner_stg"  { backend = "s3"; key = "hetzner/stg.tfstate";  ... }
locals {
  prod_vps_ipv4 = data.terraform_remote_state.hetzner_prod.outputs.server_ip
  ...
}
```

**Why this is the right end state**:

1. **Single source of truth**: hetzner output → cloudflare DNS, with no
   intermediate human step. An IP-changing hetzner apply flows through to
   the cloudflare apply that follows.
2. **Eliminates the deploy#86 coordination requirement**: previously
   `PROD_VPS_*` repo vars would need synchronized updates with the prod
   cutover. New shape: hetzner re-creates VPS → state has new IP →
   cloudflare reads new IP atomically.
3. **`apply-cloudflare needs: apply` is now load-bearing, not aesthetic**:
   data sources read hetzner state at plan/apply time, so hetzner must
   converge first.

The `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars (from
`TF_STATE_B2_KEY_ID` / `_APP_KEY`) now serve double duty: cloudflare's own
B2 backend AND the remote-state reads of hetzner — same bucket, same auth.

## Acceptance (vs #250)

- [x] **AC1** — `terraform.yml` apply matrix includes `cloudflare` (and `backblaze`)
- [x] **AC2** — `cloudflare` apply triggers on `main` push when `terraform/cloudflare/**` changes
- [x] **AC3** — `CLOUDFLARE_API_TOKEN` available to the Apply job at workflow scope
- [ ] **AC4** — At least one CI-driven apply has executed successfully (no-op apply OK)
- [x] **AC5** — Local-only apply is no longer required for `terraform/cloudflare/`

**AC4 is owner-gated runtime validation, not PR acceptance** (per memory
`feedback_pr_vs_runtime_acceptance_criteria.md`). The first CI-driven
apply will trigger on the next push-to-main that touches `terraform/**`.
Reporting back here once that's observed satisfies AC4.

## Pre-merge owner action required (post-refactor — minimal)

The new apply jobs reference repo secrets that don't exist yet. Without
them, the new apply jobs fail-fast on missing credentials. **Validate
jobs are unaffected (no credentials needed); existing hetzner plan/apply
jobs are unchanged.**

### New repo Secrets (B2 master key for the backblaze provider)

The `terraform/backblaze/` module uses the `Backblaze/b2` provider, which
needs the B2 *master* application key — distinct from the
state-bucket-scoped `TF_STATE_B2_*` keys we already have.

```bash
gh secret set B2_MASTER_KEY_ID  --body '<keyId>'
gh secret set B2_MASTER_APP_KEY --body '<applicationKey>'
```

Generated via the B2 console — needs `writeBuckets` + `writeKeys`
capabilities.

**That's the entire owner pre-merge surface now.** The original 4 IP
repo Variables (`PROD_VPS_IPV4_ADDRESS` etc.) are no longer needed —
the `terraform_remote_state` data sources read those from hetzner's
tfstate directly.

## Why per-module jobs vs extending the hetzner matrix

Considered three shapes:

1. **Extend hetzner matrix with `module` axis** — would multiplex cloudflare/backblaze across stg/prod even though they're single-stack. Wastes runner-minutes and forces fake env values.
2. **Single matrix with mixed dimensions** — heterogeneous matrix (some entries with env, some without) is harder to read and read-back-verify.
3. **Per-module jobs (chosen)** — each job's working-directory, env block, and `needs` are explicit. Easier to audit credential exposure (cf-only secrets only on cf jobs).

(3) also makes the `apply-cloudflare needs: apply` ordering clean — a single matrix can't easily express "this matrix entry waits on a different matrix entry."

## Test plan

- [x] `actionlint .github/workflows/terraform.yml` — clean
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/terraform.yml'))"` — clean
- [x] `terraform fmt -check -recursive terraform/` — clean
- [x] `terraform init -backend=false && terraform validate` (cloudflare module, post-refactor) — clean
- [ ] Reviewer (Aisha): confirm job-graph and the data-source design pivot
- [ ] **Post-merge runtime (AC4)**: owner adds the 2 B2 master-key secrets above, observes `apply-cloudflare` + `apply-backblaze` no-op success on first push-to-main that touches `terraform/**`. Reported back as a comment on this PR.

## Refs

- `deploy#226` — the local-apply that exposed this gap (merged 2026-05-02)
- `deploy#249` (concurrent — Aisha-249) — `cold-rebuild-dryrun.yml`; will exercise this `terraform.yml` as part of its gate
- `terraform/hetzner/envs/{prod,stg}/outputs.tf` — `server_ip` / `server_ipv6` outputs the data sources read
- `repos/deploy.yaml` ontology lines 36-43 — cloudflare module path + B2 state backend topology
- charter `emergency-mode.md` — P3W2 emergency thread origin

## TechDebt

TechDebt: #none
