### PR TITLE
fix(bootstrap): add safe.directory exceptions to allow root re-runs (#113)

### DIFF
--- a/scripts/bootstrap-vps.sh
+++ b/scripts/bootstrap-vps.sh
@@ -21,6 +21,16 @@ REPO_URL="https://github.com/noorinalabs/noorinalabs-deploy.git"
 INSTALL_DIR="/opt/noorinalabs-deploy"
 DEPLOY_USER="deploy"
 
+# Auxiliary repo directories pre-provisioned under /opt/ (see Step 4.5).
+# Hoisted from Step 4.5 to module scope so the safe.directory loop in Step 3.5
+# can reference the same list — keeping AUX_REPOS as the single source of truth
+# for "directories root should be allowed to git-operate on after deploy
+# takes ownership."
+AUX_REPOS=(
+  "noorinalabs-isnad-graph"
+  "noorinalabs-design-system"
+)
+
 echo "============================================="
 echo "  Noorina Labs VPS bootstrap"
 echo "============================================="
@@ -120,6 +130,20 @@ else
   echo "    You'll need to manually add your public key to $DEPLOY_AUTH_KEYS"
 fi
 
+# ── Step 3.5: git safe.directory exceptions ────────────────────────────────
+# Allow root to operate on repos owned by the deploy user (git 2.35+
+# CVE-2022-24765 mitigation). Step 4's `git fetch && git reset --hard` runs
+# as root inside $INSTALL_DIR, which gets chowned to $DEPLOY_USER at the end
+# of Step 4 on first-run; every subsequent re-run hits the ownership-mismatch
+# refusal without these exceptions. Aux-repo dirs are listed too because the
+# same hazard applies if/when bootstrap evolves to git-operate on them. See
+# deploy#113. Runs after Step 1 (git installed) and before Step 4 (first git
+# call) — the `${AUX_REPOS[@]/#//opt/}` form prefixes each entry with /opt/.
+echo "==> [3.5/7] Adding git safe.directory exceptions..."
+for dir in "$INSTALL_DIR" "${AUX_REPOS[@]/#//opt/}"; do
+  git config --global --add safe.directory "$dir"
+done
+
 # ── Step 4: Clone the repository ────────────────────────────────────────────
 echo "==> [4/7] Cloning repository to $INSTALL_DIR..."
 if [ -d "$INSTALL_DIR/.git" ]; then
@@ -134,13 +158,11 @@ chown -R $DEPLOY_USER:$DEPLOY_USER "$INSTALL_DIR"
 # /opt/ is root-owned by default, so the deploy user can't `git clone` into it
 # without these dirs existing first with the right ownership. The deploy
 # workflow (.github/workflows/deploy-isnad-graph.yml) clone-or-pulls into each
-# of these. To add a new repo to the deploy pipeline: append it to AUX_REPOS,
-# re-run this bootstrap script (idempotent), done. See deploy#108 for context.
+# of these. To add a new repo to the deploy pipeline: append it to AUX_REPOS
+# (declared at the top of this script alongside INSTALL_DIR — that placement
+# also feeds the safe.directory loop), re-run this bootstrap script
+# (idempotent), done. See deploy#108 for context.
 echo "==> [4.5/7] Pre-provisioning auxiliary repo directories under /opt/..."
-AUX_REPOS=(
-  "noorinalabs-isnad-graph"
-  "noorinalabs-design-system"
-)
 for repo in "${AUX_REPOS[@]}"; do
   dir="/opt/$repo"
   if [ ! -d "$dir" ]; then


### PR DESCRIPTION
## Summary

Fixes #113. Bootstrap script aborts on every re-run at Step 4 with `fatal: detected dubious ownership in repository at '/opt/noorinalabs-deploy'`.

**Root cause** (per issue body): script runs as root via `sudo bash bootstrap-vps.sh`, but `/opt/noorinalabs-deploy` is chowned to `deploy:deploy` (by Step 4 first-run and re-chowned by Step 4.5 every run). Git 2.35+ (CVE-2022-24765) refuses operations across ownership boundaries unless the path is in `safe.directory`. First-run works (no .git yet); re-runs hit the mismatch immediately.

## Change

Two small edits to `scripts/bootstrap-vps.sh`:

1. **Hoist `AUX_REPOS`** from Step 4.5 (line 140) up to module scope alongside `INSTALL_DIR` and `DEPLOY_USER` (line 22). Single source of truth for "dirs that may be deploy-owned and root-touched."
2. **Add Step 3.5** between SSH setup and the first git operation:

   ```bash
   echo "==> [3.5/7] Adding git safe.directory exceptions..."
   for dir in "$INSTALL_DIR" "${AUX_REPOS[@]/#//opt/}"; do
     git config --global --add safe.directory "$dir"
   done
   ```

   `${AUX_REPOS[@]/#//opt/}` is bash pattern-substitution that prefixes each element with `/opt/` (verified: produces `/opt/noorinalabs-isnad-graph`, `/opt/noorinalabs-design-system`).

Placement rationale: AFTER Step 1 (git is installed) and BEFORE Step 4 (first `git fetch`). Step 3.5 sits naturally between Step 3 (SSH user setup) and Step 4 (clone/pull).

## Why option (a) over option (b)

Issue #113 lays out two options and defers to the owner:

- **(a)** `safe.directory` exceptions — smallest possible change, scoped to the specific paths (no `*` wildcard), no new sudo plumbing. **Chosen.**
- **(b)** Run each git operation as `sudo -u "$DEPLOY_USER" git ...` — sidesteps the security feature entirely, architecturally cleaner, but requires touching every git invocation and threading sudo through subsequent flows.

Per issue body: "(a) is the smallest possible change to unblock today. (b) is closer to 'do the right thing' since it sidesteps the ownership-mismatch security feature rather than papering over it." Owner framing in the spawn brief: "smallest possible change to unblock today" — going with (a).

**Follow-up not yet filed:** option (b) is tracked as the architecturally-cleaner direction if/when bootstrap evolves toward a "root provisions, then drops privileges per task" shape. Worth filing once owner decides on that broader posture.

## Test Plan

- [ ] Operator: re-run `sudo bash scripts/bootstrap-vps.sh` on the existing stg VPS — Step 3.5 logs the safe.directory adds, then Step 4 succeeds against the deploy-owned `/opt/noorinalabs-deploy` without the manual `git config` workaround.
- [ ] Verify `cat /root/.gitconfig` afterwards shows the three `safe.directory` entries (one per `/opt/noorinalabs-*` path).
- [ ] Local validation already passed: `bash -n scripts/bootstrap-vps.sh` clean, `shellcheck scripts/bootstrap-vps.sh` exit 0.
- [ ] AUX_REPOS expansion verified out-of-band: `${AUX_REPOS[@]/#//opt/}` produces the expected `/opt/<repo>` paths.

## Cross-references

- PR #109 — surfaced the re-run requirement that exposed this bug
- PR #111 — sibling fix for the apt/debconf re-run hang (#110)
- #112 — sibling SSH-key-overwrite bug (PR #N.Kavtaradze/0112-... in flight)

Closes #113.
