### PR TITLE
docs(runbook): polish oauth-per-env failure-modes (refresh-token + scope mismatch + cleanup ordering) (#268)

### DIFF
--- a/docs/runbooks/oauth-per-env.md
+++ b/docs/runbooks/oauth-per-env.md
@@ -39,6 +39,8 @@ User-service's OAuth callback path is `/auth/oauth/{provider}/callback` (`POST`,
 
 **Only the env's own callback URL goes in that env's app.** Do not mix prod and stg URIs in one app — that re-creates the shared-app posture this runbook exists to prevent.
 
+> **Adding a new OAuth provider:** follow the same per-env pattern — provision one provider app per env, set `AUTH_<PROVIDER>_CLIENT_ID` + `AUTH_<PROVIDER>_CLIENT_SECRET` at the env-scope for each env, and add the callback URI to the redirect URI conventions table above.
+
 ## Provisioning a new env (4 steps)
 
 Follow when adding any new env (e.g., `dev` between stg and prod, or a `canary` post-prod). Each step is owner-only because OAuth provider consoles require interactive auth that is out-of-band of CI.


### PR DESCRIPTION
## Summary

The three mandatory failure-mode rows from #268 (rows 5–7: `invalid_scope`, `invalid_grant` on refresh-token revocation, cleanup ordering hazard) landed in the Bereket-review addendum commit on PR #267. That commit's message explicitly noted #268 as still open for the optional bonus item.

This PR delivers the remaining open item: a one-line "new provider" convention note in §Redirect URI conventions, completing all #268 acceptance criteria.

## What changed

`docs/runbooks/oauth-per-env.md` (+2 lines): blockquote note after the redirect URI conventions table — if adding a new OAuth provider, follow the same per-env pattern with `AUTH_<PROVIDER>_CLIENT_ID` + `AUTH_<PROVIDER>_CLIENT_SECRET` at env-scope.

## Acceptance criteria from #268

- [x] §Failure modes gains rows for refresh-token revocation (`invalid_grant`) — done in #267 addendum
- [x] §Failure modes gains row for scope mismatch (`invalid_scope`) — done in #267 addendum
- [x] §Failure modes gains cleanup ordering hazard row — done in #267 addendum
- [x] §Provisioning (redirect URI conventions) gains a one-line "new provider" note — this PR

Closes #268