### PR TITLE
docs(runbook): add Cloudflare Web Analytics utilization runbook + cadence (#253)

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -20,6 +20,7 @@ own what they build. This repo owns what runs on the server.").
 | User-service Alembic migration | [`docs/runbooks/user-service-alembic.md`](docs/runbooks/user-service-alembic.md) |
 | Per-env OAuth provisioning | [`docs/runbooks/oauth-per-env.md`](docs/runbooks/oauth-per-env.md) |
 | Blackbox probes / synthetic checks | [`docs/runbooks/blackbox-probes.md`](docs/runbooks/blackbox-probes.md) |
+| Observability stack index + Cloudflare Web Analytics | [`docs/runbooks/observability.md`](docs/runbooks/observability.md) |
 | Break-glass `workflow_dispatch` inputs | [`docs/runbooks/break-glass.md`](docs/runbooks/break-glass.md) |
 | Cold-rebuild dry-run gate | [`docs/runbooks/cold-rebuild-dry-run.md`](docs/runbooks/cold-rebuild-dry-run.md) |
 | First-time VPS bring-up | [`docs/runbooks/user-service-migration.md`](docs/runbooks/user-service-migration.md) + § Build below |

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -1,0 +1,166 @@
+# Runbook — Observability
+
+Index of the observability stack and the dashboards / external surfaces
+that complement it. This file is intentionally an entrypoint: each named
+sub-system has its own runbook (linked below) for the deep procedure.
+
+The deploy-repo observability stack is documented per-component in
+`infra/{prometheus,grafana,loki,promtail,alertmanager,blackbox-exporter}/`.
+The list of running containers is canonical in
+`compose/docker-compose.prod.yml` and mirrored in
+`ontology/repos/deploy.yaml` (services.observability).
+
+## Surfaces
+
+| Surface | Signal type | Where it lives | Runbook |
+|---|---|---|---|
+| Prometheus | metrics scrape | prod VPS, port 9090 (internal) | per-alert links in `infra/prometheus/alerts.yml` |
+| Grafana | metrics + log visualisation | prod VPS, `/grafana` behind Caddy | n/a (browse + edit in-app) |
+| Loki + Promtail | log aggregation | prod VPS, container-side `docker-socket` scrape | [`log-ingestion.md`](log-ingestion.md) |
+| Alertmanager | alert routing | prod VPS, port 9093 (internal) | [`alertmanager-slack-routing.md`](alertmanager-slack-routing.md) |
+| blackbox-exporter | synthetic probes (HTTP) | prod VPS, container `blackbox-exporter` | [`blackbox-probes.md`](blackbox-probes.md) |
+| Cloudflare Web Analytics (CWA) | real-user RUM | CF dashboard (per zone) | § below |
+
+The synthetic-vs-real-user distinction matters for triage:
+**blackbox** answers "is this route reachable from a third-party host?" and
+**CWA** answers "what does a real visitor's browser see for p75 LCP?"
+The two are complements, not duplicates — a regression in either signal
+is independently actionable.
+
+---
+
+## Cloudflare Web Analytics (CWA)
+
+### What this is
+
+Cloudflare's cookieless real-user monitoring (RUM), shipped free with
+any zone on the platform. It collects Core Web Vitals (LCP, FID, CLS,
+INP), pageviews, top pages, status-code breakdown, geo, browser, OS,
+and referrer at p75/p90 percentiles, 30-day retention.
+
+Free tier is **dashboard-only** — there is no API export and no
+programmatic alerting. The Pro tier ($20/zone/month) adds Web Analytics
+GraphQL API for Grafana export and custom dimensions / events; that
+tier is explicitly out of scope today and will be re-evaluated no
+earlier than 2026-08-01 (issue #253 acceptance).
+
+### Operator pre-step: verify enablement
+
+CWA must be enabled in the Cloudflare dashboard for each zone we want
+RUM coverage on. This is one of the few CF surfaces not managed via
+Terraform — there is no `cloudflare_web_analytics_site` resource in
+`terraform/cloudflare/` and adding one is not in scope here.
+
+For each zone:
+
+1. Open `https://dash.cloudflare.com/{account-id}/{zone}/analytics/web`
+   (the dashboard auto-resolves to your account; the URL above is the
+   shape you'll see).
+2. If the page reads "Web Analytics is not enabled," click **Enable**.
+   First data appears ~10 minutes after enablement.
+3. Repeat for both zones if they are separate:
+   - `noorinalabs.com` — covers `www.noorinalabs.com`,
+     `isnad.noorinalabs.com`, `users.noorinalabs.com`
+   - `stg.noorinalabs.com` — covers `*.stg.noorinalabs.com`
+     (verify whether this is a separate zone or a sub-record on the
+     parent zone; coverage shape differs)
+
+This step is operator-only because the runbook process has no
+credentials to the Cloudflare dashboard. Confirm enablement here is
+treated as a pre-condition for the rest of this section.
+
+### Dashboard URLs
+
+Fill in the per-account URLs after first enablement — they are
+account-scoped and not knowable from this repo:
+
+| Zone | Dashboard URL |
+|---|---|
+| `noorinalabs.com` (prod) | `https://dash.cloudflare.com/<account>/<zone-id>/analytics/web` |
+| `stg.noorinalabs.com` (stg, if separate zone) | `https://dash.cloudflare.com/<account>/<zone-id>/analytics/web` |
+
+When you fill these in, prefer the stable `account` slug over the
+numeric id (CF accepts both, the slug survives org rename).
+
+### Baseline snapshot
+
+A baseline of current CWV per top page lets a frontend change
+(e.g. the `users.noorinalabs.com` absolute-URL shift in deploy#245)
+be evaluated against a known-good before-picture. Snapshot is text
+in this runbook; no automation.
+
+**Snapshot template — fill in after first enablement + 7 days of data:**
+
+```
+as of YYYY-MM-DD (7-day window, all zones)
+
+Top page                              | p75 LCP | p75 CLS | p75 INP | pageviews
+--------------------------------------|---------|---------|---------|----------
+noorinalabs.com/                      |         |         |         |
+isnad.noorinalabs.com/                |         |         |         |
+isnad.noorinalabs.com/search          |         |         |         |
+users.noorinalabs.com/login           |         |         |         |
+```
+
+Core Web Vitals thresholds (Google's "Good" bucket, for reference when
+reading the table):
+
+| Metric | Good | Needs improvement | Poor |
+|---|---|---|---|
+| LCP (largest contentful paint) | ≤ 2.5s | ≤ 4.0s | > 4.0s |
+| CLS (cumulative layout shift) | ≤ 0.1 | ≤ 0.25 | > 0.25 |
+| INP (interaction to next paint) | ≤ 200ms | ≤ 500ms | > 500ms |
+
+Re-snapshot after any frontend-shipping wave (especially deploy#245
+absolute-URL shift) and after any noticeable CF/Caddy/Compose
+change that could affect the request path.
+
+### Cadence
+
+- **Default:** monthly review — open the dashboard, scan the CWV
+  trend per top page, note anything trending out of "Good." A
+  five-minute read.
+- **During active frontend work:** weekly. Frontend changes are the
+  most common cause of CWV regressions, so the tighter cadence pairs
+  with the wave that's shipping them.
+- **Ad-hoc:** any time blackbox reports a probe regression on a
+  frontend route (`landing-root`, the isnad frontend), check CWA for
+  the same window — real-user signal often surfaces the cause that
+  synthetic probes can only see as a 200/timeout boolean.
+
+### Optional: wave-retro check-in
+
+Wave retros are a natural cadence anchor. The minimum useful read is:
+
+- Open each zone's CWA dashboard for the wave window.
+- For each top page, note whether p75 LCP / CLS / INP shifted
+  bucket (Good → Needs improvement, etc.).
+- If any did, file an issue against the owning service repo with
+  the before/after snapshot.
+
+This is currently a manual habit, not a charter-enforced step;
+deploy#253 acceptance is to document it here for adoption.
+
+### Out of scope
+
+- **Pro-tier upgrade.** Re-evaluate no earlier than 2026-08-01.
+  Trigger conditions are: (a) we want CWV in Grafana alongside
+  blackbox, (b) we want event-level export for funnels, (c) we want
+  custom dimensions / events. Not pre-paying for capability we may
+  not use.
+- **Programmatic alerting** on RUM metrics — requires Pro-tier API
+  access; deferred with the Pro upgrade above.
+- **Custom event tracking** (button clicks, form submits) — a
+  different tool (PostHog, Plausible) is the right shape if/when
+  this becomes load-bearing.
+
+### Why this isn't in Terraform
+
+`cloudflare_web_analytics_site` is a real provider resource; we
+intentionally don't manage it from `terraform/cloudflare/` today
+because (a) free-tier CWA has no per-site configuration worth
+codifying, (b) enabling it is a one-click operator action, and
+(c) the auto-injected `beacon.min.js` is the only runtime artifact
+and has no per-env variance. If we adopt Pro tier or start managing
+custom rules, that decision changes — open an ADR before adding
+the resource.


### PR DESCRIPTION
## Summary

Closes #253. Documents free-tier Cloudflare Web Analytics utilization per the 2026-05-03 P3W3 owner-pivot (keep CWA enabled, use it as a real-user RUM complement to blackbox-exporter's synthetic probes — they are independent signals, not duplicates).

## What's in this PR

**New file: `docs/runbooks/observability.md`** — observability stack index. Indexes Prometheus, Grafana, Loki/Promtail, Alertmanager, blackbox-exporter, and CWA, with pointers to the existing per-component runbooks (`blackbox-probes.md`, `alertmanager-slack-routing.md`, `log-ingestion.md`).

The CWA section covers:

- **Operator pre-step:** verify enablement at the CF dashboard. Documented honestly as a precondition — the runbook process has no CF credentials, so this stays operator-only. Both `noorinalabs.com` and `stg.noorinalabs.com` zones noted (with the "is stg a separate zone or sub-record" question called out for the operator).
- **Dashboard URLs:** placeholder table for both zones; account-scoped, filled in by operator after first enablement.
- **Baseline snapshot template:** text-only table (no automation), with Google's Good / Needs improvement / Poor CWV thresholds inlined for reading.
- **Cadence:** monthly default; weekly during active frontend work; ad-hoc when blackbox flags a frontend-route regression.
- **Optional wave-retro check-in:** documented shape (open dashboard, scan CWV bucket shifts per top page, file issue if regressed). Currently a habit — not charter-enforced.
- **Out of scope, explicit:** Pro tier ($20/zone/month) with re-evaluation date 2026-08-01 and trigger conditions; programmatic alerting; custom event tracking.
- **"Why this isn't in Terraform" note** — `cloudflare_web_analytics_site` is a real resource but free-tier has nothing worth codifying; ADR-gated for future Pro adoption.

**Modified: `RUNBOOK.md`** — Quick links table adds a row pointing at the new file so the observability stack index is discoverable from the operational entrypoint.

## Acceptance from #253

- [x] CWA confirmed-enabled documented as operator pre-step (runbook side; operator action still pending)
- [x] Observability runbook updated with CWA dashboard URLs (placeholders; account-scoped)
- [x] Snapshot template for p75 CWV per top page recorded
- [x] Cadence documented: "monthly review default; weekly during active frontend work"
- [x] Wave-retro check-in shape documented as optional (no charter hook today — see Test Plan)
- [x] Pro-upgrade re-evaluation date set to 2026-08-01

## Test Plan

- [ ] Operator: open `https://dash.cloudflare.com/{account}/{zone}/analytics/web` for each zone (`noorinalabs.com`, and `stg.noorinalabs.com` if separate); confirm CWA is enabled. If not, click Enable and wait ~10 min for first data.
- [ ] Operator: fill in the per-zone dashboard URL placeholders in `docs/runbooks/observability.md` § Dashboard URLs.
- [ ] Operator: wait 7 days for sufficient data, then fill in the baseline snapshot table.
- [ ] Operator: confirm zone-shape question for `stg.noorinalabs.com` (separate zone vs sub-record on parent) and update the runbook with the answer.

## Out of scope (intentionally deferred)

- **Pro-tier upgrade.** Re-evaluate no earlier than 2026-08-01 per acceptance criteria. Not pre-paying for capability we may not use.
- **Wave-retro charter hook for the optional CWA-trend read.** The `/wave-retro` skill doesn't currently have an external checklist hook to mount onto. Documented as a manual habit in the runbook; future addition if/when a checklist mechanism lands in the retro skill.
- **`cloudflare_web_analytics_site` Terraform resource.** Free-tier CWA has no per-site config worth codifying; ADR-gated for future Pro adoption.

## Related

- `deploy#183` blackbox-exporter for prod-route probing (synthetic complement)
- `deploy#245` frontend → absolute URLs at `users.{base}` (P3W3; CWA baseline matters before this ships)
- 2026-05-03 P3W3 owner-pivot (kept CWA enabled, scoped this utilization issue)
