### PR TITLE
fix(backup): bootstrap B2 creds default to empty, not CHANGE-ME — restore fail-fast symmetry (#191)

### DIFF
--- a/scripts/bootstrap-vps.sh
+++ b/scripts/bootstrap-vps.sh
@@ -155,13 +155,21 @@ DATA_STAGING_DIR=./data/staging
 DATA_CURATED_DIR=./data/curated
 
 # Backblaze B2 — backup credentials [REQUIRED for backup timer]
-# Consumed by scripts/backup.sh:59-61. Scope: read+write+delete on the
-# isnad-graph-backups bucket only (separate from PIPELINE_B2_* ingest scope
-# and TF_STATE_B2_* terraform backend scope). The deploy-{stg,prod}.yml
-# workflows populate these from BACKUP_B2_* GH secrets; manual operators
-# bootstrapping a new VPS must fill these in by hand. See deploy#188.
-B2_KEY_ID=CHANGE-ME
-B2_APP_KEY=CHANGE-ME
+# Consumed by scripts/backup.sh:59-61 which uses `${VAR:?...}` fail-fast.
+# Scope: read+write+delete on the isnad-graph-backups bucket only (separate
+# from PIPELINE_B2_* ingest scope and TF_STATE_B2_* terraform backend scope).
+# The deploy-{stg,prod}.yml workflows populate these from BACKUP_B2_* GH
+# secrets (writing empty strings when unset, so backup.sh fails fast at
+# preflight); manual operators bootstrapping a new VPS must fill these in
+# by hand. See deploy#188 / #191.
+#
+# IMPORTANT: leave B2_KEY_ID and B2_APP_KEY EMPTY (not "CHANGE-ME") at
+# bootstrap. The ${VAR:?} preflight in backup.sh treats unset and empty
+# identically; a literal "CHANGE-ME" satisfies :? and would let backup.sh
+# proceed to rclone, which then fails with an opaque B2 401. Empty values
+# give the operator the actually-useful "B2_KEY_ID must be set" error.
+B2_KEY_ID=
+B2_APP_KEY=
 B2_BUCKET=isnad-graph-backups
 ENVEOF
   chmod 600 "$ENV_FILE"


### PR DESCRIPTION
## Summary

`scripts/bootstrap-vps.sh` wrote literal `B2_KEY_ID=CHANGE-ME` and `B2_APP_KEY=CHANGE-ME` as bootstrap defaults. `scripts/backup.sh:62-64` uses the `${VAR:?}` preflight, which trips on unset OR empty values — but a literal `"CHANGE-ME"` satisfies it. Result: backup.sh would proceed past preflight and fail later inside rclone with an opaque B2 401 instead of the immediately-useful `"B2_KEY_ID must be set"` error.

The workflow path in `deploy-{stg,prod}.yml` already writes empty strings when the GH secret is unset (per #189's "Empty values are written as empty so backup.sh fails fast at preflight"). This PR restores symmetry between the workflow path and the manual-bootstrap path.

Adopts **option (1)** from the issue's three-option ladder — empty defaults in bootstrap. `B2_BUCKET=isnad-graph-backups` preserved as-is (it's a real default value, not a credential).

## Mechanism

```diff
-B2_KEY_ID=CHANGE-ME
-B2_APP_KEY=CHANGE-ME
+B2_KEY_ID=
+B2_APP_KEY=
 B2_BUCKET=isnad-graph-backups
```

Plus an inline comment explaining *why* the values are intentionally empty — so the next operator who would otherwise "fix" them back to `CHANGE-ME` placeholders sees the reasoning.

## Local trace

`/tmp/test_d_backup_failfast.sh` — 5 cases × 9 assertions, all pass:

| Case | Setup | Expected | Result |
|---|---|---|---|
| (a) | all three UNSET (workflow path when secret unset) | fail-fast trips with `B2_KEY_ID must be set` | PASS |
| (b) | all three EMPTY (NEW bootstrap default) | fail-fast trips with same message | PASS |
| (c) | all three = `CHANGE-ME` (the OLD bug shape) | fail-fast does NOT trip | PASS (demonstrates the bug) |
| (d) | all three set to real values | proceeds past preflight | PASS |
| (e) | partial: KEY+BUCKET set, APP_KEY empty (operator-fills-2-of-3) | fail-fast trips with `B2_APP_KEY must be set` | PASS |

## Acceptance from #191

- ✅ Option (1) chosen as recommended in the issue body.
- ✅ Bootstrap path no longer writes placeholder values that defeat the preflight.
- ✅ Inline comment captures the *why*, so the empty-default isn't lost to a future "let me add a sensible default" edit.

## Test plan (post-merge runtime — out of PR-time scope per `[[feedback_runtime_gate_scoping]]`)

- [ ] On a fresh Hetzner VPS: run `bootstrap-vps.sh`, confirm `/opt/noorinalabs-deploy/.env` has empty `B2_KEY_ID=` and `B2_APP_KEY=` lines.
- [ ] On same VPS without operator filling in the values: run `bash scripts/backup.sh`. Expect exit-1 within first second with stderr `B2_KEY_ID must be set` (NOT opaque B2 401 inside rclone).
- [ ] Operator fills in valid creds; re-run; expect dump → compress → B2 upload → retention prune all succeed (the cutover gate from `main#212`).

## Reviewers

- **Weronika Zielinska** (platform architect) — bootstrap surface
- **Aisha Idrissi** (SRE) — backup operational path, owns the rclone+B2 plumbing

Per charter: both must use literal `Approved` per `[[feedback_validate_pr_review_approved_not_reply]]`. Reviewers already context-warm from PR #287.

## Cross-references

- #189 — established the workflow-side empty-string-when-unset pattern this PR mirrors to bootstrap
- #188 — original BACKUP_B2_* provisioning issue
- `backup_service_state` in `ontology/repos/deploy.yaml` — the broader backup-broken context

Closes #191
