### PR TITLE
docs(runbook): cold-rebuild-dry-run — backlink #230 + add SCHEME_TO_PKG playbook step (#265)

### DIFF
--- a/docs/runbooks/cold-rebuild-dry-run.md
+++ b/docs/runbooks/cold-rebuild-dry-run.md
@@ -22,7 +22,7 @@ the helper script `.github/workflows/scripts/cold_rebuild_static_checks.py`.
 | Bug | Issue | Fix PR | Detection |
 |-----|-------|--------|-----------|
 | terraform.yml ephemeral keypair | [#216](https://github.com/noorinalabs/noorinalabs-deploy/issues/216) | [#217](https://github.com/noorinalabs/noorinalabs-deploy/pull/217) | static — `cold_rebuild_static_checks.py` asserts (a) terraform.yml contains no `ssh-keygen`, (b) `modules/hetzner-vps/deploy.pub` exists, (c) env-root `ssh_public_key_path` defaults point at the canonical pubkey. |
-| promote.yml retag-token mismatch | (no issue — fixed inline via PAT regen + `GH_PACKAGES_TOKEN` swap) | (inline) | static — asserts the retag job's docker/login-action authenticates with `secrets.GH_PACKAGES_TOKEN`, never `secrets.GITHUB_TOKEN`. |
+| promote.yml retag-token mismatch | [#230](https://github.com/noorinalabs/noorinalabs-deploy/issues/230) | (inline) | static — asserts the retag job's docker/login-action authenticates with `secrets.GH_PACKAGES_TOKEN`, never `secrets.GITHUB_TOKEN`. |
 | promote.yml stg-latest TOCTOU | [#234](https://github.com/noorinalabs/noorinalabs-deploy/issues/234) | [#236](https://github.com/noorinalabs/noorinalabs-deploy/pull/236) | static — asserts `Resolve source tag` step assigns `source_tag="sha-${SHORT}"` and never to a `*-latest` floating tag. |
 | promote.yml multi-arch parity | [#239](https://github.com/noorinalabs/noorinalabs-deploy/issues/239) | [#240](https://github.com/noorinalabs/noorinalabs-deploy/pull/240) | dynamic — `buildx-shape-dryrun` job builds a multi-arch + single-arch fixture against a local registry, runs `imagetools create`, and asserts the shape-aware parity logic from promote.yml passes for both shapes. Includes a negative control that asserts the pre-#239 naive comparison still fails on single-arch. |
 | db-migrate.yml psycopg-vs-asyncpg | [#235](https://github.com/noorinalabs/noorinalabs-deploy/issues/235) | [#236](https://github.com/noorinalabs/noorinalabs-deploy/pull/236) | static — extracts the `postgresql+<driver>://` scheme from db-migrate.yml's `DATABASE_URL=` line and asserts the driver package is declared in user-service/pyproject.toml (read from the wave-aware sibling checkout, matching `integration-tests.yml`'s pattern). |
@@ -133,7 +133,11 @@ When a new first-deploy / cold-start bug surfaces:
 2. **Add a guard** to `cold_rebuild_static_checks.py` (for static-shape
    bugs) or to `cold-rebuild-dryrun.yml` (for dynamic-shape bugs that
    need a fixture). The guard should fail loudly if the bug shape
-   reappears AND prove the fix shape is still in place.
+   reappears AND prove the fix shape is still in place. If the guard
+   checks a `DATABASE_URL` driver scheme, add the new driver to the
+   `SCHEME_TO_PKG` dict at `cold_rebuild_static_checks.py:317` —
+   unrecognized schemes fire `db-migrate-driver-known` with an
+   "extend SCHEME_TO_PKG" diagnostic.
 3. **Update this runbook**: add a row to the "What the gate covers"
    table with the issue number, fix PR, and detection mechanism.
 4. **Update `cold-rebuild-dryrun.yml`'s top-of-file comment** with the


### PR DESCRIPTION
Closes #265

## What

Two minor prose fixes to `docs/runbooks/cold-rebuild-dry-run.md` (landed in #260):

**1. L25 — backlink retag-token bug to #230.**
- Before: `(no issue — fixed inline via PAT regen + \`GH_PACKAGES_TOKEN\` swap)`
- After: `[#230](https://github.com/noorinalabs/noorinalabs-deploy/issues/230)`

Issue #230 ("infra(secrets): GH_PACKAGES_TOKEN PAT lacks write:packages scope — promote.yml retag fails 403", closed 2026-05-02) is the actual postmortem. Link restores the bug → fix → guard traceability chain.

**2. "Adding a new guard" step 2 — SCHEME_TO_PKG extension note.**
Added note that guards checking `DATABASE_URL` driver schemes must also extend `SCHEME_TO_PKG` at `cold_rebuild_static_checks.py:317`. Unrecognized schemes fire `db-migrate-driver-known` with "extend SCHEME_TO_PKG" diagnostic (dict verified at lines 317–322).

## Requestor: Weronika Zielinska
## Requestee: Weronika Zielinska
## RequestOrReplied: Approved
## TechDebt: none