### PR TITLE
fix(verify-deploy): swap phantom /auth/login → /auth/oauth/google/login (#256)

### DIFF
--- a/scripts/verify_prod_smoke.sh
+++ b/scripts/verify_prod_smoke.sh
@@ -14,8 +14,13 @@
 #                                  user-service auth is in the path, not
 #                                  Caddy bypass returning plaintext)
 #   5. /.well-known/jwks.json → HTTP 200 + valid JWKS shape (.keys[])
-#   6. /auth/login            → HTTP 3xx redirect to OAuth provider
-#                                (proves user-service auth wiring alive)
+#   6. /auth/oauth/google/login → HTTP 200 + JSON .authorization_url
+#                                  pointing at accounts.google.com
+#                                  (proves user-service OAuth wiring
+#                                  alive: env client_id, PKCE generator,
+#                                  Redis state-store all reachable).
+#                                  Hit on USER_SERVICE_BASE_URL directly
+#                                  for honest attribution — see #256.
 #
 # Env (defaults reflect TODAY's prod Caddy — caddy/Caddyfile:18 serves
 # `isnad-graph.noorinalabs.com` and routes user-service traffic in the
@@ -155,37 +160,39 @@ ms_from_secs() {
   fi
 }
 
-# --- 6. /auth/login (expect 3xx → OAuth provider) -------------------
-# We use -o /dev/null and inspect Location via a separate -I pass to keep
-# the body tiny but still see the redirect target.
+# --- 6. /auth/oauth/google/login (expect 200 + JSON authorization_url) ----
+# user-service exposes GET /auth/oauth/{provider}/login (see
+# user-service/src/app/routers/auth.py:269) which returns
+# OAuthLoginResponse — a JSON body with `authorization_url` pointing at
+# the OAuth provider. It is NOT a 302 redirect; the SPA reads the JSON
+# and navigates the browser. A 200 + .authorization_url containing the
+# expected provider domain proves the wiring (provider client_id env
+# present, PKCE generation working, Redis state-store reachable).
+#
+# We hit ${USER_SERVICE_BASE_URL} directly rather than ${ISNAD_BASE_URL}
+# so attribution is honest (deploy#256 caveat 4): /auth/* is dual-bound
+# on isnad.* + users.* during the absolute-URL frontend cutover (#245
+# phase 2), but the canonical user-service vhost is users.*.
 {
-  # First: status code only (no follow)
-  read -r code secs <<<"$(http_check "${ISNAD_BASE_URL}/auth/login")"
+  read -r code secs <<<"$(http_check "${USER_SERVICE_BASE_URL}/auth/oauth/google/login")"
+  body="$(read_body)"
   ms="$(ms_from_secs "$secs")"
-  # Then: grab Location header (separate call; cheap, still under budget)
-  loc="$(curl -sSI --max-time "$TIMEOUT" "${ISNAD_BASE_URL}/auth/login" 2>/dev/null \
-          | grep -i '^location:' | head -1 | sed 's/^[Ll]ocation:[[:space:]]*//' | tr -d '\r' || true)"
-  case "$code" in
-    301|302|303|307|308)
-      if [ -n "$loc" ] && echo "$loc" | grep -qiE 'google|github|accounts\.google|github\.com/login'; then
-        # Mask the redirect target for log hygiene (state/nonce in query)
-        host="$(echo "$loc" | sed -E 's|^https?://([^/]+).*|\1|')"
-        record "/auth/login wiring" pass "$ms" "HTTP $code → OAuth provider ($host)"
-      elif [ -n "$loc" ]; then
-        record "/auth/login wiring" pass "$ms" "HTTP $code → $(echo "$loc" | sed -E 's|^(https?://[^/]+).*|\1|') (non-canonical OAuth host)"
+  if [ "$code" = "200" ]; then
+    if echo "$body" | jq -e '.authorization_url' >/dev/null 2>&1; then
+      auth_url="$(echo "$body" | jq -r '.authorization_url')"
+      if echo "$auth_url" | grep -qiE 'accounts\.google\.com|google\.com/o/oauth'; then
+        host="$(echo "$auth_url" | sed -E 's|^https?://([^/]+).*|\1|')"
+        record "/auth/oauth/google/login wiring" pass "$ms" "HTTP 200 + .authorization_url → $host"
       else
-        record "/auth/login wiring" fail "$ms" "HTTP $code but no Location header"
+        host="$(echo "$auth_url" | sed -E 's|^https?://([^/]+).*|\1|')"
+        record "/auth/oauth/google/login wiring" fail "$ms" "HTTP 200 but .authorization_url host=$host (expected accounts.google.com)"
       fi
-      ;;
-    200)
-      # Some OAuth flows render an interstitial page instead of redirect.
-      # Treat as pass only if body looks HTML-ish (route is alive).
-      record "/auth/login wiring" pass "$ms" "HTTP 200 (route alive, non-redirect handler)"
-      ;;
-    *)
-      record "/auth/login wiring" fail "$ms" "HTTP $code (expected 3xx or 200)"
-      ;;
-  esac
+    else
+      record "/auth/oauth/google/login wiring" fail "$ms" "HTTP 200 but body missing .authorization_url"
+    fi
+  else
+    record "/auth/oauth/google/login wiring" fail "$ms" "HTTP $code (expected 200)"
+  fi
 }
 
 # --- Summary --------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the remaining 1/6 of [#252](https://github.com/noorinalabs/noorinalabs-deploy/issues/252) acceptance — the **phantom-route** half. PR#254 (Aisha-252) fixed the hostname-rot 5/6; this PR fixes the 1 check that was hitting a route user-service has never exposed.

`scripts/verify_prod_smoke.sh` check 6 hit `GET /auth/login`. user-service exposes `/auth/oauth/{provider}/{login,callback}` (see `user-service/src/app/routers/auth.py:269`); there is no flat `/auth/login`. The check has been latently broken since deploy#87 introduced the smoke battery — surfaced today by Aisha-252's live-trace of PR#254 (`feedback_live_trace_over_synthetic_acceptance.md` win).

## Changes

- **Route swap**: `${ISNAD_BASE_URL}/auth/login` → `${USER_SERVICE_BASE_URL}/auth/oauth/google/login` (the real route).
- **Assertion shape**: `OAuthLoginResponse` returns a JSON body with `.authorization_url` — it is NOT a 302 redirect; the SPA reads the JSON and navigates the browser. The check now asserts HTTP 200 + `.authorization_url` host matching `accounts.google.com`.
- **Honest attribution** (`#256` caveat 4): hit `${USER_SERVICE_BASE_URL}` directly. `/auth/*` is dual-bound on `isnad.*` + `users.*` during the absolute-URL frontend cutover (#245 phase 2), but `users.*` is the canonical user-service vhost. This closes the defined-but-unused `USER_SERVICE_BASE_URL` env var.
- **Docstring updated** to reflect the new check.

A 200 + `accounts.google.com` authorization URL proves the full OAuth wiring is alive: provider client_id env present, PKCE generator working, Redis state-store reachable, Caddy `/auth/*` → user-service routing intact.

## Live-trace verification (per `feedback_live_trace_over_synthetic_acceptance.md`)

Run against current prod (post-emergency-restore, 2026-05-03):

```
PASS [129ms]: isnad /health                  status=healthy
PASS [ 71ms]: user-service /health           HTTP 200 via Caddy rewrite
PASS [124ms]: landing /                      HTTP 200
PASS [ 62ms]: narrator /api/v1/narrators     HTTP 401 + JSON body (auth path live)
PASS [ 66ms]: jwks.json                      HTTP 200, 1 key(s)
PASS [125ms]: /auth/oauth/google/login wiring  HTTP 200 + .authorization_url → accounts.google.com

Prod smoke summary: 6/6 passed, total 655ms
```

**Phantom-route sanity check** — confirming the OLD route is genuinely dead:

```
$ curl -sS -o - -w '%{http_code}' https://isnad.noorinalabs.com/auth/login
{"detail":"Not Found"}404
```

## Sequencing note

Branched from `deployments/phase-3/wave-3` (SHA `0b3b214`) per spawn instruction — Path (b), parallel work with rebase cost. **PR#254 (Aisha-252) is editing the same file**: hostname-rot defaults + check-2 hostname comments. After PR#254 merges, this branch will need a rebase. Conflict surface should be small — only the docstring `Env` block (PR#254 updates default values + comment; this PR updates only check 6 docstring line). Diff here is purely the route-fix.

## Acceptance

- [x] Smoke check 6 hits a REAL user-service auth route (not phantom)
- [x] All 6 prod-smoke checks pass against live infra (curl trace above)
- [x] `${USER_SERVICE_BASE_URL}` is now used by check 6 (relevant check) for honest attribution
- [x] PR base = `deployments/phase-3/wave-3`, labels `p3-wave-3 + bug + ci-cd`

## Test plan

- [x] `bash -n scripts/verify_prod_smoke.sh` — syntax OK
- [x] `shellcheck scripts/verify_prod_smoke.sh` — clean (exit 0)
- [x] Live-trace 6/6 PASS, 655ms total (budget: <60s)
- [x] Phantom route confirmed dead (404 on `${ISNAD_BASE_URL}/auth/login`)

## Followups (out of scope per multi-layer-gap discipline)

None for this PR — `#256` was the last open Aisha-252-surfaced caveat. Other open items (`#249` cold-rebuild, `#250` TF matrix, `#251` break-glass audit, `#252` self acceptance closure post-#254-merge, `#255` blackbox targets) are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
