### PR TITLE
infra(cloudflare): add www.stg CNAME to stop Caddy ACME loop (#227)

### DIFF
--- a/terraform/cloudflare/main.tf
+++ b/terraform/cloudflare/main.tf
@@ -197,3 +197,18 @@ resource "cloudflare_record" "stg_users_cname" {
   ttl     = 1
   proxied = false
 }
+
+# www.stg.noorinalabs.com → stg apex. Caddy's first vhost block matches
+# `www.{$BASE_DOMAIN}` and on stg that resolves to `www.stg.noorinalabs.com`;
+# without this record Caddy retries the LE HTTP-01 challenge forever
+# (slow-burn LE rate-limit risk). Gray-cloud (proxied=false) matches the
+# other stg.* records — Cloudflare Universal SSL only covers one level
+# deep, so 3rd-level subdomains can't proxy through CF.
+resource "cloudflare_record" "stg_www_cname" {
+  zone_id = var.cloudflare_zone_id
+  name    = "www.stg"
+  content = "stg.${var.domain}"
+  type    = "CNAME"
+  ttl     = 1
+  proxied = false
+}


### PR DESCRIPTION
## Summary

Closes #227.

Caddy's first vhost block matches `www.{$BASE_DOMAIN}` and 301-redirects to apex. On prod that's `www.noorinalabs.com` (has live A/AAAA, ACME succeeds). On stg `$BASE_DOMAIN=stg.noorinalabs.com` so the block matches `www.stg.noorinalabs.com`, which had no DNS record — Caddy retried the LE HTTP-01 challenge forever (noise + slow-burn LE rate-limit risk).

Per issue body, Option A chosen: add a CNAME so behavior is symmetric across envs. New resource follows the sibling `stg_isnad_cname` / `stg_users_cname` pattern.

## Deviation from issue body

Issue snippet specified `proxied = true`, but the existing STG-records header comment (terraform/cloudflare/main.tf:151-162) documents that Cloudflare Universal SSL only covers `*.noorinalabs.com` one level deep; 3rd-level subdomains like `www.stg.*` fail TLS at the CF edge when proxied. Used `proxied = false` to match the documented stg gray-cloud convention. Caddy on the stg VPS will serve directly with its LE cert (HTTP-01 now works because the CNAME resolves).

## Test Plan

- [ ] Operator: cloudflare apply (manual until #90 wires CF into the apply matrix)
- [ ] `dig +short www.stg.noorinalabs.com` returns CNAME → `stg.noorinalabs.com`
- [ ] Caddy stg logs: no further ACME failures for `www.stg.noorinalabs.com` within ~1 hour
- [ ] `curl -ILk https://www.stg.noorinalabs.com/` returns `301` → `https://stg.noorinalabs.com/`

TechDebt: none