### PR TITLE
fix(bootstrap): SSH key merge is append-with-fingerprint-dedup, not destructive cp (#112)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -166,7 +166,7 @@ First-time setup is performed by `scripts/bootstrap-vps.sh`, which runs as root 
 
 1. Installs Docker, docker-compose-v2, docker-buildx, git, curl
 2. Creates a `deploy` user with Docker group access
-3. Copies SSH authorized keys from root to deploy user
+3. Merges SSH authorized keys from root into the deploy user (append-with-fingerprint-dedup — idempotent across re-runs, never wipes a key already present in `/home/deploy/.ssh/authorized_keys`; see deploy#112)
 4. Clones this repo to `/opt/noorinalabs-deploy`
 5. Creates a template `.env` file with placeholder values
 6. Installs rclone for backups

--- a/scripts/bootstrap-vps.sh
+++ b/scripts/bootstrap-vps.sh
@@ -57,21 +57,68 @@ else
 fi
 usermod -aG docker "$DEPLOY_USER"
 
-# ── Step 3: Copy SSH authorized_keys to deploy user ─────────────────────────
+# ── Step 3: Merge SSH authorized_keys into deploy user (append-with-dedup) ──
+# Per deploy#112: this used to be a destructive `cp` of root's authorized_keys
+# over the deploy user's file. That wiped the deploy CI key any time an
+# operator added a personal admin key to /root/.ssh/authorized_keys and then
+# re-ran bootstrap (as PR #109 instructs for new aux-repos). The next
+# workflow_dispatch then failed with `ssh: handshake failed`.
+#
+# Fix: append each root key to deploy's file only if its fingerprint isn't
+# already present. Idempotent across any number of re-runs; preserves the
+# deploy CI key and any keys an operator has already added to deploy directly.
+# Owner's manual unblock recipe (`cat key.pub | ssh prod 'tee -a ...'`) is
+# the same shape — append, not overwrite.
 echo "==> [3/7] Setting up SSH for deploy user..."
-mkdir -p /home/$DEPLOY_USER/.ssh
-touch /home/$DEPLOY_USER/.ssh/authorized_keys
-# Copy root's authorized_keys (Terraform puts the deploy key here)
+DEPLOY_AUTH_KEYS="/home/$DEPLOY_USER/.ssh/authorized_keys"
+mkdir -p "/home/$DEPLOY_USER/.ssh"
+touch "$DEPLOY_AUTH_KEYS"
+chown -R "$DEPLOY_USER:$DEPLOY_USER" "/home/$DEPLOY_USER/.ssh"
+chmod 700 "/home/$DEPLOY_USER/.ssh"
+chmod 600 "$DEPLOY_AUTH_KEYS"
+
+# Fingerprint a single authorized_keys line. Echoes the SHA256 fingerprint
+# or empty on failure. Wrapped in `|| true` so a malformed line in an
+# operator-edited file doesn't trip the script's `set -e`.
+ssh_key_fp() {
+  echo "$1" | ssh-keygen -lf - 2>/dev/null | awk '{print $2}' || true
+}
+
 if [ -f /root/.ssh/authorized_keys ]; then
-  cp /root/.ssh/authorized_keys /home/$DEPLOY_USER/.ssh/authorized_keys
-  echo "    Copied root authorized_keys to deploy user."
+  # Build the set of fingerprints already authorized for deploy. We fingerprint
+  # each line individually rather than passing the whole file to `ssh-keygen -lf`
+  # because that bails on the first malformed line.
+  declare -A DEPLOY_FPS=()
+  while IFS= read -r existing_line; do
+    case "$existing_line" in ''|\#*) continue ;; esac
+    fp=$(ssh_key_fp "$existing_line")
+    [ -n "$fp" ] && DEPLOY_FPS["$fp"]=1
+  done < "$DEPLOY_AUTH_KEYS"
+
+  added=0
+  skipped=0
+  while IFS= read -r root_line; do
+    case "$root_line" in ''|\#*) continue ;; esac
+    fp=$(ssh_key_fp "$root_line")
+    # Malformed line in root's file — skip rather than copy garbage into
+    # deploy's authorized_keys.
+    [ -z "$fp" ] && continue
+    if [ -n "${DEPLOY_FPS[$fp]:-}" ]; then
+      skipped=$((skipped + 1))
+    else
+      echo "$root_line" >> "$DEPLOY_AUTH_KEYS"
+      DEPLOY_FPS["$fp"]=1
+      added=$((added + 1))
+    fi
+  done < /root/.ssh/authorized_keys
+
+  chown "$DEPLOY_USER:$DEPLOY_USER" "$DEPLOY_AUTH_KEYS"
+  chmod 600 "$DEPLOY_AUTH_KEYS"
+  echo "    Merged root authorized_keys → deploy: $added added, $skipped already present."
 else
   echo "    WARNING: /root/.ssh/authorized_keys not found."
-  echo "    You'll need to manually add your public key to /home/$DEPLOY_USER/.ssh/authorized_keys"
+  echo "    You'll need to manually add your public key to $DEPLOY_AUTH_KEYS"
 fi
-chown -R $DEPLOY_USER:$DEPLOY_USER /home/$DEPLOY_USER/.ssh
-chmod 700 /home/$DEPLOY_USER/.ssh
-chmod 600 /home/$DEPLOY_USER/.ssh/authorized_keys
 
 # ── Step 4: Clone the repository ────────────────────────────────────────────
 echo "==> [4/7] Cloning repository to $INSTALL_DIR..."


### PR DESCRIPTION
## Summary

`scripts/bootstrap-vps.sh:53` (the line cited in #112) was a destructive `cp /root/.ssh/authorized_keys /home/$DEPLOY_USER/.ssh/authorized_keys`. Every time an operator added a personal admin key to `/root/.ssh/authorized_keys` (normal sysadmin behavior) and then re-ran bootstrap (which PR #109 explicitly instructs for new aux-repos), the deploy CI public key got wiped from deploy's authorized_keys and the next `workflow_dispatch` failed with `ssh: handshake failed`.

This swaps the `cp` for an append-with-fingerprint-dedup merge. Idempotent across any number of re-runs; preserves the deploy CI key and any keys an operator added to deploy directly. The same shape as the owner's manual unblock recipe (`cat key.pub | ssh prod 'tee -a /home/deploy/.ssh/authorized_keys'`).

Picked option (a) from #112's 3-option ladder — lowest-friction unblock. Option (c) (cloud-init injection) is the longer-term shape and lives in #165 (separate PR), not here.

## Mechanism

- Builds the set of fingerprints already authorized for deploy by piping each line through `ssh-keygen -lf -`.
- For each line in `/root/.ssh/authorized_keys`, fingerprints it and appends only if that fingerprint isn't already present.
- Tolerates malformed lines, blank lines, and comments without aborting (`set -euo pipefail` safe).
- The `ssh_key_fp` helper wraps the pipeline in `|| true` so a malformed line doesn't trip `set -e`.

## Acceptance from #112

- ✅ Bootstrap re-run with arbitrary changes to `/root/.ssh/authorized_keys` (add admin keys, remove CI key, full reordering) MUST NOT break the deploy CI's SSH access to the deploy user.
- ✅ The deploy CI public key remains in `/home/deploy/.ssh/authorized_keys` after every bootstrap re-run.
- ✅ Documentation updated — `docs/architecture.md` step-3 description now reflects the append-with-dedup behavior.

## Local trace

`/tmp/test_ssh_merge.sh` exercises the merge logic across 8 scenarios:

| # | Scenario | Result |
|---|---|---|
| 1 | Fresh bootstrap — root has CI key, deploy is empty | PASS |
| 2 | Re-run after owner adds personal admin key to root (the #112 bug) | PASS |
| 3 | Re-run with no changes (pure idempotency) | PASS |
| 4 | deploy has SRE key added directly (not via root) — preserve | PASS |
| 5 | Same key material, different comment — fingerprint dedup | PASS |
| 6 | Malformed line in root's file — skipped, not propagated | PASS |
| 7 | Mixed key types (ed25519 + rsa) — both fingerprint correctly | PASS |
| 8 | Full #112 lifecycle: t=0 fresh → t=1 admin added → t=2 re-run → t=3 second admin → 5x more re-runs | PASS |

20/20 assertions pass. Shellcheck clean.

## Test plan (post-merge runtime — out of PR-time scope per `[[feedback_runtime_gate_scoping]]`)

- [ ] On a fresh Hetzner staging VM: `terraform apply` + `curl -sL .../bootstrap-vps.sh | bash`. Confirm `/home/deploy/.ssh/authorized_keys` contains the deploy CI key.
- [ ] Re-run bootstrap on the same VM with no changes; confirm key count is unchanged and "0 added, N already present" line shows up.
- [ ] Add a personal admin key to `/root/.ssh/authorized_keys` on the VM, re-run bootstrap, confirm deploy CI key is still present AND new admin key was appended.
- [ ] Trigger a `workflow_dispatch` deploy that SSHs to the VM as the deploy user; confirm handshake succeeds.

## Reviewers

- **Weronika Zielinska** (platform architect) — TF/bootstrap interface
- **Aisha Idrissi** (SRE) — actually ran bootstrap-vps.sh on real VPSes in P2W10 cutover; best positioned to spot operational gotchas

Per charter, both must `Approved` (literal verdict — `Reply` doesn't count for Hook 4 gate per `[[feedback_validate_pr_review_approved_not_reply]]`).

## Cross-references

- #112 — this issue (3-option ladder; chose option a)
- #165 — PR-B sibling (cloud-init SSH key injection — the long-term option c)
- #109 — the PR whose owner-instruction-to-re-run-bootstrap surfaced this
- #110 / #111 — sibling apt/debconf bug from the same bootstrap re-run

Closes #112
