### PR TITLE
tech-debt(infra): add B2 lifecycle rule on terraform-state (#194)

### DIFF
--- a/docs/runbooks/state-bucket-lifecycle.md
+++ b/docs/runbooks/state-bucket-lifecycle.md
@@ -1,0 +1,160 @@
+# Runbook — `noorinalabs-terraform-state` lifecycle policy
+
+Source: [deploy#194](https://github.com/noorinalabs/noorinalabs-deploy/issues/194).
+Composes with: [deploy#172](https://github.com/noorinalabs/noorinalabs-deploy/issues/172)
+(SSE-B2 at-rest), [ADR 0004](../adr/0004-b2-state-bucket-and-key-management.md)
+(IaC-management strategy).
+
+## Why this is a console runbook (not Terraform-managed today)
+
+The `noorinalabs-terraform-state` bucket is the load-bearing root of every
+Terraform apply in this repo — it holds the `*.tfstate` for `terraform/hetzner/`,
+`terraform/cloudflare/`, and `terraform/backblaze/`. The bucket itself is
+**not currently IaC-managed**: it was created out-of-band in the B2 console
+during initial repo bootstrap, and no `b2_bucket` resource for it exists in
+any `terraform/` root.
+
+[ADR 0004 Decision A](../adr/0004-b2-state-bucket-and-key-management.md#decision-a--noorinalabs-terraform-state-bucket-iac-management)
+accepts the chicken-and-egg problem (the bucket holds the state for the modules
+that would otherwise manage it) and adopts **Option A2**: a new
+`terraform/backblaze-bootstrap/` root module with a `local` backend, executed
+once-per-DR-event. That module does not yet exist — its implementation is
+tracked as the Part-2 issue for #180 (to be filed). Until that module ships,
+bucket-config changes (lifecycle, versioning, object-lock, SSE-B2 toggle, etc.)
+are operator-applied via the B2 console, with the desired state documented
+here as the canonical spec.
+
+Adding a `b2_bucket` resource for the state bucket to the existing
+`terraform/backblaze/main.tf` would be wrong: that module manages the
+**pipeline bucket** (`noorinalabs-pipeline`) and its scoped keys; introducing
+the state bucket there crosses domains and re-introduces the chicken-and-egg
+without the bounded once-per-cycle posture that ADR 0004 chose to make it
+acceptable.
+
+## Canonical lifecycle spec
+
+```json
+[
+  {
+    "fileNamePrefix": "",
+    "daysFromHidingToDeleting": 7,
+    "daysFromUploadingToHiding": null
+  }
+]
+```
+
+Semantics:
+
+- `daysFromHidingToDeleting: 7` — once a version is hidden (because a newer
+  version was uploaded over it, or because `b2 rm` / hide-marker was applied),
+  the hidden version is permanently deleted after 7 days.
+- `daysFromUploadingToHiding: null` — never auto-hide based on upload age.
+  The current version of every `*.tfstate` object stays accessible forever;
+  only previously-superseded versions are aged out.
+- `fileNamePrefix: ""` — applies to the entire bucket (all `hetzner/*.tfstate`,
+  `cloudflare/*.tfstate`, `backblaze/*.tfstate` keys).
+
+### Rationale for 7 days
+
+- **Recovery window.** 7 days is long enough that an operator who notices a
+  bad `terraform apply` within a normal on-call rotation can still pull the
+  prior version via `terraform state pull` against the pre-apply object.
+- **Bounded plaintext-history accumulation.** State files contain
+  infrastructure-shaped metadata (resource IDs, IPs, tags). Pre-#172, the
+  bucket had 13 prior versions across 3 path families, each retaining the
+  same secret-ish content. SSE-B2 (#172) protects at-rest but doesn't bound
+  retention; the lifecycle rule does.
+- **No conflict with active applies.** The rule only acts on **hidden**
+  versions. A version becomes hidden when a newer one is written; the
+  current head of every key remains unaffected indefinitely.
+
+## Apply procedure (B2 console)
+
+This is operator-only — there is no CI path until the `backblaze-bootstrap/`
+module ships per ADR 0004.
+
+1. Log in to the [B2 console → Buckets](https://secure.backblaze.com/b2_buckets.htm).
+2. Click **`noorinalabs-terraform-state`** → **Lifecycle Settings**.
+3. Pick **Use custom lifecycle rules**.
+4. Configure a single rule with:
+   - **File name prefix:** *(empty — applies to entire bucket)*
+   - **Days from hiding to deleting:** `7`
+   - **Days from uploading to hiding:** *(leave blank / not set)*
+5. **Save**.
+
+### Equivalent via `b2` CLI
+
+If the operator has the [b2 CLI](https://www.backblaze.com/docs/cloud-storage-command-line-tools)
+installed and authenticated with the master key:
+
+```bash
+b2 update-bucket noorinalabs-terraform-state allPrivate \
+  --lifecycleRules '[{"fileNamePrefix":"","daysFromHidingToDeleting":7,"daysFromUploadingToHiding":null}]'
+```
+
+## Verification
+
+After applying via either path:
+
+```bash
+b2 bucket get noorinalabs-terraform-state | jq .lifecycleRules
+```
+
+Expected output:
+
+```json
+[
+  {
+    "fileNamePrefix": "",
+    "daysFromHidingToDeleting": 7,
+    "daysFromUploadingToHiding": null
+  }
+]
+```
+
+## Acceptance over time
+
+- **T+0 (apply):** `b2 bucket get` returns the rule above.
+- **T+1 apply cycle:** the next `terraform apply` against any backend
+  (`hetzner/stg`, `hetzner/prod`, `cloudflare`, `backblaze`) hides the prior
+  version of the relevant `*.tfstate` object — visible via
+  `b2 ls --versions noorinalabs-terraform-state hetzner/stg.tfstate`
+  (look for an `action: hide` entry).
+- **T+7 days (per object):** any version hidden by a subsequent apply is
+  permanently removed. Re-running `b2 ls --versions` shows only the current
+  head plus any not-yet-7-day-old hidden versions.
+
+## When the `backblaze-bootstrap/` module lands (Part-2 of #180)
+
+The `b2_bucket "terraform_state"` resource in the new bootstrap module
+**MUST** declare a `lifecycle_rules` block matching the spec above
+verbatim:
+
+```hcl
+lifecycle_rules {
+  file_name_prefix              = ""
+  days_from_hiding_to_deleting  = 7
+  # days_from_uploading_to_hiding intentionally omitted — keep current
+  # versions accessible forever; only age out hidden (superseded) versions.
+}
+```
+
+At that point this runbook becomes the spec-of-record + DR fallback; the
+bootstrap module becomes the apply-path. Update this section accordingly
+when the module ships.
+
+## Parent-ontology coupling
+
+The parent `noorinalabs-main:ontology/repos/deploy.yaml` § `state_backend`
+entry currently records `{ type: s3, bucket: noorinalabs-terraform-state,
+endpoint: backblaze-b2, region: us-east-005 }`. Once this rule is applied,
+that entry should grow a `lifecycle: { days_from_hiding_to_deleting: 7 }`
+sub-field so the parent ontology reflects the bucket's real configuration.
+Orchestrator follow-up (cross-repo; not in this PR's scope).
+
+## Refs
+
+- [deploy#194](https://github.com/noorinalabs/noorinalabs-deploy/issues/194) — this issue.
+- [deploy#172](https://github.com/noorinalabs/noorinalabs-deploy/issues/172) — SSE-B2 verification (the at-rest control this composes with).
+- [ADR 0004](../adr/0004-b2-state-bucket-and-key-management.md) — IaC-management strategy that makes this a runbook (today) and a `backblaze-bootstrap` resource block (after Part-2 lands).
+- [deploy#180](https://github.com/noorinalabs/noorinalabs-deploy/issues/180) — parent ADR issue (Part-2 implementation follow-up to be filed).

--- a/terraform/backblaze/README.md
+++ b/terraform/backblaze/README.md
@@ -249,7 +249,8 @@ plaintext on disk outside the password manager and GH-secrets store.
 
 ## Lifecycle
 
-The module configures two lifecycle rules:
+The module configures two lifecycle rules **on the pipeline bucket** (this
+module's domain):
 
 1. **Unfinished multipart uploads** — abandoned after
    `lifecycle_days_unfinished_uploads` days (default 7).
@@ -260,6 +261,23 @@ The module configures two lifecycle rules:
 `raw/` is the only stage where the pipeline expects archival retention;
 downstream stages are rebuildable from `raw/` via `/ontology-librarian
 pipeline reset levels`.
+
+### State-bucket lifecycle is a separate concern
+
+The `noorinalabs-terraform-state` bucket referenced by this module's S3
+backend (`versions.tf`) is **not** managed by this module — it predates the
+repo and is currently console-managed pending the
+`terraform/backblaze-bootstrap/` root module (see
+[ADR 0004 Decision A](../../docs/adr/0004-b2-state-bucket-and-key-management.md#decision-a--noorinalabs-terraform-state-bucket-iac-management)).
+Adding a `b2_bucket` resource for the state bucket here would re-introduce the
+chicken-and-egg ADR 0004 explicitly rejects.
+
+The state bucket's lifecycle policy (7-day hidden-version expiry, per
+[#194](https://github.com/noorinalabs/noorinalabs-deploy/issues/194)) is
+documented as an operator-applied procedure in
+[`docs/runbooks/state-bucket-lifecycle.md`](../../docs/runbooks/state-bucket-lifecycle.md).
+The Part-2 implementation of ADR 0004 will adopt that spec verbatim into the
+new bootstrap module's `b2_bucket` resource.
 
 ## Rotating the state-bucket key (CI + workstation)
 


### PR DESCRIPTION
## Summary

- New runbook `docs/runbooks/state-bucket-lifecycle.md` documents the operator-applied B2 lifecycle rule (`daysFromHidingToDeleting: 7`) for the `noorinalabs-terraform-state` bucket — console procedure + `b2` CLI equivalent + verification command.
- `terraform/backblaze/README.md` § Lifecycle gets a "State-bucket lifecycle is a separate concern" subsection cross-referencing the new runbook + ADR 0004, so operators who land in the pipeline-bucket module asking about the state bucket get pointed to the right place.
- No Terraform code change. The runbook captures the canonical spec for the future `backblaze-bootstrap` module (Part-2 of #180) to adopt verbatim.

## Approach decision — why console + docs (not TF-managed today)

ADR 0004 landed earlier today (commit `6abf459`, PR #315, closes #180). Its Decision A explicitly chose **Option A2** — a future `terraform/backblaze-bootstrap/` root module with a `local` backend, executed once-per-DR-event — as the IaC-management vehicle for the state bucket. The Part-2 issue implementing that module is *to be filed* (per ADR 0004's closing line and refs section) and does not exist yet.

Two TF-in-this-PR alternatives were considered and rejected:

1. **Add a `b2_bucket` resource for the state bucket to `terraform/backblaze/main.tf`** — wrong domain (that module is for the pipeline bucket `noorinalabs-pipeline` + its scoped keys), and re-introduces the chicken-and-egg ADR 0004 explicitly rejects (the module's own state lives in the bucket it would be managing) without the bounded once-per-cycle posture that makes A2 acceptable.
2. **Standalone `b2_bucket_lifecycle_rule` resource targeting the bucket by name** — the `Backblaze/b2 ~> 0.10` provider in use (`terraform/backblaze/versions.tf`) does not expose a decoupled lifecycle resource; `lifecycle_rules` is a block on `b2_bucket`. Managing only the lifecycle would still require declaring the whole bucket as a resource — same problem as option 1.

So the runbook + ADR-0004-deferred-implementation is the right shape today. The runbook is structured so that when Part-2 lands, its `b2_bucket "terraform_state"` block adopts the spec verbatim (the runbook quotes the HCL block to copy), and the runbook downgrades to spec-of-record + DR fallback.

### Bootstrap chicken-and-egg — how addressed

This PR does not address it (no TF code touches the state bucket). ADR 0004 Decision A is the addressing artifact: a separate `terraform/backblaze-bootstrap/` root with a `local` backend (or `bootstrap/` prefix in the bucket itself; deferred to Part-2) makes bucket-config changes reviewable while bounding the chicken-and-egg to a once-per-cycle event. This PR keeps the bucket console-managed until that module ships.

## Files changed

- `docs/runbooks/state-bucket-lifecycle.md` — new (canonical spec + console procedure + CLI equivalent + verification + when-bootstrap-lands guidance + parent-ontology note).
- `terraform/backblaze/README.md` — § Lifecycle gets a new subsection cross-referencing the runbook + ADR 0004.

## Parent-ontology follow-up

The parent `noorinalabs-main:ontology/repos/deploy.yaml` § `state_backend` entry (line 27) currently records:

```yaml
state_backend: { type: s3, bucket: noorinalabs-terraform-state, endpoint: backblaze-b2, region: us-east-005 }
```

It should grow a `lifecycle: { days_from_hiding_to_deleting: 7 }` sub-field once the console rule is applied so the parent ontology reflects the bucket's real configuration. **Not in this PR's scope** (this PR is in a worktree off the deploy repo; the parent ontology is a sibling-repo edit). Flagged here for the orchestrator to fold into the next ontology pass.

## Test plan

- [ ] (Local) `terraform plan` in `terraform/backblaze/` shows **no changes** — confirms this PR does not touch TF state. Plan run pending owner credentials; the change is doc-only so no plan delta is expected.
- [ ] (Operator action, post-merge) apply the lifecycle rule via the B2 console procedure in the new runbook.
- [ ] (Post-apply, manual) `b2 bucket get noorinalabs-terraform-state | jq .lifecycleRules` returns the rule per the runbook's "Verification" section.
- [ ] (Post-7-days, manual) any `*.tfstate` version hidden by a subsequent apply against `terraform/hetzner/envs/{stg,prod}` or `terraform/cloudflare/` is auto-removed; verifiable via `b2 ls --versions noorinalabs-terraform-state hetzner/stg.tfstate`.
- [ ] (Orchestrator follow-up) parent ontology `state_backend` entry grows `lifecycle: { days_from_hiding_to_deleting: 7 }` sub-field.
- [ ] (Orchestrator follow-up) Part-2 implementation issue for ADR 0004 is filed (the runbook's "When the `backblaze-bootstrap/` module lands" section is the spec the new module must adopt verbatim).

## Refs

- [deploy#194](https://github.com/noorinalabs/noorinalabs-deploy/issues/194) — this issue.
- [deploy#172](https://github.com/noorinalabs/noorinalabs-deploy/issues/172) — SSE-B2 verification (the at-rest control this composes with).
- [deploy#315](https://github.com/noorinalabs/noorinalabs-deploy/pull/315) — ADR 0004 (the IaC-management strategy that makes this a runbook today).
- [deploy#180](https://github.com/noorinalabs/noorinalabs-deploy/issues/180) — parent ADR issue (Part-2 implementation follow-up to be filed).

Closes #194

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
