### PR TITLE
ci(deps): wire Dependabot for Docker base-image digest pins (#264)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: /infra/neo4j
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - tech-debt
+      - ci-cd
+      - "deps:docker"
+    commit-message:
+      prefix: "deps(docker)"
+
+  - package-ecosystem: docker
+    directory: /integration-tests/fake_oauth
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - tech-debt
+      - ci-cd
+      - "deps:docker"
+    commit-message:
+      prefix: "deps(docker)"


### PR DESCRIPTION
## Summary

Wires Dependabot to monitor Docker base-image digest pins in this repo per #264. Issue origin: post-#854 followup — Linh-review surfaced the pin-rot failure mode where explicitly-pinned digests stay current at write-time but the upstream `:tag` advances, leaving CVE patches uncaught until Trivy fires reactively.

## Scope

`noorinalabs-deploy` only. The 4 child repos (`isnad-graph`, `isnad-graph-frontend`, `landing-page`, `user-service`) each have their own Dockerfile and CI flow, so each gets its own Dependabot PR as a separate follow-up.

## Changes

Adds `.github/dependabot.yml` with two `package-ecosystem: docker` entries, one per Dockerfile:

| Directory | Base image | Auth |
| --- | --- | --- |
| `/infra/neo4j` | `neo4j:5-community` | public |
| `/integration-tests/fake_oauth` | `python:3.12-slim` | public |

Both base images are public Docker Hub. **No `registries:` block / GHCR auth needed** — this repo's Dockerfiles do not pull from `ghcr.io/noorinalabs/...`. (Those private GHCR images are pulled by docker-compose at runtime, not built FROM here.)

Config matches the issue body spec verbatim:
- `schedule: weekly`
- `open-pull-requests-limit: 5` (per ecosystem entry)
- `commit-message.prefix: deps(docker)`
- `labels: [tech-debt, ci-cd, deps:docker]`

## Test Plan

- [x] Local: `python3 -c 'import yaml; yaml.safe_load(open(".github/dependabot.yml"))'` parses clean (2 update entries, version 2).
- [ ] **Post-merge** (runtime acceptance, per `feedback_runtime_gate_scoping`): GitHub Settings → Security → Dependabot alerts shows the config registered. First bump PR appears within ~1 week if either base image has a newer digest available.
- [ ] **Post-merge**: any opened Dependabot PR carries `deps(docker)` commit prefix and `[tech-debt, ci-cd, deps:docker]` labels.

## Out of scope

- Child-repo Dependabot configs (separate followups per issue body).
- Auto-merge policy for `digest-only` bumps (separate auto-merge governance issue per #264 acceptance bullet 3).
- Charter convention referencing this bot (companion charter-promotion issue).

Closes #264 (deploy-repo portion).

Requestor: TBD
Requestee: TBD
RequestOrReplied: TBD
TechDebt: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
