### PR TITLE
tech-debt(tf): skip GHCR auth-config write when ghcr_auth_b64 empty (#28)

### DIFF
--- a/terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl
+++ b/terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl
@@ -93,6 +93,18 @@ write_files:
   # write_files module runs before users, hits OSError('Unknown user "deploy"'),
   # aborts the entire write_files stage, and silently drops the remaining
   # entries (this file, .env.user-service, .cloud-init-provisioned). See #173 gap B.
+  #
+  # Conditional skip (deploy#28): when ghcr_auth_b64 is empty, omit this
+  # write_files entry entirely rather than writing an empty `"auth": ""`
+  # blob. An empty auth blob silently breaks `docker pull ghcr.io/...` for
+  # private images on first boot (per ontology/repos/deploy.yaml line 159,
+  # all app services are GHCR-only with no local-build fallback). Skipping
+  # the file means docker pull fails LOUDLY with "no basic auth credentials"
+  # instead of half-succeeding with a broken config — the operator sees the
+  # missing-credential error and supplies the value, rather than chasing a
+  # silently-misconfigured deploy. Public-only deploys (rare, e.g. infra-only
+  # bring-up before app images publish) work fine without the file present.
+%{ if ghcr_auth_b64 != "" ~}
   - path: /home/deploy/.docker/config.json
     owner: deploy:deploy
     permissions: '0600'
@@ -105,6 +117,7 @@ write_files:
           }
         }
       }
+%{ endif ~}
 
   # ---------------------------------------------------------------------------
   # User-service environment file


### PR DESCRIPTION
Closes #28.

## Summary

`var.ghcr_auth_b64` defaults to `""` in `terraform/hetzner/modules/hetzner-vps/variables.tf`. Pre-change, cloud-init unconditionally wrote `/home/deploy/.docker/config.json` with `"auth": ""` — an empty auth blob that silently broke `docker pull ghcr.io/...` for the GHCR-only app services (api, frontend, landing, user-service per `ontology/repos/deploy.yaml:159`).

This PR wraps the `/home/deploy/.docker/config.json` `write_files` entry in cloud-init in a `%{ if ghcr_auth_b64 != "" }...%{ endif }` template conditional. When the variable is empty, the file is no longer written at all. When populated, behavior is identical to before.

## Option chosen: (b) conditional skip

The issue offered two options:

- **(a)** remove the `default = ""` → make `ghcr_auth_b64` a required variable
- **(b)** add a conditional in cloud-init to skip the write when empty

**Chose (b).** Removing the default would break any existing `terraform plan` invocation that doesn't pass the value (e.g. infra-only bring-up runs, module-only `terraform validate`, CI-side plan jobs). Conditional skip preserves backwards compatibility while still removing the silent-write-empty-auth foot-gun. An explicit empty value now produces a clean `terraform plan`; only the behavior on first-boot cloud-init render changes:

- **Before:** file written with `"auth": ""` → `docker pull` half-succeeds, then fails opaquely at image-fetch time with a config that looks valid
- **After:** file absent → `docker pull` fails LOUDLY with "no basic auth credentials"

Loud failure is the safer mode — the operator sees the missing-credential error immediately and supplies the value, rather than chasing a silently-misconfigured deploy.

The `mkdir /home/deploy/.docker && chown deploy:deploy` runcmd entries remain unchanged. They're harmless when no config.json is later written, and necessary when the operator drops one in post-provision (or when the populated path renders the file).

## Test Plan

- [x] `terraform fmt -check` clean (module)
- [x] `terraform validate` Success on `envs/stg`
- [x] `terraform validate` Success on `envs/prod`
- [x] templatefile render harness with `ghcr_auth_b64 = ""`: `write_files` paths list does NOT include `/home/deploy/.docker/config.json`; renders as valid YAML
- [x] templatefile render harness with `ghcr_auth_b64 = "dXNlcm5hbWU6dG9rZW4="`: `write_files` paths list DOES include `/home/deploy/.docker/config.json`, auth value interpolated correctly; renders as valid YAML
- [ ] **Operator (runtime):** `terraform plan` with empty `ghcr_auth_b64` should show a clean diff (no resource changes) on already-provisioned VPSes — `user_data` is in the `lifecycle.ignore_changes` list per `modules/hetzner-vps/main.tf:80`, so existing servers will not be recreated
- [ ] **Operator (fresh provision):** `terraform apply` with populated `ghcr_auth_b64` produces a VPS where `cat /home/deploy/.docker/config.json` shows the expected auth blob
- [ ] **Operator (fresh provision, empty case):** `terraform apply` with empty `ghcr_auth_b64` produces a VPS where `/home/deploy/.docker/config.json` does NOT exist; `docker pull ghcr.io/noorinalabs/noorinalabs-isnad-graph` fails with "no basic auth credentials"

## Notes for reviewers

- The only template-interpolation site for `ghcr_auth_b64` is the single `write_files` entry guarded by this change (verified by `grep -rn ghcr_auth_b64 terraform/hetzner/modules/`). No other places to guard.
- `lifecycle { ignore_changes = [..., user_data] }` on `hcloud_server.app` means this template change does NOT trigger a destructive replace on already-provisioned servers — consistent with `docs/runbooks/cloud-init-template-changes.md` and the comment block at `main.tf:65-78`. The fix takes effect on next fresh-provision only.

Requestor: TBD
Requestee: Nino Kavtaradze
RequestOrReplied: Request
TechDebt: none
