### PR TITLE
infra(b2): expose ETag header in CORS rule for browser S3-endpoint clients (#89)

### DIFF
--- a/terraform/backblaze/main.tf
+++ b/terraform/backblaze/main.tf
@@ -29,7 +29,7 @@ resource "b2_bucket" "pipeline" {
       allowed_operations = ["s3_get", "s3_head", "s3_put"]
       max_age_seconds    = 3600
       allowed_headers    = ["*"]
-      expose_headers     = ["x-bz-content-sha1"]
+      expose_headers     = ["x-bz-content-sha1", "ETag"]
     }
   }
 }


### PR DESCRIPTION
## Summary

Preemptive single-line fix: add `ETag` to the pipeline-bucket CORS
`expose_headers` list so future browser-side S3-endpoint clients can
read it for conditional requests (`If-Match` / `If-None-Match`) and
SDK upload-verification flows.

```diff
-      expose_headers     = ["x-bz-content-sha1"]
+      expose_headers     = ["x-bz-content-sha1", "ETag"]
```

## Why now? (Blast radius today: zero)

The CORS rule is wrapped in:

```hcl
dynamic "cors_rules" {
  for_each = length(var.cors_allowed_origins) > 0 ? [1] : []
  ...
}
```

and `var.cors_allowed_origins` defaults to `[]`
(`terraform/backblaze/variables.tf:40`, also `terraform.tfvars.example:19`),
so no CORS rule is emitted today. This change is a no-op at the resource
graph until a future PR populates `cors_allowed_origins`. Filing it now
so the rule is correct out of the box once browser clients are wired up
(via the S3-compatible endpoint that exposes ETag natively for the
underlying object verification).

Origin: issue #89.

## Test Plan

- [x] `terraform fmt -check` — clean
- [ ] `terraform validate` — skipped (requires `terraform init` for the
  `backblaze/b2` provider; CI matrix at `.github/workflows/terraform.yml`
  covers this against the `backblaze` module)
- [ ] Operator: `terraform plan` against the `backblaze` module with
  default vars (`cors_allowed_origins=[]`) should show **no diff** —
  the `dynamic` block emits nothing.
- [ ] Operator: when a future PR sets `cors_allowed_origins` to a
  non-empty list, the resulting CORS rule should include both
  `x-bz-content-sha1` and `ETag` in `expose_headers`.

Closes #89.
