### PR TITLE
ci(deploy-stg): drop landing-page from repository_dispatch types — no sender exists (#285)

### DIFF
--- a/.github/workflows/deploy-landing-page.yml
+++ b/.github/workflows/deploy-landing-page.yml
@@ -1,10 +1,11 @@
 name: Deploy noorinalabs-landing-page (LEGACY — manual only)
 
-# DEPRECATED in P2W10 by deploy#84. Landing-page stg fan-in now flows via
-# `deploy-stg.yml`'s `deploy-noorinalabs-landing-page` repository_dispatch
-# handler; landing-page prod rollout flows via `promote.yml` →
-# `deploy-prod.yml`. Retained here as a manual-only rollback path to the
-# legacy single VPS until `deploy#86` decommission.
+# DEPRECATED in P2W10 by deploy#84. Landing-page prod rollout flows via
+# `promote.yml` registry retag → `deploy-prod.yml`. Landing-page does NOT
+# participate in the stg auto-deploy fan-in (deploy-stg.yml): no sender
+# was ever wired and the listener type was dropped in deploy#285.
+# Retained here as a manual-only rollback path to the legacy single VPS
+# until `deploy#86` decommission.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -1,11 +1,16 @@
 # Deploy to staging (noorinalabs-stg VPS).
 #
 # Triggers:
-#   - repository_dispatch from any service repo (isnad-graph, user-service,
-#     landing-page) — the auto-deploy fan-in point for stg. Service repos
-#     send `deploy-noorinalabs-<service>` events after their ghcr-publish.yml
-#     has pushed the four stg tags (sha-<short>, latest, stg-<short>,
-#     stg-latest) per Contract v6 (canonical per Khoury ruling).
+#   - repository_dispatch from isnad-graph or user-service — the auto-deploy
+#     fan-in point for stg. Those service repos send
+#     `deploy-noorinalabs-<service>` events after their ghcr-publish.yml has
+#     pushed the four stg tags (sha-<short>, latest, stg-<short>, stg-latest)
+#     per Contract v6 (canonical per Khoury ruling).
+#     Note: landing-page does NOT participate in this fan-in. Its prod
+#     rollout flows through promote.yml registry retag (see promote.yml
+#     § landing_short), not push-time dispatch. Listener type for
+#     `deploy-noorinalabs-landing-page` was dropped in deploy#285 because
+#     no sender ever wired to it.
 #   - workflow_dispatch — manual redeploy, e.g. to re-pull stg-latest after
 #     a registry hiccup.
 #
@@ -28,7 +33,6 @@ on:
     types:
       - deploy-noorinalabs-isnad-graph
       - deploy-noorinalabs-user-service
-      - deploy-noorinalabs-landing-page
   workflow_dispatch:
     inputs:
       image_tag:


### PR DESCRIPTION
## Summary

Resolves #285 — **option B**: drop `deploy-noorinalabs-landing-page` from `deploy-stg.yml`'s `repository_dispatch` listener types because no sender was ever wired in the landing-page repo.

## Evidence

- `grep -rn 'deploy-noorinalabs-landing-page'` across all org repos: only two hits, both inside `noorinalabs-deploy` itself (the listener line being removed + a documentation comment in `deploy-landing-page.yml` that this PR also fixes). **Zero senders.**
- `ontology/repos/deploy.yaml` already documents the asymmetry at `dispatch_contracts_received[0].senders[name=deploy-landing-page]` with `sender_repo: NO_SENDER` and a pointer to deploy#285.
- Landing-page production rollout actually flows via `promote.yml` registry retag (`landing_short` plan output + `retag-landing` job → emits `prod-<short>` / `prod-latest` tags), not push-time dispatch — verified in `promote.yml` lines 215, 394, 803, 814.

## Why option B (not A)

Option A would grow a sender in the landing-page repo (cross-repo work). Option B is a single-repo edit that matches reality: there is no push-time stg fan-in for landing-page, only registry retag. If/when push-time stg deploy for landing-page becomes desired, the sender + listener can be re-added symmetrically.

## Dead-code check

No job branched on `github.event.action == 'deploy-noorinalabs-landing-page'`:

- `migrate` job (lines 53-55): `deploy-noorinalabs-user-service` only — unaffected.
- `deploy` job: no per-action gating — fan-in for both surviving types stays intact.
- `Report status` step: echoes `github.event.action` generically, no branching — unaffected.

So this is a single-line removal in the `on:` block; no dead-code cleanup needed.

## Bundled doc-only fix

`deploy-landing-page.yml`'s file-header comment claimed landing-page stg fan-in *flows via* the `deploy-stg.yml` listener handler — that handler never fired in production because no sender existed. Replaced with the actual flow (promote.yml retag) plus a pointer to this PR. Pure comment change, no runtime effect.

## Ontology follow-up

Next `/ontology-rebuild` should refresh `ontology/repos/deploy.yaml dispatch_contracts_received[0].senders` to drop the landing-page `NO_SENDER` entry — listener and sender are now both absent, symmetric and consistent.

## Test plan

- [x] YAML parse OK (`python3 -c 'import yaml; yaml.safe_load(...)'`)
- [x] `actionlint` clean (with `shellcheck` on PATH per [[feedback_actionlint_needs_shellcheck]])
- [x] grep across all org repos confirms zero senders for `deploy-noorinalabs-landing-page`
- [ ] CI green on PR

Closes #285.

---

Requestor: Aino Virtanen
Requestee: <reviewer-tbd>
RequestOrReplied: Request
TechDebt: none
