### PR TITLE
feat(ci): cold-rebuild dry-run gate for first-deploy bug class (closes #249)

### DIFF
--- a/.github/workflows/cold-rebuild-dryrun.yml
+++ b/.github/workflows/cold-rebuild-dryrun.yml
@@ -1,0 +1,337 @@
+# Cold-rebuild dry-run — acceptance gate for first-deploy / cold-start bugs.
+#
+# Why this workflow exists
+# ------------------------
+# The P3W2 emergency thread (2026-05-01 → 2026-05-02) surfaced FIVE distinct
+# workflow bugs that no PR-time review could have caught because they only
+# manifest on first contact with cold/empty state:
+#
+#   1. terraform.yml generated a runner-ephemeral SSH keypair, lost the
+#      privkey at runner shutdown — every VPS provisioned by the workflow
+#      was authorized for an unrecoverable key (#216, root-fixed in #217).
+#   2. promote.yml retag step authenticated to GHCR with the workflow's
+#      default GITHUB_TOKEN, which lacks write:packages scope on packages
+#      owned by sibling repos — root-fixed by switching to the org-scoped
+#      GH_PACKAGES_TOKEN.
+#   3. promote.yml retag sourced from the floating `stg-latest` tag,
+#      creating a TOCTOU race when a concurrent service-repo ghcr-publish
+#      bumped stg-latest mid-window (#234, root-fixed in #236).
+#   4. promote.yml digest-parity check assumed multi-arch index source;
+#      broke on landing-page's single-arch v2 manifest because
+#      `imagetools create` wraps single-arch sources in a NEW index whose
+#      top-level digest necessarily differs from the source manifest's
+#      digest (#239, root-fixed in #240).
+#   5. db-migrate.yml's alembic gate set DATABASE_URL=postgresql+psycopg://
+#      but the user-service image only ships asyncpg — every alembic run
+#      hit `ModuleNotFoundError: No module named psycopg` (#235, root-fixed
+#      in #236).
+#
+# Each failure required first contact with cold state to trigger. PR review
+# cannot detect this class. The acceptance gate this workflow establishes is:
+# any change to a promotion-pathway / migration / TF-apply workflow MUST run
+# this gate green before merge. The gate runs on schedule (weekly) so a
+# regression that lands via a non-workflow-file PR (e.g., a refactor in
+# integration-tests/scripts/) is still caught within a week.
+#
+# Scope (deliberately bounded)
+# ----------------------------
+# This workflow is dry-run-only. It does NOT touch the real GHCR registry,
+# the real Hetzner project, or the real B2 tfstate. It exercises:
+#
+#   * Static structural invariants of the workflow YAML (regex/grep guards)
+#     that codify the lessons of bugs #1, #2, #3, #5 — "the bug shape is
+#     visible in the YAML; assert the fix shape stays in place".
+#
+#   * Dynamic registry-shape behavior (bug #4) against a scratch local
+#     registry plus a multi-arch + single-arch fixture pair, exercising
+#     `docker buildx imagetools create` and the parity logic copied from
+#     promote.yml's verify step.
+#
+#   * Driver/pyproject parity (bug #5 dynamic complement) by parsing the
+#     scheme out of db-migrate.yml's DATABASE_URL line and asserting the
+#     named driver appears in user-service/pyproject.toml.
+#
+# What this workflow CANNOT catch
+# -------------------------------
+# This is a regression gate for the bug shapes already seen, not a discovery
+# tool for new first-deploy bugs. Genuinely-novel cold-state defects (e.g.,
+# a future cloud-init template change that breaks `cloud-init status` on
+# fresh VPSes) still have to be found at first-deploy time — see the
+# "Limitations" section of docs/runbooks/cold-rebuild-dry-run.md.
+
+name: Cold-rebuild dry-run
+
+on:
+  schedule:
+    # Weekly Monday 06:00 UTC — once-per-wave catches drift introduced by
+    # PRs that didn't trigger the path filter below (e.g., refactors to
+    # integration-tests/scripts/ or runbook updates that change driver
+    # naming). 06:00 UTC is before EU-morning standup so a failure is
+    # visible to the full team by their first sync of the week.
+    - cron: "0 6 * * 1"
+  pull_request:
+    paths:
+      - ".github/workflows/promote.yml"
+      - ".github/workflows/terraform.yml"
+      - ".github/workflows/db-migrate.yml"
+      - ".github/workflows/deploy-stg.yml"
+      - ".github/workflows/deploy-prod.yml"
+      - ".github/workflows/deploy-all.yml"
+      - ".github/workflows/deploy-isnad-graph.yml"
+      - ".github/workflows/deploy-landing-page.yml"
+      - ".github/workflows/cold-rebuild-dryrun.yml"
+      - ".github/workflows/scripts/cold_rebuild_static_checks.py"
+      - "terraform/hetzner/**"
+      - "docs/runbooks/cold-rebuild-dry-run.md"
+  push:
+    branches:
+      - main
+      - "deployments/phase-*/wave-*"
+    paths:
+      - ".github/workflows/promote.yml"
+      - ".github/workflows/terraform.yml"
+      - ".github/workflows/db-migrate.yml"
+      - ".github/workflows/deploy-stg.yml"
+      - ".github/workflows/deploy-prod.yml"
+      - ".github/workflows/cold-rebuild-dryrun.yml"
+      - ".github/workflows/scripts/cold_rebuild_static_checks.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  workflow-cold-checks:
+    name: Static workflow-shape guards (bugs #1, #2, #3, #5)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Sibling-repo refs are wave-aware — same pattern as integration-tests.yml
+      # (#159, P2W10). The driver/pyproject parity check needs to read the
+      # asyncpg-vs-psycopg dependency list from the same wave the deploy PR
+      # is targeting, not from main, otherwise a coordinated cross-repo
+      # change (e.g., user-service swapping driver) shows a false positive
+      # here while the wave's user-service half is still on the old driver.
+      - name: Resolve sibling refs (wave-aware)
+        id: sibling-refs
+        run: |
+          BASE="${{ github.base_ref }}"
+          if [ -z "$BASE" ]; then BASE="${{ github.ref_name }}"; fi
+
+          if [[ "$BASE" == deployments/* ]] && \
+             git ls-remote --exit-code \
+                "https://github.com/noorinalabs/noorinalabs-user-service.git" \
+                "refs/heads/${BASE}" >/dev/null 2>&1; then
+            US_REF="$BASE"
+          else
+            US_REF="main"
+          fi
+          echo "user_service_ref=${US_REF}" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Resolved sibling refs"
+            echo "- base branch: \`${BASE}\`"
+            echo "- noorinalabs-user-service: \`${US_REF}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Checkout user-service (for pyproject parity)
+        uses: actions/checkout@v4
+        with:
+          repository: noorinalabs/noorinalabs-user-service
+          ref: ${{ steps.sibling-refs.outputs.user_service_ref }}
+          path: _siblings/user-service
+
+      - name: Run static cold-rebuild checks
+        env:
+          USER_SERVICE_PYPROJECT: _siblings/user-service/pyproject.toml
+        run: |
+          python3 .github/workflows/scripts/cold_rebuild_static_checks.py
+
+  buildx-shape-dryrun:
+    name: Buildx multi-arch / single-arch parity dryrun (bug #4)
+    runs-on: ubuntu-latest
+    services:
+      # Local registry for the dryrun. Hermetic — no real GHCR contact.
+      # Port 5000 inside the runner's docker network is reachable from the
+      # buildx builder we configure below via host.docker.internal once we
+      # bind the registry to the runner host.
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU (for multi-arch fixture)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx (with insecure-registry for local fixture)
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            network=host
+
+      - name: Build multi-arch fixture image
+        # Two-arch index — exercises the multi-arch branch of promote.yml's
+        # parity check. We use a `FROM scratch`-style minimal image to keep
+        # the build deterministic and quick. The fact that the image is
+        # functionally empty is fine: the parity check looks at manifest
+        # digests, not at runnable layers.
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/fixture-multi
+          cat > /tmp/fixture-multi/Dockerfile <<'EOF'
+          FROM scratch
+          COPY README /README
+          EOF
+          # Per-arch content is identical apart from the base; that's enough
+          # to produce a real two-entry index.
+          echo "fixture-multi-arch" > /tmp/fixture-multi/README
+          docker buildx build \
+            --push \
+            --platform linux/amd64,linux/arm64 \
+            --tag localhost:5000/fixture/multi:sha-aaaaaaa \
+            --tag localhost:5000/fixture/multi:stg-aaaaaaa \
+            --tag localhost:5000/fixture/multi:stg-latest \
+            /tmp/fixture-multi
+
+      - name: Build single-arch fixture image (landing-page shape)
+        # `docker buildx build --platform linux/amd64` (single platform)
+        # produces a single-arch v2 manifest — exactly the shape landing-page
+        # ships and the shape that broke #239.
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/fixture-single
+          cat > /tmp/fixture-single/Dockerfile <<'EOF'
+          FROM scratch
+          COPY README /README
+          EOF
+          echo "fixture-single-arch" > /tmp/fixture-single/README
+          docker buildx build \
+            --push \
+            --platform linux/amd64 \
+            --provenance=false \
+            --tag localhost:5000/fixture/single:sha-bbbbbbb \
+            --tag localhost:5000/fixture/single:stg-bbbbbbb \
+            --tag localhost:5000/fixture/single:stg-latest \
+            /tmp/fixture-single
+
+      - name: Retag — multi-arch path
+        # Mirrors promote.yml retag: `imagetools create` writes
+        # prod-<short> + prod-latest from the sha-<short> source.
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            --tag localhost:5000/fixture/multi:prod-aaaaaaa \
+            --tag localhost:5000/fixture/multi:prod-latest \
+            localhost:5000/fixture/multi:sha-aaaaaaa
+
+      - name: Retag — single-arch path
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            --tag localhost:5000/fixture/single:prod-bbbbbbb \
+            --tag localhost:5000/fixture/single:prod-latest \
+            localhost:5000/fixture/single:sha-bbbbbbb
+
+      - name: Verify parity check shape-aware logic catches both shapes
+        # This is the assertion that closes #239: the parity check copied
+        # from promote.yml MUST handle both shapes correctly. We reproduce
+        # the exact verify-step logic from promote.yml here against the
+        # fixtures and assert PASS.
+        run: |
+          set -euo pipefail
+          parity_check() {
+            local image="$1"
+            local short="$2"
+            local source_tag="sha-${short}"
+            local src src_media ps pl shape
+
+            src=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$image:$source_tag")
+            src_media=$(docker buildx imagetools inspect --format '{{.Manifest.MediaType}}' "$image:$source_tag")
+
+            if echo "$src_media" | grep -qE 'index|manifest\.list'; then
+              ps=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$image:prod-$short")
+              pl=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$image:prod-latest")
+              shape="multi-arch (direct top-level digest comparison)"
+            else
+              ps=$(docker buildx imagetools inspect --raw "$image:prod-$short" | jq -r '.manifests[0].digest')
+              pl=$(docker buildx imagetools inspect --raw "$image:prod-latest" | jq -r '.manifests[0].digest')
+              shape="single-arch (compare source to destination's manifests[0].digest)"
+            fi
+
+            echo "  image:       $image"
+            echo "  shape:       $shape"
+            echo "  source:      $src"
+            echo "  prod-<short>:$ps"
+            echo "  prod-latest: $pl"
+            if [ "$src" != "$ps" ] || [ "$src" != "$pl" ]; then
+              echo "::error::Parity check FAILED for $image — shape-aware logic regressed."
+              return 1
+            fi
+            echo "  parity OK"
+          }
+
+          echo "== multi-arch fixture =="
+          parity_check localhost:5000/fixture/multi aaaaaaa
+
+          echo ""
+          echo "== single-arch fixture (landing-page shape) =="
+          parity_check localhost:5000/fixture/single bbbbbbb
+
+      - name: Verify naive (pre-#239) parity check would FAIL on single-arch
+        # Negative control: assert that the OLD parity logic (top-level
+        # digest comparison only) fails on single-arch — i.e. the bug we
+        # fixed is REAL and reproducible. If this step PASSES, the registry
+        # behavior changed and the dryrun is no longer modeling the bug;
+        # the fix in #240 may have become redundant or a buildx version
+        # bump silently obviated it.
+        run: |
+          set -euo pipefail
+          src=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' \
+            localhost:5000/fixture/single:sha-bbbbbbb)
+          ps=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' \
+            localhost:5000/fixture/single:prod-bbbbbbb)
+          if [ "$src" = "$ps" ]; then
+            echo "::warning::Naive top-level digest comparison no longer fails on single-arch."
+            echo "::warning::Registry/buildx behavior may have changed; #240 fix may be obsolete."
+            echo "::warning::This is informational — the shape-aware check still passes either way."
+            {
+              echo "## Negative control: behavior change detected"
+              echo ""
+              echo "The pre-#239 naive comparison did NOT fail on the single-arch fixture."
+              echo "Registry behavior likely changed; review whether #240's shape-aware"
+              echo "logic is still load-bearing."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Pre-#239 naive comparison correctly fails on single-arch (src != ps)."
+            echo "  src:          $src"
+            echo "  prod-<short>: $ps"
+          fi
+
+  summary:
+    name: Cold-rebuild dryrun summary
+    needs: [workflow-cold-checks, buildx-shape-dryrun]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate
+        env:
+          STATIC: ${{ needs.workflow-cold-checks.result }}
+          BUILDX: ${{ needs.buildx-shape-dryrun.result }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Cold-rebuild dryrun"
+            echo ""
+            echo "| Job | Result | Bugs guarded |"
+            echo "|-----|--------|--------------|"
+            echo "| workflow-cold-checks | ${STATIC} | #216 (TF ephemeral keypair), retag-token scope, #234 (TOCTOU floating tag), #235 (alembic driver) |"
+            echo "| buildx-shape-dryrun  | ${BUILDX} | #239 (single-arch parity) |"
+            echo ""
+            echo "See \`docs/runbooks/cold-rebuild-dry-run.md\` for failure triage."
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "${STATIC}" != "success" ] || [ "${BUILDX}" != "success" ]; then
+            echo "::error::Cold-rebuild dryrun failed — see job logs and runbook."
+            exit 1
+          fi

--- a/.github/workflows/scripts/cold_rebuild_static_checks.py
+++ b/.github/workflows/scripts/cold_rebuild_static_checks.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""Static workflow-shape guards for the cold-rebuild dryrun gate.
+
+Each check codifies one of the five P3W2-emergency-thread bugs as an
+inverted invariant: "the bug shape MUST NOT reappear, and the fix shape
+MUST stay in place". Failure prints a per-check diagnosis pointing at the
+canonical issue and the fix PR.
+
+Inputs (env):
+    USER_SERVICE_PYPROJECT — path to the user-service pyproject.toml,
+        already checked out via the wave-aware sibling-ref step.
+
+This script does NOT contact GHCR, Hetzner, or any external registry. It
+reads the workflow YAML files, the terraform sources, and the user-service
+pyproject and asserts shape. The dynamic complement (registry shape parity
+for bug #4) is the buildx-shape-dryrun job in cold-rebuild-dryrun.yml.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+WORKFLOWS = Path(".github/workflows")
+TF_MODULE = Path("terraform/hetzner/modules/hetzner-vps")
+
+
+class Failure:
+    """A single check failure with diagnostic context."""
+
+    def __init__(self, check: str, bug: str, msg: str) -> None:
+        self.check = check
+        self.bug = bug
+        self.msg = msg
+
+    def render(self) -> str:
+        return f"  - [{self.check}] ({self.bug}) {self.msg}"
+
+
+def check_terraform_no_ephemeral_keypair() -> list[Failure]:
+    """Bug #1 (#216, fixed #217): terraform.yml must NOT generate runner
+    keypairs. The fix shape: a canonical pubkey is committed at
+    modules/hetzner-vps/deploy.pub and `ssh_public_key_path` defaults
+    point at it.
+    """
+    failures: list[Failure] = []
+    tf_yml = (WORKFLOWS / "terraform.yml").read_text(encoding="utf-8")
+
+    # Negative invariant: the workflow must NOT call ssh-keygen.
+    if re.search(r"\bssh-keygen\b", tf_yml):
+        failures.append(
+            Failure(
+                "tf-no-ssh-keygen",
+                "#216",
+                "terraform.yml contains `ssh-keygen` — the runner-ephemeral keypair "
+                "anti-pattern is back. Every VPS provisioned by the workflow will be "
+                "authorized for a key whose private half is destroyed when the runner "
+                "shuts down. Restore the canonical-pubkey approach from #217.",
+            )
+        )
+
+    # Positive invariant: the canonical pubkey must exist on disk.
+    pubkey = TF_MODULE / "deploy.pub"
+    if not pubkey.is_file():
+        failures.append(
+            Failure(
+                "tf-canonical-pubkey-present",
+                "#216",
+                f"{pubkey} is missing — the canonical deploy pubkey checked in by "
+                "#217 is gone. Restore it (matches DEPLOY_SSH_PRIVATE_KEY org-secret).",
+            )
+        )
+    else:
+        # Sanity-check the pubkey looks like an SSH ed25519 line. We do
+        # NOT validate the cryptographic content (rotation is operator
+        # scope), only that the file isn't a stub or a different format.
+        line = pubkey.read_text(encoding="utf-8").strip()
+        if not re.match(r"^ssh-(ed25519|rsa)\s+[A-Za-z0-9+/=]+(\s+\S+)?$", line):
+            failures.append(
+                Failure(
+                    "tf-canonical-pubkey-shape",
+                    "#216",
+                    f"{pubkey} does not look like a valid SSH public key line. "
+                    "Format must be `ssh-ed25519 <base64-key> [comment]`.",
+                )
+            )
+
+    # Positive invariant: the env-root variables.tf default must point at
+    # the canonical pubkey, not `~/.ssh/id_ed25519.pub` (the operator's
+    # local key — what was there before #217 fixed it).
+    for env in ("stg", "prod"):
+        var_tf = Path(f"terraform/hetzner/envs/{env}/variables.tf")
+        if not var_tf.is_file():
+            failures.append(
+                Failure(
+                    "tf-env-variables-present",
+                    "#216",
+                    f"{var_tf} missing — env-root structure broken.",
+                )
+            )
+            continue
+        contents = var_tf.read_text(encoding="utf-8")
+        # Find the default for ssh_public_key_path.
+        m = re.search(
+            r'variable\s+"ssh_public_key_path"\s*\{[^}]*?default\s*=\s*"([^"]+)"',
+            contents,
+            re.DOTALL,
+        )
+        if not m:
+            failures.append(
+                Failure(
+                    "tf-ssh-key-default-present",
+                    "#216",
+                    f"{var_tf}: ssh_public_key_path variable missing or has no default.",
+                )
+            )
+            continue
+        default = m.group(1)
+        if "id_ed25519.pub" in default or default.startswith("~"):
+            failures.append(
+                Failure(
+                    "tf-ssh-key-default-canonical",
+                    "#216",
+                    f"{var_tf}: ssh_public_key_path default is `{default}` — must "
+                    "point at the canonical checked-in deploy.pub "
+                    "(`../../modules/hetzner-vps/deploy.pub`). Operator-local paths "
+                    "like `~/.ssh/id_ed25519.pub` recreate the #216 lockout class.",
+                )
+            )
+
+    return failures
+
+
+def check_promote_token_scope() -> list[Failure]:
+    """Bug #2 (retag-token mismatch): promote.yml's retag step writes
+    prod-* tags onto packages owned by sibling repos, requiring write:packages
+    scope that the default GITHUB_TOKEN lacks. The fix shape: the retag job's
+    docker/login-action uses GH_PACKAGES_TOKEN (org secret), not GITHUB_TOKEN.
+    """
+    failures: list[Failure] = []
+    pm = (WORKFLOWS / "promote.yml").read_text(encoding="utf-8")
+
+    # Locate the `retag:` job. We need to know which password: line is
+    # inside the retag job vs. inside the plan job (which only reads, so
+    # GITHUB_TOKEN is fine there).
+    retag_match = re.search(r"^  retag:\s*$", pm, re.MULTILINE)
+    if not retag_match:
+        failures.append(
+            Failure(
+                "promote-retag-job-present",
+                "retag-token",
+                "promote.yml has no `retag:` job — workflow shape changed. Check "
+                "that the cold-rebuild dryrun's expectations match.",
+            )
+        )
+        return failures
+
+    # Take everything from `retag:` to either the next top-level job or EOF.
+    retag_start = retag_match.start()
+    next_job = re.search(r"^  [a-z][a-z0-9_-]*:\s*$", pm[retag_start + 1:], re.MULTILINE)
+    retag_end = retag_start + 1 + next_job.start() if next_job else len(pm)
+    retag_block = pm[retag_start:retag_end]
+
+    # The retag block's docker/login-action MUST use GH_PACKAGES_TOKEN.
+    # We require at least one `password: ${{ secrets.GH_PACKAGES_TOKEN }}`
+    # in the retag block, and zero `password: ${{ secrets.GITHUB_TOKEN }}`
+    # uses in that block (the latter would mean the wrong token snuck back
+    # onto a login step).
+    has_packages_token = bool(
+        re.search(r"password:\s*\$\{\{\s*secrets\.GH_PACKAGES_TOKEN\s*\}\}", retag_block)
+    )
+    bad_default_token = bool(
+        re.search(r"password:\s*\$\{\{\s*secrets\.GITHUB_TOKEN\s*\}\}", retag_block)
+    )
+
+    if not has_packages_token:
+        failures.append(
+            Failure(
+                "promote-retag-uses-packages-token",
+                "retag-token",
+                "promote.yml retag job does NOT authenticate with "
+                "secrets.GH_PACKAGES_TOKEN. The default GITHUB_TOKEN lacks "
+                "write:packages on noorinalabs/* container packages owned by "
+                "sibling repos — this caused the 2026-05-02 emergency-restore "
+                "403 permission_denied failures. Restore GH_PACKAGES_TOKEN at "
+                "the retag step's docker/login-action.",
+            )
+        )
+    if bad_default_token:
+        failures.append(
+            Failure(
+                "promote-retag-no-default-token",
+                "retag-token",
+                "promote.yml retag job has a docker/login-action authenticating "
+                "with secrets.GITHUB_TOKEN. That token cannot write packages "
+                "owned by sibling repos. Switch every login step in the retag "
+                "job to GH_PACKAGES_TOKEN.",
+            )
+        )
+
+    return failures
+
+
+def check_promote_no_floating_source() -> list[Failure]:
+    """Bug #3 (#234, fixed #236): promote.yml retag must source from
+    `sha-<short>` (digest-stable per Contract v6), never from the floating
+    `stg-latest` tag. The TOCTOU race surfaced when a concurrent
+    service-repo ghcr-publish bumped stg-latest mid-window.
+    """
+    failures: list[Failure] = []
+    pm = (WORKFLOWS / "promote.yml").read_text(encoding="utf-8")
+
+    # Locate "Resolve source tag" step inside the retag job.
+    src_step_match = re.search(
+        r"name:\s*Resolve source tag\s*\n.*?run:\s*\|.*?(?=\n      - name:|\Z)",
+        pm,
+        re.DOTALL,
+    )
+    if not src_step_match:
+        failures.append(
+            Failure(
+                "promote-resolve-src-present",
+                "#234",
+                "promote.yml has no `Resolve source tag` step — workflow shape "
+                "changed. Update the cold-rebuild dryrun's expectations.",
+            )
+        )
+        return failures
+
+    src_block = src_step_match.group(0)
+
+    # The source_tag assignment must always be sha-${SHORT}. We accept
+    # either bare `source_tag="sha-${SHORT}"` (the post-#236 shape) or any
+    # branch that ALWAYS resolves to sha-<short>. The negative-invariant
+    # we enforce: source_tag must NEVER be assigned to "stg-latest" or any
+    # `<env>-latest` floating-tag form.
+    if re.search(r'source_tag\s*=\s*"(stg|prod)-latest"', src_block):
+        failures.append(
+            Failure(
+                "promote-no-floating-source",
+                "#234",
+                "promote.yml `Resolve source tag` step assigns source_tag to a "
+                "floating tag (stg-latest or prod-latest). This re-introduces "
+                "the #234 TOCTOU race: a concurrent service-repo ghcr-publish "
+                "between this step and the parity check moves the floating "
+                "tag's digest, breaking parity. Always source from sha-<short>.",
+            )
+        )
+
+    # Positive invariant: the assignment to source_tag must reference
+    # ${SHORT} (the plan-resolved digest-stable SHA).
+    if not re.search(r'source_tag\s*=\s*"sha-\$\{?SHORT\}?"', src_block):
+        failures.append(
+            Failure(
+                "promote-source-tag-uses-short",
+                "#234",
+                "promote.yml `Resolve source tag` step does not assign source_tag "
+                'to `"sha-${SHORT}"`. The fix from #236 requires the source tag '
+                "to be the digest-stable sha-<short> form.",
+            )
+        )
+
+    return failures
+
+
+def check_db_migrate_driver_aligned() -> list[Failure]:
+    """Bug #5 (#235, fixed #236): db-migrate.yml's DATABASE_URL driver
+    scheme must match a driver actually shipped in the user-service
+    image's pyproject.toml. The original bug used `postgresql+psycopg://`
+    while the image only had asyncpg.
+    """
+    failures: list[Failure] = []
+    db_yml_text = (WORKFLOWS / "db-migrate.yml").read_text(encoding="utf-8")
+
+    # Extract the driver scheme from any DATABASE_URL= assignment in
+    # db-migrate.yml. We accept `postgresql+<driver>://...` or bare
+    # `postgresql://` (which SQLAlchemy maps to the default driver).
+    schemes: set[str] = set()
+    for m in re.finditer(
+        r'DATABASE_URL\s*=\s*"postgresql(?:\+([a-z][a-z0-9_]*))?://',
+        db_yml_text,
+    ):
+        driver = m.group(1)
+        # Bare postgresql:// in SQLAlchemy 2.x routes to psycopg2 by
+        # default — record as `psycopg2` so the pyproject check applies.
+        schemes.add(driver if driver else "psycopg2")
+
+    if not schemes:
+        failures.append(
+            Failure(
+                "db-migrate-database-url-present",
+                "#235",
+                "db-migrate.yml has no DATABASE_URL= assignment recognizable to "
+                "this guard. If the workflow shape changed, update the regex.",
+            )
+        )
+        return failures
+
+    pyproject_path = os.environ.get("USER_SERVICE_PYPROJECT", "")
+    if not pyproject_path or not Path(pyproject_path).is_file():
+        failures.append(
+            Failure(
+                "db-migrate-pyproject-resolvable",
+                "#235",
+                f"USER_SERVICE_PYPROJECT={pyproject_path!r} does not resolve. The "
+                "wave-aware sibling checkout for user-service likely failed; this "
+                "guard cannot run without it.",
+            )
+        )
+        return failures
+    pyproject = Path(pyproject_path).read_text(encoding="utf-8")
+
+    # Map known SQLAlchemy driver scheme suffixes to the package name we
+    # expect in pyproject.toml. The set covers what's been used in this
+    # codebase plus the likely-next options (psycopg2 / psycopg / asyncpg).
+    SCHEME_TO_PKG = {
+        "asyncpg":  "asyncpg",
+        "psycopg":  "psycopg",   # psycopg 3
+        "psycopg2": "psycopg2",
+        "pg8000":   "pg8000",
+    }
+
+    for scheme in sorted(schemes):
+        pkg = SCHEME_TO_PKG.get(scheme)
+        if pkg is None:
+            failures.append(
+                Failure(
+                    "db-migrate-driver-known",
+                    "#235",
+                    f"db-migrate.yml uses unrecognized DATABASE_URL driver "
+                    f"`postgresql+{scheme}` — extend SCHEME_TO_PKG in this "
+                    "guard before merging the change.",
+                )
+            )
+            continue
+        # pyproject.toml should declare the package as a dependency. We
+        # match it as a quoted string at start of a dep line — the same
+        # pattern user-service uses (`"asyncpg>=0.30.0",`).
+        if not re.search(rf'"\s*{re.escape(pkg)}\s*[<>=!~]', pyproject):
+            failures.append(
+                Failure(
+                    "db-migrate-driver-shipped",
+                    "#235",
+                    f"db-migrate.yml's DATABASE_URL uses `postgresql+{scheme}://` "
+                    f"but `{pkg}` is NOT declared in user-service/pyproject.toml. "
+                    "Running alembic against the user-service image will hit "
+                    "`ModuleNotFoundError` (the original #235 failure). Either "
+                    "switch the URL to a driver the image ships, or add the "
+                    "driver to user-service's pyproject in the same wave.",
+                )
+            )
+
+    return failures
+
+
+def main() -> int:
+    sections = [
+        ("Terraform: no ephemeral keypair (bug #1, #216)", check_terraform_no_ephemeral_keypair),
+        ("Promote: retag uses GH_PACKAGES_TOKEN (bug #2)",  check_promote_token_scope),
+        ("Promote: no floating-tag source (bug #3, #234)",  check_promote_no_floating_source),
+        ("DB-migrate: driver matches pyproject (bug #5, #235)", check_db_migrate_driver_aligned),
+    ]
+    all_failures: list[Failure] = []
+    for label, fn in sections:
+        try:
+            f = fn()
+        except Exception as exc:
+            print(f"[ERROR] {label}: check raised: {exc}", file=sys.stderr)
+            return 2
+        if f:
+            print(f"[FAIL]  {label}")
+            for failure in f:
+                print(failure.render())
+            all_failures.extend(f)
+        else:
+            print(f"[OK]    {label}")
+
+    if all_failures:
+        print(
+            f"\nCold-rebuild static checks: {len(all_failures)} failure(s).",
+            file=sys.stderr,
+        )
+        print(
+            "See docs/runbooks/cold-rebuild-dry-run.md for triage steps per bug.",
+            file=sys.stderr,
+        )
+        return 1
+    print("\nCold-rebuild static checks: all guards green.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/runbooks/cold-rebuild-dry-run.md
+++ b/docs/runbooks/cold-rebuild-dry-run.md
@@ -1,0 +1,145 @@
+# Cold-rebuild dry-run
+
+## Purpose
+
+The cold-rebuild dry-run is the **acceptance gate for the first-deploy /
+cold-start workflow-bug class** that surfaced under emergency pressure
+during P3W2 (2026-05-01 → 2026-05-02).
+
+PR-time review cannot detect this class — every one of these bugs only
+manifests when the workflow encounters fresh / empty / cold state for the
+first time. The gate codifies each known bug shape as a static or dynamic
+invariant and runs it on every PR that touches a promotion-pathway,
+migration, or TF-apply workflow.
+
+This runbook is acceptance criterion 1 for [`#249`](https://github.com/noorinalabs/noorinalabs-deploy/issues/249).
+
+## What the gate covers
+
+The gate is implemented as `.github/workflows/cold-rebuild-dryrun.yml` and
+the helper script `.github/workflows/scripts/cold_rebuild_static_checks.py`.
+
+| Bug | Issue | Fix PR | Detection |
+|-----|-------|--------|-----------|
+| terraform.yml ephemeral keypair | [#216](https://github.com/noorinalabs/noorinalabs-deploy/issues/216) | [#217](https://github.com/noorinalabs/noorinalabs-deploy/pull/217) | static — `cold_rebuild_static_checks.py` asserts (a) terraform.yml contains no `ssh-keygen`, (b) `modules/hetzner-vps/deploy.pub` exists, (c) env-root `ssh_public_key_path` defaults point at the canonical pubkey. |
+| promote.yml retag-token mismatch | (no issue — fixed inline via PAT regen + `GH_PACKAGES_TOKEN` swap) | (inline) | static — asserts the retag job's docker/login-action authenticates with `secrets.GH_PACKAGES_TOKEN`, never `secrets.GITHUB_TOKEN`. |
+| promote.yml stg-latest TOCTOU | [#234](https://github.com/noorinalabs/noorinalabs-deploy/issues/234) | [#236](https://github.com/noorinalabs/noorinalabs-deploy/pull/236) | static — asserts `Resolve source tag` step assigns `source_tag="sha-${SHORT}"` and never to a `*-latest` floating tag. |
+| promote.yml multi-arch parity | [#239](https://github.com/noorinalabs/noorinalabs-deploy/issues/239) | [#240](https://github.com/noorinalabs/noorinalabs-deploy/pull/240) | dynamic — `buildx-shape-dryrun` job builds a multi-arch + single-arch fixture against a local registry, runs `imagetools create`, and asserts the shape-aware parity logic from promote.yml passes for both shapes. Includes a negative control that asserts the pre-#239 naive comparison still fails on single-arch. |
+| db-migrate.yml psycopg-vs-asyncpg | [#235](https://github.com/noorinalabs/noorinalabs-deploy/issues/235) | [#236](https://github.com/noorinalabs/noorinalabs-deploy/pull/236) | static — extracts the `postgresql+<driver>://` scheme from db-migrate.yml's `DATABASE_URL=` line and asserts the driver package is declared in user-service/pyproject.toml (read from the wave-aware sibling checkout, matching `integration-tests.yml`'s pattern). |
+
+## When the gate runs
+
+- **Every PR** that touches any of: `promote.yml`, `terraform.yml`,
+  `db-migrate.yml`, `deploy-{stg,prod,all,isnad-graph,landing-page}.yml`,
+  `cold-rebuild-dryrun.yml`, `cold_rebuild_static_checks.py`,
+  `terraform/hetzner/**`, this runbook.
+- **Push to `main`** or any `deployments/phase-*/wave-*` branch with the
+  same path filter — catches direct merges and wave-branch progress.
+- **Weekly schedule** (Mon 06:00 UTC) — catches drift introduced by PRs
+  that did not match the path filter (e.g., a refactor in
+  `integration-tests/scripts/check_tag_invariants.py` that silently
+  changed the contract).
+- **`workflow_dispatch`** — operator-initiated re-run.
+
+## How to read a failure
+
+The summary job emits a per-bug-guard table. Click into the failed
+upstream job for the diagnostic line. Each `cold_rebuild_static_checks.py`
+failure prints in the form:
+
+```
+[FAIL]  Promote: no floating-tag source (bug #3, #234)
+  - [promote-no-floating-source] (#234) promote.yml `Resolve source tag` ...
+```
+
+The bracketed check ID is searchable in the script. The parenthesized
+issue is the canonical bug ticket.
+
+### Static check failures
+
+Open `cold_rebuild_static_checks.py` and grep for the check ID. The
+docstring of the function that emitted the failure describes the bug
+shape and the fix shape. Fix the workflow to restore the fix shape
+(commit-by-commit revert if a recent change re-introduced the bug
+shape).
+
+### `buildx-shape-dryrun` failures
+
+A failure here means either:
+
+1. The shape-aware parity logic was regressed — check whether
+   `promote.yml`'s `Verify digest parity` step changed. The fixture-pair
+   builds in this job mirror the production shape distribution
+   (api/frontend/user-service multi-arch; landing-page single-arch).
+2. `docker buildx imagetools create` behavior changed in a runner image
+   bump. Compare the runner's docker version to the version in use when
+   #239 was filed (Docker 24.0.x era). If buildx semantics changed,
+   review whether #240's shape-aware logic is still load-bearing — the
+   negative-control step in this job will surface that as a `::warning::`.
+
+## Limitations
+
+This is a **regression gate for known bug shapes**, not a discovery tool
+for new first-deploy bugs.
+
+- Genuinely-novel cold-state defects (e.g., a future cloud-init template
+  change that breaks `cloud-init status` on fresh VPSes) still have to be
+  found at first-deploy time.
+- The gate does **not** apply Terraform against a real Hetzner project,
+  does **not** push to the real GHCR, and does **not** run alembic
+  against a real Postgres. Real cold-rebuild ship-tests still happen at
+  the next first-deploy event (new VPS bring-up, new env, DR restore).
+- The `buildx-shape-dryrun` job is hermetic: it uses a `registry:2`
+  service container on the runner and `localhost:5000` references. It
+  does NOT exercise GHCR's auth path or rate limits.
+- The driver/pyproject parity check assumes the user-service image is
+  built from `pyproject.toml` and that any DB-driver package is declared
+  there as a dep with a quoted-string-plus-version-constraint shape
+  (matches today's `"asyncpg>=0.30.0",`). A future move to a different
+  packaging tool may need the regex updated.
+
+## Manual cold-rebuild ship-test
+
+The dryrun gate does NOT replace a real cold-rebuild rehearsal. When the
+team needs to validate end-to-end cold provisioning (new env, DR drill,
+pre-merge of a major TF change), follow these steps against a scratch
+Hetzner project:
+
+1. **Hetzner**: create a fresh project. Do NOT reuse the existing
+   `noorinalabs` project — TF state collisions guaranteed.
+2. **TF state**: temporarily point `TF_STATE_B2_KEY_ID` /
+   `TF_STATE_B2_APP_KEY` at a scratch B2 bucket, OR override
+   `state_key` in the env root to `hetzner/cold-test.tfstate`.
+3. **GHCR**: do NOT exercise promote.yml against the real registry. Use
+   the dryrun job's local-registry fixture pattern if you need to test
+   retag changes; for the real first-deploy class, observe the next
+   genuine first-deploy event.
+4. **Alembic**: spin up a scratch user-postgres + user-service image
+   locally (`docker-compose.dev.yml` is sufficient) and run `alembic
+   upgrade head` against the URL the workflow assembles.
+5. **VPS bring-up**: `terraform apply` from the scratch state, then SSH
+   in with the `DEPLOY_SSH_PRIVATE_KEY` half. Verify the canonical
+   pubkey from `modules/hetzner-vps/deploy.pub` is in
+   `/home/deploy/.ssh/authorized_keys`. Tear the VPS down when done.
+
+This rehearsal is at-most quarterly — the dryrun gate is what catches
+day-to-day regressions.
+
+## Adding a new guard
+
+When a new first-deploy / cold-start bug surfaces:
+
+1. **Triage the bug** as usual. Land the fix PR.
+2. **Add a guard** to `cold_rebuild_static_checks.py` (for static-shape
+   bugs) or to `cold-rebuild-dryrun.yml` (for dynamic-shape bugs that
+   need a fixture). The guard should fail loudly if the bug shape
+   reappears AND prove the fix shape is still in place.
+3. **Update this runbook**: add a row to the "What the gate covers"
+   table with the issue number, fix PR, and detection mechanism.
+4. **Update `cold-rebuild-dryrun.yml`'s top-of-file comment** with the
+   new bug count and a one-line summary.
+
+The path filter on the workflow's `pull_request` / `push` triggers
+already covers any future workflow file added under `.github/workflows/`
+that matches the existing patterns; if the new workflow falls outside
+those patterns, add its path to the filter.


### PR DESCRIPTION
## Summary

Closes #249.

Establishes the acceptance gate for the **first-deploy / cold-start workflow-bug class** that surfaced under emergency pressure during the P3W2 thread (2026-05-01 → 2026-05-02). Five distinct workflow bugs, none catchable by PR-time review:

| # | Bug | Issue | Fix PR |
|---|-----|-------|--------|
| 1 | terraform.yml ephemeral keypair | #216 | #217 |
| 2 | promote.yml retag-token scope mismatch | (inline — GH_PACKAGES_TOKEN swap) | inline |
| 3 | promote.yml stg-latest TOCTOU | #234 | #236 |
| 4 | promote.yml multi-arch parity assumption | #239 | #240 |
| 5 | db-migrate.yml psycopg-vs-asyncpg URL | #235 | #236 |

Each only manifested when the workflow encountered fresh / empty / cold state. The gate codifies each as a static or dynamic invariant; PRs touching promotion-pathway / migration / TF-apply workflows must run it green.

## Per-bug simulation paths

| Bug | Caught by | Mechanism |
|-----|-----------|-----------|
| #1 (TF ephemeral keypair) | `workflow-cold-checks` job → `check_terraform_no_ephemeral_keypair()` | Negative invariant: terraform.yml MUST NOT contain `ssh-keygen`. Positive invariants: `modules/hetzner-vps/deploy.pub` exists; env-root `ssh_public_key_path` defaults point at `../../modules/hetzner-vps/deploy.pub` (not `~/.ssh/id_ed25519.pub`). Verified locally: re-injecting `ssh-keygen` step → guard fires with exit 1. |
| #2 (retag-token) | `workflow-cold-checks` → `check_promote_token_scope()` | Locates the `retag:` job block in promote.yml; asserts `password: ${{ secrets.GH_PACKAGES_TOKEN }}` appears AND no `password: ${{ secrets.GITHUB_TOKEN }}` appears within that block. Verified locally: swapping the retag login back to GITHUB_TOKEN → guard fires. |
| #3 (stg-latest TOCTOU) | `workflow-cold-checks` → `check_promote_no_floating_source()` | Extracts the `Resolve source tag` step from promote.yml; asserts `source_tag="sha-${SHORT}"` and forbids `source_tag="(stg|prod)-latest"`. Verified locally: replacing the assignment with `stg-latest` → both sub-guards fire. |
| #4 (multi-arch parity) | `buildx-shape-dryrun` job | Builds two fixture images on a `registry:2` service container — one multi-arch (linux/amd64+linux/arm64) matching api/frontend/user-service shape, one single-arch (linux/amd64 + `--provenance=false`) matching landing-page shape. Runs `docker buildx imagetools create` for each and asserts the shape-aware parity logic from promote.yml passes both. Includes a **negative control** that asserts the pre-#239 naive top-level comparison still fails on single-arch — surfaces a `::warning::` if registry/buildx behavior changes silently obviate the #240 fix. |
| #5 (psycopg-vs-asyncpg) | `workflow-cold-checks` → `check_db_migrate_driver_aligned()` | Parses `postgresql+<driver>://` from db-migrate.yml's `DATABASE_URL=` line; asserts the named driver package is declared as a dependency in user-service's pyproject.toml (read via wave-aware sibling checkout, mirroring integration-tests.yml's #159 pattern). Verified locally: switching back to `postgresql+psycopg://` → guard fires (psycopg not in pyproject; only asyncpg is). |

## Triggers

- `pull_request` on changes to: promote.yml, terraform.yml, db-migrate.yml, deploy-{stg,prod,all,isnad-graph,landing-page}.yml, this workflow + its script, terraform/hetzner/**, the runbook.
- `push` to main + any `deployments/phase-*/wave-*` with the same path filter.
- `schedule: 0 6 * * 1` (weekly Mon 06:00 UTC) — catches drift introduced by PRs that didn't trigger the path filter.
- `workflow_dispatch`.

## Limitations

Documented in `docs/runbooks/cold-rebuild-dry-run.md`:

- **Dry-run only.** No real GHCR contact. No real Hetzner project. No real B2 tfstate. No real Postgres.
- **Regression gate, not discovery tool.** Catches RE-introduction of the 5 known bug shapes. Genuinely-novel cold-state defects still surface at first-deploy time (new VPS bring-up, new env, DR restore).
- **Static checks rely on grep/regex shape-matching.** A workflow-shape refactor (e.g., moving the retag step into a reusable workflow) would need the regexes updated. The runbook documents this in the "Adding a new guard" section.

## Files

- `.github/workflows/cold-rebuild-dryrun.yml` — meta-CI workflow (3 jobs: static checks, buildx shape dryrun, summary).
- `.github/workflows/scripts/cold_rebuild_static_checks.py` — 4 guards (bugs #1, #2, #3, #5), one function per bug, each with a docstring linking the bug + fix.
- `docs/runbooks/cold-rebuild-dry-run.md` — per-bug detection table, triage guide, scope/limits, manual cold-rebuild ship-test procedure, add-a-new-guard playbook.

## Test plan

- [ ] PR-CI: cold-rebuild-dryrun.yml self-triggers on this PR (path filter includes itself + the script). Both jobs green.
- [ ] PR-CI: lint-workflows.yml (actionlint) passes — verified locally with actionlint 1.7.7 + shellcheck 0.10.0 on PATH.
- [ ] PR-CI: integration-tests.yml passes (no overlap, but worth confirming nothing was broken in the workflow set).
- [ ] Static guards verified locally:
  - All 4 green against current `deployments/phase-3/wave-3` HEAD.
  - Each individually re-introduced (ssh-keygen / GITHUB_TOKEN at retag / stg-latest source / postgresql+psycopg URL) → fails with clear diagnostic and exit 1; restoring the fix returns the guard to green.
- [ ] Lucas review: per-bug-guard mapping vs. each cited fix PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
