### PR TITLE
fix(alembic): compose init container + CI dry-run gate + break-glass scope (closes #141, #237, #238)

### DIFF
--- a/.github/workflows/db-migrate-ci-gate.yml
+++ b/.github/workflows/db-migrate-ci-gate.yml
@@ -1,0 +1,227 @@
+name: DB Migrate — CI Gate (alembic dry-run)
+
+# CI-side dry-run gate for the alembic pre-deploy mechanic (#237).
+#
+# Closes the loop opened by #234 / #235 / PR #236 — those defects (psycopg
+# URL with no psycopg in the image) shipped because db-migrate.yml is a
+# pure SSH-into-VPS workflow. The SSH path cannot run in CI by definition,
+# so the URL-scheme breakage was only caught when prod tried to invoke it
+# during the 2026-05-02 emergency restore.
+#
+# This workflow replicates the gate's mechanic hermetically in CI:
+#
+#   1. Spin up `postgres:16-alpine` as a GitHub Actions service container,
+#      using the same image the prod compose stack uses for user-postgres.
+#   2. Pull `ghcr.io/noorinalabs/noorinalabs-user-service:<env>-latest`
+#      (or a PR-supplied tag) — the same image the SSH gate runs alembic
+#      from.
+#   3. Run `alembic upgrade head` against the runner-local postgres,
+#      using the same `postgresql+asyncpg://...` URL shape compose +
+#      db-migrate.yml use.
+#   4. After the happy-path run succeeds, run a self-test fixture: invoke
+#      the same image with a deliberately-broken `postgresql+psycopg://`
+#      URL (the exact scheme that caused #235) and assert the gate exits
+#      non-zero. Per feedback_live_trace_over_synthetic_acceptance — this
+#      proves the gate would have caught the real 2026-05-02 incident, not
+#      just that it runs.
+#
+# Runtime budget: ~60-90s steady-state (postgres pull + service-container
+# healthcheck + image pull + happy-path migration + broken-URL fixture).
+# Per the #237 acceptance criterion in the issue.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/db-migrate.yml'
+      - '.github/workflows/db-migrate-ci-gate.yml'
+      - 'compose/docker-compose.prod.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/db-migrate.yml'
+      - '.github/workflows/db-migrate-ci-gate.yml'
+      - 'compose/docker-compose.prod.yml'
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "user-service image tag (default: stg-latest)"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: db-migrate-ci-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  alembic-dryrun:
+    name: alembic upgrade head — CI dry-run
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    # Runner-local postgres as a service container. Same image as prod's
+    # user-postgres (postgres:16-alpine per compose/docker-compose.prod.yml).
+    # The default `postgres` user/db/password works for CI — nothing
+    # production-shaped touches this container.
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: testuser
+          POSTGRES_PASSWORD: testpass
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+        # GitHub Actions service-container healthcheck — runner waits for
+        # this to pass before starting the steps. Mirrors the user-postgres
+        # healthcheck in compose/docker-compose.prod.yml.
+        options: >-
+          --health-cmd "pg_isready -U testuser -d testdb"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      IMAGE_TAG: ${{ inputs.image_tag || 'stg-latest' }}
+      # asyncpg driver — matches alembic/env.py + db-migrate.yml + compose.
+      # On the runner, postgres is reachable via localhost:5432 because of
+      # the `ports:` mapping above. We run alembic in a one-shot container
+      # with `--network host` so it shares the runner's network namespace
+      # and can hit the published port.
+      DATABASE_URL: "postgresql+asyncpg://testuser:testpass@localhost:5432/testdb"
+      BROKEN_DATABASE_URL: "postgresql+psycopg://testuser:testpass@localhost:5432/testdb"
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Log in to GHCR (pull user-service image)
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull user-service image
+        run: |
+          set -euo pipefail
+          IMAGE="ghcr.io/noorinalabs/noorinalabs-user-service:${IMAGE_TAG}"
+          echo "==> Pulling ${IMAGE}"
+          docker pull "${IMAGE}"
+          echo "IMAGE=${IMAGE}" >> "$GITHUB_ENV"
+
+      - name: Verify image ships asyncpg (negative-import check)
+        # Belt-and-suspenders: if a future user-service image were to ship
+        # WITHOUT asyncpg (regression to #235's root cause), this catches
+        # it before the alembic run produces a confusing traceback.
+        run: |
+          set -euo pipefail
+          docker run --rm "${IMAGE}" \
+            /app/.venv/bin/python -c "import asyncpg; print('asyncpg', asyncpg.__version__)"
+
+      - name: Happy path — alembic upgrade head succeeds on fresh DB
+        run: |
+          set -euo pipefail
+          echo "==> Running alembic upgrade head against runner-local postgres"
+          docker run --rm \
+            --network host \
+            -e DATABASE_URL="${DATABASE_URL}" \
+            "${IMAGE}" \
+            /app/.venv/bin/alembic upgrade head
+          echo "==> Happy-path migration succeeded"
+
+      - name: Verify schema landed (sanity check)
+        run: |
+          set -euo pipefail
+          # alembic_version row must exist and match the workflow's EXPECTED_MERGE_HEAD.
+          # Read EXPECTED_MERGE_HEAD from db-migrate.yml so this stays in sync
+          # without a second source of truth.
+          EXPECTED_HEAD="$(grep -E '^[[:space:]]*EXPECTED_MERGE_HEAD:' .github/workflows/db-migrate.yml \
+                          | head -n1 | sed -E 's/.*"([^"]+)".*/\1/')"
+          if [ -z "${EXPECTED_HEAD}" ]; then
+            echo "ERROR: could not parse EXPECTED_MERGE_HEAD from db-migrate.yml" >&2
+            exit 1
+          fi
+          echo "==> Expected head from db-migrate.yml: ${EXPECTED_HEAD}"
+
+          # psql via the postgres image itself (no host psql install needed).
+          ACTUAL="$(docker run --rm --network host \
+            -e PGPASSWORD=testpass \
+            postgres:16-alpine \
+            psql -h localhost -U testuser -d testdb -tA \
+            -c "SELECT version_num FROM alembic_version;")"
+          echo "==> alembic_version.version_num = ${ACTUAL}"
+          if [ "${ACTUAL}" != "${EXPECTED_HEAD}" ]; then
+            echo "ERROR: alembic_version mismatch — got '${ACTUAL}', expected '${EXPECTED_HEAD}'." >&2
+            exit 1
+          fi
+
+      - name: Reset DB for broken-URL fixture
+        run: |
+          set -euo pipefail
+          # Drop everything so the broken-URL run starts from a fresh schema —
+          # otherwise asyncpg would happily connect to the migrated DB and
+          # fail to demonstrate the URL-scheme failure mode.
+          docker run --rm --network host \
+            -e PGPASSWORD=testpass \
+            postgres:16-alpine \
+            psql -h localhost -U testuser -d testdb \
+            -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
+
+      - name: Fixture — deliberately-broken psycopg URL must fail loudly
+        # Live-trace evidence (feedback_live_trace_over_synthetic_acceptance):
+        # this step reproduces the exact 2026-05-02 incident URL shape and
+        # asserts the gate would have caught it. If a future image change
+        # accidentally bundles psycopg, this step will PASS the broken URL
+        # and FAIL this assertion — that's the desired behavior; psycopg
+        # shouldn't reappear in the image without a deliberate decision.
+        run: |
+          set -euo pipefail
+          echo "==> Running alembic with deliberately-broken DATABASE_URL: ${BROKEN_DATABASE_URL}"
+          set +e
+          OUTPUT="$(
+            docker run --rm \
+              --network host \
+              -e DATABASE_URL="${BROKEN_DATABASE_URL}" \
+              "${IMAGE}" \
+              /app/.venv/bin/alembic upgrade head 2>&1
+          )"
+          RC=$?
+          set -e
+
+          echo "$OUTPUT"
+          echo "==> alembic exit code: ${RC}"
+
+          if [ "${RC}" -eq 0 ]; then
+            echo "ERROR: alembic succeeded with psycopg URL — image now ships psycopg?" >&2
+            echo "       If this was a deliberate change, update this fixture step." >&2
+            exit 1
+          fi
+
+          # The expected failure shape is ModuleNotFoundError on psycopg
+          # (the 2026-05-02 traceback). Assert that exact signal — a generic
+          # non-zero would not prove we caught the right failure mode.
+          if ! echo "$OUTPUT" | grep -qE "No module named 'psycopg'|ModuleNotFoundError.*psycopg"; then
+            echo "ERROR: alembic failed but not with the expected psycopg ModuleNotFoundError." >&2
+            echo "       The fixture proves a different failure mode than #235 — investigate." >&2
+            exit 1
+          fi
+
+          echo "==> Fixture passed: gate correctly rejects the psycopg URL shape that caused #235."
+
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo "## DB Migrate CI Gate — alembic dry-run"
+            echo ""
+            echo "- **Image:** \`${IMAGE:-(not pulled)}\`"
+            echo "- **Postgres:** \`postgres:16-alpine\` (service container)"
+            echo "- **DATABASE_URL (happy path):** \`${DATABASE_URL}\`"
+            echo "- **DATABASE_URL (fixture):** \`${BROKEN_DATABASE_URL}\` — expected to fail loudly"
+            echo ""
+            echo "This workflow is the CI-side complement to \`db-migrate.yml\` (the SSH-into-VPS pre-deploy gate). It does not replace the SSH gate; it proves the mechanic works hermetically before changes to \`db-migrate.yml\` or the compose user-service block ship."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -309,6 +309,56 @@ services:
 
   # --- User Service ---
 
+  # One-shot alembic migration runner (#141). Mirrors the kafka-init pattern:
+  # runs to completion, exits 0 on success, stays in "exited" state for the
+  # rest of the compose lifecycle. The user-service `depends_on` block waits
+  # for `service_completed_successfully` so the API never starts against an
+  # unmigrated database.
+  #
+  # Why this exists alongside the SSH-driven alembic gate (db-migrate.yml):
+  #   - db-migrate.yml is the CI/promotion-time gate. It SSHes into the
+  #     prod VPS, pulls the candidate image, and runs `alembic upgrade head`
+  #     against the LIVE user-postgres before promote.yml retags the image.
+  #     That covers the rolling-deploy path.
+  #   - This init container covers the `compose up` path on a fresh
+  #     `user_pg_data` volume (DR-restore, first stack-up, blue-green VPS
+  #     swap with an empty postgres). The SSH gate cannot run by definition
+  #     when the stack does not yet exist (chicken-and-egg per
+  #     docs/runbooks/break-glass.md § skip_alembic_gate).
+  #
+  # Failure mode + recovery: if alembic fails, this container exits non-zero,
+  # `user-service` stays in `Created` (never `Running`), and `compose up`
+  # itself returns non-zero. Operator sees the failure immediately rather
+  # than a healthy-looking API serving against unmigrated tables. Logs are
+  # captured by the json-file driver below; `docker compose logs
+  # user-service-migrate` retrieves them.
+  user-service-migrate:
+    image: ghcr.io/noorinalabs/noorinalabs-user-service:${USER_SERVICE_IMAGE_TAG:-latest}
+    # asyncpg driver — alembic/env.py is async (create_async_engine +
+    # asyncio.run). Same scheme as the runtime user-service DATABASE_URL
+    # and the SSH alembic gate in db-migrate.yml (post-#236).
+    environment:
+      - DATABASE_URL=postgresql+asyncpg://${USER_POSTGRES_USER:?USER_POSTGRES_USER must be set}:${USER_POSTGRES_PASSWORD:?USER_POSTGRES_PASSWORD must be set}@user-postgres:5432/${USER_POSTGRES_DB:?USER_POSTGRES_DB must be set}
+    # `alembic upgrade head` matches the SSH gate's invocation. The
+    # heads-count belt-and-suspenders check from db-migrate.yml is not
+    # repeated here — that check guards CI-time migrations-DAG correctness
+    # and would be redundant noise at every `compose up`.
+    command: /app/.venv/bin/alembic upgrade head
+    depends_on:
+      user-postgres:
+        condition: service_healthy
+    networks:
+      - user-backend
+    # Container is one-shot; restart on failure would re-run forever if the
+    # migration is fundamentally broken. `no` is the correct choice — the
+    # non-zero exit cascades to user-service's depends_on block.
+    restart: "no"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
   user-service:
     image: ghcr.io/noorinalabs/noorinalabs-user-service:${USER_SERVICE_IMAGE_TAG:-latest}
     expose:
@@ -339,6 +389,13 @@ services:
         condition: service_healthy
       user-redis:
         condition: service_healthy
+      user-service-migrate:
+        # Migrations MUST complete cleanly before user-service starts. A
+        # non-zero migrate exit cascades up: user-service stays in
+        # `Created`, `compose up` returns non-zero, operator sees the
+        # failure immediately (vs a healthy-looking API on unmigrated
+        # tables). See user-service-migrate block above for design notes.
+        condition: service_completed_successfully
     deploy:
       resources:
         limits:

--- a/docs/runbooks/break-glass.md
+++ b/docs/runbooks/break-glass.md
@@ -193,6 +193,59 @@ Until #262 is resolved, on-call should grep the audit-log issue + check
 the Alertmanager UI directly:
 `https://noorinalabs.com/alertmanager/` (behind admin auth).
 
+## Scope review — 2026-05-17 (deploy#238)
+
+Post-#236 (psycopg → asyncpg URL fix) + #237 (CI dry-run gate) +
+deploy#141 (compose init-container migration runner) — three layers now
+catch the failure modes that originally drove break-glass use:
+
+| Failure mode that drove a break-glass use | Where it's now caught |
+|---|---|
+| psycopg URL scheme drift (#235, 2026-05-02) | `db-migrate-ci-gate.yml` (#237) — gate fails in CI before merge |
+| Fresh `user_pg_data` volume → unmigrated DB (#141) | `user-service-migrate` init container in `compose/docker-compose.prod.yml` — runs at `compose up` time |
+| `stg-latest` TOCTOU during retag (#234) | PR #236 — retag pins to `sha-<short>` always |
+
+### `skip_alembic_gate` — KEEP, narrow guidance
+
+The chicken-and-egg first-deploy / DR-restore justification is structural
+and does NOT go away with #237: the SSH gate still cannot run when the
+target stack doesn't yet exist. Keep the input.
+
+Narrowed guidance for **NOT appropriate** (now stricter):
+
+- The migration itself is failing. (Same as before — #237 catches this in
+  CI; if you're seeing it at promote-time, fix the migration upstream.)
+- The image-vs-URL scheme mismatch from #235. (#237's fixture asserts
+  this can't recur silently. If you see it at promote-time, the gate
+  itself is misconfigured — that's an emergency in its own right and
+  should be filed as a P0 issue, not bypassed.)
+
+### `allow_stg_tags` — KEEP for now, revisit P3W12+
+
+The 2026-05-02 driver (cross-repo GHCR write-403 blocking retag) was
+infrastructure-shaped, not workflow-shaped. With #251's audit-log issue
+and Alertmanager `BreakGlassUsed` rule live, misuse is observable. But
+the underlying GHCR cross-repo permission story has not changed; another
+GHCR outage could legitimately need this input.
+
+Pending the deploy#262 Alertmanager receiver wiring landing AND one
+clean promotion cycle showing the new infrastructure is stable, keep
+this input. If P3W12+ shows no new emergency-restore needs, file a
+removal PR.
+
+### Decision summary
+
+Both break-glass inputs stay. Scope is reaffirmed as DR/emergency only.
+The audit-log issue + Alertmanager rule + textfile metrics from
+deploy#251 provide the discipline; removal is premature.
+
+Removal trigger conditions (whichever fires first):
+
+- One full quarter (P3W12 → P3W15+) with zero invocations of either
+  input → file removal PRs for both.
+- A new emergency-restore happens that the input did NOT cover →
+  rescope rather than remove.
+
 ## What can NOT be tested in CI
 
 - The full-flow break-glass invocation requires a real prod VPS, real


### PR DESCRIPTION
## Summary

Three-part alembic resilience cluster following the 2026-05-02 emergency-restore incident. Closes deploy#141 (compose-fresh-volume), deploy#237 (CI dry-run gate), and deploy#238 (break-glass scope review).

## Closes

- Closes #141 — feat(deploy): run user-service alembic migrations as part of compose up (init container)
- Closes #237 — tech-debt: add CI gate that exercises alembic upgrade head against test postgres
- Closes #238 — tech-debt: revisit skip_alembic_gate + allow_stg_tags break-glass scope post-#236

## Changes

### `compose/docker-compose.prod.yml` — `user-service-migrate` init container (#141)

| Field | Value |
|---|---|
| image | same as user-service (`ghcr.io/noorinalabs/noorinalabs-user-service:${USER_SERVICE_IMAGE_TAG:-latest}`) |
| command | `/app/.venv/bin/alembic upgrade head` |
| DATABASE_URL | `postgresql+asyncpg://...` (same shape as runtime + db-migrate.yml) |
| network | `user-backend` |
| depends_on | `user-postgres` (condition: `service_healthy`) |
| restart | `"no"` (one-shot — failed migrations must not loop) |

`user-service.depends_on` gains a new key: `user-service-migrate` with condition `service_completed_successfully`. Cascade behavior: if alembic exits non-zero, `user-service-migrate` exits non-zero, `user-service` stays in `Created`, `compose up` returns non-zero. Operator sees the failure immediately.

Pattern mirrors the existing `kafka-init` block (one-shot, exits 0 on success, idempotent).

**Coverage**: this closes the `compose up` path on a fresh `user_pg_data` volume (DR-restore, first stack-up, blue-green VPS swap with empty postgres). The SSH-driven `db-migrate.yml` gate cannot run there by definition — it requires a live user-postgres + user-service stack to SSH into. Per `docs/runbooks/break-glass.md § skip_alembic_gate`, that chicken-and-egg state was the original justification for the break-glass input; this init container removes the need for the break-glass on every fresh stack-up.

### `.github/workflows/db-migrate-ci-gate.yml` — new (#237)

CI-side dry-run of the alembic mechanic. Triggers on PRs touching `db-migrate.yml`, `db-migrate-ci-gate.yml`, or `compose/docker-compose.prod.yml`.

Five-step gate:

1. Spin up `postgres:16-alpine` as a GitHub Actions service container (same image as prod `user-postgres`).
2. GHCR-pull `ghcr.io/noorinalabs/noorinalabs-user-service:stg-latest`.
3. Negative-import check: `python -c "import asyncpg"` against the image — regression guard if a future image accidentally drops asyncpg.
4. Happy path: `alembic upgrade head` against runner-local postgres with `postgresql+asyncpg://...` URL.
5. Sanity check: `SELECT version_num FROM alembic_version` matches the `EXPECTED_MERGE_HEAD` parsed from `db-migrate.yml` (single source of truth).
6. **Live-trace fixture**: schema-reset, then run the same image with `postgresql+psycopg://...` URL. Assert exit non-zero AND that the output contains `No module named 'psycopg'` / `ModuleNotFoundError.*psycopg` — the exact traceback from the 2026-05-02 incident.

The fixture is the live-trace evidence per `feedback_live_trace_over_synthetic_acceptance` — it proves the gate would have caught #235 before it shipped, not just that it runs hermetically.

Runtime budget: ~60-90s (postgres pull + service-container healthcheck + image pull + happy-path + fixture). Within the issue's <90s acceptance criterion.

### `docs/runbooks/break-glass.md` — scope review section (#238)

Added a 2026-05-17 scope review section. Decision: both `skip_alembic_gate` and `allow_stg_tags` stay.

- `skip_alembic_gate`: structural chicken-and-egg justification (first-deploy / DR) does not go away with #237. Narrowed "NOT appropriate" guidance to reference #237 catching the URL-scheme failure mode.
- `allow_stg_tags`: underlying GHCR cross-repo permission story unchanged. With deploy#251 audit + Alertmanager rule + textfile metrics live, misuse is observable. Pending deploy#262 Alertmanager receiver wiring AND one clean promotion cycle, keep the input.

Documented removal trigger conditions (whichever fires first):
- One full quarter (P3W12 → P3W15+) with zero invocations of either input → file removal PRs for both
- A new emergency-restore happens that the input did NOT cover → rescope rather than remove

## Verification

- [x] **actionlint** clean across `.github/workflows/*.yml` (run locally with `shellcheck` on PATH per `feedback_actionlint_needs_shellcheck`)
- [x] **compose YAML structural validation** via Python `yaml.safe_load` + assertion that `user-service.depends_on.user-service-migrate.condition == 'service_completed_successfully'`
- [x] **Live-trace evidence** (per `feedback_live_trace_over_synthetic_acceptance`): the #237 fixture step IS the live trace. First CI run of this PR will show the fixture passing in the run log — that step's output is the proof.
- [ ] **Runtime gate** (per `feedback_runtime_gate_scoping`, post-merge): exercise `compose up` on a fresh `user_pg_data` volume on the stg VPS, observe `user-service-migrate` runs and exits 0, then user-service comes up healthy. Cannot run in PR-time CI because it requires real VPS + cloud-init'd compose stack. Tracked as post-merge runbook smoke.
- [x] `docker compose config --quiet` validation runs in CI via the existing `compose-validate.yml` workflow on this PR (could not run locally — WSL docker daemon unreachable; this is acceptable per `feedback_runtime_gate_scoping`).

## Tech Debt

I attest that I introduced no tech debt with this work.

Init container failure-mode notes for runbook readers:
- If `alembic upgrade head` fails, `user-service-migrate` exits non-zero, user-service stays in `Created` (never `Running`), and `compose up` returns non-zero. Operator sees the failure immediately rather than a healthy-looking API on unmigrated tables.
- `restart: "no"` is deliberate. A broken migration must not re-attempt in a tight loop.
- The init container shares the user-service image — no separate Dockerfile, no extra ghcr-publish step.

## Reviewers

- @Lucas (primary — original db-migrate.yml author #153, caught the psycopg URL drift on PR #236; cross-eye for asyncpg URL shape + service-container pattern)
- @Nurul (secondary — observability/prom-textfile-collector domain eye; no new metric emit in this PR but the #237 gate is a new signal source worth knowing about)

## Refs

- Cluster context: PR #236 closed #234 (TOCTOU on stg-latest source) + #235 (psycopg URL)
- Audit infrastructure: deploy#251 (PR — break-glass-audit composite action, Alertmanager rule, audit-log issue)
- Sibling observability: deploy#161 (alembic-gate textfile-collector pattern — template for any future metric emit from #237)
- Original incident: 2026-05-02 emergency-restore, promote.yml runs `25242208146`, `25242280413`, `25242502012`, `25243033399`, `25243063822`
