### PR TITLE
refactor(cloud-init): remove dead Caddy apt install — runs only via Docker (#71)

### DIFF
--- a/terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl
+++ b/terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl
@@ -1,7 +1,8 @@
 #cloud-config
 # =============================================================================
 # cloud-init template for Noorina Labs VPS provisioning
-# Installs Docker, Caddy, security hardening (fail2ban, ufw), and GHCR auth.
+# Installs Docker, security hardening (fail2ban, ufw), and GHCR auth.
+# (Caddy runs as a Docker container via compose, not via apt.)
 #
 # Services provisioned on this VPS:
 #   - isnad-graph (FastAPI + React + Neo4j)
@@ -190,26 +191,6 @@ runcmd:
   - mkdir -p /var/lib/node_exporter/textfile_collector
   - chown deploy:deploy /var/lib/node_exporter/textfile_collector
   - chmod 0755 /var/lib/node_exporter/textfile_collector
-
-  # Install Caddy via official apt repo.
-  # DEBIAN_FRONTEND=noninteractive + NEEDRESTART_MODE=a are inlined per-command
-  # because cloud-init's runcmd exec's each entry independently — `export`s in
-  # an earlier entry don't survive to the next. Without these, caddy's apt
-  # install triggers a whiptail "Pending kernel upgrade" dialog from
-  # needrestart, which prints
-  #   debconf: whiptail output the above errors, giving up!
-  # and "Use of uninitialized value $ret in scalar chomp" in cloud-init logs.
-  # The install does NOT block today (whiptail bails when it can't open a
-  # terminal) but is an apt-hang risk under stricter dialog policies and is
-  # noisy in cloud-init.log. Matches the pattern used in bootstrap-vps.sh
-  # since deploy#110. See #173 gap D.
-  - curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
-  - echo "deb [signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg] https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main" > /etc/apt/sources.list.d/caddy-stable.list
-  - DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update -qq
-  - DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -qq -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" caddy
-  - systemctl stop caddy
-  # Caddy will be run via Docker Compose, not systemd — disable the system service
-  - systemctl disable caddy
 
   # Enable automatic security updates
   - systemctl enable unattended-upgrades


### PR DESCRIPTION
## Summary

Pure deletion: removes the dead Caddy apt-install block from
`terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl`.

Per issue #71 and the #46 audit invariant, Caddy runs **only** as the
`caddy:2-alpine` Docker container managed by compose. The cloud-init
template still installed Caddy via the official apt repo and then
immediately `systemctl stop caddy && systemctl disable caddy` — the
apt-installed binary was never used. The block also carried a 14-line
preamble comment about a `NEEDRESTART_MODE=a` workaround needed only
for the apt path.

## Changes

- Removed the cloudsmith GPG key fetch, apt sources entry, `apt-get
  update`, `apt-get install caddy`, `systemctl stop caddy`, and
  `systemctl disable caddy` lines (19 lines including the preamble).
- Updated the file header comment to no longer claim host-level Caddy
  install; added a one-line note that Caddy runs as a Docker container.

Diff: **+2 / -21**. `runcmd` entries: **28 → 22** (6 steps removed).

## Verification

- `grep -rn "systemctl.*caddy\|/usr/bin/caddy\|apt.*caddy\|caddy-stable\|/etc/caddy" --include='*.sh' --include='*.tpl' --include='*.yaml' --include='*.yml' --include='*.md'` repo-wide returns **one** match — `compose/docker-compose.prod.yml:271` (the `caddy/Caddyfile -> /etc/caddy/Caddyfile:ro` container bind mount). That's the container path, not the apt binary; correct and expected.
- `scripts/bootstrap-vps.sh` has **zero** Caddy references (the deleted preamble's "matches the pattern used in bootstrap-vps.sh since deploy#110" was itself stale — bootstrap already does not install Caddy at the host level).
- YAML render-check (Terraform `${...}` stubbed, `%{ if/endif }` directives stripped) parses cleanly: 22 runcmd entries, 0 caddy lines.
- YAML indentation around the deletion boundary preserved (same `  -` runcmd entry indent above and below).

## Test Plan

- [ ] Operator: next fresh Hetzner provision should boot ~6 cloud-init steps faster than the previous template.
- [ ] Operator on freshly provisioned VPS: `docker ps | grep caddy` shows the `caddy:2-alpine` container running.
- [ ] Operator on freshly provisioned VPS: `systemctl status caddy` returns "Unit caddy.service could not be found." — confirming no host-level systemd unit was created (eliminating the prior confusion source: a disabled `caddy.service` listed alongside the running container).
- [ ] No regression in `cloud-init.log`: no `NEEDRESTART` / `whiptail` warnings (those came from the now-removed apt path).

Closes #71.
Refs #46 (Caddy-only-via-Docker invariant audit).

Requestor: N/A (will be set on review)
Requestee: Nurul Hakim
TechDebt: none
