### PR TITLE
ci(shell): shellcheck + bash -n on backup/restore/bootstrap/verify_deployment scripts (#74)

### DIFF
--- a/.github/workflows/compose-validate.yml
+++ b/.github/workflows/compose-validate.yml
@@ -56,21 +56,54 @@ jobs:
         run: docker compose -f docker-compose.prod.yml --env-file .env config --quiet
 
   shellcheck:
-    name: shellcheck infra & scripts
+    # deploy#74: backup/restore are critical DR scripts only exercised in
+    # production via the systemd timer; this job is the only PR-time gate
+    # against bash regressions before they reach the VPS. shellcheck catches
+    # quoting / word-splitting bugs; `bash -n` catches parse-time syntax
+    # errors that shellcheck doesn't always reject (e.g. mismatched heredocs
+    # in some shellcheck modes). Both are <2s — cheap belt-and-braces.
+    name: shellcheck + bash -n (infra & scripts)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: Install shellcheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
-      - name: Lint shell scripts
+      - name: Discover shell scripts
+        id: discover
         run: |
           mapfile -t files < <(find infra scripts -type f -name '*.sh' 2>/dev/null)
           if [ ${#files[@]} -eq 0 ]; then
             echo "No shell scripts found — nothing to lint."
+            echo "found=0" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           printf '%s\n' "${files[@]}"
+          # Newline-joined list, GH-Actions multiline-output safe-delimiter form.
+          {
+            echo "files<<EOF"
+            printf '%s\n' "${files[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "found=1" >> "$GITHUB_OUTPUT"
+      - name: Lint shell scripts (shellcheck)
+        if: steps.discover.outputs.found == '1'
+        run: |
+          mapfile -t files <<< "${{ steps.discover.outputs.files }}"
           shellcheck "${files[@]}"
+      - name: Validate shell script syntax (bash -n)
+        if: steps.discover.outputs.found == '1'
+        run: |
+          mapfile -t files <<< "${{ steps.discover.outputs.files }}"
+          fail=0
+          for f in "${files[@]}"; do
+            if bash -n "$f"; then
+              echo "OK  $f"
+            else
+              echo "::error file=$f::bash -n syntax check failed"
+              fail=1
+            fi
+          done
+          exit "$fail"
 
   passlist-drift:
     # deploy#97: catch drift between compose's :?-required vars and the


### PR DESCRIPTION
## Summary

Closes #74 — adds `bash -n` parse-time syntax validation to the existing
`shellcheck` CI job, completing the lint+syntax pair the issue requested.

The existing `shellcheck` job in `.github/workflows/compose-validate.yml`
(introduced in earlier waves) already lints all `infra/**/*.sh` and
`scripts/**/*.sh` against shellcheck — covering the 4 DR-critical scripts
called out in #74 (backup.sh, restore.sh, bootstrap-vps.sh,
verify_deployment.sh) plus 2 sibling scripts (emit-backup-failure-marker.sh,
verify_prod_smoke.sh) plus infra/kafka/init-topics.sh. What was missing
per #74's suggested-fix block was `bash -n` syntax validation.

## What changed

`.github/workflows/compose-validate.yml` — the existing `shellcheck` job
now does both lint and syntax-check in 3 steps:

1. **Discover** — `find infra scripts -type f -name '*.sh'` → exports the
   file list via `GITHUB_OUTPUT` (heredoc-delimiter form) for reuse.
2. **shellcheck** — unchanged behavior, runs on the discovered set.
3. **bash -n** (new) — iterates the same set, prints `OK <path>` /
   `FAIL <path>`, emits `::error file=<path>::` annotations on syntax
   failures so they land in PR-review file annotations, exits non-zero
   if any script fails.

Job renamed `shellcheck infra & scripts` → `shellcheck + bash -n
(infra & scripts)` to reflect broader scope.

## Shellcheck findings (per script)

Per the spawn brief's `(a)` vs `(b)` decision tree — `(a)` if trivial,
split-and-defer if 5+ warnings per script. Local run on wave-11 HEAD
with shellcheck 0.10.0:

| Script | Findings | Action |
|---|---|---|
| scripts/backup.sh | **0** | none — already clean |
| scripts/restore.sh | **0** | none — already clean |
| scripts/bootstrap-vps.sh | **0** | none — already clean |
| scripts/verify_deployment.sh | **0** | none — already clean |
| scripts/emit-backup-failure-marker.sh | **0** | none — already clean |
| scripts/verify_prod_smoke.sh | **0** | none — already clean |
| infra/kafka/init-topics.sh | **0** | none — already clean |

Total: **0 findings across 7 scripts**. No inline fixes needed, no
follow-up issues filed. The existing `shellcheck` job has clearly been
keeping the surface clean already; this PR just adds the second `bash -n`
gate that #74 specifically requested.

## Why both shellcheck AND `bash -n`

Overlapping but non-identical failure modes:

- shellcheck catches quoting / word-splitting / common-bash-pitfall bugs
  that pass the bash parser fine but fail at runtime.
- `bash -n` is the parser of record for what production will actually
  execute. Catches heredoc-terminator mismatches and a few syntax
  patterns shellcheck's defaults won't reject.

Both jobs combined run in <2s — cheap belt-and-braces.

## Test Plan

- [x] Local: `shellcheck` 0.10.0 on all 7 discovered scripts — 0 findings.
- [x] Local: `bash -n` on all 7 discovered scripts — all OK.
- [x] Local: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/compose-validate.yml'))"` — parses cleanly.
- [x] Local: `actionlint .github/workflows/compose-validate.yml` (with shellcheck on PATH per `feedback_actionlint_needs_shellcheck`) — clean.
- [x] Local: simulated the new step's `mapfile + for f / bash -n "$f"` loop on the discovered file list — exits 0.
- [ ] CI: the `shellcheck + bash -n` job in compose-validate.yml should be green on this PR (paths-filter triggers on `.github/workflows/**`).
- [ ] Future regression coverage: any subsequent PR that introduces a SC warning OR a syntax error in any `infra/**/*.sh` or `scripts/**/*.sh` will hard-fail this job.

## Notes for reviewer

- Implementation chose to **extend the existing job in place** rather than
  add a parallel job. Rationale: shellcheck + `bash -n` share the same
  file-discovery surface; running them in one job avoids redundant
  checkout + apt-install overhead and keeps related gates side-by-side.
- The job rename means the GH-status-check ID changes — if any branch
  protection rule pins the old `shellcheck infra & scripts` name, it
  needs updating. Worth a glance during review.

---

Requestor: Aino Virtanen
Requestee: TBD-on-open
RequestOrReplied: Request
TechDebt: none
