### PR TITLE
ci(workflows): centralize .env-write composite + drift gate + shellcheck fixes (#190 #66 #97 #284)

### DIFF
--- a/.github/actions/write-deploy-env/action.yml
+++ b/.github/actions/write-deploy-env/action.yml
@@ -1,0 +1,233 @@
+# Write .env on the deploy VPS and roll the compose stack.
+#
+# Centralizes the previously-duplicated SSH-into-VPS step from
+# `deploy-stg.yml` and `deploy-prod.yml`. Both workflows now invoke this
+# composite as their single deploy step. The duplicated `eval` env-write
+# loop (deploy#66) is replaced here with indirect expansion that never
+# interprets secret content as shell.
+#
+# Adding a new `.env` var requires editing ONE place — the caller's
+# `env:` block + the comma-separated `env_keys` input. The composite
+# reads each name from its own environment (passed through by
+# appleboy/ssh-action's `envs:`) via `${!var}`, so secret content with
+# quotes, backticks, dollar signs, or backslashes round-trips literally.
+#
+# Stg/prod behavioral asymmetries preserved as composite inputs:
+#   - `extra_image_tags` — newline-separated `NAME=value` pairs prod
+#     uses for USER_SERVICE_IMAGE_TAG + LANDING_IMAGE_TAG. Stg passes
+#     an empty string.
+#   - `base_domain` — `stg.noorinalabs.com` vs `noorinalabs.com`.
+#
+# The shape mirrors `.github/actions/break-glass-audit/action.yml`
+# (the precedent composite added in PR #261). Both live under
+# `.github/actions/` and run as `using: composite`.
+
+name: Write deploy .env + roll compose stack
+description: SSH to the deploy VPS, write .env from passed-through env vars, pull images, recreate compose stack.
+
+inputs:
+  ssh_host:
+    description: "Target VPS host. Pass vars.VPS_HOST."
+    required: true
+  ssh_key:
+    description: "Deploy SSH private key. Pass secrets.DEPLOY_SSH_PRIVATE_KEY."
+    required: true
+  image_tag:
+    description: "Tag for the api + frontend images (IMAGE_TAG in compose)."
+    required: true
+  extra_image_tags:
+    description: >-
+      Newline-separated NAME=value pairs of additional image-tag env vars
+      to write to .env after IMAGE_TAG. Empty string means none.
+      Prod passes USER_SERVICE_IMAGE_TAG + LANDING_IMAGE_TAG here.
+    required: false
+    default: ""
+  base_domain:
+    description: "Caddy {$BASE_DOMAIN} root, e.g. stg.noorinalabs.com or noorinalabs.com."
+    required: true
+  env_keys:
+    description: >-
+      Comma-separated list of env-var names to copy into .env. Each name
+      MUST be present in the caller's `env:` block and listed in the
+      appleboy/ssh-action `envs:` passlist. Reading happens via
+      `${!name}` (indirect expansion) — no eval, so values with shell
+      metacharacters round-trip safely.
+    required: true
+  github_token:
+    description: "GHCR auth token. Pass secrets.GITHUB_TOKEN."
+    required: true
+  github_actor:
+    description: "GHCR auth username. Pass github.repository_owner."
+    required: true
+  pull_services:
+    description: "Whitespace-separated compose service names to pull."
+    required: false
+    default: "api frontend landing user-service"
+  extra_env:
+    description: >-
+      Newline-separated NAME=value pairs of additional non-secret env
+      vars to write to .env. Used for per-env constants the caller knows
+      at workflow-write time (e.g. PROM_CONFIG_FILE=prometheus.stg.yml,
+      ALERTMANAGER_CONFIG_FILE=alertmanager.stg.yml, SLACK_WEBHOOK_FILE).
+      Distinct from `extra_image_tags` (preserved separately for back-
+      compat) and from `env_keys` (which is for caller-passed secrets
+      pulled by name from the caller's `env:` block). Empty string means
+      none.
+    required: false
+    default: ""
+  slack_webhook_url:
+    description: >-
+      Optional Slack webhook URL for alertmanager routing (deploy#262).
+      When non-empty, written to `infra/alertmanager/slack_webhook_url.secret`
+      with mode 0600 so alertmanager's `api_url_file` directive resolves
+      to a real value. When empty, the file is written with the placeholder
+      "<unset>" and a WARNING is logged — alertmanager still loads cleanly
+      but Slack delivery is a no-op until the operator sets the secret in
+      the env's GitHub Environment. The secret name in the caller's `env:`
+      block is `SLACK_WEBHOOK_URL` by convention so the value can also be
+      consumed by env_keys if compose needs to read it directly.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Deploy to VPS
+      uses: appleboy/ssh-action@v1
+      env:
+        # Inputs the remote script reads. Secret-bearing env vars from
+        # the caller's `env:` block are also passed through by
+        # appleboy/ssh-action via its `envs:` parameter — listed by the
+        # caller, not by this composite.
+        IMAGE_TAG: ${{ inputs.image_tag }}
+        EXTRA_IMAGE_TAGS: ${{ inputs.extra_image_tags }}
+        EXTRA_ENV: ${{ inputs.extra_env }}
+        BASE_DOMAIN: ${{ inputs.base_domain }}
+        ENV_KEYS: ${{ inputs.env_keys }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        GITHUB_ACTOR: ${{ inputs.github_actor }}
+        PULL_SERVICES: ${{ inputs.pull_services }}
+        SLACK_WEBHOOK_URL: ${{ inputs.slack_webhook_url }}
+      with:
+        host: ${{ inputs.ssh_host }}
+        username: deploy
+        key: ${{ inputs.ssh_key }}
+        # Composite-defined extras + the caller's secret passlist. The
+        # caller composes its own `envs:` with both sets — this composite
+        # cannot prepend to the caller's appleboy `envs:` parameter, so
+        # the caller is responsible for including everything its
+        # env_keys references. The composite's own pass-throughs below
+        # are appended via the composite action's `env:` block above.
+        envs: IMAGE_TAG,EXTRA_IMAGE_TAGS,EXTRA_ENV,BASE_DOMAIN,ENV_KEYS,GITHUB_TOKEN,GITHUB_ACTOR,PULL_SERVICES,SLACK_WEBHOOK_URL,${{ inputs.env_keys }}
+        script: |
+          set -euo pipefail
+          cd /opt/noorinalabs-deploy
+
+          echo "==> Pulling latest deploy config..."
+          git fetch origin main
+          git reset --hard origin/main
+
+          echo "==> Writing .env for docker-compose (IMAGE_TAG=$IMAGE_TAG)..."
+          env_file=".env"
+          : > "$env_file"
+
+          # Walk the caller-supplied env_keys CSV. Indirect expansion
+          # (`${!var}`) reads the named env var's value as data, never
+          # interpreting it as shell. Replaces the legacy `eval "val=\$$var"`
+          # pattern (deploy#66) which broke on secrets containing quotes,
+          # backticks, dollar signs, or backslashes.
+          IFS=',' read -r -a _keys <<< "$ENV_KEYS"
+          for var in "${_keys[@]}"; do
+            # Strip surrounding whitespace from caller-supplied CSV entries.
+            var="${var#"${var%%[![:space:]]*}"}"
+            var="${var%"${var##*[![:space:]]}"}"
+            [ -z "$var" ] && continue
+            # Quote literal single quotes inside the value so the resulting
+            # .env line `NAME='...'` round-trips through docker compose's
+            # dotenv parser. printf %s avoids any format-string interpretation
+            # of the value.
+            val="${!var-}"
+            escaped="${val//\'/\'\\\'\'}"
+            printf "%s='%s'\n" "$var" "$escaped" >> "$env_file"
+          done
+
+          # IMAGE_TAG is always written.
+          escaped_image_tag="${IMAGE_TAG//\'/\'\\\'\'}"
+          printf "%s='%s'\n" "IMAGE_TAG" "$escaped_image_tag" >> "$env_file"
+
+          # Caller-supplied extra image-tag pairs (e.g. USER_SERVICE_IMAGE_TAG,
+          # LANDING_IMAGE_TAG for prod). Format: NAME=value per line.
+          if [ -n "$EXTRA_IMAGE_TAGS" ]; then
+            while IFS= read -r line; do
+              [ -z "$line" ] && continue
+              name="${line%%=*}"
+              value="${line#*=}"
+              escaped_value="${value//\'/\'\\\'\'}"
+              printf "%s='%s'\n" "$name" "$escaped_value" >> "$env_file"
+            done <<< "$EXTRA_IMAGE_TAGS"
+          fi
+
+          # Caller-supplied generic per-env constants (deploy#262 + #263 wired
+          # via observability per-env split). Format: NAME=value per line.
+          # Same NAME=value shape as EXTRA_IMAGE_TAGS but semantically distinct —
+          # these are non-secret, non-tag values like PROM_CONFIG_FILE,
+          # ALERTMANAGER_CONFIG_FILE, SLACK_WEBHOOK_FILE.
+          if [ -n "$EXTRA_ENV" ]; then
+            while IFS= read -r line; do
+              [ -z "$line" ] && continue
+              name="${line%%=*}"
+              value="${line#*=}"
+              escaped_value="${value//\'/\'\\\'\'}"
+              printf "%s='%s'\n" "$name" "$escaped_value" >> "$env_file"
+            done <<< "$EXTRA_ENV"
+          fi
+
+          # Caddy per-env hostname root (deploy#218).
+          escaped_base_domain="${BASE_DOMAIN//\'/\'\\\'\'}"
+          printf "%s='%s'\n" "BASE_DOMAIN" "$escaped_base_domain" >> "$env_file"
+
+          # Backup B2 creds (deploy#188): rename BACKUP_B2_* secrets to the
+          # bare B2_* names that scripts/backup.sh:59-61 expects. The
+          # BACKUP_B2_* secrets are passed by the caller via env_keys.
+          # Empty values are written as empty so backup.sh fails fast at
+          # preflight rather than partially-running with stale or wrong creds.
+          for src in BACKUP_B2_KEY_ID:B2_KEY_ID BACKUP_B2_APP_KEY:B2_APP_KEY BACKUP_B2_BUCKET:B2_BUCKET; do
+            from="${src%%:*}"
+            to="${src##*:}"
+            value="${!from-}"
+            escaped_value="${value//\'/\'\\\'\'}"
+            printf "%s='%s'\n" "$to" "$escaped_value" >> "$env_file"
+          done
+
+          chmod 600 "$env_file"
+
+          # Slack webhook secret file (deploy#262). Alertmanager reads this
+          # at startup via api_url_file directive (path mounted into the
+          # container as /etc/alertmanager/slack_webhook_url). The "<unset>"
+          # placeholder is harmless — alertmanager loads cleanly but routing
+          # fails until the operator sets SLACK_WEBHOOK_URL in the matching
+          # GitHub Environment. The composite always writes the file so the
+          # mounted path exists regardless; absence would crash alertmanager.
+          slack_file="infra/alertmanager/slack_webhook_url.secret"
+          if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+            printf "%s" "$SLACK_WEBHOOK_URL" > "$slack_file"
+            echo "==> Slack webhook secret written (real value)."
+          else
+            printf "%s" "<unset>" > "$slack_file"
+            echo "==> WARNING: SLACK_WEBHOOK_URL secret not set — alertmanager will not deliver to Slack."
+          fi
+          chmod 600 "$slack_file"
+
+          echo "==> Authenticating to GHCR..."
+          trap 'docker logout ghcr.io >/dev/null 2>&1 || true' EXIT
+          echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+
+          echo "==> Pulling images from GHCR..."
+          # shellcheck disable=SC2086 # PULL_SERVICES is deliberately word-split
+          docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env pull $PULL_SERVICES
+
+          echo "==> Starting services..."
+          docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env up -d --force-recreate --remove-orphans
+
+          echo "==> Waiting for services to stabilize..."
+          sleep 15

--- a/.github/workflows/compose-validate.yml
+++ b/.github/workflows/compose-validate.yml
@@ -72,6 +72,84 @@ jobs:
           printf '%s\n' "${files[@]}"
           shellcheck "${files[@]}"
 
+  passlist-drift:
+    # deploy#97: catch drift between compose's :?-required vars and the
+    # deploy-stg/deploy-prod env_keys passlists at PR-review time, before
+    # a missing wire blocks a real deploy. Today the drift is detected
+    # only at compose-up time (e.g. PR #95 + run 24612922259 surfaced
+    # 6 missing vars post-merge).
+    #
+    # Compose vars known NOT to come from secrets — caller writes them
+    # directly inside the .env-write composite (IMAGE_TAG, BASE_DOMAIN)
+    # or via extra_image_tags (USER_SERVICE_IMAGE_TAG, LANDING_IMAGE_TAG).
+    # PROM_CONFIG_FILE + ALERTMANAGER_CONFIG_FILE + SLACK_WEBHOOK_FILE are
+    # also written by the composite (deploy#262 + #263 wired in via the
+    # composite per-env). These are listed in WORKFLOW_WRITTEN so the diff
+    # doesn't false-positive.
+    name: deploy passlist vs compose :?-required drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Diff compose required-vars vs workflow env_keys
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import re, sys
+          from pathlib import Path
+
+          compose = Path("compose/docker-compose.prod.yml").read_text()
+          # Match ${NAME:?...} — the compose syntax for "required, fail if unset/empty".
+          required = set(re.findall(r"\$\{([A-Z_][A-Z0-9_]*):\?", compose))
+
+          # Vars written by the workflow itself (composite action), not pulled from secrets.
+          workflow_written = {
+              "IMAGE_TAG", "BASE_DOMAIN",
+              "USER_SERVICE_IMAGE_TAG", "LANDING_IMAGE_TAG",
+              "PROM_CONFIG_FILE", "ALERTMANAGER_CONFIG_FILE", "SLACK_WEBHOOK_FILE",
+          }
+          expected_in_passlist = required - workflow_written
+
+          def passlist(workflow_path):
+              text = Path(workflow_path).read_text()
+              # `env_keys: NAME1,NAME2,...` (write-deploy-env composite shape).
+              # We only need the single-line CSV form because that's what the
+              # composite caller uses. Anchor on the leading `env_keys:`.
+              m = re.search(r"^\s*env_keys:\s*([A-Z0-9_,]+)\s*$", text, re.M)
+              if not m:
+                  print(f"::error file={workflow_path}::could not find `env_keys:` CSV line")
+                  sys.exit(1)
+              return {tok.strip() for tok in m.group(1).split(",") if tok.strip()}
+
+          stg = passlist(".github/workflows/deploy-stg.yml")
+          prod = passlist(".github/workflows/deploy-prod.yml")
+
+          failed = False
+          for env_name, passed in (("stg", stg), ("prod", prod)):
+              missing = expected_in_passlist - passed
+              if missing:
+                  failed = True
+                  print(f"::error file=.github/workflows/deploy-{env_name}.yml::"
+                        f"deploy-{env_name} env_keys missing required compose vars: {sorted(missing)}")
+                  print("  Compose declares the var as required for each. Without these in env_keys,")
+                  print(f"  the deploy will fail at `compose up` with 'required variable NAME is missing a value'.")
+
+          # Symmetric direction: vars in passlist that compose doesn't reference at all.
+          # Informational only — extras in passlist aren't a deploy-breaker, just stale-wire potential.
+          # We do NOT fail on extras (workflow may legitimately ship secrets compose doesn't use yet).
+          compose_referenced = set(re.findall(r"\$\{([A-Z_][A-Z0-9_]*)", compose))
+          for env_name, passed in (("stg", stg), ("prod", prod)):
+              extras = (passed - workflow_written) - compose_referenced
+              if extras:
+                  print(f"::warning file=.github/workflows/deploy-{env_name}.yml::"
+                        f"deploy-{env_name} env_keys references vars compose doesn't use: {sorted(extras)}")
+
+          if failed:
+              sys.exit(1)
+          print("Passlist drift check: OK")
+          print(f"  Compose required vars (filtered): {sorted(expected_in_passlist)}")
+          print(f"  Stg passlist size: {len(stg)} | Prod passlist size: {len(prod)}")
+          PY
+
   promtool-check:
     # deploy#212 — PR-time validation of Prometheus alerts.yml + per-env
     # prometheus.{stg,prod}.yml. Previously alert-author PRs relied on

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -58,14 +58,21 @@ jobs:
 
             env_file=".env"
             : > "$env_file"
+            # Indirect expansion (`${!var}`) reads the named env var as data;
+            # values with metacharacters never re-enter shell parsing.
+            # Replaces legacy `eval "val=\$$var"` (deploy#66). NAME="..."
+            # form: double-quoted strings preserve via dotenv with escaped
+            # double-quotes; backslashes are doubled as a defense-in-depth.
             for var in NEO4J_PASSWORD POSTGRES_USER POSTGRES_PASSWORD POSTGRES_DB \
                        REDIS_PASSWORD AUTH_GOOGLE_CLIENT_ID AUTH_GOOGLE_CLIENT_SECRET \
                        AUTH_GITHUB_CLIENT_ID AUTH_GITHUB_CLIENT_SECRET \
                        GRAFANA_ADMIN_PASSWORD \
                        USER_POSTGRES_USER USER_POSTGRES_PASSWORD USER_POSTGRES_DB \
                        USER_REDIS_PASSWORD JWT_PRIVATE_KEY JWT_PUBLIC_KEY; do
-              eval "val=\$$var"
-              echo "$var=\"$val\"" >> "$env_file"
+              val="${!var-}"
+              escaped="${val//\\/\\\\}"
+              escaped="${escaped//\"/\\\"}"
+              printf "%s=\"%s\"\n" "$var" "$escaped" >> "$env_file"
             done
             echo "IMAGE_TAG=\"${IMAGE_TAG}\"" >> "$env_file"
             echo "LANDING_IMAGE_TAG=\"${LANDING_IMAGE_TAG}\"" >> "$env_file"

--- a/.github/workflows/deploy-isnad-graph.yml
+++ b/.github/workflows/deploy-isnad-graph.yml
@@ -99,6 +99,11 @@ jobs:
             # SSH transport without escape-eating that strips backslash-escaped double
             # quotes. Limitation: values containing a literal "'" are not supported
             # (none of our current secrets do — see #94).
+            # Indirect expansion (`${!var}`) reads the named env var as data;
+            # values with quotes/backticks/dollars/backslashes round-trip
+            # literally. Replaces legacy `eval "val=\$$var"` (deploy#66).
+            # Embedded literal single quotes are escaped as '\'' so the
+            # `NAME='...'` form survives dotenv parsing.
             for var in NEO4J_PASSWORD POSTGRES_USER POSTGRES_PASSWORD POSTGRES_DB \
                        REDIS_PASSWORD AUTH_GOOGLE_CLIENT_ID AUTH_GOOGLE_CLIENT_SECRET \
                        AUTH_GITHUB_CLIENT_ID AUTH_GITHUB_CLIENT_SECRET \
@@ -109,8 +114,9 @@ jobs:
                        PIPELINE_B2_KEY_ID PIPELINE_B2_REGION \
                        USER_POSTGRES_DB USER_POSTGRES_PASSWORD USER_POSTGRES_USER \
                        USER_REDIS_PASSWORD; do
-              eval "val=\$$var"
-              printf "%s='%s'\n" "$var" "$val" >> "$env_file"
+              val="${!var-}"
+              escaped="${val//\'/\'\\\'\'}"
+              printf "%s='%s'\n" "$var" "$escaped" >> "$env_file"
             done
             printf "%s='%s'\n" "IMAGE_TAG" "${IMAGE_TAG}" >> "$env_file"
             chmod 600 "$env_file"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -191,8 +191,16 @@ jobs:
             echo "landing_tag=$ld"
           } >> "$GITHUB_OUTPUT"
 
+      # .env-write + compose roll via the shared composite action
+      # (deploy#190 + #66). Prod passes USER_SERVICE_IMAGE_TAG +
+      # LANDING_IMAGE_TAG via extra_image_tags — stg doesn't carry these.
+      # Both stg and prod call the same composite, so adding a new
+      # required secret needs one line in `env:` here + one entry in
+      # `env_keys` — no remote-script edit. The composite replaces the
+      # legacy `eval` env loop with indirect expansion (`${!var}`), safe
+      # for secrets containing quotes, backticks, dollars, or backslashes.
       - name: Deploy to prod VPS
-        uses: appleboy/ssh-action@v1
+        uses: ./.github/actions/write-deploy-env
         env:
           NEO4J_PASSWORD: ${{ secrets.NEO4J_PASSWORD }}
           POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
@@ -209,26 +217,11 @@ jobs:
           KAFKA_CLUSTER_ID: ${{ secrets.KAFKA_CLUSTER_ID }}
           KAFKA_UI_PASSWORD: ${{ secrets.KAFKA_UI_PASSWORD }}
           KAFKA_UI_USER: ${{ secrets.KAFKA_UI_USER }}
-          # Compose env-var names below must match
-          # compose/docker-compose.prod.yml image: ${VAR:-latest} references.
-          # Compose currently uses:
-          #   IMAGE_TAG              — api + frontend
-          #   USER_SERVICE_IMAGE_TAG — user-service
-          #   LANDING_IMAGE_TAG      — landing
-          IMAGE_TAG: ${{ steps.tags.outputs.api_frontend_tag }}
-          USER_SERVICE_IMAGE_TAG: ${{ steps.tags.outputs.user_service_tag }}
-          LANDING_IMAGE_TAG: ${{ steps.tags.outputs.landing_tag }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_ACTOR: ${{ github.repository_owner }}
           PIPELINE_B2_BUCKET: ${{ secrets.PIPELINE_B2_BUCKET }}
           PIPELINE_B2_ENDPOINT: ${{ secrets.PIPELINE_B2_ENDPOINT }}
           PIPELINE_B2_KEY: ${{ secrets.PIPELINE_B2_KEY }}
           PIPELINE_B2_KEY_ID: ${{ secrets.PIPELINE_B2_KEY_ID }}
           PIPELINE_B2_REGION: ${{ secrets.PIPELINE_B2_REGION }}
-          # Backup-scope B2 creds (deploy#188). Distinct from PIPELINE_B2_*
-          # (ingest scope) and TF_STATE_B2_* (terraform backend). Renamed to
-          # bare B2_* in the .env-write block below to match scripts/backup.sh
-          # consumer-side names. Cutover-gate (main#212) dependency.
           BACKUP_B2_KEY_ID: ${{ secrets.BACKUP_B2_KEY_ID }}
           BACKUP_B2_APP_KEY: ${{ secrets.BACKUP_B2_APP_KEY }}
           BACKUP_B2_BUCKET: ${{ secrets.BACKUP_B2_BUCKET }}
@@ -236,88 +229,31 @@ jobs:
           USER_POSTGRES_PASSWORD: ${{ secrets.USER_POSTGRES_PASSWORD }}
           USER_POSTGRES_USER: ${{ secrets.USER_POSTGRES_USER }}
           USER_REDIS_PASSWORD: ${{ secrets.USER_REDIS_PASSWORD }}
-          # Slack webhook for alertmanager routing (deploy#262). Optional —
-          # if unset, alertmanager loads with the "<unset>" placeholder and
-          # the deploy step logs a WARNING. Set in the `production` Environment.
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
-          host: ${{ vars.VPS_HOST }}
-          username: deploy
-          key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
-          envs: NEO4J_PASSWORD,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,REDIS_PASSWORD,AUTH_GOOGLE_CLIENT_ID,AUTH_GOOGLE_CLIENT_SECRET,AUTH_GITHUB_CLIENT_ID,AUTH_GITHUB_CLIENT_SECRET,GRAFANA_ADMIN_PASSWORD,JWT_PRIVATE_KEY,JWT_PUBLIC_KEY,KAFKA_CLUSTER_ID,KAFKA_UI_PASSWORD,KAFKA_UI_USER,IMAGE_TAG,USER_SERVICE_IMAGE_TAG,LANDING_IMAGE_TAG,PIPELINE_B2_BUCKET,PIPELINE_B2_ENDPOINT,PIPELINE_B2_KEY,PIPELINE_B2_KEY_ID,PIPELINE_B2_REGION,BACKUP_B2_KEY_ID,BACKUP_B2_APP_KEY,BACKUP_B2_BUCKET,USER_POSTGRES_DB,USER_POSTGRES_PASSWORD,USER_POSTGRES_USER,USER_REDIS_PASSWORD,GITHUB_TOKEN,GITHUB_ACTOR,SLACK_WEBHOOK_URL
-          script: |
-            set -euo pipefail
-            cd /opt/noorinalabs-deploy
-
-            echo "==> Pulling latest deploy config..."
-            git fetch origin main
-            git reset --hard origin/main
-
-            echo "==> Writing .env for docker-compose..."
-            echo "    IMAGE_TAG=$IMAGE_TAG (api + frontend)"
-            echo "    USER_SERVICE_IMAGE_TAG=$USER_SERVICE_IMAGE_TAG"
-            echo "    LANDING_IMAGE_TAG=$LANDING_IMAGE_TAG"
-            env_file=".env"
-            : > "$env_file"
-            for var in NEO4J_PASSWORD POSTGRES_USER POSTGRES_PASSWORD POSTGRES_DB \
-                       REDIS_PASSWORD AUTH_GOOGLE_CLIENT_ID AUTH_GOOGLE_CLIENT_SECRET \
-                       AUTH_GITHUB_CLIENT_ID AUTH_GITHUB_CLIENT_SECRET \
-                       GRAFANA_ADMIN_PASSWORD \
-                       JWT_PRIVATE_KEY JWT_PUBLIC_KEY \
-                       KAFKA_CLUSTER_ID KAFKA_UI_PASSWORD KAFKA_UI_USER \
-                       PIPELINE_B2_BUCKET PIPELINE_B2_ENDPOINT PIPELINE_B2_KEY \
-                       PIPELINE_B2_KEY_ID PIPELINE_B2_REGION \
-                       USER_POSTGRES_DB USER_POSTGRES_PASSWORD USER_POSTGRES_USER \
-                       USER_REDIS_PASSWORD; do
-              eval "val=\$$var"
-              printf "%s='%s'\n" "$var" "$val" >> "$env_file"
-            done
-            printf "%s='%s'\n" "IMAGE_TAG" "${IMAGE_TAG}" >> "$env_file"
-            printf "%s='%s'\n" "USER_SERVICE_IMAGE_TAG" "${USER_SERVICE_IMAGE_TAG}" >> "$env_file"
-            printf "%s='%s'\n" "LANDING_IMAGE_TAG" "${LANDING_IMAGE_TAG}" >> "$env_file"
-            # Per-env Caddyfile hostname root (deploy#218). Caddy interpolates
-            # {$BASE_DOMAIN} for the apex/www/isnad-graph virtual hosts.
-            printf "%s='%s'\n" "BASE_DOMAIN" "noorinalabs.com" >> "$env_file"
-            # Per-env observability config selection (deploy#263 + #262).
-            # Prod variants for prometheus + alertmanager.
-            printf "%s='%s'\n" "PROM_CONFIG_FILE" "prometheus.prod.yml" >> "$env_file"
-            printf "%s='%s'\n" "ALERTMANAGER_CONFIG_FILE" "alertmanager.prod.yml" >> "$env_file"
-            printf "%s='%s'\n" "SLACK_WEBHOOK_FILE" "slack_webhook_url.secret" >> "$env_file"
-            # Backup B2 creds (deploy#188): rename BACKUP_B2_* secrets to the
-            # bare B2_* names that scripts/backup.sh:59-61 expects. Empty values
-            # are written as empty so backup.sh fails fast at preflight rather
-            # than partially-running with stale or wrong creds.
-            printf "%s='%s'\n" "B2_KEY_ID" "${BACKUP_B2_KEY_ID:-}" >> "$env_file"
-            printf "%s='%s'\n" "B2_APP_KEY" "${BACKUP_B2_APP_KEY:-}" >> "$env_file"
-            printf "%s='%s'\n" "B2_BUCKET" "${BACKUP_B2_BUCKET:-}" >> "$env_file"
-            chmod 600 "$env_file"
-
-            # Slack webhook secret file (deploy#262). See deploy-stg.yml for
-            # full rationale on the api_url_file pattern. If SLACK_WEBHOOK_URL
-            # is unset in the `production` Environment, alerts do not deliver
-            # to Slack but alertmanager still loads cleanly.
-            slack_file="infra/alertmanager/slack_webhook_url.secret"
-            if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
-              printf "%s" "$SLACK_WEBHOOK_URL" > "$slack_file"
-              echo "==> Slack webhook secret written (real value)."
-            else
-              printf "%s" "<unset>" > "$slack_file"
-              echo "==> WARNING: SLACK_WEBHOOK_URL secret not set in 'production' env — alertmanager will not deliver to Slack."
-            fi
-            chmod 600 "$slack_file"
-
-            echo "==> Authenticating to GHCR..."
-            trap 'docker logout ghcr.io >/dev/null 2>&1 || true' EXIT
-            echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
-
-            echo "==> Pulling images from GHCR..."
-            docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env pull api frontend landing user-service
-
-            echo "==> Starting services..."
-            docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env up -d --force-recreate --remove-orphans
-
-            echo "==> Waiting for services to stabilize..."
-            sleep 15
+          ssh_host: ${{ vars.VPS_HOST }}
+          ssh_key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          # IMAGE_TAG drives compose's api + frontend image tags. The two
+          # extra pairs below map to compose/docker-compose.prod.yml's
+          # ${USER_SERVICE_IMAGE_TAG:-latest} and ${LANDING_IMAGE_TAG:-latest}.
+          image_tag: ${{ steps.tags.outputs.api_frontend_tag }}
+          extra_image_tags: |
+            USER_SERVICE_IMAGE_TAG=${{ steps.tags.outputs.user_service_tag }}
+            LANDING_IMAGE_TAG=${{ steps.tags.outputs.landing_tag }}
+          # Per-env observability config selection (deploy#263 + #262).
+          # Prod variants for prometheus + alertmanager. SLACK_WEBHOOK_FILE
+          # path is relative to /etc/alertmanager mount, populated below.
+          extra_env: |
+            PROM_CONFIG_FILE=prometheus.prod.yml
+            ALERTMANAGER_CONFIG_FILE=alertmanager.prod.yml
+            SLACK_WEBHOOK_FILE=slack_webhook_url.secret
+          base_domain: noorinalabs.com
+          env_keys: NEO4J_PASSWORD,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,REDIS_PASSWORD,AUTH_GOOGLE_CLIENT_ID,AUTH_GOOGLE_CLIENT_SECRET,AUTH_GITHUB_CLIENT_ID,AUTH_GITHUB_CLIENT_SECRET,GRAFANA_ADMIN_PASSWORD,JWT_PRIVATE_KEY,JWT_PUBLIC_KEY,KAFKA_CLUSTER_ID,KAFKA_UI_PASSWORD,KAFKA_UI_USER,PIPELINE_B2_BUCKET,PIPELINE_B2_ENDPOINT,PIPELINE_B2_KEY,PIPELINE_B2_KEY_ID,PIPELINE_B2_REGION,BACKUP_B2_KEY_ID,BACKUP_B2_APP_KEY,BACKUP_B2_BUCKET,USER_POSTGRES_DB,USER_POSTGRES_PASSWORD,USER_POSTGRES_USER,USER_REDIS_PASSWORD
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_actor: ${{ github.repository_owner }}
+          # Slack webhook for alertmanager routing (deploy#262). Optional —
+          # if unset, the composite writes "<unset>" placeholder and logs a
+          # WARNING. Set in the `production` Environment.
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Verify health check
         uses: appleboy/ssh-action@v1

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -102,8 +102,15 @@ jobs:
           echo "Resolved tag: $tag"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
+      # .env-write + compose roll via the shared composite action
+      # (deploy#190 + #66). Stg and prod call the same composite, so
+      # adding a new required secret needs one line in `env:` here +
+      # one entry in `env_keys` — no remote-script edit, no risk of
+      # stg/prod drift. The composite replaces the legacy `eval` env
+      # loop with indirect expansion (`${!var}`), safe for secrets
+      # containing quotes, backticks, dollars, or backslashes.
       - name: Deploy to stg VPS
-        uses: appleboy/ssh-action@v1
+        uses: ./.github/actions/write-deploy-env
         env:
           NEO4J_PASSWORD: ${{ secrets.NEO4J_PASSWORD }}
           POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
@@ -120,18 +127,11 @@ jobs:
           KAFKA_CLUSTER_ID: ${{ secrets.KAFKA_CLUSTER_ID }}
           KAFKA_UI_PASSWORD: ${{ secrets.KAFKA_UI_PASSWORD }}
           KAFKA_UI_USER: ${{ secrets.KAFKA_UI_USER }}
-          IMAGE_TAG: ${{ steps.tag.outputs.tag }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_ACTOR: ${{ github.repository_owner }}
           PIPELINE_B2_BUCKET: ${{ secrets.PIPELINE_B2_BUCKET }}
           PIPELINE_B2_ENDPOINT: ${{ secrets.PIPELINE_B2_ENDPOINT }}
           PIPELINE_B2_KEY: ${{ secrets.PIPELINE_B2_KEY }}
           PIPELINE_B2_KEY_ID: ${{ secrets.PIPELINE_B2_KEY_ID }}
           PIPELINE_B2_REGION: ${{ secrets.PIPELINE_B2_REGION }}
-          # Backup-scope B2 creds (deploy#188). Distinct from PIPELINE_B2_*
-          # (ingest scope) and TF_STATE_B2_* (terraform backend). Renamed to
-          # bare B2_* in the .env-write block below to match scripts/backup.sh
-          # consumer-side names.
           BACKUP_B2_KEY_ID: ${{ secrets.BACKUP_B2_KEY_ID }}
           BACKUP_B2_APP_KEY: ${{ secrets.BACKUP_B2_APP_KEY }}
           BACKUP_B2_BUCKET: ${{ secrets.BACKUP_B2_BUCKET }}
@@ -139,86 +139,26 @@ jobs:
           USER_POSTGRES_PASSWORD: ${{ secrets.USER_POSTGRES_PASSWORD }}
           USER_POSTGRES_USER: ${{ secrets.USER_POSTGRES_USER }}
           USER_REDIS_PASSWORD: ${{ secrets.USER_REDIS_PASSWORD }}
-          # Slack webhook for alertmanager routing (deploy#262). Optional —
-          # if unset, alertmanager loads with the "<unset>" placeholder and
-          # the deploy step logs a WARNING. Set in the `staging` Environment.
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
-          host: ${{ vars.VPS_HOST }}
-          username: deploy
-          key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
-          envs: NEO4J_PASSWORD,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,REDIS_PASSWORD,AUTH_GOOGLE_CLIENT_ID,AUTH_GOOGLE_CLIENT_SECRET,AUTH_GITHUB_CLIENT_ID,AUTH_GITHUB_CLIENT_SECRET,GRAFANA_ADMIN_PASSWORD,JWT_PRIVATE_KEY,JWT_PUBLIC_KEY,KAFKA_CLUSTER_ID,KAFKA_UI_PASSWORD,KAFKA_UI_USER,IMAGE_TAG,PIPELINE_B2_BUCKET,PIPELINE_B2_ENDPOINT,PIPELINE_B2_KEY,PIPELINE_B2_KEY_ID,PIPELINE_B2_REGION,BACKUP_B2_KEY_ID,BACKUP_B2_APP_KEY,BACKUP_B2_BUCKET,USER_POSTGRES_DB,USER_POSTGRES_PASSWORD,USER_POSTGRES_USER,USER_REDIS_PASSWORD,GITHUB_TOKEN,GITHUB_ACTOR,SLACK_WEBHOOK_URL
-          script: |
-            set -euo pipefail
-            cd /opt/noorinalabs-deploy
-
-            echo "==> Pulling latest deploy config..."
-            git fetch origin main
-            git reset --hard origin/main
-
-            echo "==> Writing .env for docker-compose (IMAGE_TAG=$IMAGE_TAG)..."
-            env_file=".env"
-            : > "$env_file"
-            for var in NEO4J_PASSWORD POSTGRES_USER POSTGRES_PASSWORD POSTGRES_DB \
-                       REDIS_PASSWORD AUTH_GOOGLE_CLIENT_ID AUTH_GOOGLE_CLIENT_SECRET \
-                       AUTH_GITHUB_CLIENT_ID AUTH_GITHUB_CLIENT_SECRET \
-                       GRAFANA_ADMIN_PASSWORD \
-                       JWT_PRIVATE_KEY JWT_PUBLIC_KEY \
-                       KAFKA_CLUSTER_ID KAFKA_UI_PASSWORD KAFKA_UI_USER \
-                       PIPELINE_B2_BUCKET PIPELINE_B2_ENDPOINT PIPELINE_B2_KEY \
-                       PIPELINE_B2_KEY_ID PIPELINE_B2_REGION \
-                       USER_POSTGRES_DB USER_POSTGRES_PASSWORD USER_POSTGRES_USER \
-                       USER_REDIS_PASSWORD; do
-              eval "val=\$$var"
-              printf "%s='%s'\n" "$var" "$val" >> "$env_file"
-            done
-            printf "%s='%s'\n" "IMAGE_TAG" "${IMAGE_TAG}" >> "$env_file"
-            # Per-env Caddyfile hostname root (deploy#218). Caddy interpolates
-            # {$BASE_DOMAIN} for the apex/www/isnad-graph virtual hosts.
-            printf "%s='%s'\n" "BASE_DOMAIN" "stg.noorinalabs.com" >> "$env_file"
-            # Per-env observability config selection (deploy#263 + #262).
-            # Stg variants for prometheus + alertmanager (different blackbox
-            # targets, different Slack channel routing).
-            printf "%s='%s'\n" "PROM_CONFIG_FILE" "prometheus.stg.yml" >> "$env_file"
-            printf "%s='%s'\n" "ALERTMANAGER_CONFIG_FILE" "alertmanager.stg.yml" >> "$env_file"
-            printf "%s='%s'\n" "SLACK_WEBHOOK_FILE" "slack_webhook_url.secret" >> "$env_file"
-            # Backup B2 creds (deploy#188): rename BACKUP_B2_* secrets to the
-            # bare B2_* names that scripts/backup.sh:59-61 expects. Empty values
-            # are written as empty so backup.sh fails fast at preflight rather
-            # than partially-running with stale or wrong creds.
-            printf "%s='%s'\n" "B2_KEY_ID" "${BACKUP_B2_KEY_ID:-}" >> "$env_file"
-            printf "%s='%s'\n" "B2_APP_KEY" "${BACKUP_B2_APP_KEY:-}" >> "$env_file"
-            printf "%s='%s'\n" "B2_BUCKET" "${BACKUP_B2_BUCKET:-}" >> "$env_file"
-            chmod 600 "$env_file"
-
-            # Slack webhook secret file (deploy#262). Alertmanager reads this
-            # at startup via api_url_file directive (path mounted into the
-            # container as /etc/alertmanager/slack_webhook_url). The
-            # "<unset>" placeholder is harmless — alertmanager loads cleanly
-            # but routing fails until the operator sets SLACK_WEBHOOK_URL
-            # in the staging GitHub Environment.
-            slack_file="infra/alertmanager/slack_webhook_url.secret"
-            if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
-              printf "%s" "$SLACK_WEBHOOK_URL" > "$slack_file"
-              echo "==> Slack webhook secret written (real value)."
-            else
-              printf "%s" "<unset>" > "$slack_file"
-              echo "==> WARNING: SLACK_WEBHOOK_URL secret not set in 'staging' env — alertmanager will not deliver to Slack."
-            fi
-            chmod 600 "$slack_file"
-
-            echo "==> Authenticating to GHCR..."
-            trap 'docker logout ghcr.io >/dev/null 2>&1 || true' EXIT
-            echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
-
-            echo "==> Pulling images from GHCR..."
-            docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env pull api frontend landing user-service
-
-            echo "==> Starting services..."
-            docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env up -d --force-recreate --remove-orphans
-
-            echo "==> Waiting for services to stabilize..."
-            sleep 15
+          ssh_host: ${{ vars.VPS_HOST }}
+          ssh_key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          image_tag: ${{ steps.tag.outputs.tag }}
+          # Per-env observability config selection (deploy#263 + #262).
+          # Stg variants for prometheus + alertmanager (different blackbox
+          # targets, different Slack channel routing). SLACK_WEBHOOK_FILE
+          # path is relative to /etc/alertmanager mount, populated below.
+          extra_env: |
+            PROM_CONFIG_FILE=prometheus.stg.yml
+            ALERTMANAGER_CONFIG_FILE=alertmanager.stg.yml
+            SLACK_WEBHOOK_FILE=slack_webhook_url.secret
+          base_domain: stg.noorinalabs.com
+          env_keys: NEO4J_PASSWORD,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,REDIS_PASSWORD,AUTH_GOOGLE_CLIENT_ID,AUTH_GOOGLE_CLIENT_SECRET,AUTH_GITHUB_CLIENT_ID,AUTH_GITHUB_CLIENT_SECRET,GRAFANA_ADMIN_PASSWORD,JWT_PRIVATE_KEY,JWT_PUBLIC_KEY,KAFKA_CLUSTER_ID,KAFKA_UI_PASSWORD,KAFKA_UI_USER,PIPELINE_B2_BUCKET,PIPELINE_B2_ENDPOINT,PIPELINE_B2_KEY,PIPELINE_B2_KEY_ID,PIPELINE_B2_REGION,BACKUP_B2_KEY_ID,BACKUP_B2_APP_KEY,BACKUP_B2_BUCKET,USER_POSTGRES_DB,USER_POSTGRES_PASSWORD,USER_POSTGRES_USER,USER_REDIS_PASSWORD
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_actor: ${{ github.repository_owner }}
+          # Slack webhook for alertmanager routing (deploy#262). Optional —
+          # if unset, the composite writes "<unset>" placeholder and logs a
+          # WARNING. Set in the `staging` Environment.
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Verify health check
         uses: appleboy/ssh-action@v1

--- a/integration-tests/run-tests.sh
+++ b/integration-tests/run-tests.sh
@@ -132,9 +132,12 @@ trap cleanup EXIT
 echo "--- Generating fresh test secrets ---"
 ./scripts/generate_test_secrets.sh secrets
 
-export JWT_PRIVATE_KEY="$(cat secrets/jwt.key)"
-export JWT_PUBLIC_KEY="$(cat secrets/jwt.pub)"
-export TOTP_ENCRYPTION_KEY="$(cat secrets/totp.key)"
+# Declare-then-export so `cat` exit codes surface as the script's exit
+# (export's always-zero return would mask a missing secret file). #284 / SC2155.
+JWT_PRIVATE_KEY=$(cat secrets/jwt.key)
+JWT_PUBLIC_KEY=$(cat secrets/jwt.pub)
+TOTP_ENCRYPTION_KEY=$(cat secrets/totp.key)
+export JWT_PRIVATE_KEY JWT_PUBLIC_KEY TOTP_ENCRYPTION_KEY
 
 mkdir -p reports
 
@@ -195,6 +198,12 @@ $COMPOSE up -d --build \
     neo4j isnad-postgres isnad-redis isnad-graph-api
 
 echo "--- Waiting for services to be healthy ---"
+# shellcheck disable=SC2016 # The single-quoted body is intentionally a
+# self-contained script passed to `timeout 180 bash -c '...'`. All $VAR
+# references inside the body (unhealthy, line, d) are LOCAL to that
+# subshell and MUST NOT expand in the parent shell. Switching to double
+# quotes would interpolate `$unhealthy` at script-load time as empty,
+# silently breaking the health-poll loop.
 timeout 180 bash -c '
     while :; do
         unhealthy=$(docker compose -f docker-compose.test.yml --env-file .env.test ps --format json \


### PR DESCRIPTION
## Summary

P3W11 Tier 1 CI workflow hardening cluster — four issues, single PR off `deployments/phase-3/wave-11` @ `d89f454`.

| Issue | Concern | Fix |
|-------|---------|-----|
| #190 | Duplicated `.env`-write block between deploy-stg + deploy-prod | New composite action `.github/actions/write-deploy-env/`; both workflows now call it. Stg/prod asymmetries preserved via `extra_image_tags` + `base_domain` inputs. |
| #66 | `eval "val=\$$var"` fragile on secrets with shell metachars | Indirect expansion (`${!var}`) at all 4 sites: deploy-stg + deploy-prod (via composite), deploy-isnad-graph + deploy-all (in-place legacy paths). |
| #97 | Compose `:?-required` vars drift silently from workflow passlists | New `passlist-drift` job in `compose-validate.yml` parses compose required-var declarations and diffs against deploy-stg + deploy-prod `env_keys` — fails PR on drift. |
| #284 | `integration-tests/run-tests.sh` shellcheck 4 warnings | 3×SC2155 split into declare-then-export; SC2016 explicitly disabled with rationale on the intentional single-quote `bash -c '...'` health-poll body. |

**#233 was closed separately** as already-implemented at HEAD (see [#233 close-comment](https://github.com/noorinalabs/noorinalabs-deploy/issues/233#issuecomment-4469278704)) — PR #261's `.github/actions/break-glass-audit` composite already emits `$GITHUB_STEP_SUMMARY` for `skip_alembic_gate` + `allow_stg_tags` via dedicated `audit-*` jobs. Verified at `d89f454`.

## Per-file diff summary

- **`.github/actions/write-deploy-env/action.yml`** (NEW, +174) — composite action shared by deploy-stg + deploy-prod. Inputs: `ssh_host`, `ssh_key`, `image_tag`, `extra_image_tags` (newline-separated `NAME=value` for prod's per-service tags), `base_domain`, `env_keys` (CSV passlist), `github_token`, `github_actor`, `pull_services`. Loop uses `${!var}` indirect expansion; literal single quotes in values are escaped as `'\''` so the `NAME='...'` form survives dotenv parsing.
- **`.github/workflows/deploy-stg.yml`** (-46) — replaces inline `appleboy/ssh-action@v1` env-write step with `uses: ./.github/actions/write-deploy-env`. Caller `env:` block + `env_keys` are the single source of truth for stg secrets.
- **`.github/workflows/deploy-prod.yml`** (-71) — same composite call. `extra_image_tags` carries USER_SERVICE_IMAGE_TAG + LANDING_IMAGE_TAG (compose's per-service tag interpolation points). `base_domain: noorinalabs.com`.
- **`.github/workflows/deploy-isnad-graph.yml`** (+10/-3) — eval → `${!var}` for the legacy single-VPS workflow_dispatch path (not on the active deploy-stg fan-in per ontology `repos/deploy.yaml:86-87`).
- **`.github/workflows/deploy-all.yml`** (+11/-4) — same eval → `${!var}` swap. Preserves the `NAME="..."` shape this legacy script uses; backslash + double-quote both escaped as defense-in-depth.
- **`.github/workflows/compose-validate.yml`** (+71) — new `passlist-drift` job. Python heredoc parses compose `${NAME:?...}` declarations and diffs against `env_keys:` CSV in both deploy workflows. Workflow-written vars (IMAGE_TAG, BASE_DOMAIN, USER_SERVICE_IMAGE_TAG, LANDING_IMAGE_TAG) filtered from the required set. Extras are warnings (legitimately covers BACKUP_B2_* + PIPELINE_B2_* which are consumed outside compose interpolation).
- **`integration-tests/run-tests.sh`** (+15/-3) — declare-then-export pattern for 3 secret reads; `# shellcheck disable=SC2016` annotation with multi-line rationale on the `timeout 180 bash -c '...'` body explaining why single quotes are load-bearing.

## Test plan

- [x] **Local actionlint sweep** — `actionlint` (default discovery, version 1.7.7) → exit 0 across all 18 workflows. CI uses 1.7.12; minor-version delta has no breaking rule changes.
- [x] **Local shellcheck** — `shellcheck integration-tests/run-tests.sh` → exit 0. Also clean against `integration-tests/scripts/generate_test_secrets.sh`.
- [x] **#190 .env equivalence (live trace)** — adversarial-value round-trip test at `/tmp/test_envwrite.sh` confirms the composite-action loop produces a `.env` whose `source`-back exactly reproduces inputs containing: plain ASCII; embedded single quotes (`it's a 'tricky' value`); `$(whoami)` + backticks + backslashes (kept literal, NOT executed); empty value; missing var (treated as empty). Output:
  ```
  FOO_QUOTE='it'\''s a '\''tricky'\'' value'   →   FOO_QUOTE=<it's a 'tricky' value>
  FOO_DOLLAR='$(whoami) and `id` and \backslash'   →   FOO_DOLLAR=<$(whoami) and `id` and \backslash>
  ```
- [x] **#97 passlist drift (dry-run at HEAD)** — Python check run locally against `compose/docker-compose.prod.yml` + both deploy workflows: **`missing=NONE`** for both stg and prod. Required-after-filter set = 15 vars (`GRAFANA_ADMIN_PASSWORD, JWT_PRIVATE_KEY, JWT_PUBLIC_KEY, KAFKA_CLUSTER_ID, KAFKA_UI_PASSWORD, KAFKA_UI_USER, NEO4J_PASSWORD, POSTGRES_DB, POSTGRES_PASSWORD, POSTGRES_USER, REDIS_PASSWORD, USER_POSTGRES_DB, USER_POSTGRES_PASSWORD, USER_POSTGRES_USER, USER_REDIS_PASSWORD`) — all wired in both passlists. Expected-extras-as-warnings: BACKUP_B2_* + PIPELINE_B2_* (consumed by scripts/backup.sh + user-postgres init, not compose interpolation).
- [x] **#284 shellcheck** — clean after fix.
- [x] **#66 eval surface enumeration** — `grep -n 'eval' .github/workflows/*.yml` post-fix shows only the comment match in `promote.yml:407` ("evaluate result + age"); zero `eval "val=\$$var"` occurrences remain across all 4 workflows.

## Runtime acceptance NOT verified at PR time

Per [[feedback_runtime_gate_scoping]]:

- **End-to-end stg deploy + end-to-end prod deploy post-composite-extraction** (acceptance bullet from issue #190) requires the live VPS stack + real GHCR push pipeline + admin approval gate — not reachable from PR CI. Post-merge: monitor first auto-deploy after a service-repo push lands on `deploy-stg.yml`; `.env` semantics validated structurally above. If a missed-var surfaces, the new passlist-drift gate will block at next PR (the fix-forward Mechanism is what #97 delivers).
- **#233 break-glass dispatch end-to-end live-trace** is out of scope (issue closed as already-done; existing audit composite is the implementation).

## Tech Debt

No new tech debt introduced.

The composite extraction eliminates the duplicated `.env`-write surface (#190 acceptance); the passlist-drift gate makes silent stg/prod drift impossible at PR-review time (#97 fix-forward mechanism); `eval` is gone from all 4 env-write sites (#66 closed); shellcheck is clean on the integration-test runner (#284 closed).

Closes #190
Closes #66
Closes #97
Closes #284

## Reviewers

- **Primary:** @aisha-idrissi-bot — SRE peer, deploy-stg/prod knowledge from W9-W10
- **Secondary:** @weronika-zielinska-bot — Platform Architect, cross-cutting workflow review

cc @bereket-tadesse-bot (manager FYI)
