### PR TITLE
docs(tf): add CI-side B2 secret rotation step to backblaze runbook (#182)

### DIFF
--- a/terraform/backblaze/README.md
+++ b/terraform/backblaze/README.md
@@ -261,6 +261,97 @@ The module configures two lifecycle rules:
 downstream stages are rebuildable from `raw/` via `/ontology-librarian
 pipeline reset levels`.
 
+## Rotating the state-bucket key (CI + workstation)
+
+Follow this sequence when you need to rotate the `noorinalabs-terraform-state` B2
+application key (e.g., after a key disable/expire, or on scheduled cadence).
+
+### Step 1 — Mint a new state-bucket key
+
+From the [B2 console → App Keys](https://secure.backblaze.com/app_keys.htm), create a
+new key with the same settings as described in
+[Provisioning the state-bucket key](#provisioning-the-state-bucket-key) above.
+Record `keyID` and `applicationKey` in your password manager before navigating away.
+
+Capture into shell variables (not exported yet — reduces history exposure):
+
+```bash
+NEW_KEY_ID=<keyID>
+NEW_APP_KEY=<applicationKey>
+```
+
+### Step 2 — Rotate GH Actions secrets
+
+The CI workflow `.github/workflows/terraform.yml` reads these two repo secrets:
+
+| GH Secret | Role |
+|---|---|
+| `TF_STATE_B2_KEY_ID` | `AWS_ACCESS_KEY_ID` → S3 backend auth |
+| `TF_STATE_B2_APP_KEY` | `AWS_SECRET_ACCESS_KEY` → S3 backend auth |
+
+Push the new values using stdin (`--body -` keeps secrets out of shell history):
+
+```bash
+echo "$NEW_KEY_ID"  | gh secret set TF_STATE_B2_KEY_ID  --repo noorinalabs/noorinalabs-deploy --body -
+echo "$NEW_APP_KEY" | gh secret set TF_STATE_B2_APP_KEY --repo noorinalabs/noorinalabs-deploy --body -
+```
+
+> **Per-environment scoping (future):** once #158 lands and `TF_STATE_B2_*` moves into
+> GH Environments, add `--env staging` and `--env production` flags and rotate both
+> atomically before proceeding.
+
+### Step 3 — Update your workstation shell
+
+Export the new values for any local `terraform plan/apply` runs in this session:
+
+```bash
+export AWS_ACCESS_KEY_ID=$NEW_KEY_ID
+export AWS_SECRET_ACCESS_KEY=$NEW_APP_KEY
+```
+
+Verify locally:
+
+```bash
+terraform -chdir=terraform/hetzner/envs/stg plan -input=false
+```
+
+A clean plan (no 403 / `SignatureDoesNotMatch`) confirms the state-bucket key is valid.
+
+### Step 4 — Re-trigger in-flight Terraform PRs
+
+Any open PR that ran a failed plan with the old key must be re-triggered. Pick one:
+
+```bash
+# Option A — re-run the failed run directly
+gh run rerun <run-id> --repo noorinalabs/noorinalabs-deploy
+
+# Option B — empty commit on the PR branch
+git commit --allow-empty -m "ci: re-trigger after B2 cred rotation"
+git push
+
+# Option C — manual workflow dispatch
+gh workflow run terraform.yml --ref <branch> --repo noorinalabs/noorinalabs-deploy
+```
+
+### Step 5 — Verify CI green, then disable the old key
+
+**Do not disable the old B2 key until at least one full Terraform CI run (fmt →
+validate → plan stg → plan prod) completes green with the new key.** An in-flight
+workflow that started before the GH secret update may still hold a reference to the
+old key; disabling prematurely races that run and leaves the rotation half-applied.
+
+Once CI is green:
+
+1. Return to [B2 console → App Keys](https://secure.backblaze.com/app_keys.htm).
+2. Locate the old `noorinalabs-tfstate-{operator-handle}` key.
+3. Click **Delete**. (B2 has no "disable" state for application keys — delete is final.)
+
+### Cross-references
+
+- deploy#158 — future CI `validate-creds` self-check that catches rotation drift between envs
+- deploy#180 — ADR on state-bucket key model and rotation cadence
+- deploy#93 — workstation-side runbook (closed by PR #177)
+
 ## Local development
 
 See `../../compose/docker-compose.minio.yml` for a MinIO-backed alternative


### PR DESCRIPTION
Closes #182

Adds the missing CI-side rotation step to `terraform/backblaze/README.md`.

## What was missing

The runbook landed in PR #177 (closes #93) covered operator-shell provisioning but stopped before the GH Actions secret rotation. Without the CI step, operators following the runbook rotate their workstation key but leave CI silently broken until the next `terraform/**` PR surfaces the failure (`SignatureDoesNotMatch` 403 on `noorinalabs-terraform-state ListObjectsV2`). This is exactly what happened in Phase B (2026-04-26), blocking all wave-10 in-flight TF PRs until Steven manually rotated secrets 2026-04-28.

## Changes

Adds section **"Rotating the state-bucket key (CI + workstation)"** covering:

1. Mint new state-bucket key (B2 console)
2. Rotate GH repo secrets `TF_STATE_B2_KEY_ID` + `TF_STATE_B2_APP_KEY` via `gh secret set --body -` (stdin, consistent with existing runbook style; secret names sourced from `.github/workflows/terraform.yml:68-69`)
3. Update workstation shell + local `terraform plan` verification
4. CI re-trigger patterns for in-flight PRs (`gh run rerun` / empty commit / `gh workflow run`)
5. Explicit ordering rule: CI must confirm green before the old B2 key is deleted on B2 side
6. Cross-references to #158 (future `validate-creds` automation) and #180 (key rotation ADR)

## Reviewer focus

- **Aisha (1°)**: CI/secret rotation discipline — verify step 2 secret names match `terraform.yml` consumption sites, ordering rule for old-key disable, re-trigger patterns
- **Nurul (2°)**: Runbook quality — clarity, consistency with existing style, cross-ref accuracy