### PR TITLE
docs(fake_oauth): reconcile image-size claim to measured value (#147)

### DIFF
--- a/integration-tests/fake_oauth/README.md
+++ b/integration-tests/fake_oauth/README.md
@@ -45,7 +45,30 @@ curl -s http://localhost:8080/oauth2/v3/userinfo -H 'Authorization: Bearer fake-
 
 ## Image size
 
-Target under 100 MB. `python:3.12-slim` + fastapi + uvicorn[standard] +
-python-multipart weighs in around ~160 MB uncompressed; that's acceptable
-for a test-only container. Don't add DBs, Redis clients, or crypto libs —
-id_token signature verification is not required for Google's flow.
+Reconciled per #147 (PR #146 body said "55 MB unpacked single-arch", earlier
+draft of this README said "~160 MB"). Authoritative breakdown for the current
+Dockerfile (`python:3.12-slim` + `fastapi==0.115.0` + `uvicorn[standard]==0.32.0`
++ `python-multipart==0.0.12`):
+
+- `python:3.12-slim` amd64 base: **~119 MB** on-disk (per
+  [docker-library/repo-info](https://github.com/docker-library/repo-info/blob/master/repos/python/local/3.12-slim.md)
+  Virtual Size for `3.12.13-slim-trixie`).
+- Pip deps installed into site-packages: **~39 MB** (measured by replaying
+  `pip install -r requirements.txt` into a venv; dominated by `uvloop`
+  ~15 MB, `pip`/`setuptools` are NOT included since `pip install -r` doesn't
+  add them).
+- App code (`main.py`): negligible (<1 KB).
+- No `__pycache__` overhead — `PYTHONDONTWRITEBYTECODE=1` is set in the
+  Dockerfile.
+
+**Total: ~158 MB unpacked** (estimated, not measured via `docker image
+inspect` — see #147 for the reconciliation context). The 55 MB figure in PR
+#146's body was the compressed/registry size, not the on-disk size; this
+matters for pull bandwidth but not for the docker host's disk footprint or
+the `<100 MB target` discussion. Don't add DBs, Redis clients, or crypto
+libs — id_token signature verification is not required for Google's flow.
+
+The 58 MB over the 100 MB target is dominated by `uvicorn[standard]` extras
+(`httptools` ~1.6 MB, `uvloop` ~15 MB, `watchfiles` ~1.2 MB, `websockets`
+~1.4 MB) and `python:3.12-slim` itself. Dropping `[standard]` would shave
+~18-20 MB but is a future option, not a current change.


### PR DESCRIPTION
## Summary

fake_oauth README size claim disagreed with PR #146 body (README: "~160 MB
uncompressed"; PR #146 body: "55 MB unpacked single-arch"). Reconciled to
~158 MB on-disk via structured estimation; PR #146's 55 MB was the
compressed/registry size, which conflates pull bandwidth with on-disk
footprint.

## Measurement

`docker image inspect` was NOT available in this implementer's WSL distro
(Docker Desktop integration off). Fell back to structured estimation:

| Component | Size | Source |
|---|---|---|
| `python:3.12-slim` amd64 (3.12.13-slim-trixie) | 119.2 MB | [docker-library/repo-info](https://github.com/docker-library/repo-info/blob/master/repos/python/local/3.12-slim.md) Virtual Size |
| `pip install -r requirements.txt` site-packages | 39 MB | Measured by replay into venv (`du -sb`) |
| `main.py` | <1 KB | `wc -c` |
| **Total estimated unpacked on-disk** | **~158 MB** | sum |

No `__pycache__` overhead because the Dockerfile sets `PYTHONDONTWRITEBYTECODE=1`.

The 55 MB in PR #146 body was the *compressed/registry* size (python:3.12-slim
amd64 compressed manifest = 43.2 MB per Docker Hub API + ~12 MB compressed
wheel layer). It's the right number for pull bandwidth, but the wrong number
to compare against the `<100 MB target` discussion, which is about on-disk
footprint.

## Changes

- `integration-tests/fake_oauth/README.md` — expanded the "Image size"
  section with the reconciled breakdown, sourced numbers, and an explicit
  note that the figure is estimated (not docker-measured) so future
  maintainers can re-measure when they have a docker host available.

## Future option (noted, NOT done in this PR)

Dropping `uvicorn[standard]` (httptools + uvloop + watchfiles + websockets
≈ 19 MB) would bring the image to ~139 MB; still over the 100 MB target,
but closer. Per issue scope this PR is docs-only — Dockerfile change is a
separate decision.

## Test plan

- [ ] Reviewer with docker available can re-measure (`cd
  integration-tests/fake_oauth && docker build -t fake_oauth:size_check . &&
  docker image inspect fake_oauth:size_check --format '{{.Size}}'`) and
  confirm the README number is within ~5 MB of reality
- [ ] No code or Dockerfile change — only README prose

Closes #147