### PR TITLE
infra(cloudflare): 301 redirect noorinalabs.net + noorinalabs.org → .com (#166)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -110,6 +110,10 @@ jobs:
     env:
       TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       TF_VAR_cloudflare_zone_id: ${{ vars.CLOUDFLARE_ZONE_ID }}
+      # Defensive-TLD zone IDs for the canonical-domain 301 redirect rulesets
+      # (per #166). Public DNS metadata, not secrets — stored as repo vars.
+      TF_VAR_noorinalabs_net_zone_id: ${{ vars.CLOUDFLARE_NOORINALABS_NET_ZONE_ID }}
+      TF_VAR_noorinalabs_org_zone_id: ${{ vars.CLOUDFLARE_NOORINALABS_ORG_ZONE_ID }}
       # AWS_* env vars serve double duty: cloudflare's own B2 backend AND the
       # `terraform_remote_state` data sources that read the hetzner tfstates
       # (same bucket, same auth — see terraform/cloudflare/main.tf).
@@ -237,6 +241,10 @@ jobs:
     env:
       TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       TF_VAR_cloudflare_zone_id: ${{ vars.CLOUDFLARE_ZONE_ID }}
+      # Defensive-TLD zone IDs for the canonical-domain 301 redirect rulesets
+      # (per #166). Public DNS metadata, not secrets — stored as repo vars.
+      TF_VAR_noorinalabs_net_zone_id: ${{ vars.CLOUDFLARE_NOORINALABS_NET_ZONE_ID }}
+      TF_VAR_noorinalabs_org_zone_id: ${{ vars.CLOUDFLARE_NOORINALABS_ORG_ZONE_ID }}
       # AWS_* env vars serve double duty: cloudflare's own B2 backend AND the
       # `terraform_remote_state` data sources that read the hetzner tfstates
       # (same bucket, same auth — see terraform/cloudflare/main.tf).

--- a/terraform/cloudflare/README.md
+++ b/terraform/cloudflare/README.md
@@ -1,15 +1,16 @@
 # Terraform — Cloudflare DNS
 
-Manages DNS records and zone settings for `noorinalabs.com` via the Cloudflare provider. This is a **single module** (not per-env like `terraform/hetzner/`) because there is one Cloudflare zone; both prod and stg records live in the same state.
+Manages DNS records and zone settings for `noorinalabs.com` via the Cloudflare provider, plus canonical-domain 301 redirects for the defensive `.net` + `.org` TLDs (per #166). This is a **single module** (not per-env like `terraform/hetzner/`) because the .com zone is shared between prod and stg, and the redirect rulesets on the dark zones are single-resource each.
 
 ## Layout
 
 ```
 terraform/cloudflare/
 ├── README.md                   # this file
-├── main.tf                     # provider, zone settings, all DNS records
-├── variables.tf                # cloudflare_api_token, cloudflare_zone_id, domain
-├── outputs.tf                  # prod_hostnames, stg_hostnames, ssl_mode maps
+├── main.tf                     # provider, zone settings, all .com DNS records
+├── redirects.tf                # canonical-domain 301 redirects (.net/.org → .com)
+├── variables.tf                # API token + all three zone IDs + domain
+├── outputs.tf                  # prod_hostnames, stg_hostnames, ssl_mode, redirect ruleset IDs
 ├── moved.tf                    # state-migration history (pre-#83 renames)
 ├── versions.tf
 └── terraform.tfvars.example
@@ -30,6 +31,33 @@ terraform/cloudflare/
 | `stg` AAAA | `stg_apex_aaaa` | **no** | Stg VPS IPv6 (conditional) |
 | `isnad.stg` CNAME | `stg_isnad_cname` | **no** | → `stg.noorinalabs.com` |
 | `users.stg` CNAME | `stg_users_cname` | **no** | → `stg.noorinalabs.com` |
+
+## Canonical-domain redirects (.net + .org → .com)
+
+Per #166. The owner holds `noorinalabs.net` and `noorinalabs.org` as defensive registrations. They are dark zones today (no app DNS records). To consolidate canonical-domain traffic, SEO signals, and brand consistency, both zones serve a Cloudflare-edge 301 redirect to the matching path on `noorinalabs.com`.
+
+| Source | Behavior | Defined in |
+|---|---|---|
+| `https://noorinalabs.net/<path>?<query>` | 301 → `https://noorinalabs.com/<path>?<query>` | `redirects.tf` |
+| `https://noorinalabs.org/<path>?<query>` | 301 → `https://noorinalabs.com/<path>?<query>` | `redirects.tf` |
+
+Implementation: a `cloudflare_ruleset` resource per zone in phase `http_request_dynamic_redirect`. The rule matches every request (`expression = "true"`) and rewrites the URL via a dynamic `target_url.expression`. Path + query string are preserved by string-concatenation in the expression. Because the redirect fires at the Cloudflare edge before origin lookup, no DNS A/AAAA record on `.net` / `.org` is required — the zones stay dark.
+
+### Why dynamic-redirect Rulesets
+
+Issue #166 enumerates three options:
+
+- **Bulk Redirects** (dashboard UI): no TF tracking, no diff review, no DR recovery.
+- **Page Rules**: deprecated upstream by Cloudflare.
+- **Rulesets** (chosen): TF-managed, diff-reviewable, identical secret + provider as the rest of this module.
+
+### Adding a new TLD redirect
+
+If a fourth TLD is later registered:
+
+1. Add its zone ID to `noorinalabs_<tld>_zone_id` in `variables.tf` and to `terraform.tfvars.example`.
+2. Add a `<tld> = var.noorinalabs_<tld>_zone_id` entry to `local.redirect_zones` in `redirects.tf`. The ruleset is `for_each`-driven, so no other change is needed.
+3. Wire the zone ID into the CI repo variables (`vars.CLOUDFLARE_NOORINALABS_<TLD>_ZONE_ID`) and the corresponding `TF_VAR_*` env in `.github/workflows/terraform.yml` (plan-cloudflare + apply-cloudflare jobs).
 
 ## Prod vs stg proxy posture
 

--- a/terraform/cloudflare/outputs.tf
+++ b/terraform/cloudflare/outputs.tf
@@ -24,3 +24,8 @@ output "ssl_mode" {
   description = "Current SSL/TLS mode for the zone."
   value       = cloudflare_zone_settings_override.ssl.settings[0].ssl
 }
+
+output "canonical_redirect_ruleset_ids" {
+  description = "Map of dark-TLD key (net|org) → Cloudflare ruleset ID for the canonical-domain 301 redirect. Useful for `gh api`/CF API debugging of the rule that fires on a request."
+  value       = { for k, r in cloudflare_ruleset.canonical_redirect : k => r.id }
+}

--- a/terraform/cloudflare/redirects.tf
+++ b/terraform/cloudflare/redirects.tf
@@ -1,0 +1,79 @@
+# ===========================================================================
+# Canonical-domain 301 redirects — noorinalabs.net + noorinalabs.org → .com
+#
+# The owner holds three TLD registrations as defensive (squatter-prevention).
+# `.net` and `.org` are dark zones today: no productive DNS records, no app
+# traffic. This file adds Cloudflare-edge 301 redirects so any HTTP/HTTPS
+# request landing on `.net` or `.org` is permanently redirected to the
+# matching path on `noorinalabs.com`, preserving the URL path + query string.
+#
+# Rationale (per issue #166):
+#   - Canonical-domain consolidation: users typing the wrong TLD land on the
+#     right site instead of an empty page.
+#   - SEO signal consolidation: search engines treat the .com as canonical.
+#   - Brand consistency.
+#
+# Mechanism: Cloudflare Rulesets, phase `http_request_dynamic_redirect`.
+# This phase runs at the edge before any origin lookup, so the redirect is
+# served by Cloudflare itself — no origin server needed for `.net` / `.org`
+# (which is why they can stay dark without DNS A/AAAA records).
+#
+# Why a dynamic-redirect ruleset (not Bulk Redirects, not Page Rules):
+#   - Bulk Redirects (option A in #166) live only in the CF dashboard — no
+#     TF tracking, no diff review, no DR recovery.
+#   - Page Rules (option B) are deprecated upstream by Cloudflare.
+#   - `cloudflare_ruleset` with dynamic-redirect is the supported, TF-managed
+#     equivalent and aligns with the parity-and-predictability principle
+#     (everything in TF, nothing hand-clicked).
+#
+# Why C1 (extend this module) and not C2 (new root `terraform/cloudflare-
+# redirects/`): fewer moving parts. Same provider, same backend, same
+# `CLOUDFLARE_API_TOKEN` (token scope already covers all three zones per
+# owner setup in W10). New state in a separate root would add CI matrix
+# entries and a second `terraform init` for one resource per zone.
+# ===========================================================================
+
+locals {
+  # Map of zone-key → zone-id for the dark TLDs that should 301 to .com.
+  # Add a new entry here to redirect a new TLD; everything else is for_each-
+  # driven from this map.
+  redirect_zones = {
+    net = var.noorinalabs_net_zone_id
+    org = var.noorinalabs_org_zone_id
+  }
+}
+
+resource "cloudflare_ruleset" "canonical_redirect" {
+  for_each = local.redirect_zones
+
+  zone_id     = each.value
+  name        = "canonical-domain-redirect-${each.key}"
+  description = "301 redirect noorinalabs.${each.key} → noorinalabs.com (path + query preserved)"
+  kind        = "zone"
+  phase       = "http_request_dynamic_redirect"
+
+  rules {
+    action      = "redirect"
+    description = "Permanent redirect to noorinalabs.com, preserving path + query"
+    # Matches every request — these zones carry no productive traffic, so
+    # there is nothing on `.net` / `.org` we'd want to *not* redirect.
+    expression = "true"
+    enabled    = true
+
+    action_parameters {
+      from_value {
+        status_code = 301
+        # Dynamic target: concatenate canonical host with the incoming
+        # request's path, and append `?<query>` only when a query string
+        # is present. Cloudflare's `wirefilter` expression dialect supports
+        # `concat()`, `if()`, and the `http.request.uri.{path,query}` fields.
+        # Expression-based `target_url` already covers query preservation,
+        # so the separate `preserve_query_string` boolean is intentionally
+        # omitted (it applies only to static `target_url.value` redirects).
+        target_url {
+          expression = "concat(\"https://noorinalabs.com\", http.request.uri.path, if(len(http.request.uri.query) > 0, concat(\"?\", http.request.uri.query), \"\"))"
+        }
+      }
+    }
+  }
+}

--- a/terraform/cloudflare/terraform.tfvars.example
+++ b/terraform/cloudflare/terraform.tfvars.example
@@ -5,6 +5,13 @@ cloudflare_api_token = "CHANGE-ME"
 # Zone ID — found on the Cloudflare dashboard overview page for noorinalabs.com
 cloudflare_zone_id = "CHANGE-ME"
 
+# Zone IDs for the defensive TLDs (`.net` + `.org`). Same lookup as above:
+# Cloudflare dashboard → noorinalabs.net (or .org) → Overview → Zone ID.
+# Public DNS metadata, not secrets. Used by the canonical-domain redirect
+# ruleset in redirects.tf.
+noorinalabs_net_zone_id = "CHANGE-ME"
+noorinalabs_org_zone_id = "CHANGE-ME"
+
 # Per-env VPS IPs are NOT input variables — they're read from the hetzner
 # env-root tfstates via `data "terraform_remote_state"` in main.tf. To run
 # this module locally you need read access to the hetzner state in B2:

--- a/terraform/cloudflare/variables.tf
+++ b/terraform/cloudflare/variables.tf
@@ -9,6 +9,21 @@ variable "cloudflare_zone_id" {
   type        = string
 }
 
+# Defensive-TLD zone IDs — `.net` and `.org` are dark zones owned for
+# squatter prevention. They carry no productive DNS records; the only
+# Cloudflare-managed configuration is the canonical-domain 301 redirect
+# ruleset defined in redirects.tf. Zone IDs are public-DNS metadata, not
+# secrets — sourced from the Cloudflare dashboard (Overview → Zone ID).
+variable "noorinalabs_net_zone_id" {
+  description = "Cloudflare Zone ID for noorinalabs.net (canonical-domain redirect target zone)."
+  type        = string
+}
+
+variable "noorinalabs_org_zone_id" {
+  description = "Cloudflare Zone ID for noorinalabs.org (canonical-domain redirect target zone)."
+  type        = string
+}
+
 variable "domain" {
   description = "Root domain name."
   type        = string


### PR DESCRIPTION
## Summary

Adds Cloudflare-edge **301 redirects** on the two defensive TLD zones (`noorinalabs.net`, `noorinalabs.org`) so any request landing on a dark zone is permanently redirected to the matching path on `noorinalabs.com`, preserving URL path + query string.

Owner holds the three TLDs as squatter-prevention. `.net`/`.org` are dark today (no productive DNS records). Consolidation rationale per #166: canonical-domain SEO signal, brand consistency, users-typing-wrong-TLD recovery.

## Option chosen: C1 (extend existing module)

Issue #166 enumerates three options:

| Option | Mechanism | Verdict |
|---|---|---|
| A | Cloudflare Bulk Redirects (dashboard UI) | Rejected — no TF tracking, no diff review, no DR recovery |
| B | Cloudflare Page Rules | Rejected — deprecated upstream by Cloudflare |
| **C** | `cloudflare_ruleset` (TF-managed, dynamic-redirect phase) | **Chosen** — consistent with rest of stack |

Within C, chose **C1** (extend `terraform/cloudflare/` root) over **C2** (new `terraform/cloudflare-redirects/` root). Same provider, same backend, same `CLOUDFLARE_API_TOKEN` (token scope already covers all three zones per W10 setup). C2 would add CI matrix entries + a second `terraform init` for one resource per zone — unnecessary cognitive overhead.

## Zones touched

| Zone | Action | Variable | Repo var |
|---|---|---|---|
| `noorinalabs.net` | New `cloudflare_ruleset` (dynamic-redirect phase) | `noorinalabs_net_zone_id` | `vars.CLOUDFLARE_NOORINALABS_NET_ZONE_ID` |
| `noorinalabs.org` | New `cloudflare_ruleset` (dynamic-redirect phase) | `noorinalabs_org_zone_id` | `vars.CLOUDFLARE_NOORINALABS_ORG_ZONE_ID` |
| `noorinalabs.com` | **No change** | — | — |

The redirect target is built dynamically:

```
concat("https://noorinalabs.com",
       http.request.uri.path,
       if(len(http.request.uri.query) > 0,
          concat("?", http.request.uri.query),
          ""))
```

Path + query string preserved; no double-`?` when query is empty.

## Files

| File | Change |
|---|---|
| `terraform/cloudflare/redirects.tf` | **new** — `for_each` over `local.redirect_zones` map |
| `terraform/cloudflare/variables.tf` | adds two zone-ID vars (required, non-sensitive) |
| `terraform/cloudflare/terraform.tfvars.example` | example entries |
| `terraform/cloudflare/outputs.tf` | adds `canonical_redirect_ruleset_ids` output |
| `terraform/cloudflare/README.md` | new "Canonical-domain redirects" section + updated layout |
| `.github/workflows/terraform.yml` | wires `TF_VAR_noorinalabs_{net,org}_zone_id` into both `plan-cloudflare` and `apply-cloudflare` jobs |

## Local verification

- `terraform fmt -check -diff` — clean.
- `terraform init -backend=false && terraform validate` — `Success! The configuration is valid.` (against `cloudflare/cloudflare v4.52.7`, current selection under `~> 4.43`).
- `actionlint .github/workflows/terraform.yml` — clean (shellcheck on PATH per [feedback_actionlint_needs_shellcheck]).

## Operator step (required BEFORE this PR can plan green)

The two new zone IDs must be added as GitHub Actions **repo variables** before merge, otherwise the next CI run of `plan-cloudflare` will fail with `No value for required variable "noorinalabs_net_zone_id"`.

```bash
# Look up in CF dashboard → noorinalabs.net (then .org) → Overview → Zone ID
gh variable set CLOUDFLARE_NOORINALABS_NET_ZONE_ID --body "<32-char-zone-id>" --env production --repo noorinalabs/noorinalabs-deploy
gh variable set CLOUDFLARE_NOORINALABS_ORG_ZONE_ID --body "<32-char-zone-id>" --env production --repo noorinalabs/noorinalabs-deploy
```

Zone IDs are public DNS metadata — safe as `vars.*` (not `secrets.*`).

## Test Plan

**Pre-merge (CI):**

- [ ] Operator runs the two `gh variable set` commands above.
- [ ] `plan-cloudflare` CI job posts a plan showing **two new** `cloudflare_ruleset.canonical_redirect["net"]` and `["org"]` resources and **zero diff** on existing `.com` resources.
- [ ] 2-of-2 reviewer approval (per charter).

**Post-merge (operator, post-apply):**

- [ ] `apply-cloudflare` CI job logs successful resource creation for both rulesets.
- [ ] `curl -I https://noorinalabs.net/` → `301`, `Location: https://noorinalabs.com/`
- [ ] `curl -I https://noorinalabs.net/foo?bar=1` → `301`, `Location: https://noorinalabs.com/foo?bar=1`
- [ ] `curl -I https://noorinalabs.org/` → `301`, `Location: https://noorinalabs.com/`
- [ ] `curl -I https://noorinalabs.org/foo?bar=1` → `301`, `Location: https://noorinalabs.com/foo?bar=1`

## Out of scope

- Email handling on `.net`/`.org` (per #166 — those zones should not have MX records). This PR adds no MX records and removes none; the redirect ruleset is HTTP-only.
- Adding `.net`/`.org` to the ontology — will be picked up automatically on the next `/ontology-rebuild` after merge (zone IDs become public state).

Closes #166

---

🤖 Implemented by Weronika Zielinska
