### PR TITLE
ci(tf): add validate-creds job to catch B2-rotation drift between envs (#158)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,16 +1,68 @@
 name: Terraform
 on:
   pull_request:
-    paths: ['terraform/**']
+    paths:
+      - 'terraform/**'
+      - '.github/workflows/terraform.yml'
   push:
     branches: [main]
-    paths: ['terraform/**']
+    paths:
+      - 'terraform/**'
+      - '.github/workflows/terraform.yml'
+  schedule:
+    # Weekly Monday 14:00 UTC — catches rotation-drift that landed
+    # between TF-touching PRs. Detection latency: <=7 days regardless
+    # of TF-PR cadence. See deploy#158.
+    - cron: '0 14 * * 1'
 
 permissions:
   contents: read
   pull-requests: write
 
 jobs:
+  validate-creds:
+    # Detects rotation-drift between the `staging` and `production` GH
+    # Environments for shared B2 state-bucket credentials + per-env
+    # HCLOUD tokens. Fails fast with which-env-is-stale, instead of a
+    # generic AWS-auth error buried in a later `terraform init`. See
+    # deploy#158 and ADR 0004 § Decision C (detection layer).
+    name: Validate creds (${{ matrix.env }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        env: [stg, prod]
+    environment: ${{ matrix.env == 'prod' && 'production' || 'staging' }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.TF_STATE_B2_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_B2_APP_KEY }}
+      HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+    steps:
+      - name: Probe B2 state-bucket auth
+        run: |
+          if ! aws s3api head-bucket \
+              --bucket noorinalabs-terraform-state \
+              --endpoint-url https://s3.us-east-005.backblazeb2.com \
+              2> /tmp/b2-err; then
+            echo "::error::B2 credentials for '${{ matrix.env }}' env FAILED to authenticate against noorinalabs-terraform-state."
+            echo "::error::Rotation drift suspected. Verify both 'gh secret set TF_STATE_B2_KEY_ID --env ${{ matrix.env == 'prod' && 'production' || 'staging' }}' and TF_STATE_B2_APP_KEY were set with the current B2 key."
+            echo "::error::aws error output:"
+            sed 's/^/::error::  /' /tmp/b2-err
+            exit 1
+          fi
+          echo "B2 state-bucket auth OK for '${{ matrix.env }}' env."
+      - name: Probe HCLOUD API auth
+        run: |
+          http_code=$(curl --silent --output /tmp/hcloud-resp --write-out '%{http_code}' \
+            --header "Authorization: Bearer ${HCLOUD_TOKEN}" \
+            https://api.hetzner.cloud/v1/servers)
+          if [ "${http_code}" != "200" ]; then
+            echo "::error::HCLOUD_TOKEN for '${{ matrix.env }}' env FAILED to authenticate against Hetzner API (HTTP ${http_code})."
+            echo "::error::Rotation drift suspected. Verify 'gh secret set HCLOUD_TOKEN --env ${{ matrix.env == 'prod' && 'production' || 'staging' }}' was run with the current token."
+            exit 1
+          fi
+          echo "HCLOUD API auth OK for '${{ matrix.env }}' env (HTTP 200)."
+
   fmt:
     name: Format check
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Implements [Option B from #158](https://github.com/noorinalabs/noorinalabs-deploy/issues/158): a CI `validate-creds` job in `.github/workflows/terraform.yml` that detects rotation-drift between the `staging` and `production` GH Environments for the shared B2 state-bucket credentials and per-env HCLOUD tokens, **before** the drift surfaces as an opaque `terraform init` failure on the next TF-touching PR.

## What

New `validate-creds` job:

- Matrix: `env: [stg, prod]`
- GH Environment scoping mirrors the existing `plan`/`apply` jobs: `${{ matrix.env == 'prod' && 'production' || 'staging' }}`.
- **Probe 1 — B2 state-bucket auth.** `aws s3api head-bucket --bucket noorinalabs-terraform-state --endpoint-url https://s3.us-east-005.backblazeb2.com`, using the env-scoped `TF_STATE_B2_KEY_ID` / `TF_STATE_B2_APP_KEY` secrets. `aws` CLI is pre-installed on `ubuntu-latest`, so no install step is needed.
- **Probe 2 — HCLOUD API auth.** `curl` against `https://api.hetzner.cloud/v1/servers` with `Authorization: Bearer ${HCLOUD_TOKEN}`, asserting HTTP 200.
- On failure: a `::error::` annotation names the specific env, the secret(s) to re-set, and the exact `gh secret set --env <env-name> <SECRET>` command to fix it — replacing the generic "AWS auth failed deep in terraform init" failure mode the issue describes.

Trigger expansion:

- Existing `pull_request` and `push` paths on `terraform/**` retained.
- Added `.github/workflows/terraform.yml` to both `paths` filters so workflow-file edits self-validate.
- **New `schedule` trigger** (Mondays 14:00 UTC, `0 14 * * 1`). Detection latency for rotation drift becomes <=7 days regardless of TF-PR cadence. **This is a new trigger surface for this workflow** — operators should expect a weekly run even on quiet TF weeks. The job is matrix-2-cell and runs in <30s per cell per the issue's acceptance criteria.

## Why this option

| Option | Why considered | Why not chosen |
|---|---|---|
| A: atomic-rotation runbook only | Cheapest, zero workflow change | Human discipline is the only guard; failure mode is exactly what human discipline fails at ("I rotated prod and lunch happened"). |
| **B: CI validate-creds job (chosen)** | Catches drift on next TF-touching PR + weekly. Per-env failure message replaces opaque AWS error. Composes with existing env-scoping. | Adds ~15-30s to TF CI and a recurring scheduled run. |
| C: single shared GH Environment | No drift possible by construction | Requires org-admin permission. Loses per-env access control for non-state secrets (HCLOUD_TOKEN, deploy secrets, user-service passwords). Biggest refactor; closes the door on ever having env-specific state credentials. |

Option B was the issue's recommendation and the one that aligns with [ADR 0004's Decision C detection layer](https://github.com/noorinalabs/noorinalabs-deploy/blob/main/docs/adr/0004-b2-state-bucket-and-key-management.md) — Weronika's ADR explicitly cross-references #158 as the detection companion to the per-operator key model.

## Failure-message UX improvement

Today, after a one-env rotation drift, a stale-env `terraform init` fails with a generic AWS SDK auth error several jobs deep, requiring an operator to read CI logs and infer "ah, this is a stale credential" rather than "rotation-drift, fix it like this."

After this PR, the operator sees (example for stg drift):

```
::error::B2 credentials for 'stg' env FAILED to authenticate against noorinalabs-terraform-state.
::error::Rotation drift suspected. Verify both 'gh secret set TF_STATE_B2_KEY_ID --env staging' and TF_STATE_B2_APP_KEY were set with the current B2 key.
::error::aws error output:
::error::  An error occurred (403) when calling the HeadBucket operation: Forbidden
```

The annotation surfaces in the PR Files-changed gutter and the Checks tab summary, so the diagnosis is one click from the failure, not one log-archeology session.

## Schedule cadence rationale

Weekly Monday 14:00 UTC was chosen so:

- **Day:** Monday catches anything that landed Friday after-hours (common rotation-window) before the operator week starts.
- **Time:** 14:00 UTC = 09:00 EST / 15:00 CET / 16:00 EAT — overlaps the team's typical reviewing window, so a failure ping lands during awake-hours for the largest operator overlap rather than at 03:00 local for someone.
- **Frequency:** weekly is the longest interval that still beats the typical rotation cadence (per ADR 0004 the per-operator keys are quarterly + ad-hoc; the CI keys piggyback on operator-key rotation). Bi-weekly would risk missing one rotation cycle entirely.

## Test Plan

- [ ] **CI smoke:** This PR's CI run includes the new `validate-creds` job — both stg and prod cells should pass on first run (credentials are currently in-sync; #158 has not yet had a triggering rotation event).
- [ ] **Drift smoke (manual, optional):** An operator can verify the failure mode by deliberately mis-setting `TF_STATE_B2_KEY_ID` in `staging` to an invalid value on a throwaway branch (then restoring it), observing the `stg` cell fail with the explicit drift message while the `prod` cell still passes. Not required for this PR — the negative path is straightforward shell+aws CLI semantics.
- [ ] **Schedule smoke:** After merge, the next Monday 14:00 UTC scheduled run should appear in the Actions tab.
- [ ] **Self-validation:** This PR itself modifies `.github/workflows/terraform.yml`. With the new `paths` filter that includes the workflow file, the existing `fmt` / `validate` jobs run on this PR — confirming the path-filter expansion works end-to-end.

## Out of scope (intentional)

- **Runbook cross-reference.** Issue acceptance criteria mentions a cross-reference in `terraform/hetzner/README.md`. Deferred to a follow-up doc PR because the runbook target needs alignment with ADR 0004's per-operator key model that Weronika just landed; bundling docs with the CI-mechanic change couples two reviews unnecessarily.
- **HCLOUD_TOKEN moving to a per-job env-block.** Currently the probe step inherits HCLOUD_TOKEN from the job-level env-block; same for the AWS_* secrets. This matches the shape of the existing `plan` / `apply` jobs in the same file, so no shape divergence is introduced.

## actionlint

`actionlint -color .github/workflows/terraform.yml` clean (shellcheck installed locally per [actionlint-needs-shellcheck](https://github.com/noorinalabs/noorinalabs-deploy/blob/main/.claude/team/charter.md) memory).

Closes #158.
