### PR TITLE
fix(caddy): healthcheck via admin endpoint instead of TLS-handshake-failing wget (#137)

### DIFF
--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -275,7 +275,7 @@ services:
     tmpfs:
       - /tmp:size=64M
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:80/ || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://localhost:2019/config/ >/dev/null 2>&1 || exit 1"]
       interval: 15s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary

Fixes the `noorinalabs-caddy-1` healthcheck, which had a 23-deep failing streak even though the container was functionally serving external HTTPS traffic (200 OK).

**Root cause.** Caddy's site block auto-promotes HTTP requests to HTTPS. The current healthcheck `wget -qO- http://localhost:80/` triggers that redirect and then performs a TLS handshake to `https://localhost`. Caddy serves real-domain Let's Encrypt certs (per `ontology/repos/deploy.yaml` lines 144/151), not a localhost cert, so the handshake fails and `wget` exits non-zero. The container was healthy; the healthcheck was the bug.

**Fix.** Use Caddy's built-in admin API at `127.0.0.1:2019/config/`:

```yaml
healthcheck:
  test: ["CMD-SHELL", "wget -qO- http://localhost:2019/config/ >/dev/null 2>&1 || exit 1"]
```

- Plain HTTP — no TLS layer to fail
- Enabled by default in Caddy 2 (verified `caddy/Caddyfile` contains no `admin off` directive or rebind)
- Returns 200 + JSON config when Caddy is healthy, non-zero otherwise

Closes #137.

## Related

Sibling fix: PR #128/#130 removed the promtail healthcheck for the same `wget`-vs-TLS class bug.

## Test Plan

- [x] YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(open('compose/docker-compose.prod.yml'))"`) — caddy.healthcheck.test verified post-edit
- [x] `caddy/Caddyfile` confirmed to not disable the admin endpoint (no `admin off` / no `:2019` rebind)
- [ ] **Operator (post-merge / post-deploy):** `docker inspect noorinalabs-caddy-1 --format '{{.State.Health.Status}}'` should report `healthy` within ~1 minute of stack restart (start_period 10s + up to 3×15s checks)
- [ ] **Operator:** confirm external HTTPS (`curl -I https://<BASE_DOMAIN>`) still returns 200

Note: full `docker compose -f compose/docker-compose.prod.yml config` validation was not run locally — Docker CLI is unavailable in the dev environment. YAML-shape validation only; runtime acceptance is gated on the operator checks above.

Requestor: Lucas Ferreira
Requestee: TBD
RequestOrReplied: Request
TechDebt: none

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
