### PR TITLE
docs(oauth): per-env OAuth provisioning runbook (#244)

### DIFF
--- a/docs/runbooks/oauth-per-env.md
+++ b/docs/runbooks/oauth-per-env.md
@@ -96,9 +96,16 @@ Env-scope secrets are read by the deploy workflow at SSH-step time and written t
 # but a manual run can be forced:
 gh workflow run deploy-stg.yml --repo noorinalabs/noorinalabs-deploy
 
-# prod requires manual approval through the production GH Environment
-gh workflow run promote.yml --repo noorinalabs/noorinalabs-deploy -f image_tag=stg-latest
+# prod requires manual approval through the production GH Environment.
+# Default invocation: promote.yml resolves stg-latest at plan-time and threads
+# the resolved sha-<short> through to retag — no input needed.
+gh workflow run promote.yml --repo noorinalabs/noorinalabs-deploy
+
+# Or pin to a specific immutable SHA (rollback / specific-build promotion):
+gh workflow run promote.yml --repo noorinalabs/noorinalabs-deploy -f source_sha=<short-sha>
 ```
+
+**Do not pass `-f source_sha=stg-latest` or any other floating-tag string.** The `promote-no-floating-source` static guard added by [deploy#260](https://github.com/noorinalabs/noorinalabs-deploy/pull/260) (cold-rebuild dryrun) catches floating-source values as a regression. `source_sha` must be an immutable `sha-<short>` (or bare `<short>`) — leaving it empty is the correct way to mean "whatever stg-latest currently points at."
 
 After the redeploy completes, smoke-test the OAuth flow end-to-end on the env's frontend:
 
@@ -195,14 +202,48 @@ Google occasionally requires re-verification when sensitive scopes change or the
 2. Confirming the privacy-policy and terms-of-service URLs in the consent screen still 200 (`curl -sSI <url>`).
 3. Re-submitting for verification. Until approved, prod logs in via the stg-class `Testing` interstitial — degraded UX but not broken.
 
+### 5. `invalid_scope` from Google or GitHub
+
+User-service requested a scope the OAuth app's allow-list does not cover — e.g., user-service code added `https://www.googleapis.com/auth/userinfo.email` but the app was provisioned with only `openid`. The provider returns `invalid_scope` with the offending scope name in `error_description` (Google) or in the redirect body (GitHub).
+
+**Recovery:** open the OAuth app's settings (Google: `OAuth consent screen → Scopes for Google APIs → Add or remove scopes`; GitHub: scopes are requested per-call, no console-side allow-list — symptom there means user-service is requesting a scope the provider doesn't recognize). Add the missing scope or correct the user-service request. Save. No redeploy needed for the provider-side change; user-service code change requires a redeploy.
+
+### 6. User session ends mid-flow / 401 with `invalid_grant`
+
+The provider revoked the refresh token. Triggers vary by provider:
+
+- **Google:** user changed their Google password, user revoked grant via [myaccount.google.com → Security → Third-party access](https://myaccount.google.com/permissions), admin policy revoked, or the OAuth app was deleted/recreated.
+- **GitHub:** user revoked via Settings → Applications → Authorized OAuth Apps, or the env's `CLIENT_SECRET` was rotated past the 7-day grace window (see §Rotating credentials).
+
+Symptom: user-service emits `401 invalid_grant` on the token-refresh exchange; the user is forced back to the login button.
+
+**Recovery is per-user:** the user re-completes the OAuth flow from the SPA. No on-call action for individual occurrences. **If a fleet-wide pattern emerges** (multiple users hit `invalid_grant` in a short window), check whether the env's `AUTH_GITHUB_CLIENT_SECRET` was rotated without honoring the 7-day grace window — a same-day double-rotate invalidates all in-flight tokens. Cross-reference §Rotating credentials.
+
+### 7. Prod OAuth broken right after the org→env-scope cleanup
+
+If the optional cleanup (§"Optional cleanup — move prod secrets org-scope → env-scope") was executed and prod login broke immediately after, the org-scope row was deleted before the `production` env-scope row was populated and verified. This is the order-of-operations hazard called out at §"Optional cleanup" — calling it out here too because §Failure modes is where on-call greps first.
+
+**Recovery:**
+
+1. Re-set the four `AUTH_*` secrets at `production` env-scope (`gh secret set ... --env production` per §"Optional cleanup" recipe). The owner is the only one who can do this — see §Escalation row "OAuth `AUTH_*` cleanup ordering issue."
+2. Redeploy prod via `promote.yml`.
+3. Verify the OAuth flow recovers end-to-end before declaring resolved.
+
 ## Escalation
 
-| Failure | Primary | Secondary |
-|---|---|---|
-| `redirect_uri_mismatch` | Aisha.Idrissi (SRE — owns this runbook) | Lucas.Ferreira (SRE) |
-| 500 from user-service after OAuth callback | Aisha.Idrissi | Anya.Kowalczyk (user-service) |
-| Google verification revoked / consent screen broken | parametrization (owner — only one with Google Cloud Console access for org) | Aisha.Idrissi |
-| Suspected leaked secret | Nino.Kavtaradze (Security) | Bereket.Tadesse (IM) |
+| Failure | Primary | Secondary | Tertiary |
+|---|---|---|---|
+| `redirect_uri_mismatch` | Aisha.Idrissi (SRE — owns this runbook) | Lucas.Ferreira (SRE) | — |
+| 500 from user-service after OAuth callback | Aisha.Idrissi | Anya.Kowalczyk (user-service) | — |
+| `invalid_scope` from provider | Aisha.Idrissi | Anya.Kowalczyk (user-service — owns scope-request code) | — |
+| Fleet-wide `invalid_grant` post-rotation | Aisha.Idrissi | Lucas.Ferreira | Nino.Kavtaradze (Security) |
+| Google verification revoked / consent screen broken | parametrization (owner — sole Google Cloud Console admin) | Aisha.Idrissi (acts as owner liaison; cannot self-resolve until owner reachable — see SPOF note below) | Lucas.Ferreira / Bereket.Tadesse (deploy-team-on-call if Aisha unavailable) |
+| OAuth `AUTH_*` cleanup ordering issue (org→env-scope) | parametrization (owner — only one who has the secret values) | Aisha.Idrissi (procedural support) | — |
+| Suspected leaked secret | Nino.Kavtaradze (deploy-team Senior Security Engineer — see `roster/security_engineer_nino.md`) | Bereket.Tadesse (IM) | — |
+
+**Roster disambiguation:** `Nino.Kavtaradze` is the deploy team's Senior Security Engineer (`noorinalabs-deploy/.claude/team/roster/security_engineer_nino.md`) — escalation-class for OAuth-incident scope. Reviewers from outside the deploy team may not recognize the name; the roster file is the source of truth.
+
+**SPOF note (Google verification revoked row):** until Google Cloud Console IAM is pre-staged with a `roles/oauthconfig.editor` binding for a deploy-team teammate (tracked outside this runbook's scope), an outage in this class is owner-blocked and may persist until owner is reachable. Aisha's secondary role is "owner liaison + procedural readiness," not "self-resolve." Tertiary escalation to Lucas/Bereket is for the case where Aisha is also unavailable; they can take over the liaison role but cannot bypass the owner-only console access either. Honest framing — this is the operational reality today.
 
 ## Refs
 

--- a/docs/runbooks/oauth-per-env.md
+++ b/docs/runbooks/oauth-per-env.md
@@ -1,0 +1,212 @@
+# Runbook — Per-env OAuth provisioning (Google + GitHub)
+
+**Scope:** how to provision and rotate OAuth provider apps (Google Cloud OAuth client + GitHub OAuth app) for each deployment environment, and how the four `AUTH_*` secrets resolve at deploy time.
+
+**NOT in scope:**
+- The user-service OAuth flow itself (handler code, callback parsing) — see `noorinalabs-user-service` repo.
+- JWT signing keys — see `user-service-alembic.md` and the `JWT_PRIVATE_KEY`/`JWT_PUBLIC_KEY` custodial paths in `~/.ssh/`.
+- Frontend redirect logic post-callback — see deploy#248 and the user-service auth router.
+
+## The convention
+
+**Each deployment environment gets its own Google OAuth client and its own GitHub OAuth app. They are never shared across environments.** The four secrets resolving the credentials live at GitHub Environments env-scope, not org-scope, so each env's deploy step reads only its own env's values.
+
+The four secret names are identical across envs (env-scope, not name-scope, encodes which env you're in):
+
+| Secret name | Provider | Role |
+|---|---|---|
+| `AUTH_GOOGLE_CLIENT_ID` | Google | OAuth client ID, public, surfaces in browser |
+| `AUTH_GOOGLE_CLIENT_SECRET` | Google | OAuth client secret, server-side only |
+| `AUTH_GITHUB_CLIENT_ID` | GitHub | OAuth app client ID, public |
+| `AUTH_GITHUB_CLIENT_SECRET` | GitHub | OAuth app client secret, server-side only |
+
+## Why per-env, not shared
+
+1. **Google publishing-status is per-app.** Prod must run `In Production` (consent screen reviewed, public). Stg should run `Testing` (no review needed, fast iteration, only allowlisted test users can log in). The same app cannot be in both modes.
+2. **Credential isolation.** A leaked stg credential (CI logs, dev laptop, transcript paste — see 2026-05-02 emergency restore session) does not affect prod login. Separate `CLIENT_ID`/`CLIENT_SECRET` per env makes this guarantee structural, not procedural.
+3. **Metrics & quota separation.** Prod login analytics are not polluted by stg test traffic. Rate-limit buckets are independent. Revoking a stg secret does not page prod-on-call.
+4. **Redirect URI hygiene.** Each app's allowed redirect URI list contains only its env's callback URL — no shared wildcard.
+
+## Redirect URI conventions
+
+User-service's OAuth callback path is `/auth/oauth/{provider}/callback` (`POST`, see `ontology/services.yaml` user-service entry). The full callback URL per env follows the `users.{base}` subdomain convention (deploy#241):
+
+| Env | Base | Google authorized redirect URI | GitHub authorization callback URL |
+|---|---|---|---|
+| Production | `noorinalabs.com` | `https://users.noorinalabs.com/auth/oauth/google/callback` | `https://users.noorinalabs.com/auth/oauth/github/callback` |
+| Staging | `stg.noorinalabs.com` | `https://users.stg.noorinalabs.com/auth/oauth/google/callback` | `https://users.stg.noorinalabs.com/auth/oauth/github/callback` |
+| Future env (e.g., `dev`, `canary`) | `<env>.noorinalabs.com` | `https://users.<env>.noorinalabs.com/auth/oauth/google/callback` | `https://users.<env>.noorinalabs.com/auth/oauth/github/callback` |
+
+**Only the env's own callback URL goes in that env's app.** Do not mix prod and stg URIs in one app — that re-creates the shared-app posture this runbook exists to prevent.
+
+## Provisioning a new env (4 steps)
+
+Follow when adding any new env (e.g., `dev` between stg and prod, or a `canary` post-prod). Each step is owner-only because OAuth provider consoles require interactive auth that is out-of-band of CI.
+
+### 1. Provision the Google OAuth client
+
+1. Go to [Google Cloud Console → APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials) for the `noorinalabs` project.
+2. Click `Create Credentials → OAuth client ID`. Application type: `Web application`. Name: `noorinalabs-<env>` (e.g., `noorinalabs-stg`).
+3. **Authorized JavaScript origins:** `https://users.<env-base>` (no trailing slash).
+4. **Authorized redirect URIs:** `https://users.<env-base>/auth/oauth/google/callback` (one entry only).
+5. Save. Copy the displayed `Client ID` and `Client Secret` — the secret is only shown once.
+
+**Publishing status:**
+
+- For **prod**: configure the OAuth consent screen with full branding (app name, logo, support email, terms-of-service URL, privacy-policy URL), submit for verification, switch to `In Production` once approved. Required scopes — only `openid`, `email`, `profile` — do not require sensitive-scope review, so verification is typically same-week.
+- For **stg / dev / canary**: leave the consent screen in `Testing` mode. Add allowlisted test-user emails (owner + any teammates needing OAuth access). No verification needed. Only allowlisted users can OAuth into a `Testing`-mode app.
+
+### 2. Provision the GitHub OAuth app
+
+1. Go to [GitHub → Settings → Developer settings → OAuth Apps](https://github.com/settings/developers) (under the `noorinalabs` org if you have org-app permissions, otherwise under your personal account is acceptable for stg-class envs).
+2. Click `New OAuth App`. Application name: `noorinalabs-<env>` (e.g., `noorinalabs-stg`).
+3. **Homepage URL:** `https://users.<env-base>`.
+4. **Authorization callback URL:** `https://users.<env-base>/auth/oauth/github/callback` (one entry — GitHub allows only one callback URL per app, which is part of why per-env apps are mandatory).
+5. Generate a client secret. Copy the `Client ID` and the freshly generated `Client Secret`.
+
+GitHub OAuth apps have no `Testing`/`Production` distinction — the only switch is `public` vs `private` (irrelevant for this app class). All envs use the same shape; only the callback URL differs.
+
+### 3. Set the four env-scope secrets
+
+The `<env-name>` below is the GitHub Environments name (`staging` or `production` today; lowercase env name for any future env added via `gh api repos/.../environments`):
+
+```bash
+gh secret set AUTH_GOOGLE_CLIENT_ID     --repo noorinalabs/noorinalabs-deploy --env <env-name>
+gh secret set AUTH_GOOGLE_CLIENT_SECRET --repo noorinalabs/noorinalabs-deploy --env <env-name>
+gh secret set AUTH_GITHUB_CLIENT_ID     --repo noorinalabs/noorinalabs-deploy --env <env-name>
+gh secret set AUTH_GITHUB_CLIENT_SECRET --repo noorinalabs/noorinalabs-deploy --env <env-name>
+```
+
+`gh secret set` will prompt for the value on stdin — paste the value from steps 1 and 2.
+
+Verify all four are set (names only — values are write-only):
+
+```bash
+gh secret list --repo noorinalabs/noorinalabs-deploy --env <env-name> | grep AUTH_
+```
+
+Expect 4 rows. If any are missing, the user-service container will boot with empty `AUTH_*_CLIENT_ID/SECRET` env vars and the OAuth flow will return a generic 500 from the provider on first attempted login.
+
+### 4. Redeploy the env
+
+Env-scope secrets are read by the deploy workflow at SSH-step time and written to `/opt/noorinalabs-deploy/.env` on the VPS. The user-service container reads them at container start. So a redeploy is required for the new credentials to take effect:
+
+```bash
+# stg auto-deploys on push to wave branch via repository_dispatch
+# but a manual run can be forced:
+gh workflow run deploy-stg.yml --repo noorinalabs/noorinalabs-deploy
+
+# prod requires manual approval through the production GH Environment
+gh workflow run promote.yml --repo noorinalabs/noorinalabs-deploy -f image_tag=stg-latest
+```
+
+After the redeploy completes, smoke-test the OAuth flow end-to-end on the env's frontend:
+
+```bash
+# Replace <env-base> with the env's base domain (e.g., stg.noorinalabs.com)
+curl -sSI "https://users.<env-base>/auth/oauth/google/login"   # expect 302 to accounts.google.com
+curl -sSI "https://users.<env-base>/auth/oauth/github/login"   # expect 302 to github.com/login/oauth/authorize
+```
+
+Then complete the flow in a real browser — `redirect_uri_mismatch` from the provider means step 1 or 2's allowed redirect URI is wrong; check it character-for-character against the table in §Redirect URI conventions.
+
+## Rotating credentials for an existing env
+
+Steps are the same as §3 above, except you re-issue the secret in the OAuth provider console first:
+
+- **Google:** Credentials → click the OAuth client → `Reset secret`. Old secret becomes invalid immediately. Copy the new value, re-run `gh secret set` for `AUTH_GOOGLE_CLIENT_SECRET` only, redeploy. The `Client ID` is unchanged.
+- **GitHub:** OAuth Apps → click the app → `Generate a new client secret`. The old secret continues to work for 7 days (GitHub's grace period) — useful for zero-downtime rotation. Copy the new value, re-run `gh secret set` for `AUTH_GITHUB_CLIENT_SECRET` only, redeploy.
+
+`CLIENT_ID` is public and only ever rotates if you delete and recreate the entire app — which is the same procedure as §Provisioning above.
+
+## Current state (2026-05-03)
+
+| Scope | `AUTH_*_CLIENT_ID/SECRET` set? | Notes |
+|---|---|---|
+| Org-scope (`noorinalabs` org, `vis=selected`) | yes — 4 secrets, set 2026-04-26 | Prod fallback. The 4 prod-app values live here today. |
+| `staging` env-scope | yes — 4 secrets, set 2026-05-02 | Separate stg OAuth app per env. Overrides org-scope at deploy. |
+| `production` env-scope | empty | Prod resolves from org-scope fallback. |
+
+Both envs run their own Google + GitHub OAuth apps end-to-end (provisioning verified by owner 2026-05-03 — see [deploy#244](https://github.com/noorinalabs/noorinalabs-deploy/issues/244#issuecomment-4366806318)). The remaining row is whether prod's secrets stay at org-scope (current) or move to env-scope.
+
+### Optional cleanup — move prod secrets org-scope → env-scope
+
+This is **owner-action** (GitHub secret values are write-only — Aisha cannot read existing org-scope values to copy them). Recommended to schedule as a 5-minute owner step:
+
+```bash
+# Owner re-pastes the four prod-app values (from Google Cloud Console + GitHub OAuth App console — same values that were
+# pasted at org-scope on 2026-04-26):
+gh secret set AUTH_GOOGLE_CLIENT_ID     --repo noorinalabs/noorinalabs-deploy --env production
+gh secret set AUTH_GOOGLE_CLIENT_SECRET --repo noorinalabs/noorinalabs-deploy --env production
+gh secret set AUTH_GITHUB_CLIENT_ID     --repo noorinalabs/noorinalabs-deploy --env production
+gh secret set AUTH_GITHUB_CLIENT_SECRET --repo noorinalabs/noorinalabs-deploy --env production
+
+# Verify production env-scope is now non-empty:
+gh secret list --repo noorinalabs/noorinalabs-deploy --env production | grep AUTH_   # expect 4 rows
+
+# Then delete the org-scope copies (the env-scope values now resolve directly, no fallback needed):
+gh secret delete AUTH_GOOGLE_CLIENT_ID     --org noorinalabs
+gh secret delete AUTH_GOOGLE_CLIENT_SECRET --org noorinalabs
+gh secret delete AUTH_GITHUB_CLIENT_ID     --org noorinalabs
+gh secret delete AUTH_GITHUB_CLIENT_SECRET --org noorinalabs
+
+# Verify org-scope is empty:
+gh secret list --org noorinalabs | grep AUTH_   # expect zero rows
+```
+
+Redeploy prod (`promote.yml` with manual approval) to confirm env-scope resolution works end-to-end before deleting org-scope. Order matters — if org-scope is deleted before env-scope is verified, the prod OAuth flow breaks until env-scope is populated.
+
+**Why bother:** symmetry with stg (both envs resolve from env-scope, not a mix of env+org), and an empty org-scope row that future `AUTH_*` audits don't have to reason about. The current org-scope-fallback posture is correct and working — this cleanup is hygiene, not a bug fix.
+
+## Failure modes and recovery
+
+### 1. `redirect_uri_mismatch` from Google or GitHub
+
+Provider console's allowed redirect URI list does not contain the URL the user-service sent. Cause: env's OAuth app was provisioned with a wrong/stale URI, or someone rotated the env's base domain without updating the app.
+
+**Recovery:**
+
+1. Inspect the failing request — Google returns the offending URI in the redirect URL's `error_description`. GitHub returns it in the body.
+2. Open the OAuth provider's app settings (Google Cloud Console → Credentials, or GitHub → OAuth Apps).
+3. Add the correct URI per §Redirect URI conventions. Save. The change is effective within ~30 seconds for both providers.
+4. Retry the OAuth flow — no redeploy needed, this is a provider-side change.
+
+### 2. Login returns 500 from user-service immediately
+
+Most common cause: env's `AUTH_*` secrets are empty. The user-service starts but emits a generic 500 when the provider redirects back because `CLIENT_SECRET` is the empty string and the token-exchange POST returns `invalid_client`.
+
+**Recovery:**
+
+1. `gh secret list --repo noorinalabs/noorinalabs-deploy --env <env-name> | grep AUTH_` — expect 4 rows. If org-scope fallback is in play (production today): also check `gh secret list --org noorinalabs | grep AUTH_` returns 4 rows.
+2. If any are missing, redo §3 for the missing names.
+3. Redeploy the env. The container reads the env vars at start, not per-request.
+
+### 3. Stg test users can log in but get "App is not verified"
+
+Google's `Testing` mode posts a generic warning interstitial before redirecting back. This is expected for stg/dev/canary and is the price of skipping verification. If a teammate complains, add their email to the test-user allowlist in Google Cloud Console (`OAuth consent screen → Test users → Add users`).
+
+If the warning is reaching prod users: the prod app is not in `In Production` status. Re-check Google Cloud Console — verification may have been revoked, or the consent screen was edited after publication (which kicks the app back to `Testing`).
+
+### 4. Prod app suddenly demands re-verification
+
+Google occasionally requires re-verification when sensitive scopes change or the policy URL becomes unreachable. Recover by:
+
+1. Checking Google Cloud Console for the OAuth client's status.
+2. Confirming the privacy-policy and terms-of-service URLs in the consent screen still 200 (`curl -sSI <url>`).
+3. Re-submitting for verification. Until approved, prod logs in via the stg-class `Testing` interstitial — degraded UX but not broken.
+
+## Escalation
+
+| Failure | Primary | Secondary |
+|---|---|---|
+| `redirect_uri_mismatch` | Aisha.Idrissi (SRE — owns this runbook) | Lucas.Ferreira (SRE) |
+| 500 from user-service after OAuth callback | Aisha.Idrissi | Anya.Kowalczyk (user-service) |
+| Google verification revoked / consent screen broken | parametrization (owner — only one with Google Cloud Console access for org) | Aisha.Idrissi |
+| Suspected leaked secret | Nino.Kavtaradze (Security) | Bereket.Tadesse (IM) |
+
+## Refs
+
+- Issue: [deploy#244](https://github.com/noorinalabs/noorinalabs-deploy/issues/244) (this runbook closes the docs sub-task).
+- Surfacing PR: [deploy#241](https://github.com/noorinalabs/noorinalabs-deploy/pull/241) — `users.{base}` vhost carve-out, where the redirect URI convention was first established.
+- Charter codification: tracked in `noorinalabs-main` (see PR body for follow-up issue link).
+- Adjacent secret patterns: `user-service-alembic.md` § Environment protection (env-scope `USER_POSTGRES_*`, `JWT_*`).


### PR DESCRIPTION
## Summary

Lands the docs portion of the reduced-scope #244. OAuth provisioning was completed during 2026-05-02 emergency (separate Google + GitHub OAuth apps for stg, env-scope secrets at `staging` env, prod still resolves from org-scope fallback). Remaining work was docs + cleanup decision; this PR ships the docs and frames the cleanup as a 5-minute owner-action followup.

Reduced-scope kickoff audit: deploy#244 issuecomment-4366806318.

## What's in this PR

- New runbook `docs/runbooks/oauth-per-env.md` (212 lines) covering:
  - Per-env-not-shared rationale (Google publishing-status, credential isolation, metrics separation, redirect-URI hygiene).
  - Redirect URI conventions table — `https://users.{env-base}/auth/oauth/{provider}/callback` per env.
  - 4-step provisioning recipe: Google OAuth client → GitHub OAuth app → 4 env-scope secrets → redeploy + smoke-test.
  - Rotation procedure (Google immediate-invalidation vs GitHub 7-day grace).
  - Current state table (org-scope, staging env-scope, production env-scope) as of 2026-05-03.
  - Optional org-scope → env-scope cleanup as documented owner-action step.
  - Failure modes (`redirect_uri_mismatch`, 500 from user-service, stg "App is not verified", verification revoked).
  - Escalation table.

## Cleanup decision (org-scope → production env-scope)

**Decided: documented as owner-action followup, not executed.** Rationale recorded in PR body for review:

GitHub Actions secret values are **write-only** — `gh secret list` returns names + dates only, never values. Moving the four prod `AUTH_*` secrets from org-scope to `production` env-scope therefore requires re-pasting the values from the source-of-truth (Google Cloud Console + GitHub OAuth Apps console), which is owner-action territory. Aisha cannot read the existing org-scope values to copy them; the operation is intrinsically owner-only.

Two postures considered:

1. **Cleanup (recommended in runbook):** owner re-pastes the 4 values into `production` env-scope, verifies prod redeploy works on env-scope alone, then deletes org-scope copies. Final state: empty org-scope row, both envs uniform on env-scope.
2. **Status-quo (current):** prod resolves from org-scope fallback. Working today (verified by owner 2026-05-03 — separate per-env OAuth apps are in use, only the secret-resolution-source asymmetry remains).

The runbook recommends posture (1) for symmetry with stg and an empty org-scope row that future audits don't have to reason about, but documents the exact 5-minute owner procedure rather than blocking this PR on it. The current org-scope-fallback posture is correct and not a bug.

## Charter promotion (path b — separate issue)

Per spawn instructions, picked path (b): filed [`noorinalabs-main#240`](https://github.com/noorinalabs/noorinalabs-main/issues/240) for Aino to codify the per-env OAuth convention into `noorinalabs-main/.claude/team/charter/tech-decisions.md` (or wherever Aino judges the right home). Keeps this PR clean (deploy-repo only, no parent-repo identity-switching).

## Acceptance

- [x] Optional cleanup decision made + rationale documented (status-quo + owner-action followup, see runbook §"Optional cleanup").
- [x] Cleanup framed as owner action — `production` env-scope unchanged in this PR; runbook spells out the 5-minute procedure.
- [x] Runbook entry exists at `docs/runbooks/oauth-per-env.md` covering 4-step provisioning + redirect URI conventions.
- [x] Charter-promotion follow-up filed as `noorinalabs-main#240`.
- [x] PR base = `deployments/phase-3/wave-3`, labels `p3-wave-3 + infra-docs`.

## Verification done

- Confirmed via `gh secret list` that org-scope (4 rows, set 2026-04-26), `staging` env-scope (4 rows, set 2026-05-02), and `production` env-scope (empty) match the kickoff audit table.
- Read-walked the runbook against `noorinalabs-deploy/docs/runbooks/user-service-alembic.md` shape — same § order (scope, why, current state, action recipe, failure modes, escalation, refs).

## Refs

- Issue: deploy#244
- Reduced-scope audit comment: deploy#244 issuecomment-4366806318
- Surfacing PR (`users.{base}` vhost): deploy#241
- Charter follow-up: noorinalabs-main#240
- Adjacent runbook (env-scope-secrets precedent): `docs/runbooks/user-service-alembic.md`

TechDebt: none
