### PR TITLE
tech-debt(caddy): tune CSP/COOP/CORP for users.${BASE_DOMAIN} API surface (closes #243)

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -229,13 +229,33 @@ users.{$BASE_DOMAIN} {
         reverse_proxy user-service:8000
     }
 
-    # Security headers
+    # Security headers — API-surface tuned (closes #243).
+    #
+    # CSP: this vhost only serves JSON from user-service (no HTML, no
+    # scripts, no styles). `default-src 'none'` is the strict OWASP
+    # JSON-API lockdown; `frame-ancestors 'none'` is the CSP-native
+    # successor to X-Frame-Options: DENY (modern browsers prefer it);
+    # `base-uri 'none'` blocks <base> injection on the off-chance an
+    # endpoint regresses to text/html. script-src/style-src/img-src etc.
+    # are subsumed by default-src 'none' and intentionally omitted.
+    #
+    # COOP `same-origin`: isolates this browsing context from any
+    # cross-origin window.opener — defensive against Spectre-class side-
+    # channels and OAuth-flow popup leakage.
+    #
+    # CORP `same-site`: the frontend (isnad.{$BASE_DOMAIN}) fetches
+    # auth/user-service resources cross-origin but same-site. `same-site`
+    # permits these reads while blocking cross-site embeds. `same-origin`
+    # would be too strict and break frontend → user-service fetches.
     header {
         Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
         X-Content-Type-Options "nosniff"
         X-Frame-Options "DENY"
         X-XSS-Protection "0"
         Referrer-Policy "strict-origin-when-cross-origin"
+        Content-Security-Policy "default-src 'none'; frame-ancestors 'none'; base-uri 'none'"
+        Cross-Origin-Opener-Policy "same-origin"
+        Cross-Origin-Resource-Policy "same-site"
         -Server
     }
 }


### PR DESCRIPTION
## Summary

Closes #243. Adds API-surface-tuned `Content-Security-Policy`, `Cross-Origin-Opener-Policy`, and `Cross-Origin-Resource-Policy` headers to the `users.${BASE_DOMAIN}` vhost carved out in #241. The new vhost intentionally omitted CSP at carve-out time because the existing frontend-tuned CSP on `isnad.${BASE_DOMAIN}` isn't a 1:1 fit for an API-only surface — this PR resolves that gap with API-appropriate strictness.

`isnad.${BASE_DOMAIN}` CSP is **not** touched by this PR (frontend posture stays as-is).

## Header rationale

### CSP — `default-src 'none'; frame-ancestors 'none'; base-uri 'none'`

Post-#247 + #248, `users.*` is a pure JSON-only API surface:
- The default catch-all routes to `user-service:8000`, not `frontend:80` (`#247`).
- The `/auth/callback/*` HTML-returning route was dropped from `users.*`; OAuth post-login redirects cross-origin to `isnad.${BASE_DOMAIN}/auth/callback/{provider}` (`#248`, current `b241dda`).

So `default-src 'none'` is the strict OWASP JSON-API lockdown. `script-src` / `style-src` / `img-src` / `font-src` / `connect-src` are subsumed by `default-src 'none'` and intentionally omitted. This addresses the issue's concern (3) — without an HTML route on users.*, the strict CSP cannot break anything.

`frame-ancestors 'none'` is the CSP-native successor to the existing `X-Frame-Options: DENY`; modern browsers prefer it. `base-uri 'none'` is defense-in-depth against `<base>` injection if any endpoint ever regresses to text/html.

### COOP — `Cross-Origin-Opener-Policy: same-origin`

Isolates the browsing context from any cross-origin `window.opener`. Defensive against Spectre-class side-channels and OAuth-flow popup-leakage patterns. The OAuth flow itself is not popup-based on this surface (it's a redirect chain), but the header is correct posture for any future cookie-bearing response.

### CORP — `Cross-Origin-Resource-Policy: same-site` (NOT `same-origin`)

This is the most consequential choice. The deployment topology is:

| Origin | Role |
|--------|------|
| `isnad.${BASE_DOMAIN}` | Frontend SPA |
| `users.${BASE_DOMAIN}` | API surface (this vhost) |

These are different origins but the **same site** (registrable suffix `noorinalabs.com`). The frontend on `isnad.*` performs cross-origin-but-same-site fetches against `users.*` for auth/user-service endpoints (especially after frontend abs-URLs migration in `#245`).

- `same-origin` would block all `isnad.* → users.*` reads. Too strict; would break the frontend.
- `same-site` permits these same-site cross-origin reads while still blocking truly cross-site embeds (e.g., `evil.com` trying to fetch a user-service resource).

`same-site` is the right level for this topology.

## Sequencing context

- This PR ships **before** `#245` (frontend absolute-URLs phase 2). `#245` will rebase onto post-merge wave-3 once this lands.
- Blast radius: server-side header config only. No client/frontend code change. No build artifact change.

## Validation

```
$ docker run --rm -v "$(pwd)/caddy:/etc/caddy:ro" -e BASE_DOMAIN=noorinalabs.com \
    caddy:2-alpine caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
{"level":"info","msg":"using config from file","file":"/etc/caddy/Caddyfile"}
{"level":"info","msg":"adapted config to JSON","adapter":"caddyfile"}
{"level":"warn","msg":"Caddyfile input is not formatted; ...","line":2}    # pre-existing on origin
Valid configuration
```

Local `caddy` CLI not installed; validated via `caddy:2-alpine` docker image. Baseline-compared the formatting warning — present on origin baseline pre-change, so unchanged by this PR.

## Acceptance checklist

- [x] users.* vhost has CSP + COOP + CORP at API-appropriate strictness
- [x] No regression in existing security headers on users.* (HSTS / X-Content-Type-Options / X-Frame-Options DENY / X-XSS-Protection 0 / Referrer-Policy / -Server all preserved verbatim)
- [x] No change to isnad.* vhost CSP (out of scope for this PR)
- [x] Caddyfile validates: `caddy validate` clean
- [x] PR base = `deployments/phase-3/wave-3`, labels `p3-wave-3 + tech-debt`
- [x] CORP=same-site choice documented inline (Caddyfile comment) + here

## Test plan

- [ ] Reviewer (Bereket) confirms header semantics on the API surface
- [ ] Reviewer confirms CORP=same-site rationale aligns with frontend abs-URLs migration in #245
- [ ] After merge: post-deploy verification on stg should observe the three new headers via `curl -I https://users.stg.noorinalabs.com/api/v1/users/health` (or any 401-returning auth endpoint — header attaches regardless of body status)
- [ ] After merge: smoke that `isnad.* → users.*` cross-origin fetches still succeed (covered by `#245` post-rebase test)

## Charter compliance

- Per-commit `-c` identity flags. `parametrization+Lucas.Ferreira@gmail.com`.
- Two `Co-Authored-By` trailers (Lucas + Claude Opus 4.7).
- Reviewer Bereket Tadesse — charter-format review (Requestor/Requestee/RequestOrReplied + `TechDebt: <none|#N>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
