### PR TITLE
tech-debt(docs): user-service-alembic runbook + compose comment drift cleanup (#211, post-#210)

### DIFF
--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -693,13 +693,13 @@ services:
       - /sys:/host/sys:ro
       - /:/rootfs:ro
       # Textfile collector input directory (deploy#161). The host path is
-      # owned by the `deploy` user (mode 0775) and populated by the alembic
+      # owned by `deploy:deploy` (mode 0755) and populated by the alembic
       # pre-deploy gate in db-migrate.yml on every run via `if: always()`.
       # Read-only mount so a compromised node-exporter cannot clobber the
-      # written .prom files. Provisioning of the host directory is a runbook
-      # step today (`mkdir -p /var/lib/node_exporter/textfile_collector &&
-      # chown deploy:deploy && chmod 0775`); cloud-init bake-in is tracked as
-      # a follow-up if Nurul prefers it move to TF.
+      # written .prom files. The host directory is provisioned automatically
+      # by Terraform cloud-init (terraform/hetzner/modules/hetzner-vps/
+      # cloud-init.yaml.tpl runcmd:) on every fresh VPS — no manual step
+      # needed. Mode 0755 set by cloud-init (PR #210, Bereket amendment).
       - /var/lib/node_exporter/textfile_collector:/var/lib/node_exporter/textfile_collector:ro
     command:
       - "--path.procfs=/host/proc"

--- a/docs/runbooks/user-service-alembic.md
+++ b/docs/runbooks/user-service-alembic.md
@@ -158,7 +158,7 @@ If a migration needs to land urgently (e.g., a prod outage fix):
 
 **Status: implemented — [`deploy#161`](https://github.com/noorinalabs/noorinalabs-deploy/issues/161) (P3W1) wired the textfile-collector plumbing and landed the Prometheus alert.**
 
-Gate runs emit two gauges to node-exporter's textfile collector via an `if: always()` SSH step in `db-migrate.yml`. The metric file lives at `/var/lib/node_exporter/textfile_collector/user_service_alembic_gate.prom` on the VPS (mode 0644, written by the `deploy` user via temp + atomic rename). The host directory is provisioned as a one-time runbook step on each VPS (`mkdir -p /var/lib/node_exporter/textfile_collector && chown deploy:deploy && chmod 0775`); the `node-exporter` service in `compose/docker-compose.prod.yml` mounts that directory read-only and reads the file on each scrape.
+Gate runs emit two gauges to node-exporter's textfile collector via an `if: always()` SSH step in `db-migrate.yml`. The metric file lives at `/var/lib/node_exporter/textfile_collector/user_service_alembic_gate.prom` on the VPS (mode 0644, written by the `deploy` user via temp + atomic rename). The host directory is provisioned automatically by Terraform cloud-init on every VPS — see `terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl` `runcmd:` (creates `/var/lib/node_exporter/textfile_collector`, owned `deploy:deploy`, mode `0755`). No manual runbook step is needed on fresh VPSes. The `node-exporter` service in `compose/docker-compose.prod.yml` mounts that directory read-only and reads the file on each scrape.
 
 Metric schema:
 


### PR DESCRIPTION
Closes #211

## What

Two prose sites described the pre-#210 provisioning model (one-time runbook step, mode 0775). PR #210 (squash 851bd71) landed Bereket-amendment cloud-init wiring that pre-creates the directory automatically at mode 0755. Both sites now reflect the actual merged state.

**`docs/runbooks/user-service-alembic.md` (§Observability, first paragraph):**
- Before: "provisioned as a one-time runbook step on each VPS (`mkdir ... chmod 0775`)"
- After: "provisioned automatically by Terraform cloud-init (`cloud-init.yaml.tpl` runcmd:), mode 0755. No manual runbook step is needed on fresh VPSes."

**`compose/docker-compose.prod.yml` (node-exporter textfile_collector mount comment):**
- Before: "mode 0775 … Provisioning of the host directory is a runbook step today … cloud-init bake-in is tracked as a follow-up"
- After: "mode 0755 … provisioned automatically by Terraform cloud-init … no manual step needed. Mode 0755 set by cloud-init (PR #210, Bereket amendment)."

Source-of-truth verified: `terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl` runcmd: confirms `chmod 0755` at squash 851bd71.

Surfaced by Lucas Ferreira in his 2° review on #210 (issuecomment-4356807378).

## Requestor: Lucas Ferreira
## Requestee: Weronika Zielinska
## RequestOrReplied: Approved
## TechDebt: none