### PR TITLE
tech-debt(caddy): codify longer-prefix-first carve-out invariant + verify-script §11 (#135)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -240,6 +240,31 @@ All responses include:
 
 Caddy automatically obtains and renews certificates via ACME (Let's Encrypt).
 
+### Routing invariant: longer-prefix-first ordering
+
+Caddy evaluates `handle` blocks **in source order**; the first match wins. This means any path-prefix carve-out that should go to a different upstream than its catch-all parent MUST appear as an earlier `handle` block than the catch-all. **Adding a new top-level path on any upstream service requires reviewing this Caddyfile.**
+
+Concrete example from `caddy/Caddyfile` (the `isnad.{$BASE_DOMAIN}` block):
+
+```
+handle /auth/callback/* {        # carve-out — frontend (React AuthCallbackPage)
+    reverse_proxy frontend:80
+}
+handle /auth/* {                 # catch-all — user-service auth API
+    reverse_proxy user-service:8000
+}
+```
+
+If the two blocks are swapped, `/auth/callback/google` matches `/auth/*` first and hits user-service, which returns a JSON 404 — the user's browser receives JSON instead of the React callback page. This is the failure mode that broke prod Google login on 2026-04-19 (see deploy#133, #134). The same shape applies to every other carve-out in the Caddyfile (`/api/v1/users*`, `/api/v1/sessions*`, etc., must precede `/api/*`; `/health` and `/status` precede the default `handle`; etc.).
+
+**When adding a new route on an upstream service:**
+
+1. Check whether the new path overlaps any existing `handle` block prefix in `caddy/Caddyfile`.
+2. If it would be shadowed by an earlier catch-all, add it as an earlier `handle` block.
+3. Run `scripts/verify_deployment.sh` against the target environment after deploy — §11 ("Routing carve-outs") exercises the known boundaries.
+
+A per-PR Caddyfile order-lint that detects longer-prefix `handle` blocks placed AFTER their shorter-prefix parents is tracked as a follow-up (see deploy#135 part 3).
+
 ## Post-Deployment Verification
 
 The `verify-deploy.yml` workflow runs automatically after a successful deploy (via `workflow_run` trigger on `Deploy to staging` and `Deploy to production`) and can also be triggered manually with a `target` input (`stg` or `prod`).

--- a/scripts/verify_deployment.sh
+++ b/scripts/verify_deployment.sh
@@ -350,6 +350,119 @@ if [ -n "$ROLLBACK_TAG" ]; then
   fi
 fi
 
+# ---------- 11. Routing Carve-outs (deploy#135) ----------
+
+# Caddy evaluates `handle` blocks in source order; first match wins. Any
+# path-prefix carve-out that should land on a different upstream than its
+# catch-all parent MUST appear as an earlier `handle` block. This section
+# exercises one representative path per known carve-out on $SITE_URL and
+# asserts the response shape (status code + body content-type) is
+# consistent with the intended upstream. It would have caught the deploy#133
+# regression where `/auth/callback/*` matched `/auth/*` and hit user-service
+# (JSON 404) instead of the frontend (React AuthCallbackPage HTML).
+#
+# Carve-out → expected-upstream map (mirrors caddy/Caddyfile `isnad.*` block):
+#   /auth/callback/*      → frontend       (HTML, 200/404)
+#   /auth/oauth/*/login   → user-service   (JSON, 302/401/404 — NOT HTML)
+#   /api/v1/health        → isnad-graph    (JSON, 200/401/404)
+#   /api/v1/narrators     → isnad-graph    (JSON, 200/401/403)
+#   /api/v1/users         → user-service   (JSON, 401/405 — carve-out from /api/*)
+#   /.well-known/jwks.json → user-service  (JSON, 200)
+
+section "Routing Carve-outs"
+
+# Fetch headers + body in one shot per probe; check status code AND
+# content-type. Body sniff is a defense-in-depth check for the case where
+# both upstreams return the "right" status code but for the wrong reason.
+probe() {
+  local path="$1"
+  local expected_codes="$2"   # space-separated, e.g. "200 404"
+  local expected_kind="$3"    # "html" or "json"
+  local label="$4"
+
+  local url="${SITE_URL}${path}"
+  local body_file headers_file
+  body_file=$(mktemp)
+  headers_file=$(mktemp)
+  local code
+  code=$(curl -s -o "$body_file" -D "$headers_file" -w "%{http_code}" --max-time "$TIMEOUT" "$url" 2>/dev/null || echo "000")
+  local ct
+  ct=$(grep -i '^content-type:' "$headers_file" 2>/dev/null | head -1 | cut -d: -f2- | xargs || echo "")
+
+  local code_ok=false
+  for ec in $expected_codes; do
+    if [ "$code" = "$ec" ]; then
+      code_ok=true
+      break
+    fi
+  done
+
+  if [ "$code_ok" = "false" ]; then
+    fail "$label: $path returned HTTP $code (expected one of: $expected_codes) — possible carve-out shadowing"
+    rm -f "$body_file" "$headers_file"
+    return
+  fi
+
+  # Body-shape assertion: HTML carve-out must NOT return JSON; JSON
+  # carve-out must NOT return HTML. The error mode this defends against
+  # is a misordered handle block routing to the wrong upstream that
+  # happens to return the expected status code.
+  case "$expected_kind" in
+    html)
+      if echo "$ct" | grep -qi 'application/json'; then
+        fail "$label: $path returned JSON content-type ($ct) but should hit frontend (HTML) — carve-out likely shadowed by an earlier catch-all"
+      elif head -c 200 "$body_file" | grep -qi '"detail"\|"message"\|"status_code"'; then
+        # FastAPI/Starlette/user-service JSON error shape leaking through
+        fail "$label: $path body looks like JSON error shape but expected HTML — likely hitting user-service instead of frontend"
+      else
+        pass "$label: $path → HTTP $code, content-type=${ct:-unset} (frontend-shaped)"
+      fi
+      ;;
+    json)
+      if echo "$ct" | grep -qi 'text/html'; then
+        fail "$label: $path returned HTML content-type ($ct) but should hit an API upstream (JSON) — carve-out likely shadowed by frontend default"
+      else
+        pass "$label: $path → HTTP $code, content-type=${ct:-unset} (API-shaped)"
+      fi
+      ;;
+  esac
+  rm -f "$body_file" "$headers_file"
+}
+
+# Frontend carve-out from /auth/* catch-all. The probe path is intentionally
+# non-existent on the React SPA so we don't depend on a real OAuth state;
+# the React app serves index.html for any unmatched path, so 200 with HTML
+# is the success shape (the SPA renders an error route client-side).
+probe "/auth/callback/verify-shape-probe" "200 404" "html" "frontend /auth/callback/*"
+
+# user-service /auth/* catch-all (no carve-out). Hitting the OAuth login
+# initiator without a configured provider should give a 302 (redirect to
+# provider), 401 (unauthenticated), 404 (provider not configured in this
+# env), or 400 (validation). All four are valid "user-service answered"
+# shapes; HTML response would indicate the request fell through to the
+# frontend default handler.
+probe "/auth/oauth/google/login" "200 302 400 401 404" "json" "user-service /auth/oauth/*/login"
+
+# isnad-graph /api/v1/health — carve-out from /api/* (api:8000 — same
+# upstream, but exercises the /api/* block, distinct from the top-level
+# /health block tested in §3).
+probe "/api/v1/health" "200 401 404" "json" "isnad-graph /api/v1/health"
+
+# isnad-graph /api/v1/narrators — covered by §5 but classified here too
+# under the carve-out lens.
+probe "/api/v1/narrators" "200 401 403" "json" "isnad-graph /api/v1/narrators"
+
+# user-service /api/v1/users — carve-out from the /api/* catch-all (which
+# would otherwise send it to isnad-graph). 401/405 are valid auth-required
+# shapes from user-service; HTML or 501 would indicate a routing
+# regression (501 is isnad-graph's "delegated to user-service via Caddy"
+# response per ontology/repos/isnad-graph.yaml:72).
+probe "/api/v1/users" "401 403 405" "json" "user-service /api/v1/users (carve-out)"
+
+# user-service JWKS endpoint — well-known IETF path, carve-out from any
+# parent prefix. Should always be 200 with JSON keys array.
+probe "/.well-known/jwks.json" "200" "json" "user-service /.well-known/jwks.json"
+
 # ---------- Summary ----------
 
 section "Summary"


### PR DESCRIPTION
## Summary

Codifies the longer-prefix-first Caddy carve-out invariant that has been implicit in `caddy/Caddyfile` since deploy#134. Two artifacts:

1. **`docs/architecture.md`** — new "Routing invariant: longer-prefix-first ordering" subsection under `Caddy Configuration`, with the concrete `/auth/callback/*` vs `/auth/*` example that broke prod Google login on 2026-04-19 (deploy#133/#134), the engineer-facing checklist for adding a new upstream route, and a forward pointer to verify-script §11.

2. **`scripts/verify_deployment.sh`** — new §11 "Routing Carve-outs" that probes one representative path per known carve-out and asserts BOTH HTTP status code AND `Content-Type` header (defense-in-depth: an upstream returning the "right" code for the wrong reason is exactly the silent shadowing the invariant defends against). Six probes:

   | Path | Expected upstream | Expected codes | Body shape |
   |------|-------------------|----------------|-----------|
   | `/auth/callback/verify-shape-probe` | frontend | 200, 404 | HTML |
   | `/auth/oauth/google/login` | user-service | 200, 302, 400, 401, 404 | JSON |
   | `/api/v1/health` | isnad-graph | 200, 401, 404 | JSON |
   | `/api/v1/narrators` | isnad-graph | 200, 401, 403 | JSON |
   | `/api/v1/users` | user-service (carve-out from `/api/*`) | 401, 403, 405 | JSON |
   | `/.well-known/jwks.json` | user-service | 200 | JSON |

   The HTML probe additionally fails on JSON error-shape sniffing (`"detail"`/`"message"`/`"status_code"` in first 200 bytes of body) — catches the case where Caddy somehow proxies HTML content-type from user-service while the body is FastAPI error JSON.

## Scope deviations from the issue body

- **Issue says "subsection of the existing Deployment Flow section"; this PR adds it under "Caddy Configuration" instead.** The actual `Deployment Flow` section (line 93) describes the deploy-workflow steps, not routing. The `Caddy Configuration` section (line 212) is where the existing `Routing` subsection lives and where a future engineer adding a new route will look. Topical fit over literal wording.
- **Part 3 (per-PR Caddyfile order-lint) deferred to a follow-up.** Per issue body's "punt to a separate issue if non-trivial" guidance. Left as a forward reference in the new architecture.md subsection. I'll file the follow-up after this PR merges (or @team-lead can — flagging either way).
- **`ontology/services.yaml:152` update NOT done in this PR.** The issue's acceptance bullet mentions it, but the cited path belongs to noorinalabs-main (parent repo), not deploy. Deploy has no ontology mirror (per #195/#304 audit), so the ontology resolver will pick up these changes from the parent side after merge.

## Test plan

- [x] `bash -n scripts/verify_deployment.sh` — syntax clean
- [x] `shellcheck scripts/verify_deployment.sh` — clean (exit 0)
- [ ] **Operator post-merge:** run `scripts/verify_deployment.sh` against stg; §11's six probes should all PASS against current carve-out config. If any FAIL, the failure message names the suspected shadowing direction so the operator can grep for the misordered `handle` block.
- [ ] **Reviewer:** verify the §11 probes are non-destructive (only `curl GET`, no state mutation) and complete in well under the existing `$TIMEOUT` budget (six probes × ~1s typical = ~6s added to script runtime).

## Refs

- Closes #135.
- Parent meta: noorinalabs/noorinalabs-main#145
- Failure-mode origin: #133 (prod Google login regression), #134 (carve-out fix)
- Defers: per-PR Caddyfile order-lint (issue body part 3 → new follow-up).
