### PR TITLE
docs: prune hcloud_ssh_key references after #223 (#225)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -157,8 +157,8 @@ The `.env` file is ephemeral: recreated fresh on each deployment, written with `
 Provisioned via Terraform in `terraform/hetzner/`. The Terraform configuration creates:
 
 - `hcloud_server` — the VPS instance
-- `hcloud_ssh_key` — deploy SSH key
 - `hcloud_firewall` — allows SSH (22), HTTP (80), HTTPS (443)
+- SSH authorized keys are injected via cloud-init (`cloud-init.yaml.tpl` in `terraform/hetzner/modules/hetzner-vps/`); there is no `hcloud_ssh_key` Terraform resource
 
 ### Bootstrap
 

--- a/terraform/hetzner/README.md
+++ b/terraform/hetzner/README.md
@@ -47,8 +47,8 @@ Each env is a self-contained Terraform root module. **Working directory IS the e
 Terraform manages:                    Docker Compose manages:
 ├── VPS (hcloud_server)               ├── isnad-graph (FastAPI + React)
 ├── Firewall (hcloud_firewall)        ├── neo4j
-├── SSH Key (hcloud_ssh_key)          ├── user-service (FastAPI)
-└── cloud-init bootstrap              ├── user-postgres
+└── cloud-init bootstrap              ├── user-service (FastAPI)
+   (injects SSH authorized_keys)     ├── user-postgres
                                       ├── user-redis
                                       └── caddy (reverse proxy)
 ```

--- a/terraform/hetzner/modules/hetzner-vps/README.md
+++ b/terraform/hetzner/modules/hetzner-vps/README.md
@@ -1,6 +1,6 @@
 # `modules/hetzner-vps` — Shared Hetzner VPS module
 
-Provisions one Hetzner Cloud VPS plus its firewall and SSH key, bootstrapped with cloud-init. Consumed by per-env root modules under `terraform/hetzner/envs/{stg,prod}/`.
+Provisions one Hetzner Cloud VPS plus its firewall, bootstrapped with cloud-init. Consumed by per-env root modules under `terraform/hetzner/envs/{stg,prod}/`.
 
 This module is **intentionally backend-less**. Backend configuration lives in each env root module so state is isolated per env — see ADR `docs/adr/0001-tf-hetzner-per-env-state-strategy.md`.
 
@@ -10,7 +10,8 @@ This module is **intentionally backend-less**. Backend configuration lives in ea
 |---|---|
 | `hcloud_server.app` | `noorinalabs-${var.env}` |
 | `hcloud_firewall.web` | `noorinalabs-${var.env}-firewall` |
-| `hcloud_ssh_key.deploy` | `noorinalabs-${var.env}-deploy` |
+
+SSH authorized keys (`/root/.ssh/authorized_keys` and `/home/deploy/.ssh/authorized_keys`) are injected via `cloud-init.yaml.tpl`; there is no `hcloud_ssh_key` resource.
 
 All resources carry labels `{ project = "noorinalabs", environment = var.env }`.
 


### PR DESCRIPTION
Closes #225

## Changes

Four doc locations orphaned by PR #223 (which removed `resource "hcloud_ssh_key" "deploy"` from the hetzner-vps module):

| File | Line | Before | After |
|------|------|--------|-------|
| `terraform/hetzner/modules/hetzner-vps/README.md` | 3 | "…plus its firewall and SSH key, bootstrapped…" | "…plus its firewall, bootstrapped…" |
| `terraform/hetzner/modules/hetzner-vps/README.md` | 13 | `hcloud_ssh_key.deploy` row in Resources table | Row removed; cloud-init note added below table |
| `terraform/hetzner/README.md` | 50 | `├── SSH Key (hcloud_ssh_key)` in ASCII tree | Row replaced with `cloud-init bootstrap (injects SSH authorized_keys)` annotation |
| `docs/architecture.md` | 160 | `- \`hcloud_ssh_key\` — deploy SSH key` bullet | Replaced with cloud-init injection description cross-linking `cloud-init.yaml.tpl` |

All references to `hcloud_ssh_key` as an existing resource have been removed. The replacement prose accurately describes the cloud-init path (`cloud-init.yaml.tpl`) for `/root/.ssh/authorized_keys` and `/home/deploy/.ssh/authorized_keys` injection.