### PR TITLE
ci(deploy): add hooks-lint CI workflow gating .claude/hooks/** additions

### DIFF
--- a/.github/workflows/hooks-lint.yml
+++ b/.github/workflows/hooks-lint.yml
@@ -1,0 +1,114 @@
+name: CI — Hooks & Skills Lint
+
+on:
+  push:
+    branches: [main, "deployments/**"]
+    paths:
+      - ".claude/hooks/**"
+      - ".claude/skills/**"
+      - ".github/workflows/hooks-lint.yml"
+      - "pyproject.toml"
+  pull_request:
+    branches: [main, "deployments/**"]
+    paths:
+      - ".claude/hooks/**"
+      - ".claude/skills/**"
+      - ".github/workflows/hooks-lint.yml"
+      - "pyproject.toml"
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Ruff lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ruff
+      - name: Ruff check (skip when no hooks present)
+        shell: bash
+        run: |
+          shopt -s nullglob
+          files=(.claude/hooks/*.py)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No hooks present (dispatcher-style child) — skipping ruff check."
+            exit 0
+          fi
+          ruff check .claude/hooks/
+
+  format:
+    name: Ruff format check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ruff
+      - name: Ruff format --check (skip when no hooks present)
+        shell: bash
+        run: |
+          shopt -s nullglob
+          files=(.claude/hooks/*.py)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No hooks present (dispatcher-style child) — skipping ruff format."
+            exit 0
+          fi
+          ruff format --check .claude/hooks/
+
+  typecheck:
+    name: Mypy type check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install mypy
+      - name: Mypy (skip when no hooks present)
+        shell: bash
+        run: |
+          shopt -s nullglob
+          files=(.claude/hooks/*.py)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No hooks present (dispatcher-style child) — skipping mypy."
+            exit 0
+          fi
+          mypy .claude/hooks/ --ignore-missing-imports --no-error-summary
+
+  smoke-test:
+    name: Smoke test — hooks compile and exit cleanly
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Verify all hooks compile
+        shell: bash
+        run: |
+          shopt -s nullglob
+          files=(.claude/hooks/*.py)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No hooks present (dispatcher-style child) — skipping compile check."
+            exit 0
+          fi
+          for f in "${files[@]}"; do
+            python3 -c "import py_compile; py_compile.compile('$f', doraise=True)"
+          done
+      - name: Verify hooks exit 0 on empty stdin
+        shell: bash
+        run: |
+          shopt -s nullglob
+          files=(.claude/hooks/*.py)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No hooks present (dispatcher-style child) — skipping stdin smoke."
+            exit 0
+          fi
+          for f in "${files[@]}"; do
+            echo '{}' | python3 "$f" || true
+          done


### PR DESCRIPTION
## Reviewers

- R1: Weronika (platform_architect — hooks/charter alignment)
- R2: Nurul (observability — CI gate behavior)

## Summary

Add `.github/workflows/hooks-lint.yml` to gate future additions under
`.claude/hooks/**` and `.claude/skills/**`. Mirrors the parent
`noorinalabs-main/.github/workflows/ci.yml` shape (ruff check, ruff format
--check, mypy, smoke compile + stdin-empty exit-0) with one
dispatcher-aware adaptation.

Closes noorinalabs/noorinalabs-deploy#277
Refs noorinalabs/noorinalabs-main#300 (W7 audit meta), noorinalabs/noorinalabs-main#311 (charter dispatcher sub-clause)

## Why dispatcher-aware

Per Bereket's pre-spawn verification at HEAD, deploy is dispatcher-style at
origin: `gh api repos/noorinalabs/noorinalabs-deploy/contents/.claude/hooks?ref=main`
returns 404. W5 PR #271 (merged 2026-05-05) deleted all stale `.py` files.
Charter `hooks.md § 5. Parser-Fixture Coverage Requirements` (Aino's open
#311 sub-clause) names deploy as the dispatcher-style exemplar — coverage
fulfilled by parent's tests, no per-child fixture requirement.

The workflow must therefore not false-positive on the current empty-hooks
state while still gating the moment any hook .py is committed. Each job
nullglob-checks `.claude/hooks/*.py` and exits 0 cleanly when no hooks are
present:

- `ruff check` exits 0 with a "no Python files" warning on empty dir, but
- `ruff format --check` does the same, while
- `mypy` exits 2 ("can't read file" on missing dir, "no .py files" on
  empty dir).

So all four jobs use the same `shopt -s nullglob; files=(.claude/hooks/*.py)`
guard rather than relying on tool-by-tool empty-dir behavior.

## Local verification

- `actionlint -color .github/workflows/hooks-lint.yml` — clean (shellcheck
  installed locally per memory `feedback_actionlint_needs_shellcheck.md` so
  embedded `bash` blocks are checked end-to-end).
- 3-case smoke matrix simulated locally:
  - `MISSING .claude/hooks/`: all 4 jobs skip → exit 0
  - `EMPTY .claude/hooks/`: all 4 jobs skip → exit 0
  - `POPULATED .claude/hooks/` (one Python file): jobs run normally,
    catching unused-import / format / type errors as designed.

## Acceptance scope

Per memory `feedback_runtime_gate_scoping.md` and
`feedback_pr_vs_runtime_acceptance_criteria.md`: this PR delivers
unit-mechanic correctness — the workflow YAML lints clean, the smoke
matrix exits 0 on dispatcher-style state, the gate triggers on path
changes. **Operational gates are post-merge Test Plan items, not PR
acceptance.**

## Test plan (post-merge)

- [ ] First push to `main` after merge: workflow appears in Actions tab,
      runs once on the empty hooks state, all 4 jobs exit 0.
- [ ] Subsequent PR that touches `.claude/hooks/**` (when deploy stops
      being dispatcher-style): workflow runs ruff/mypy/smoke against
      committed hook files, fails-closed on lint/format/type/compile
      regressions.
- [ ] Subsequent PR that touches `.claude/skills/**` only: workflow runs
      with empty `.claude/hooks/` → all jobs skip → exit 0 (path-trigger
      coverage without false-positive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
