### PR TITLE
fix(cloud-init): post-Phase-B hardening — defer write_files, ssh unit, noninteractive apt (#173 gaps B+C+D)

### DIFF
--- a/terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl
+++ b/terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl
@@ -14,6 +14,20 @@
 package_update: true
 package_upgrade: true
 
+# Apt configuration applied to cloud-init's own `packages:` install + the
+# package_upgrade step. Per #173 gap D: cloud-init defaults don't set
+# DEBIAN_FRONTEND, so any package with an interactive postinst (needrestart's
+# whiptail "Pending kernel upgrade" being the most common) creates noise in
+# cloud-init.log and is a hang risk. --force-confold/confdef preserves
+# operator-modified config files on upgrade; matches the apt invocation
+# pattern in bootstrap-vps.sh since deploy#110.
+apt:
+  conf: |
+    DPkg::Options {
+      "--force-confdef";
+      "--force-confold";
+    };
+
 packages:
   - docker.io
   - docker-compose-v2
@@ -72,10 +86,16 @@ write_files:
       Unattended-Upgrade::AutoFixInterruptedDpkg "true";
       Unattended-Upgrade::Remove-Unused-Dependencies "true";
 
-  # GHCR Docker auth config for deploy user
+  # GHCR Docker auth config for deploy user.
+  # defer: true so cloud-init waits until the `users:` module has created
+  # `deploy` before chowning this file — without it, cloud-init's
+  # write_files module runs before users, hits OSError('Unknown user "deploy"'),
+  # aborts the entire write_files stage, and silently drops the remaining
+  # entries (this file, .env.user-service, .cloud-init-provisioned). See #173 gap B.
   - path: /home/deploy/.docker/config.json
     owner: deploy:deploy
     permissions: '0600'
+    defer: true
     content: |
       {
         "auths": {
@@ -89,10 +109,12 @@ write_files:
   # User-service environment file
   # Docker Compose reads this to configure user-postgres, user-redis, and
   # user-service containers. Values are injected from Terraform variables.
+  # defer: true — same reason as the .docker/config.json entry above. See #173 gap B.
   # ---------------------------------------------------------------------------
   - path: /opt/noorinalabs-deploy/.env.user-service
     owner: deploy:deploy
     permissions: '0600'
+    defer: true
     content: |
       # user-service secrets — managed by Terraform cloud-init
       USER_POSTGRES_PASSWORD=${user_postgres_password}
@@ -124,10 +146,14 @@ runcmd:
   - systemctl enable fail2ban
   - systemctl start fail2ban
 
-  # Disable root SSH password login (key-only)
+  # Disable root SSH password login (key-only).
+  # Ubuntu 24.04 unit name is `ssh.service`, not `sshd.service` (debian-style
+  # naming). The old `systemctl restart sshd` silently failed with
+  # "Unit sshd.service not found" — sshd_config edits then only took effect
+  # on the next kernel-upgrade reboot. See #173 gap C.
   - sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
   - sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
-  - systemctl restart sshd
+  - systemctl restart ssh
 
   # Clone deploy repo
   - git clone https://github.com/noorinalabs/noorinalabs-deploy.git /opt/noorinalabs-deploy || true
@@ -155,11 +181,22 @@ runcmd:
   - chown deploy:deploy /var/lib/node_exporter/textfile_collector
   - chmod 0755 /var/lib/node_exporter/textfile_collector
 
-  # Install Caddy via official apt repo
+  # Install Caddy via official apt repo.
+  # DEBIAN_FRONTEND=noninteractive + NEEDRESTART_MODE=a are inlined per-command
+  # because cloud-init's runcmd exec's each entry independently — `export`s in
+  # an earlier entry don't survive to the next. Without these, caddy's apt
+  # install triggers a whiptail "Pending kernel upgrade" dialog from
+  # needrestart, which prints
+  #   debconf: whiptail output the above errors, giving up!
+  # and "Use of uninitialized value $ret in scalar chomp" in cloud-init logs.
+  # The install does NOT block today (whiptail bails when it can't open a
+  # terminal) but is an apt-hang risk under stricter dialog policies and is
+  # noisy in cloud-init.log. Matches the pattern used in bootstrap-vps.sh
+  # since deploy#110. See #173 gap D.
   - curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
   - echo "deb [signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg] https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main" > /etc/apt/sources.list.d/caddy-stable.list
-  - apt-get update -qq
-  - apt-get install -y -qq caddy
+  - DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update -qq
+  - DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -qq -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" caddy
   - systemctl stop caddy
   # Caddy will be run via Docker Compose, not systemd — disable the system service
   - systemctl disable caddy


### PR DESCRIPTION
## Summary

Closes the three remaining gaps in #173 (gaps B + C + D) — `terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl` hardening discovered during Phase B stg rebuild. Gaps A + E from the issue body are already fixed at HEAD; see #173's amended issue body for the verified-at-HEAD status table.

Single file changed, +43/-6.

## Gap B — write_files defer:true

Two `owner: deploy:deploy` write_files entries were running before the `users:` module created the deploy user, aborting the entire write_files stage with `OSError('Unknown user "deploy"')`. Added `defer: true` to both, which is cloud-init's canonical "wait until users have been created" annotation.

## Gap C — `systemctl restart sshd` → `ssh`

Ubuntu 24.04 unit is `ssh.service`, not `sshd.service`. The old line silently failed; sshd_config edits only took effect on next reboot.

## Gap D — DEBIAN_FRONTEND / noninteractive apt

Two-layered fix because cloud-init has two apt code paths:
1. **`packages:` directive** uses cloud-init's apt config. Added top-level `apt:` block with `--force-confdef --force-confold` DPkg options.
2. **runcmd `apt-get install caddy`** is exec'd independently (runcmd entries don't share env). Inlined `DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a` per-command on the caddy install lines; also added the same Dpkg options for symmetry with the bootstrap-vps.sh pattern from deploy#110.

## Acceptance (from #173 amended body)

- [x] Gap B: `defer: true` on both `owner: deploy:deploy` write_files entries (lines 77 + 94 in the patch context). 2/2 covered. The third write_files entry (`.cloud-init-provisioned`) doesn't have owner: set so didn't trigger the OSError; the aborted-stage cascade nuked it anyway, fixed automatically when stage no longer bails.
- [x] Gap C: `cloud-init.yaml.tpl:130` → `systemctl restart ssh`.
- [x] Gap D: `apt:` block + per-runcmd `DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a` inlines on the apt-get calls.

## Pre-coding verification (per [[feedback_pre_spawn_brief_verified_at_head]])

Enumerated all 5 gaps at origin/wave-11 HEAD before authoring this PR (results documented in #173's amended body). PR scope is exactly B + C + D, no scope creep into A/E (already-landed) or adjacent module surface.

## Verification

- `terraform fmt -check terraform/hetzner/modules/hetzner-vps/` clean
- `terraform init -backend=false && terraform validate` on the module — clean
- YAML-validated the rendered template (substituted templatefile vars with plausible values, parsed with PyYAML):
  - Top-level keys: `package_update, package_upgrade, apt, packages, users, write_files, runcmd`
  - write_files: 6 entries, **2 with `defer:true`** (the deploy-owned ones)
  - runcmd: 30 entries; ssh-related correctly cite `systemctl restart ssh`
  - apt block: `conf` key present

## Test plan (post-merge runtime — out of PR-time scope per `[[feedback_runtime_gate_scoping]]`)

- [ ] `terraform apply` against a fresh throwaway Hetzner stg VM with this PR merged.
- [ ] B: `cloud-init status` post-boot reports `done` (not `error`); `/opt/noorinalabs-deploy/.cloud-init-provisioned` exists; `/home/deploy/.docker/config.json` exists.
- [ ] C: cloud-init log shows successful sshd restart; no `Unit sshd.service not found`.
- [ ] D: cloud-init log clean of whiptail/debconf messages; caddy installed without prompts.

Per [[feedback_verify_third_party_integrity_claims]]: claims about Ubuntu 24.04 unit naming + cloud-init `defer:true` semantics are cloud-init upstream documented behavior; the apt-config `conf:` shape is from cloud-init's `cc_apt_configure` module docs. No third-party integrity claims about binary verification here.

## Reviewers

- **Weronika Zielinska** (primary, platform architect) — TF module + cloud-init surface
- **Aisha Idrissi** (secondary, SRE) — ran the Phase B stg rebuild that surfaced these gaps; best positioned to confirm the fix shape matches the actual failures she hit

Both per [[feedback_validate_pr_review_approved_not_reply]] must use literal `Approved`. Reviewers context-warm from PR #287.

## Cross-references

- #173 (this PR) — amended body has the HEAD-verified gap-status table
- #165 — closed as done at HEAD (#222 + #223 covered SSH cloud-init injection)
- #223 — prior PR that landed the SSH cloud-init injection mechanism
- #110 — bootstrap-vps.sh DEBIAN_FRONTEND pattern (the same problem in the sibling code path)
- main#212 — Phase C cutover plan; these fixes need to land before Phase C runs

Closes #173
