### PR TITLE
feat(audit): break-glass workflow input audit + alerting (#251)

### DIFF
--- a/.github/actions/break-glass-audit/action.yml
+++ b/.github/actions/break-glass-audit/action.yml
@@ -1,0 +1,254 @@
+# Break-glass audit composite action (deploy#251).
+#
+# Centralizes the audit emissions for any workflow that consumes a break-glass
+# input (skip_alembic_gate, allow_stg_tags, skip_stg_verify). When invoked, it:
+#
+#   1. Writes a `## ⚠ BREAK-GLASS USED` block to $GITHUB_STEP_SUMMARY.
+#   2. Emits a `::warning::` annotation so the run lists the bypass at a glance.
+#   3. Appends a comment to the pinned audit-log issue (label
+#      `break-glass-audit-log`) — find-or-create on first use.
+#   4. SSHes to the prod VPS and writes a node-exporter textfile-collector
+#      metric `break_glass_invocation_*.prom` so Prometheus can fire
+#      `BreakGlassUsed` (infra/prometheus/alerts.yml).
+#
+# Reason input MUST be non-empty — callers validate that before invoking
+# (single source of truth is the workflow input definition + a `validate-reason`
+# step the caller emits early). This action assumes reason is already
+# validated; passing an empty reason is a programming error and the action
+# will fail loudly to surface that.
+#
+# Why centralized: drift across the three break-glass invocation sites
+# (promote.yml skip_alembic_gate, deploy-prod.yml allow_stg_tags, the
+# pre-existing skip_stg_verify path) is the exact failure mode #251 is meant
+# to prevent. One implementation, three call sites.
+
+name: Break-glass audit
+description: Emit job summary, warning, audit issue comment, and Prometheus textfile metric for a break-glass workflow input usage.
+
+inputs:
+  input_name:
+    description: "The break-glass input that was set true (e.g., skip_alembic_gate, allow_stg_tags, skip_stg_verify)."
+    required: true
+  reason:
+    description: "Non-empty operator-supplied reason. Caller validates non-empty before invoking; passing empty here will fail the action."
+    required: true
+  bypassed:
+    description: "Short human-readable description of what gate was bypassed (e.g., 'alembic pre-retag migration gate')."
+    required: true
+  vps_host:
+    description: "Prod VPS host for textfile-collector metric. Pass vars.VPS_HOST."
+    required: true
+  ssh_key:
+    description: "Deploy SSH private key. Pass secrets.DEPLOY_SSH_PRIVATE_KEY."
+    required: true
+  github_token:
+    description: "Token with issues:write scope for audit-log issue comment. Pass secrets.GITHUB_TOKEN (caller grants the permission)."
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Validate reason is non-empty
+      shell: bash
+      env:
+        REASON: ${{ inputs.reason }}
+        INPUT_NAME: ${{ inputs.input_name }}
+      run: |
+        set -euo pipefail
+        if [ -z "${REASON// /}" ]; then
+          echo "::error::break-glass-audit invoked with empty reason for input ${INPUT_NAME}." >&2
+          echo "::error::Callers MUST validate a non-empty reason BEFORE invoking this action." >&2
+          echo "::error::See docs/runbooks/break-glass.md and deploy#251." >&2
+          exit 1
+        fi
+
+    - name: Job summary + warning annotation
+      shell: bash
+      env:
+        INPUT_NAME: ${{ inputs.input_name }}
+        REASON: ${{ inputs.reason }}
+        BYPASSED: ${{ inputs.bypassed }}
+        ACTOR: ${{ github.actor }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        set -euo pipefail
+        echo "::warning::BREAK-GLASS used: ${INPUT_NAME}=true by ${ACTOR}. Bypassed: ${BYPASSED}. See audit-log issue."
+        {
+          echo "## ⚠ BREAK-GLASS USED"
+          echo ""
+          echo "| Field | Value |"
+          echo "|-------|-------|"
+          echo "| **Input** | \`${INPUT_NAME}=true\` |"
+          echo "| **Actor** | ${ACTOR} |"
+          echo "| **Reason** | ${REASON} |"
+          echo "| **Bypassed** | ${BYPASSED} |"
+          echo "| **Run** | ${RUN_URL} |"
+          echo ""
+          echo "This run proceeded with a documented safety bypass. Audit trail:"
+          echo "comment appended to the pinned audit-log issue (label \`break-glass-audit-log\`)"
+          echo "and \`break_glass_invocation\` Prometheus metric on the prod VPS."
+          echo ""
+          echo "Runbook: \`docs/runbooks/break-glass.md\`"
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Append to pinned audit-log issue
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        REPO: ${{ github.repository }}
+        INPUT_NAME: ${{ inputs.input_name }}
+        REASON: ${{ inputs.reason }}
+        BYPASSED: ${{ inputs.bypassed }}
+        ACTOR: ${{ github.actor }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        WORKFLOW: ${{ github.workflow }}
+      run: |
+        set -euo pipefail
+
+        # Find or create the singleton audit-log issue. Identified by the
+        # `break-glass-audit-log` label, which is created on demand. We do
+        # not search by title because operators may rename the issue —
+        # the label is the durable identity.
+        AUDIT_LABEL="break-glass-audit-log"
+
+        # Ensure label exists (idempotent — `gh label create` errors on
+        # duplicate; we swallow that one specific error and re-raise others).
+        if ! gh label list --repo "${REPO}" --json name --jq '.[].name' | grep -qx "${AUDIT_LABEL}"; then
+          gh label create "${AUDIT_LABEL}" \
+            --repo "${REPO}" \
+            --color "B60205" \
+            --description "Pinned thread for every break-glass workflow input invocation (deploy#251)."
+        fi
+
+        # Find the open audit-log issue. There MUST be at most one; if two
+        # exist (operator error), pick the lowest-numbered (oldest) and
+        # warn — keeping the comment thread linear is more important than
+        # which-of-two we pick.
+        ISSUE_NUMBER="$(
+          gh issue list \
+            --repo "${REPO}" \
+            --state open \
+            --label "${AUDIT_LABEL}" \
+            --json number \
+            --jq 'sort_by(.number) | .[0].number // empty'
+        )"
+
+        if [ -z "${ISSUE_NUMBER}" ]; then
+          # Create the audit-log issue. Body explains the convention so an
+          # operator landing here cold understands what they're looking at.
+          INIT_BODY_FILE="$(mktemp)"
+          {
+            printf '%s\n' "This issue is the audit thread for every workflow run that used a break-glass input"
+            printf '%s\n' "(\`skip_alembic_gate\`, \`allow_stg_tags\`, \`skip_stg_verify\`). One comment per"
+            printf '%s\n' "invocation. Do not close — the audit composite action (\`.github/actions/break-glass-audit\`)"
+            printf '%s\n' "auto-creates a replacement if closed, but the comment history is then split."
+            printf '\n'
+            printf '%s\n' "See \`docs/runbooks/break-glass.md\` for the policy + acceptance criteria of when"
+            printf '%s\n' "each input is appropriate. Filed by deploy#251."
+          } > "${INIT_BODY_FILE}"
+          # `gh issue create --label X` requires the label to already exist
+          # (it does — we ensured it above). Capture the URL and parse the
+          # number from the trailing path segment; this works on every gh
+          # version we support.
+          ISSUE_URL="$(
+            gh issue create \
+              --repo "${REPO}" \
+              --title "audit: break-glass usage log (pinned)" \
+              --label "${AUDIT_LABEL}" \
+              --body-file "${INIT_BODY_FILE}"
+          )"
+          rm -f "${INIT_BODY_FILE}"
+          ISSUE_NUMBER="${ISSUE_URL##*/}"
+          if ! printf '%s' "${ISSUE_NUMBER}" | grep -qE '^[0-9]+$'; then
+            echo "::error::Could not parse issue number from gh issue create output: ${ISSUE_URL}"
+            exit 1
+          fi
+          echo "Created audit-log issue #${ISSUE_NUMBER} (${ISSUE_URL})"
+        else
+          echo "Reusing audit-log issue #${ISSUE_NUMBER}"
+        fi
+
+        # Append the per-invocation comment. Use a body file so newlines +
+        # quoting survive (operator-supplied REASON is free text).
+        BODY_FILE="$(mktemp)"
+        trap 'rm -f "$BODY_FILE"' EXIT
+        {
+          echo "### ⚠ Break-glass invocation"
+          echo ""
+          echo "- **Timestamp:** $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "- **Workflow:** ${WORKFLOW}"
+          echo "- **Input:** \`${INPUT_NAME}=true\`"
+          echo "- **Actor:** @${ACTOR}"
+          echo "- **Bypassed:** ${BYPASSED}"
+          echo "- **Run:** ${RUN_URL}"
+          echo ""
+          echo "**Reason:**"
+          echo ""
+          # Quote the reason as a code block to neutralize markdown injection
+          # via operator-supplied free text.
+          echo '```'
+          printf '%s\n' "${REASON}"
+          echo '```'
+        } > "${BODY_FILE}"
+
+        gh issue comment "${ISSUE_NUMBER}" \
+          --repo "${REPO}" \
+          --body-file "${BODY_FILE}"
+        echo "Appended audit comment to #${ISSUE_NUMBER}"
+
+    - name: Emit textfile-collector metric on prod VPS
+      uses: appleboy/ssh-action@v1
+      env:
+        INPUT_NAME: ${{ inputs.input_name }}
+        ACTOR: ${{ github.actor }}
+        WORKFLOW: ${{ github.workflow }}
+        RUN_ID: ${{ github.run_id }}
+      with:
+        host: ${{ inputs.vps_host }}
+        username: deploy
+        key: ${{ inputs.ssh_key }}
+        envs: INPUT_NAME,ACTOR,WORKFLOW,RUN_ID
+        script: |
+          set -euo pipefail
+          TEXTFILE_DIR="/var/lib/node_exporter/textfile_collector"
+          # Per-input filename so concurrent break-glass uses on different
+          # inputs don't clobber each other's metric. node-exporter merges
+          # all .prom files in the dir into one scrape response.
+          FINAL="${TEXTFILE_DIR}/break_glass_invocation_${INPUT_NAME}.prom"
+          TMP="${FINAL}.$$"
+
+          # Same bootstrap-permissions discipline as the alembic gate
+          # textfile emit (db-migrate.yml) — fail loud if the dir isn't
+          # writable, since silent metric loss defeats the entire purpose
+          # of this audit.
+          if ! [ -w "${TEXTFILE_DIR}" ]; then
+            echo "ERROR: ${TEXTFILE_DIR} is not writable by deploy user." >&2
+            echo "       This usually means cloud-init did not fire on this VPS." >&2
+            echo "       Investigate per docs/runbooks/break-glass.md." >&2
+            exit 1
+          fi
+
+          NOW="$(date -u +%s)"
+
+          # Sanitize label values for Prometheus exposition format.
+          # Alphanumeric + underscore + dash for input/actor/workflow;
+          # backslashes and double-quotes are escaped per the exposition
+          # format spec. Free-text reason is NOT included as a label
+          # (label-value cardinality risk + free text is in the audit issue).
+          sanitize() {
+            printf '%s' "$1" | tr -c 'A-Za-z0-9_.\-' '_'
+          }
+          INPUT_LABEL="$(sanitize "${INPUT_NAME}")"
+          ACTOR_LABEL="$(sanitize "${ACTOR}")"
+          WORKFLOW_LABEL="$(sanitize "${WORKFLOW}")"
+          RUN_ID_LABEL="$(sanitize "${RUN_ID}")"
+
+          {
+            echo "# HELP break_glass_invocation_timestamp_seconds Unix timestamp of the most recent break-glass workflow input invocation, labeled by input name."
+            echo "# TYPE break_glass_invocation_timestamp_seconds gauge"
+            echo "break_glass_invocation_timestamp_seconds{input=\"${INPUT_LABEL}\",actor=\"${ACTOR_LABEL}\",workflow=\"${WORKFLOW_LABEL}\",run_id=\"${RUN_ID_LABEL}\"} ${NOW}"
+          } > "${TMP}"
+          chmod 0644 "${TMP}"
+          mv -f "${TMP}" "${FINAL}"
+          echo "Wrote ${FINAL}: input=${INPUT_LABEL} actor=${ACTOR_LABEL} timestamp=${NOW}"
+          cat "${FINAL}"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -54,16 +54,87 @@ on:
           broken and prod must be restored. Mirrors skip_stg_verify /
           skip_alembic_gate discipline. Surfaced 2026-05-02 emergency
           restore — GHCR cross-repo write blocked at token-scope level.
+          REQUIRES a non-empty `break_glass_reason` input — see deploy#251.
         required: false
         default: false
         type: boolean
+      break_glass_reason:
+        description: >-
+          REQUIRED when allow_stg_tags=true. Free-text operator-supplied
+          reason. Logged in job summary, appended to the pinned audit-log
+          issue (label `break-glass-audit-log`), and surfaced via the
+          BreakGlassUsed Alertmanager rule. Empty value with
+          allow_stg_tags=true fails the run at validate-break-glass-reason.
+          See deploy#251 + docs/runbooks/break-glass.md.
+        required: false
+        default: ""
+        type: string
 
 concurrency:
   group: deploy-production
   cancel-in-progress: false
 
 jobs:
+  # ─────────────────────────────────────────────────────────────────
+  # Break-glass reason validation (deploy#251). When allow_stg_tags=true
+  # the operator MUST supply a non-empty break_glass_reason. Runs first
+  # to fail-fast before any deploy machinery starts.
+  # ─────────────────────────────────────────────────────────────────
+  validate-break-glass-reason:
+    name: Validate break-glass reason
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reason is required when allow_stg_tags=true
+        env:
+          ALLOW_STG_TAGS: ${{ inputs.allow_stg_tags }}
+          REASON: ${{ inputs.break_glass_reason }}
+        run: |
+          set -euo pipefail
+          if [ "${ALLOW_STG_TAGS}" = "true" ]; then
+            stripped="${REASON//[$' \t\r\n']/}"
+            if [ -z "${stripped}" ]; then
+              echo "::error::allow_stg_tags=true but \`break_glass_reason\` is empty."
+              echo "::error::Set \`break_glass_reason\` to a free-text reason describing WHY stg-* tags are being accepted in prod."
+              echo "::error::Example: 'DR restore — promote.yml retag path blocked by GHCR cross-repo write 403'."
+              echo "::error::See docs/runbooks/break-glass.md (deploy#251)."
+              exit 1
+            fi
+            echo "Break-glass: allow_stg_tags=true, reason supplied (length=${#REASON})."
+          else
+            echo "allow_stg_tags=false — reason validation N/A."
+          fi
+
+  # ─────────────────────────────────────────────────────────────────
+  # Break-glass audit (deploy#251). Fires only when allow_stg_tags=true.
+  # Records the bypass in the pinned audit-log issue, emits the textfile-
+  # collector metric for Prometheus, and writes the job-summary block.
+  # Runs in parallel with `deploy` — does NOT gate the deploy itself,
+  # since a failed audit must not block an emergency restore. The audit
+  # exists to record the fact, not to gate the action.
+  # ─────────────────────────────────────────────────────────────────
+  audit-allow-stg-tags:
+    name: Audit — allow_stg_tags break-glass
+    needs: validate-break-glass-reason
+    if: ${{ inputs.allow_stg_tags }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout (for local composite action)
+        uses: actions/checkout@v4
+      - name: Break-glass audit (allow_stg_tags)
+        uses: ./.github/actions/break-glass-audit
+        with:
+          input_name: allow_stg_tags
+          reason: ${{ inputs.break_glass_reason }}
+          bypassed: "deploy-prod prod-* tag-shape check (accepting stg-* digests directly)"
+          vps_host: ${{ vars.VPS_HOST }}
+          ssh_key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
   deploy:
+    needs: validate-break-glass-reason
     runs-on: ubuntu-latest
     environment: production
     permissions:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -75,10 +75,23 @@ on:
           exist (chicken-and-egg). Use ONLY when restoring prod from a
           state where the alembic gate cannot run by definition. Mirrors
           the skip_stg_verify break-glass discipline: emits a warning
-          annotation + job-summary entry on use.
+          annotation + job-summary entry on use. REQUIRES a non-empty
+          `break_glass_reason` input — see deploy#251.
         required: false
         default: false
         type: boolean
+      break_glass_reason:
+        description: >-
+          REQUIRED when skip_stg_verify=true OR skip_alembic_gate=true.
+          Free-text operator-supplied reason. Logged in job summary,
+          appended to the pinned audit-log issue (label
+          `break-glass-audit-log`), and surfaced in Slack/email via
+          Alertmanager. Empty value with any break-glass input set will
+          fail the run at the validate-break-glass-reason job. See
+          deploy#251 + docs/runbooks/break-glass.md.
+        required: false
+        default: ""
+        type: string
 
 concurrency:
   # All promotions serialize globally — we never want two promotions racing
@@ -89,13 +102,60 @@ concurrency:
 permissions:
   contents: read
   packages: write
+  # `issues: write` is required by the break-glass-audit composite action
+  # to find-or-create + comment on the pinned audit-log issue. Scoped at the
+  # workflow level because the audit step runs from inside the `gate-stg-verify`
+  # and (TBD downstream of skip_alembic_gate) jobs which both need it on the
+  # break-glass branch only. Non-break-glass runs never invoke `gh issue`,
+  # so the additional scope is unused for the common path.
+  issues: write
 
 env:
   REGISTRY: ghcr.io
 
 jobs:
+  # ─────────────────────────────────────────────────────────────────
+  # Break-glass reason validation (deploy#251). When ANY break-glass
+  # input is set true, `break_glass_reason` MUST be non-empty. This
+  # job runs before any other and short-circuits the entire promotion
+  # if the operator forgot to document why they're bypassing a gate.
+  #
+  # The audit composite action also re-validates non-empty reason at
+  # call time as defense-in-depth, but failing here is faster + clearer.
+  # ─────────────────────────────────────────────────────────────────
+  validate-break-glass-reason:
+    name: Validate break-glass reason
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reason is required when any break-glass input is set
+        env:
+          SKIP_STG_VERIFY: ${{ inputs.skip_stg_verify }}
+          SKIP_ALEMBIC_GATE: ${{ inputs.skip_alembic_gate }}
+          REASON: ${{ inputs.break_glass_reason }}
+        run: |
+          set -euo pipefail
+          if [ "${SKIP_STG_VERIFY}" = "true" ] || [ "${SKIP_ALEMBIC_GATE}" = "true" ]; then
+            # Strip whitespace before checking — operators sometimes type a
+            # space hoping to satisfy a "required" check. Fail those too.
+            stripped="${REASON//[$' \t\r\n']/}"
+            if [ -z "${stripped}" ]; then
+              echo "::error::A break-glass input was set true but \`break_glass_reason\` is empty."
+              echo "::error::Set \`break_glass_reason\` to a free-text reason describing WHY the bypass is needed."
+              echo "::error::Example: 'DR restore — prod stack does not exist, alembic gate cannot run by definition'."
+              echo "::error::See docs/runbooks/break-glass.md (deploy#251)."
+              exit 1
+            fi
+            echo "Break-glass inputs:"
+            echo "  skip_stg_verify  = ${SKIP_STG_VERIFY}"
+            echo "  skip_alembic_gate = ${SKIP_ALEMBIC_GATE}"
+            echo "Reason supplied (length=${#REASON})."
+          else
+            echo "No break-glass inputs set — reason validation N/A."
+          fi
+
   plan:
     name: Plan promotion
+    needs: validate-break-glass-reason
     runs-on: ubuntu-latest
     outputs:
       # Each matrix cell of `retag` picks its per-image short from here.
@@ -278,22 +338,19 @@ jobs:
     outputs:
       gate_result: ${{ steps.gate.outputs.gate_result }}
     steps:
-      - name: Break-glass override (skip_stg_verify)
+      - name: Checkout (for local composite action)
         if: ${{ inputs.skip_stg_verify }}
-        env:
-          ACTOR: ${{ github.actor }}
-        run: |
-          set -euo pipefail
-          echo "::warning::stg-verify gate SKIPPED via break-glass input by $ACTOR"
-          {
-            echo "## ⚠ stg-verify gate SKIPPED (break-glass)"
-            echo ""
-            echo "- **Actor:** $ACTOR"
-            echo "- **Input:** \`skip_stg_verify=true\`"
-            echo ""
-            echo "This promotion proceeded WITHOUT confirming the latest stg verify-deploy succeeded."
-            echo "Use only when the gate itself is broken; otherwise investigate the gate failure first."
-          } >> "$GITHUB_STEP_SUMMARY"
+        uses: actions/checkout@v4
+      - name: Break-glass audit (skip_stg_verify)
+        if: ${{ inputs.skip_stg_verify }}
+        uses: ./.github/actions/break-glass-audit
+        with:
+          input_name: skip_stg_verify
+          reason: ${{ inputs.break_glass_reason }}
+          bypassed: "stg-verify gate (verify-deploy.yml stg-verify-result artifact freshness check)"
+          vps_host: ${{ vars.VPS_HOST }}
+          ssh_key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Locate recent verify-deploy runs
         if: ${{ !inputs.skip_stg_verify }}
@@ -506,6 +563,42 @@ jobs:
       # image (prod-<short> doesn't exist until retag below).
       image_tag: stg-${{ needs.plan.outputs.user_service_short }}
     secrets: inherit
+
+  # ─────────────────────────────────────────────────────────────────
+  # Break-glass audit for skip_alembic_gate (deploy#251).
+  #
+  # When `migrate-prod` is skipped because `skip_alembic_gate=true`, no
+  # natural job runs to record the bypass. This job fires only on that
+  # branch and emits the full audit set (job summary, warning,
+  # audit-issue comment, prom textfile metric) via the composite action.
+  #
+  # Runs in parallel with `retag` — does NOT gate retag because the
+  # bypass decision was already made operationally; this job records
+  # the fact for post-hoc audit. If THIS job fails (e.g. SSH down,
+  # GH token issue), it's a noisy signal but must not block the
+  # emergency promotion that the bypass was for in the first place.
+  # `retag` does not depend on this job.
+  # ─────────────────────────────────────────────────────────────────
+  audit-skip-alembic-gate:
+    name: Audit — skip_alembic_gate break-glass
+    needs: [plan, gate-stg-verify]
+    if: ${{ inputs.skip_alembic_gate }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout (for local composite action)
+        uses: actions/checkout@v4
+      - name: Break-glass audit (skip_alembic_gate)
+        uses: ./.github/actions/break-glass-audit
+        with:
+          input_name: skip_alembic_gate
+          reason: ${{ inputs.break_glass_reason }}
+          bypassed: "alembic pre-retag migration gate (db-migrate.yml on prod user-postgres)"
+          vps_host: ${{ vars.VPS_HOST }}
+          ssh_key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   retag:
     name: Retag ${{ matrix.key }} (stg → prod)

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -335,6 +335,13 @@ jobs:
     permissions:
       actions: read
       contents: read
+      # `issues: write` required by the break-glass-audit composite action
+      # invoked from this job when `inputs.skip_stg_verify` is true. The
+      # job-level `permissions:` block fully replaces the workflow-level
+      # one at YAML resolution time — so without this line the audit
+      # step would 403 from the GitHub Issues API on the exact path
+      # the audit instrumentation exists for. (Bereket-261-rev catch.)
+      issues: write
     outputs:
       gate_result: ${{ steps.gate.outputs.gate_result }}
     steps:

--- a/docs/runbooks/break-glass.md
+++ b/docs/runbooks/break-glass.md
@@ -183,11 +183,13 @@ Replace `<input>` with the value from the alert's `input` label.
 
 As of 2026-05-03, Alertmanager's `critical` receiver webhook is a
 localhost placeholder (`http://localhost:9095/webhook`) pending real
-Slack/email routing — tracked in deploy#127. The `BreakGlassUsed` rule
+Slack/email routing — tracked in deploy#262 (post-#251 sequel; the
+parse-error fix for `${VAR}` interpolation that landed the placeholder
+itself was deploy#127, closed 2026-04-19). The `BreakGlassUsed` rule
 fires correctly inside Prometheus + Alertmanager, but the human-facing
-notification path requires #127 to land first.
+notification path requires #262 to land first.
 
-Until #127 is resolved, on-call should grep the audit-log issue + check
+Until #262 is resolved, on-call should grep the audit-log issue + check
 the Alertmanager UI directly:
 `https://noorinalabs.com/alertmanager/` (behind admin auth).
 
@@ -205,6 +207,7 @@ the Alertmanager UI directly:
 
 - deploy#251 — this audit/alert layer (this PR)
 - deploy#232 — original break-glass inputs landing
-- deploy#127 — Alertmanager receiver webhook (localhost placeholder)
+- deploy#262 — wire Alertmanager receivers to a real human surface (post-#251 sequel)
+- deploy#127 — alertmanager.yml `${VAR}` parse-error fix that landed the localhost placeholder (closed 2026-04-19; historical reference)
 - deploy#161 — alembic-gate textfile pattern (template for our metric emit)
 - charter/emergency-mode.md — `[OWNER-ACTION]` discipline this audit complements

--- a/docs/runbooks/break-glass.md
+++ b/docs/runbooks/break-glass.md
@@ -1,0 +1,210 @@
+# Break-glass workflow inputs — audit + usage
+
+This runbook covers the three break-glass `workflow_dispatch` inputs in this
+repo, when each is appropriate, and how the audit trail is captured.
+
+Filed by deploy#251 (P3W3 Tier 1) following the P3W2 emergency-thread retro
+(`charter/emergency-mode.md`). PR #232 added the bypass mechanisms; this
+runbook + the audit composite action `.github/actions/break-glass-audit` are
+the audibility layer that ensures every bypass is recorded, alerted, and
+attributable.
+
+## TL;DR
+
+Every break-glass invocation MUST supply a `break_glass_reason`. On
+invocation, four audit signals fire:
+
+1. `## ⚠ BREAK-GLASS USED` block in the workflow's `$GITHUB_STEP_SUMMARY`
+2. `::warning::` annotation in the run log
+3. Comment appended to the pinned `audit: break-glass usage log` issue
+   (label `break-glass-audit-log`)
+4. Prometheus textfile-collector metric `break_glass_invocation_*.prom` on
+   the prod VPS, scraped by node-exporter, surfaced via the
+   `BreakGlassUsed` Alertmanager rule
+
+Empty reason → `validate-break-glass-reason` job fails the run before any
+deploy/promotion machinery starts.
+
+## The three inputs
+
+### `skip_stg_verify` (promote.yml)
+
+Bypasses the gate that requires a fresh successful `verify-deploy.yml` stg
+run before promotion to prod. Default freshness window is 24h (configurable
+via `stg_verify_max_age_hours`).
+
+**Appropriate when:**
+- The verify-deploy workflow itself is broken (e.g. broken assertion logic,
+  GHCR authz issue with the verify path) AND prod must be promoted
+- Stg has been verified out-of-band and the artifact is missing/expired
+
+**NOT appropriate when:**
+- Stg verify is failing because stg is genuinely broken — fix stg first
+- You're in a hurry and don't want to wait for the gate — that's what the
+  gate is FOR
+
+### `skip_alembic_gate` (promote.yml)
+
+Bypasses the alembic pre-retag migration gate (`db-migrate.yml` against
+prod user-postgres). The gate runs `alembic upgrade head` to confirm the
+incoming user-service image migrates cleanly before retagging.
+
+**Appropriate when:**
+- First-deploy / DR-restore where the prod user-service stack does not
+  yet exist (the gate cannot run by definition — chicken-and-egg)
+- Recovering prod from a state where user-postgres is unreachable
+
+**NOT appropriate when:**
+- The migration itself is failing — fix the migration; this gate exists
+  precisely to catch migration breakage before retag
+- Skipping is being used to "make the gate stop being noisy"
+
+### `allow_stg_tags` (deploy-prod.yml)
+
+Bypasses the `prod-*` tag-shape check that normally rejects `stg-*` tags
+in deploy-prod. Surfaced 2026-05-02 emergency-restore where the
+`promote.yml` retag path was blocked at the GHCR cross-repo write-403 level.
+
+**Appropriate when:**
+- The promote.yml retag path is broken AND prod must be deployed from
+  stg-* digests directly
+- DR restore where retag is impossible
+
+**NOT appropriate when:**
+- You skipped the promotion approval gate and want to deploy stg → prod
+  directly. That bypass crosses an authorization boundary, not just a
+  shape check
+
+## Acceptance criteria for using a break-glass input
+
+Before invoking any of the three inputs:
+
+1. Have you announced the bypass per `charter/emergency-mode.md` (the
+   `[OWNER-ACTION]`-style state delta)?
+2. Is the underlying gate genuinely unable to run, OR is it correctly
+   reporting a real problem?
+3. Will the audit-log issue comment make sense to a reader six months
+   from now without you in the room?
+
+If any answer is "no" or "unclear", investigate the gate failure first.
+
+## How the audit trail is captured
+
+### Composite action
+
+`.github/actions/break-glass-audit` is a single composite action invoked by:
+
+- `promote.yml` → `gate-stg-verify` job (when `skip_stg_verify=true`)
+- `promote.yml` → `audit-skip-alembic-gate` job (when `skip_alembic_gate=true`)
+- `deploy-prod.yml` → `audit-allow-stg-tags` job (when `allow_stg_tags=true`)
+
+The composite emits all four audit signals atomically per invocation.
+
+### Job-summary block
+
+Visible in the GH Actions run page under each job's summary tab. Includes
+the input name, actor, reason, what was bypassed, and the run URL.
+
+### Audit-log issue (pinned)
+
+Label: `break-glass-audit-log`. The composite action find-or-creates by
+label — operators can rename the issue title without breaking the audit.
+
+To find the audit log:
+
+```bash
+gh issue list \
+  --repo noorinalabs/noorinalabs-deploy \
+  --state open \
+  --label break-glass-audit-log \
+  --json number,title,url \
+  --jq '.[]'
+```
+
+There MUST be at most one open issue with this label. If two exist, the
+composite picks the lowest-numbered (oldest) and warns; close the duplicate
+manually.
+
+### Prometheus textfile metric
+
+Filename: `/var/lib/node_exporter/textfile_collector/break_glass_invocation_<input>.prom`
+on the prod VPS. One file per input name (so concurrent break-glass uses
+on different inputs don't clobber each other).
+
+Schema (one gauge per file):
+
+```
+break_glass_invocation_timestamp_seconds{input="...",actor="...",workflow="...",run_id="..."} <unix-ts>
+```
+
+The free-text reason is NOT included as a label — operator-supplied free
+text is high-cardinality + injection-prone for label values; it lives in
+the audit-log issue comment instead.
+
+Permission discipline: same `[ -w "${TEXTFILE_DIR}" ]` pre-check as the
+alembic gate emit (db-migrate.yml). Fail loud rather than silent metric
+loss if cloud-init didn't fire on the VPS.
+
+## Alert investigation
+
+### Alert: `BreakGlassUsed`
+
+Fires within ~scrape-interval of break-glass invocation; resolves after
+10 minutes of no fresh invocation.
+
+Investigation steps:
+
+1. Note the labels: `input`, `actor`, `workflow`, `run_id`.
+2. Open the workflow run:
+   `https://github.com/noorinalabs/noorinalabs-deploy/actions/runs/<run_id>`.
+3. Read the `## ⚠ BREAK-GLASS USED` block in the run's job summary.
+4. Read the latest comment on the audit-log issue
+   (`gh issue list --label break-glass-audit-log --state open`).
+5. Confirm the bypass was authorized — cross-reference the
+   `[OWNER-ACTION]` post in the active wave thread per
+   `charter/emergency-mode.md`.
+6. If the bypass appears unauthorized: page the program director and
+   investigate. The audit-log comment is the durable record.
+
+### Alert: `BreakGlassMetricStale` (`#metric-stale-cleanup`)
+
+Fires when a `break_glass_invocation_*.prom` file is more than 30 days old.
+Cleanup is informational — the audit-log issue carries the historical
+record.
+
+```bash
+ssh deploy@noorinalabs-prod \
+  "rm /var/lib/node_exporter/textfile_collector/break_glass_invocation_<input>.prom"
+```
+
+Replace `<input>` with the value from the alert's `input` label.
+
+## Receiver routing caveat
+
+As of 2026-05-03, Alertmanager's `critical` receiver webhook is a
+localhost placeholder (`http://localhost:9095/webhook`) pending real
+Slack/email routing — tracked in deploy#127. The `BreakGlassUsed` rule
+fires correctly inside Prometheus + Alertmanager, but the human-facing
+notification path requires #127 to land first.
+
+Until #127 is resolved, on-call should grep the audit-log issue + check
+the Alertmanager UI directly:
+`https://noorinalabs.com/alertmanager/` (behind admin auth).
+
+## What can NOT be tested in CI
+
+- The full-flow break-glass invocation requires a real prod VPS, real
+  GitHub Issue creation, and a real Prometheus scrape. CI exercises only
+  the validate-reason short-circuit (empty reason → fail).
+- The audit-log issue find-or-create idempotency is exercised once per
+  workflow run in production; CI does not validate it.
+- Alertmanager rule firing requires a live Prometheus scrape against the
+  prod VPS textfile.
+
+## Related issues
+
+- deploy#251 — this audit/alert layer (this PR)
+- deploy#232 — original break-glass inputs landing
+- deploy#127 — Alertmanager receiver webhook (localhost placeholder)
+- deploy#161 — alembic-gate textfile pattern (template for our metric emit)
+- charter/emergency-mode.md — `[OWNER-ACTION]` discipline this audit complements

--- a/infra/prometheus/alerts.yml
+++ b/infra/prometheus/alerts.yml
@@ -260,3 +260,74 @@ groups:
             ~30 days before expiry, so reaching this threshold indicates
             renewal is failing.
           runbook: "docs/runbooks/blackbox-probes.md#cert-expiring-soon"
+
+  # Break-glass workflow input usage alerts (deploy#251).
+  #
+  # The audit composite action `.github/actions/break-glass-audit` writes a
+  # textfile-collector metric on the prod VPS at
+  # /var/lib/node_exporter/textfile_collector/break_glass_invocation_<input>.prom
+  # whenever a break-glass workflow input is consumed by promote.yml or
+  # deploy-prod.yml. Schema (one-line gauge per filename, labels carry which
+  # input + actor + workflow):
+  #
+  #   break_glass_invocation_timestamp_seconds{input="...",actor="...",workflow="...",run_id="..."} <unix-ts>
+  #
+  # The audit-log issue (label `break-glass-audit-log`) carries the free-text
+  # reason; this alert exists so the on-call surface fires within ~5min of
+  # invocation rather than waiting for someone to read the issue thread.
+  #
+  # Receiver: routes through Alertmanager `critical` (alertmanager.yml). Note
+  # the receiver webhook is currently a localhost placeholder pending real
+  # Slack/email routing per #127. This rule lands the durable detection now;
+  # connecting it to a human surface is #127's job.
+  - name: break_glass
+    rules:
+      - alert: BreakGlassUsed
+        # `for: 0m` — every break-glass invocation is operator-actionable.
+        # The audit composite emits the metric synchronously during the
+        # workflow run, so the metric appears within seconds of operator
+        # input. We want a page on first appearance, not after a hold-down.
+        #
+        # Freshness window: fire when the most recent invocation timestamp
+        # is within the last 10 minutes. Above that, the alert resolves so
+        # we don't keep paging for an event hours-old. The audit-log issue
+        # carries the durable record — Alertmanager fires on the recency.
+        expr: |
+          (time() - break_glass_invocation_timestamp_seconds) < 600
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Break-glass workflow input used: {{ $labels.input }}"
+          description: >-
+            A workflow_dispatch run set break-glass input
+            `{{ $labels.input }}=true` (workflow {{ $labels.workflow }},
+            actor @{{ $labels.actor }}, run_id {{ $labels.run_id }}). This
+            bypasses a documented safety gate. The operator-supplied
+            reason + run URL are appended to the pinned audit-log issue
+            (label `break-glass-audit-log`). Verify the bypass was
+            authorized + appropriate per the runbook.
+          runbook: "docs/runbooks/break-glass.md#alert-investigation"
+
+      - alert: BreakGlassMetricStale
+        # Defense-in-depth: detects the metric file existing on disk but
+        # not being updated. If a break-glass invocation wrote the file
+        # ages ago and nothing has touched it since, the freshness window
+        # in BreakGlassUsed won't fire — but we don't want stale gauges
+        # silently sitting there suggesting a gap. Fire if any invocation
+        # metric is older than 30 days, prompting cleanup.
+        expr: |
+          (time() - break_glass_invocation_timestamp_seconds) > 30 * 86400
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "Break-glass metric stale: {{ $labels.input }} (>30d old)"
+          description: >-
+            A `break_glass_invocation_timestamp_seconds` gauge for
+            input `{{ $labels.input }}` is more than 30 days old. The
+            metric is informational at this point — clean up the
+            textfile collector entry on the prod VPS:
+            `rm /var/lib/node_exporter/textfile_collector/break_glass_invocation_{{ $labels.input }}.prom`.
+            See the audit-log issue for the historical record.
+          runbook: "docs/runbooks/break-glass.md#metric-stale-cleanup"


### PR DESCRIPTION
## Summary

Closes #251.

P3W3 Tier 1 follow-up to #232 + the P3W2 emergency-thread retro
(`charter/emergency-mode.md`). Adds an audit + alerting layer on top of
the three break-glass `workflow_dispatch` inputs (`skip_alembic_gate`,
`allow_stg_tags`, `skip_stg_verify`) so every bypass is recorded,
attributed, and surfaced.

Four audit signals fire per invocation, all centralized in a new
composite action `.github/actions/break-glass-audit`:

1. `## ⚠ BREAK-GLASS USED` block in `$GITHUB_STEP_SUMMARY`
2. `::warning::` annotation in the run log
3. Comment appended to a singleton pinned audit-log issue
   (find-or-create by label `break-glass-audit-log`)
4. Prometheus textfile-collector metric on the prod VPS, wired to a
   new `BreakGlassUsed` Alertmanager rule

A new `break_glass_reason` input is required (validated pre-flight)
when any break-glass input is set true. Empty reason → run fails at
`validate-break-glass-reason` before any deploy machinery starts.

## Files changed

- `.github/actions/break-glass-audit/action.yml` — new composite action,
  emits all four audit signals
- `.github/workflows/promote.yml` — adds `break_glass_reason` input,
  pre-flight validation job, replaces inline `skip_stg_verify` block
  with composite call, adds new `audit-skip-alembic-gate` job
- `.github/workflows/deploy-prod.yml` — adds `break_glass_reason` input,
  pre-flight validation job, new `audit-allow-stg-tags` job
- `infra/prometheus/alerts.yml` — new `break_glass` rule group with
  `BreakGlassUsed` (active fire, 10min freshness) and
  `BreakGlassMetricStale` (>30d cleanup hint) alerts
- `docs/runbooks/break-glass.md` — full runbook: when each bypass is
  appropriate, how the audit trail is captured, alert investigation,
  receiver-routing caveat

## Design notes

**Composite action vs. inlining**: Three call sites × four audit emits
= 12 places to keep in sync. The exact failure mode #251 prevents is
drift across those sites. One implementation, three call sites.

**Audit log = pinned GH issue**: Issue body says "B2 OR pinned issue
thread (your call)". Pinned issue is strictly more discoverable +
auth'd via existing `GITHUB_TOKEN` + free of new B2 attack surface.

**Free-text reason in issue comment, not Prom label**: Operator-supplied
free text is high-cardinality and injection-prone for label values.
The label set is `input,actor,workflow,run_id`; the reason lives in the
audit-log comment thread.

**Audit-log issue find-or-create**: Identified by label
`break-glass-audit-log` (not title — operators may rename). Creates on
first invocation if missing. Singleton; if two ever exist (operator
error) the composite picks the lowest-numbered + warns.

**Audit job does NOT gate the action**: The audit fires in parallel with
`retag` / `deploy`. A failed audit (SSH down, GH token issue) is a noisy
signal but must not block the emergency promotion the bypass was for in
the first place. The audit records facts; the bypass decision was already
made operationally.

## Receiver routing caveat

Alertmanager's `critical` receiver webhook is currently a localhost
placeholder per #262 (post-#251 sequel; #127 itself closed 2026-04-19 with localhost placeholder fix-forward). `BreakGlassUsed` fires correctly inside
Prometheus + Alertmanager — the human-facing notification path requires
#262 to land first. Until then, on-call should grep the audit-log issue
+ check Alertmanager UI directly. This PR lands the durable detection
layer; #262 wires the human surface.

## TechDebt

TechDebt: #262

(Receiver routing dependency — when #262 closes, the `BreakGlassUsed`
alert routes to a real human surface automatically; no further work in
this PR's scope.)

## Test plan

What was tested locally:

- [x] `yaml.safe_load` on all four modified/new files
- [x] `actionlint 1.7.7` on both modified workflows (clean)
- [x] Prometheus rule-group structure validated via Python yaml
  (7 groups, `break_glass` group adds 2 rules)
- [x] Read-back: composite action's `gh issue create` URL parsing
  (`${URL##*/}`) verified against `gh issue create --help`

What CANNOT be tested in CI (per `feedback_runtime_gate_scoping.md`):

- [ ] Full-flow real-VPS textfile metric emit on prod VPS
- [ ] Real GH issue find-or-create idempotency under concurrent
      invocations
- [ ] Live `BreakGlassUsed` Alertmanager rule firing against scraped
      metric
- [ ] End-to-end empty-reason validation against a real
      `workflow_dispatch` trigger

Post-merge verification (manager assignment): trigger one dry-run of
each break-glass path with a synthetic reason and observe all four
audit signals on the prod VPS + audit-log issue.

## Acceptance criteria (from #251)

- [x] All 4 audit signals shipped (job summary, Alertmanager rule,
      audit log artifact via pinned issue, required reason)
- [x] Empty reason → validation failure (covered by
      `validate-break-glass-reason` job)
- [x] `docs/runbooks/break-glass.md` covering when each bypass is
      appropriate + the audit trail
- [x] PR base = `deployments/phase-3/wave-3`, labels
      `p3-wave-3 + tech-debt`

---

Requestor: Bereket
Requestee: Weronika
Request: Please review per charter format (continuity from #183
blackbox-exporter review). Particular attention requested on:
1. composite-action design (first composite in this repo — is the
   pattern right?), 2. textfile-metric label cardinality
   (`actor,workflow,run_id` — am I creating a high-cardinality
   problem?), 3. the "audit does NOT gate" decision in `audit-skip-
   alembic-gate` and `audit-allow-stg-tags` — operationally correct?

TechDebt: #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)
