### PR TITLE
tech-debt(tf): remove unused Docker volume pre-creation; Compose owns volumes (#38)

### DIFF
--- a/terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl
+++ b/terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl
@@ -163,10 +163,6 @@ runcmd:
   - mkdir -p /home/deploy/.docker
   - chown -R deploy:deploy /home/deploy/.docker
 
-  # Pre-create Docker volumes for user-service data persistence
-  - docker volume create user-postgres-data
-  - docker volume create user-redis-data
-
   # node-exporter textfile_collector input directory (deploy#161).
   # Owned by deploy:deploy because the alembic pre-deploy gate's SSH step
   # (.github/workflows/db-migrate.yml) writes .prom files here as the


### PR DESCRIPTION
## Summary

Drops two orphan `docker volume create` lines from `terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl`. They created volumes named with hyphens (`user-postgres-data`, `user-redis-data`) that nothing references — Compose declares and uses underscore-named volumes (`user_pg_data`, `user_redis_data`) and creates them itself at `compose up` time.

## Investigation

**What was checked:**
- `grep -rn "docker_volume" terraform/` → **no** Terraform `docker_volume` resources. The "pre-creation" is shell `docker volume create` commands inside cloud-init runcmd.
- `grep -rn "user-postgres-data\|user_pg_data" .`:
  - hyphen form (`user-postgres-data`): **only** the two cloud-init lines. Zero consumers.
  - underscore form (`user_pg_data`): declared at `compose/docker-compose.prod.yml:958` and mounted at `:431` by the `user-postgres` service. Documented in `docs/runbooks/break-glass.md:211` as the DR-restore volume.
- Symmetric mismatch confirmed for redis: hyphen `user-redis-data` orphan vs underscore `user_redis_data` in Compose (`:464` mount, `:959` declaration).
- No TF-managed container outside Compose references the hyphenated volumes (no `docker_container` resource consuming them anywhere).

**What was found:**
- The hyphenated volumes were dead from creation. Every fresh VPS bootstraps two orphan named volumes Compose never touches.

## Decision

**Remove the TF pre-creation** rather than rename Compose volumes.

Rationale:
- Compose is the canonical owner of stack volumes — the `user-service-migrate` init container (`compose/docker-compose.prod.yml`, see "Why this exists" comment block) is the documented bootstrap path for a fresh `user_pg_data`.
- Renaming Compose volumes would force a one-time data migration on every existing prod/stg VPS to remap the live underscore volume to a hyphen name — pure churn for zero gain.
- The cloud-init lines have been orphaned since first introduction; removing them changes runtime behavior to "what was always actually happening" (Compose creates on `up`).

## Local validation

- `terraform fmt -check` on `terraform/hetzner/modules/hetzner-vps/` → clean (cloud-init.yaml.tpl is a YAML template, not `.tf`; fmt is unaffected).
- `terraform validate` requires `terraform init` with hcloud provider + backend → skipped locally.

## Test plan

- [ ] **Operator:** run `terraform plan` against stg backend to verify the change is no-op for stg (cloud-init.yaml.tpl content change does **not** trigger VPS replacement; only re-rendered template — affects new VPS bootstrap only).
- [ ] **Operator:** on next fresh-VPS bootstrap (e.g. blue-green swap), verify `docker volume ls` shows only `user_pg_data` / `user_redis_data` and **not** the hyphenated forms.

Closes #38

---

Requestor: Lucas Ferreira
Requestee:
RequestOrReplied:
TechDebt: none
