### PR TITLE
tech-debt(tf): refactor templatefile() vars into locals block (#37)

### DIFF
--- a/terraform/hetzner/modules/hetzner-vps/main.tf
+++ b/terraform/hetzner/modules/hetzner-vps/main.tf
@@ -4,6 +4,13 @@ locals {
     project     = "noorinalabs"
     environment = var.env
   }
+  cloud_init_vars = {
+    ssh_public_key          = sensitive(chomp(file(var.ssh_public_key_path)))
+    ghcr_auth_b64           = var.ghcr_auth_b64
+    user_postgres_password  = var.user_postgres_password
+    user_redis_password     = var.user_redis_password
+    user_service_jwt_secret = var.user_service_jwt_secret
+  }
 }
 
 # hcloud_ssh_key.deploy was removed in #222 — Hetzner enforces SSH-key content
@@ -52,13 +59,7 @@ resource "hcloud_server" "app" {
 
   firewall_ids = [hcloud_firewall.web.id]
 
-  user_data = templatefile("${path.module}/cloud-init.yaml.tpl", {
-    ssh_public_key          = sensitive(chomp(file(var.ssh_public_key_path)))
-    ghcr_auth_b64           = var.ghcr_auth_b64
-    user_postgres_password  = var.user_postgres_password
-    user_redis_password     = var.user_redis_password
-    user_service_jwt_secret = var.user_service_jwt_secret
-  })
+  user_data = templatefile("${path.module}/cloud-init.yaml.tpl", local.cloud_init_vars)
 
   labels = local.labels
 


### PR DESCRIPTION
## Summary

Lift the inline `cloud-init.yaml.tpl` var map from the `templatefile()` call inside `hcloud_server.app.user_data` into `local.cloud_init_vars` in the module's existing `locals` block.

**Vars before / after:** 5 / 5 — same keys, same value expressions. Pure mechanical refactor, zero behaviour change.

## Diff shape

`terraform/hetzner/modules/hetzner-vps/main.tf`:
- `locals { ... }` gains a `cloud_init_vars = { ... }` map (5 keys)
- `user_data = templatefile("${path.module}/cloud-init.yaml.tpl", local.cloud_init_vars)` replaces the inline map literal

## Zero-behaviour-change verification

- Map keys: `ssh_public_key`, `ghcr_auth_b64`, `user_postgres_password`, `user_redis_password`, `user_service_jwt_secret` — identical set, identical order
- Value expressions: identical (`sensitive(chomp(file(var.ssh_public_key_path)))` for `ssh_public_key`; `var.<name>` for the other four)
- No conditionals existed in the original map, so none to preserve
- `terraform fmt -check` clean
- `terraform validate` passes (with `-backend=false` init)

## Test Plan

- [ ] Operator: `terraform plan` against an existing applied state should show **zero** diff (no `user_data` change, no resource replacement). `user_data` is also in the `lifecycle.ignore_changes` list, so even if it did differ the live server wouldn't be re-created — but the templatefile output is byte-identical because inputs are unchanged.
- [ ] CI: `terraform fmt -check` and `terraform validate` gates pass.

## Notes

- Closes #37 (raised by Nadia Khoury in PR #34 review).
- Sibling work: issue #28 (`ghcr_auth_b64` conditional/required) touches the same `cloud_init_vars` map. If #28 lands first, this PR will rebase trivially; if this lands first, #28's PR will edit the lifted `cloud_init_vars` map (cleaner change surface).

Closes #37
