### PR TITLE
docs(cf): document stg-vs-prod proxy-posture asymmetry + ACM consideration (#229)

### DIFF
--- a/terraform/cloudflare/README.md
+++ b/terraform/cloudflare/README.md
@@ -31,9 +31,37 @@ terraform/cloudflare/
 | `isnad.stg` CNAME | `stg_isnad_cname` | **no** | → `stg.noorinalabs.com` |
 | `users.stg` CNAME | `stg_users_cname` | **no** | → `stg.noorinalabs.com` |
 
-### Why are stg records gray-cloud (proxied=false)?
+## Prod vs stg proxy posture
 
-Cloudflare Universal SSL only covers one level of wildcards (`*.noorinalabs.com`). Third-level subdomains like `isnad.stg.noorinalabs.com` get a TLS handshake failure at the CF edge. Until Cloudflare Advanced Certificate Manager (paid) is enabled, stg lives outside the proxy. Origin Caddy provides valid Let's Encrypt certs for the stg hostnames and serves directly. Tracked as a tech-debt followup if needed.
+The two environments have asymmetric Cloudflare proxy posture by necessity:
+
+| Env | Records | Proxied | TLS terminated at | Edge benefits |
+|-----|---------|---------|-------------------|---------------|
+| prod | apex, www, isnad, users | **true** (orange-cloud) | CF edge | DDoS mitigation, WAF, edge cache |
+| stg | stg, isnad.stg, users.stg | **false** (gray-cloud) | origin Caddy (Let's Encrypt) | none |
+
+### Why the asymmetry is forced
+
+Cloudflare Universal SSL covers `*.noorinalabs.com` (one wildcard level) and the apex. Third-level subdomains like `isnad.stg.noorinalabs.com` are **not covered**: TLS handshake at the CF edge fails with a certificate mismatch. Enabling `proxied = true` on stg records causes immediate TLS errors (#228 confirmed this — toggled all stg records back to `proxied = false` as the forced fix).
+
+Origin Caddy auto-provisions valid Let's Encrypt certificates for the stg hostnames directly, so stg HTTPS works without the CF proxy.
+
+### Trade-off
+
+Stg without the CF proxy means:
+- No Cloudflare DDoS / rate-limit / WAF rules apply at the edge for stg traffic
+- No CF edge caching for stg responses
+- Stg origin is directly reachable (IP exposed) — acceptable for non-prod
+
+Prod keeps the full orange-cloud posture (DDoS mitigation, WAF, edge cache).
+
+### Remediation option: Cloudflare Advanced Certificate Manager (ACM)
+
+Cloudflare ACM (~$10/month) adds wildcard cert coverage at any subdomain depth, including `*.stg.noorinalabs.com`. Enabling ACM would allow stg records to be proxied like prod (one dashboard toggle in the CF zone). Owner decision — paid feature, not a defect. Tracked in deploy#229.
+
+**If ACM is enabled:** flip all stg records to `proxied = true` in `main.tf` and re-apply. No DNS record renames needed — the `proxied` field is the only change.
+
+**If stg stays gray-cloud:** no action needed. Document the decision in deploy#229 and close as won't-fix.
 
 ### IP source — no manual var needed
 


### PR DESCRIPTION
Closes #229

## What was missing

The prod-vs-stg Cloudflare proxy asymmetry (prod=orange-cloud, stg=gray-cloud) was only documented as an inline comment in `terraform/cloudflare/main.tf`. The README had a one-sentence sub-note. New operators had no operator decision guidance for why new stg records must use `proxied=false`, what they lose by being gray-cloud, or when/how to revisit (ACM path).

## Changes

Expanded the minimal gray-cloud sub-note into a full **"Prod vs stg proxy posture"** top-level section in `terraform/cloudflare/README.md` covering:

1. Canonical per-env table (records, proxied, TLS termination, edge benefits)
2. Root cause: Universal SSL one-level wildcard scope — 3rd-level subdomains like `isnad.stg.noorinalabs.com` cause TLS handshake failure at the CF edge (#228 confirmed)
3. Trade-off: stg loses DDoS/WAF/cache + origin IP exposed — acceptable for non-prod
4. ACM remediation option (~$10/mo, single dashboard toggle, owner decision, tracked in deploy#229)
5. Operator decision points: what to change in `main.tf` if ACM is enabled vs stg stays gray-cloud

## Out of scope note

Issue #229 acceptance criterion also calls for an `ontology/conventions.md` entry. That file lives in the parent `noorinalabs-main` repo, not noorinalabs-deploy. The deploy README is the canonical source-of-truth for operator guidance; `ontology/conventions.md` should be a follow-up PR against the main repo.

## Refs

- #226 — all-proxied attempt (CF DNS apply)
- #228 — forced gray-cloud followup (Universal SSL handshake failure confirmed)
- PR #298 — `terraform/cloudflare/README.md` base (wave-11 HEAD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)