### PR TITLE
ci(deploy #280): bump checkout/github-script/upload-artifact to Node 20 versions

### DIFF
--- a/.github/workflows/cold-rebuild-dryrun.yml
+++ b/.github/workflows/cold-rebuild-dryrun.yml
@@ -105,7 +105,7 @@ jobs:
     name: Static workflow-shape guards (bugs #1, #2, #3, #5)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Sibling-repo refs are wave-aware — same pattern as integration-tests.yml
       # (#159, P2W10). The driver/pyproject parity check needs to read the
@@ -135,7 +135,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Checkout user-service (for pyproject parity)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: noorinalabs/noorinalabs-user-service
           ref: ${{ steps.sibling-refs.outputs.user_service_ref }}
@@ -160,7 +160,7 @@ jobs:
         ports:
           - 5000:5000
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up QEMU (for multi-arch fixture)
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/compose-validate.yml
+++ b/.github/workflows/compose-validate.yml
@@ -22,7 +22,7 @@ jobs:
     name: docker compose config
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Materialize .env from .env.example with CI placeholders
         working-directory: compose
         run: |
@@ -51,7 +51,7 @@ jobs:
     name: shellcheck infra & scripts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install shellcheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
       - name: Lint shell scripts

--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -69,7 +69,7 @@ jobs:
       # here means "the migration DAG moved under us" and is a hard stop.
       EXPECTED_MERGE_HEAD: "0040"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Resolve image tag
         id: tag

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Full stack deploy
         uses: appleboy/ssh-action@v1

--- a/.github/workflows/deploy-isnad-graph.yml
+++ b/.github/workflows/deploy-isnad-graph.yml
@@ -32,7 +32,7 @@ jobs:
       packages: read
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Determine image tag
         id: tag

--- a/.github/workflows/deploy-landing-page.yml
+++ b/.github/workflows/deploy-landing-page.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Deploy landing page to VPS
         uses: appleboy/ssh-action@v1

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -122,7 +122,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout (for local composite action)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Break-glass audit (allow_stg_tags)
         uses: ./.github/actions/break-glass-audit
         with:
@@ -141,7 +141,7 @@ jobs:
       packages: read
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Resolve + validate per-service tags
         id: tags

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -80,7 +80,7 @@ jobs:
       packages: read
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Resolve image tag
         id: tag

--- a/.github/workflows/image-tag-invariants.yml
+++ b/.github/workflows/image-tag-invariants.yml
@@ -58,7 +58,7 @@ jobs:
           - noorinalabs/noorinalabs-user-service
           - noorinalabs/noorinalabs-landing-page
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check publish + promote tag invariants
         env:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout noorinalabs-deploy
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: noorinalabs-deploy
 
@@ -56,14 +56,14 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Checkout noorinalabs-user-service
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: noorinalabs/noorinalabs-user-service
           path: noorinalabs-user-service
           ref: ${{ steps.sibling-refs.outputs.user_service_ref }}
 
       - name: Checkout noorinalabs-isnad-graph
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: noorinalabs/noorinalabs-isnad-graph
           path: noorinalabs-isnad-graph
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload test report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: integration-junit
           path: noorinalabs-deploy/integration-tests/reports/

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -16,7 +16,7 @@ jobs:
     name: actionlint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install shellcheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
       - name: Download and verify actionlint

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -347,7 +347,7 @@ jobs:
     steps:
       - name: Checkout (for local composite action)
         if: ${{ inputs.skip_stg_verify }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Break-glass audit (skip_stg_verify)
         if: ${{ inputs.skip_stg_verify }}
         uses: ./.github/actions/break-glass-audit
@@ -596,7 +596,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout (for local composite action)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Break-glass audit (skip_alembic_gate)
         uses: ./.github/actions/break-glass-audit
         with:

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Rollback services
         uses: appleboy/ssh-action@v1

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -15,7 +15,7 @@ jobs:
     name: Format check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "~> 1.6"
@@ -41,7 +41,7 @@ jobs:
       run:
         working-directory: ${{ matrix.path }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "~> 1.6"
@@ -68,7 +68,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.TF_STATE_B2_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_B2_APP_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "~> 1.6"
@@ -79,7 +79,7 @@ jobs:
         run: terraform plan -no-color -out=tfplan
         continue-on-error: true
       - name: Comment PR with plan
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const envName = '${{ matrix.env }}';
@@ -116,7 +116,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.TF_STATE_B2_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_B2_APP_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "~> 1.6"
@@ -127,7 +127,7 @@ jobs:
         run: terraform plan -no-color -out=tfplan
         continue-on-error: true
       - name: Comment PR with plan
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const output = `#### Terraform Plan (cloudflare)
@@ -160,7 +160,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.TF_STATE_B2_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_B2_APP_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "~> 1.6"
@@ -171,7 +171,7 @@ jobs:
         run: terraform plan -no-color -out=tfplan
         continue-on-error: true
       - name: Comment PR with plan
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const output = `#### Terraform Plan (backblaze)
@@ -211,7 +211,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.TF_STATE_B2_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_B2_APP_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "~> 1.6"
@@ -243,7 +243,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.TF_STATE_B2_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_B2_APP_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "~> 1.6"
@@ -267,7 +267,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.TF_STATE_B2_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_B2_APP_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "~> 1.6"

--- a/.github/workflows/verify-deploy.yml
+++ b/.github/workflows/verify-deploy.yml
@@ -108,7 +108,7 @@ jobs:
       # verification is ever revived, restore that sequence from
       # `git show 6e8f450:.github/workflows/verify-deploy.yml`.
       - name: Checkout noorinalabs-deploy
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: noorinalabs-deploy
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
@@ -127,7 +127,7 @@ jobs:
 
       - name: Upload junit report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: verify-stg-junit
           path: noorinalabs-deploy/integration-tests/reports/
@@ -171,7 +171,7 @@ jobs:
 
       - name: Upload verify-stg-result artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: stg-verify-result
           path: stg-verify-result-${{ github.run_id }}.json
@@ -254,7 +254,7 @@ jobs:
       # ref pin matters: workflow_run defaults checkout to the default
       # branch (main), which would silently run a wave-branch deploy's
       # verify against main's revision. Same fix as verify-stg above.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
@@ -281,7 +281,7 @@ jobs:
 
       - name: Upload smoke output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: verify-prod-smoke-output
           path: |


### PR DESCRIPTION
## Summary

Mechanical version bumps to remove Node 16 deprecation warnings from CI. Closes noorinalabs/noorinalabs-deploy#280; rolls up under noorinalabs/noorinalabs-main#309 (org-wide Node 20 actions audit).

| Action family | Old → New | Sites |
|---|---|---|
| `actions/checkout` | `@v4` → `@v6` | 30 |
| `actions/github-script` | `@v7` → `@v8` | 3 (terraform.yml only) |
| `actions/upload-artifact` | `@v4` → `@v7` | 4 (integration-tests.yml, verify-deploy.yml) |
| **Total** | | **37 sites across 15 workflows** |

## Surface (origin-verified at HEAD)

Re-verified against the wave-8 base SHA `d42f08d` before editing — Bereket's pre-spawn enumeration listed 14/2/4; the actual surface at HEAD was 30/3/4. Counts above reflect what was changed.

Per-file site count (post-bump):

| File | Sites |
|---|---|
| terraform.yml | 11 (8 checkout + 3 github-script) |
| verify-deploy.yml | 5 (2 checkout + 3 upload-artifact) |
| integration-tests.yml | 4 (3 checkout + 1 upload-artifact) |
| cold-rebuild-dryrun.yml | 3 |
| compose-validate.yml | 2 |
| deploy-prod.yml | 2 |
| promote.yml | 2 |
| db-migrate.yml, deploy-all.yml, deploy-isnad-graph.yml, deploy-landing-page.yml, deploy-stg.yml, image-tag-invariants.yml, lint-workflows.yml, rollback.yml | 1 each |

## upload-artifact v4 → v7 safety verification

`upload-artifact@v5+` enforces per-job artifact name uniqueness AND removed `--name` overwrite semantics. All 4 producer sites have unique artifact names within their job context. **Zero `download-artifact` invocations exist** anywhere in deploy workflows (`grep -nE "uses:\s*actions/download-artifact" .github/workflows/*.yml` → 0 matches).

| Producer | Name | Job context | Cross-job collision? | Consumer pattern |
|---|---|---|---|---|
| `integration-tests.yml:81` | `integration-junit` | single job | No | terminal artifact (no consumer) |
| `verify-deploy.yml:130` | `verify-stg-junit` | single job | No | terminal artifact (no consumer) |
| `verify-deploy.yml:174` | `stg-verify-result` | single job | No | `promote.yml:421` consumes via `gh api .../actions/runs/${run_id}/artifacts` REST — NOT `download-artifact` |
| `verify-deploy.yml:284` | `verify-prod-smoke-output` | single job | No | terminal artifact (no consumer) |

`download-artifact` invocation count across all 15 deploy workflows: **0** (verified via grep).

## Out of scope (explicitly NOT touched)

Per parent #309 scope, the following actions remain at their current versions:

- `appleboy/ssh-action@v1`
- `docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0`
- `docker/setup-qemu-action@v3`
- `hashicorp/setup-terraform@v3`

These are tracked separately and are not part of the Node 20 deprecation surface.

## Acceptance

- [x] All 3 action families bumped at all 37 enumerated sites
- [x] `actionlint .github/workflows/*.yml` clean on the wave branch (run locally with shellcheck 0.10.0 on PATH)
- [x] No remaining `@v4` checkout, `@v7` github-script, or `@v4` upload-artifact references
- [x] PR body cross-links parent #309, deploy #280
- [x] PR body includes upload-artifact safety table + out-of-scope list

Runtime acceptance (production deploy/rollback exercising these workflows live) is NOT PR acceptance per `feedback_runtime_gate_scoping.md` and `feedback_pr_vs_runtime_acceptance_criteria.md`. Unit-mechanic correctness (actionlint-clean, no Node 16 warning) is delivered here; operational gates are post-merge events.

## Reviewers

- R1: Lucas Ferreira (CI workflow familiarity from #277)
- R2: Weronika (infra-shape)

Closes noorinalabs/noorinalabs-deploy#280.
Cross-links: noorinalabs/noorinalabs-main#309.
