### PR TITLE
ops(bootstrap): audit bootstrap-vps.sh post-cloud-init (#163)

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -65,20 +65,35 @@ State is stored in Backblaze B2 bucket `noorinalabs-terraform-state`,
 with per-env state keys (`hetzner/stg.tfstate`, `hetzner/prod.tfstate`).
 Apply via CI is the preferred path — see § Apply via CI below.
 
-After `apply`, the new VPS still needs first-time setup. SSH in as `root`
-using whichever key was authorized at provisioning time (Hetzner cloud-init
-user-data, console password reset, or operator's local key — see the
-`cloud_init_ssh_key_gap` note in [`ontology/repos/deploy.yaml`](ontology/repos/deploy.yaml))
-and run:
+After `apply`, the new VPS is bootstrapped end-to-end by
+[`terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl`](terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl)
+on first boot — Docker, docker-compose, fail2ban, ufw, unattended-upgrades,
+rclone, the `deploy` user, SSH keys (root + deploy), GHCR auth (conditional
+on `ghcr_auth_b64`), `.env.user-service`, root SSH password disable, and
+the repo clone to `/opt/noorinalabs-deploy` are all provisioned without
+operator action. SSH in as `root` (or `deploy`) using the key authorized
+at provisioning time — see the `cloud_init_ssh_key_gap` note in
+[`ontology/repos/deploy.yaml`](ontology/repos/deploy.yaml) for the known
+gap on stg.
+
+[`scripts/bootstrap-vps.sh`](scripts/bootstrap-vps.sh) is the **residual**
+bootstrap, idempotent on re-run, kept for:
+
+- **Pre-cloud-init VPSes** (the hand-made `isnad-graph-prod` box outside
+  Terraform — decom tracked in deploy#86)
+- **Gaps cloud-init does not yet cover** (#163): aux-repo dirs under `/opt/`,
+  the systemd backup units, `git safe.directory` exceptions, and the
+  append-with-dedup SSH key merge for operator-added admin keys
+
+Run only when one of those conditions applies:
 
 ```bash
 curl -sL https://raw.githubusercontent.com/noorinalabs/noorinalabs-deploy/main/scripts/bootstrap-vps.sh | bash
 ```
 
-`scripts/bootstrap-vps.sh` is idempotent: installs Docker, creates the
-`deploy` user, clones this repo to `/opt/noorinalabs-deploy`, configures
-log rotation, and stages the systemd backup units. Re-run it any time the
-bootstrap needs to be re-applied.
+The script preflight-checks for the `deploy` user and `docker` binary and
+exits fast if either is missing — i.e., it will not silently half-bootstrap
+a host that should have been cloud-init'd but wasn't.
 
 ### Apply Terraform via CI
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,7 +56,7 @@ noorinalabs-deploy/
 │       └── promtail-config.yml
 ├── scripts/
 │   ├── backup.sh                 # Automated database backup
-│   ├── bootstrap-vps.sh          # First-time VPS setup
+│   ├── bootstrap-vps.sh          # Residual bootstrap — cloud-init gaps only (#163)
 │   ├── restore.sh                # Database restore from backup
 │   └── verify_deployment.sh      # Live deployment verification
 ├── systemd/
@@ -162,15 +162,25 @@ Provisioned via Terraform in `terraform/hetzner/`. The Terraform configuration c
 
 ### Bootstrap
 
-First-time setup is performed by `scripts/bootstrap-vps.sh`, which runs as root on a fresh VPS and:
+First-time setup of a Terraform-provisioned VPS is performed end-to-end by `terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl`, which on first boot:
 
-1. Installs Docker, docker-compose-v2, docker-buildx, git, curl
-2. Creates a `deploy` user with Docker group access
-3. Merges SSH authorized keys from root into the deploy user (append-with-fingerprint-dedup — idempotent across re-runs, never wipes a key already present in `/home/deploy/.ssh/authorized_keys`; see deploy#112)
-4. Clones this repo to `/opt/noorinalabs-deploy`
-5. Creates a template `.env` file with placeholder values
-6. Installs rclone for backups
-7. Installs and enables the backup systemd timer
+1. Installs Docker, docker-compose-v2, docker-buildx, git, curl, fail2ban, ufw, unattended-upgrades, rclone, jq
+2. Creates a `deploy` user with `docker, sudo` groups (NOPASSWD sudo) and seeds its SSH authorized_keys with the per-env `ssh_public_key`
+3. Writes the same key into `/root/.ssh/authorized_keys` (canonical operator/CI key)
+4. Configures fail2ban (SSH brute-force jail), ufw (default-deny incoming, allow 22/80/443), and unattended-upgrades (security patches only)
+5. Disables root SSH password login (`PermitRootLogin prohibit-password`, `PasswordAuthentication no`)
+6. Writes `/home/deploy/.docker/config.json` with GHCR auth when `ghcr_auth_b64` is non-empty (per #28 conditional skip)
+7. Writes `/opt/noorinalabs-deploy/.env.user-service` from Terraform secrets
+8. Clones this repo to `/opt/noorinalabs-deploy` and chowns to `deploy`
+9. Creates `/var/lib/node_exporter/textfile_collector` (deploy:deploy 0755) for the alembic pre-deploy gate's failure markers
+
+`scripts/bootstrap-vps.sh` is the **residual** bootstrap, run only on VPSes that pre-date cloud-init or to cover gaps cloud-init does not yet fill (#163):
+
+- Append-with-dedup SSH key merge from `/root/.ssh/authorized_keys` → `/home/deploy/.ssh/authorized_keys` (idempotent across re-runs, never wipes the deploy CI key; see deploy#112)
+- `git config --global --add safe.directory` exceptions for `/opt/noorinalabs-deploy` and the auxiliary repo dirs
+- Idempotent `git fetch && git reset --hard` of `/opt/noorinalabs-deploy`
+- Pre-provisioning the auxiliary repo dirs under `/opt/` (e.g., `/opt/noorinalabs-isnad-graph`, `/opt/noorinalabs-design-system`) with deploy ownership
+- Installing the systemd backup units (`isnad-backup.{service,timer}`, failure-marker, tmpfiles.d) and enabling the timer
 
 ## Docker Compose Stack
 

--- a/docs/runbooks/new-service-deploy-checklist.md
+++ b/docs/runbooks/new-service-deploy-checklist.md
@@ -69,11 +69,14 @@ user. The reusable workflows (`deploy-stg.yml`, `db-migrate.yml`,
       on either. (Wave-B failure #1.)
 - [ ] **`secrets.DEPLOY_SSH_PRIVATE_KEY` set** at the org level (or per-env
       override). Public half is in the VPS's `/home/deploy/.ssh/authorized_keys`.
-      *Automated in:* [`scripts/bootstrap-vps.sh`](../../scripts/bootstrap-vps.sh)
-      installs the public key when the VPS is first provisioned. Cloud-init
-      gap surfaced 2026-04-24 (`cloud_init_ssh_key_gap` in
+      *Automated in:* [`cloud-init.yaml.tpl`](../../terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl)
+      seeds both root and deploy authorized_keys with the per-env
+      `ssh_public_key` on first boot (Terraform-provisioned VPSes only).
+      Cloud-init gap surfaced 2026-04-24 (`cloud_init_ssh_key_gap` in
       `ontology/repos/deploy.yaml`) — for TF-provisioned boxes confirm the key
-      actually landed before relying on it.
+      actually landed before relying on it. For pre-cloud-init VPSes or
+      operator-added admin keys, [`scripts/bootstrap-vps.sh`](../../scripts/bootstrap-vps.sh)
+      provides an idempotent append-with-dedup merge from root → deploy (#163).
 - [ ] **Runtime GHCR auth** — the deploy script logs in with the
       auto-provisioned `GITHUB_TOKEN` and `trap`s a logout. No long-lived
       GHCR PAT lives on the VPS for app-service pulls.

--- a/scripts/bootstrap-vps.sh
+++ b/scripts/bootstrap-vps.sh
@@ -1,8 +1,23 @@
 #!/usr/bin/env bash
 # =============================================================================
-# bootstrap-vps.sh — First-time VPS setup for Noorina Labs
+# bootstrap-vps.sh — Residual VPS bootstrap for Noorina Labs
 #
-# Run as root on a fresh Hetzner VPS:
+# !! ONLY run this on existing VPSes that pre-date cloud-init, or as an !!
+# !! idempotent refresher for the items cloud-init does NOT cover yet:  !!
+# !!   - aux-repo dir pre-provisioning under /opt/                      !!
+# !!   - systemd backup timer (isnad-backup.{service,timer})            !!
+# !!   - safe.directory exceptions for root-run git in /opt/            !!
+# !!   - SSH key merge for operator-added admin keys on root            !!
+# !!   - first-time .env stub for manual (non-CI) bring-ups             !!
+#
+# Fresh Terraform-provisioned VPSes are bootstrapped end-to-end by
+# terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl, which now
+# handles: Docker, docker-compose, docker-buildx, git, curl, fail2ban,
+# ufw, unattended-upgrades, rclone, deploy user, SSH keys (root + deploy),
+# GHCR auth, .env.user-service, root SSH password disable, firewall.
+# That coverage obsoletes Steps 1, 2, and 6 of the legacy bootstrap (#163).
+#
+# Run as root:
 #   ssh -i ~/.ssh/isnad_deploy root@isnad.noorinalabs.com
 #   curl -sL https://raw.githubusercontent.com/noorinalabs/noorinalabs-deploy/main/scripts/bootstrap-vps.sh | bash
 #
@@ -11,28 +26,29 @@
 # =============================================================================
 set -euo pipefail
 
-# Suppress all interactive debconf prompts during apt operations. Without this,
-# any package whose postinst asks a question (docker.io "restart Docker?",
-# openssh-server, libc6, etc.) hangs the script indefinitely on the first
-# upgrade-with-prompt. See #110 for the incident this fixes.
+# Suppress all interactive debconf prompts during any apt operations this
+# script may trigger transitively (e.g. via `apt-get update` if a re-run
+# refreshes lists). Cloud-init's own apt: conf: handles --force-conf{def,old}
+# for fresh boots; this guard remains for safety on re-runs. See #110.
 export DEBIAN_FRONTEND=noninteractive
 
 REPO_URL="https://github.com/noorinalabs/noorinalabs-deploy.git"
 INSTALL_DIR="/opt/noorinalabs-deploy"
 DEPLOY_USER="deploy"
 
-# Auxiliary repo directories pre-provisioned under /opt/ (see Step 4.5).
-# Hoisted from Step 4.5 to module scope so the safe.directory loop in Step 3.5
-# can reference the same list — keeping AUX_REPOS as the single source of truth
-# for "directories root should be allowed to git-operate on after deploy
-# takes ownership."
+# Auxiliary repo directories pre-provisioned under /opt/ (see Step 3).
+# Single source of truth — also drives the safe.directory loop in Step 2.
+# To add a new repo to the deploy pipeline: append it here, re-run this
+# script (idempotent). cloud-init does NOT pre-create these dirs (gap to
+# close — see #163 PR body); until then, this script is the canonical
+# place that adds them.
 AUX_REPOS=(
   "noorinalabs-isnad-graph"
   "noorinalabs-design-system"
 )
 
 echo "============================================="
-echo "  Noorina Labs VPS bootstrap"
+echo "  Noorina Labs VPS bootstrap (residual)"
 echo "============================================="
 echo ""
 
@@ -42,44 +58,45 @@ if [ "$(id -u)" -ne 0 ]; then
   exit 1
 fi
 
-# ── Step 1: System packages ─────────────────────────────────────────────────
-echo "==> [1/7] Installing system packages..."
-apt-get update -qq
-# --force-confold: keep operator-modified config files on upgrade (don't blow
-#   away changes under /etc/docker/, /etc/ssh/, etc.).
-# --force-confdef: use the package's default when there's no existing file to
-#   preserve. Standard idempotent-upgrade pair.
-apt-get install -y -qq \
-  -o Dpkg::Options::="--force-confdef" \
-  -o Dpkg::Options::="--force-confold" \
-  docker.io docker-compose-v2 docker-buildx git curl > /dev/null
-systemctl enable docker
-systemctl start docker
-echo "    Docker version: $(docker --version)"
-
-# ── Step 2: Create deploy user ──────────────────────────────────────────────
-echo "==> [2/7] Creating deploy user..."
-if id "$DEPLOY_USER" &>/dev/null; then
-  echo "    User '$DEPLOY_USER' already exists, skipping."
-else
-  adduser --disabled-password --gecos "" "$DEPLOY_USER"
-  echo "    Created user '$DEPLOY_USER'."
+# Sanity-check that the deploy user exists. Fresh cloud-init boots create
+# it via the `users:` block; if it's missing, this VPS was NOT cloud-init'd
+# AND the legacy steps (1+2) need re-introducing — bail with a clear
+# message so the operator doesn't end up with a half-state.
+if ! id "$DEPLOY_USER" &>/dev/null; then
+  echo "ERROR: User '$DEPLOY_USER' does not exist on this host."
+  echo "       This script expects cloud-init to have created the user (or"
+  echo "       a prior bootstrap-vps.sh run that pre-dates #163's reduction)."
+  echo "       Recreate manually: adduser --disabled-password --gecos '' deploy"
+  echo "       Then re-run this script."
+  exit 1
 fi
-usermod -aG docker "$DEPLOY_USER"
 
-# ── Step 3: Merge SSH authorized_keys into deploy user (append-with-dedup) ──
-# Per deploy#112: this used to be a destructive `cp` of root's authorized_keys
-# over the deploy user's file. That wiped the deploy CI key any time an
-# operator added a personal admin key to /root/.ssh/authorized_keys and then
-# re-ran bootstrap (as PR #109 instructs for new aux-repos). The next
-# workflow_dispatch then failed with `ssh: handshake failed`.
+# Similarly, Docker is a cloud-init prereq. If it's missing on a host that
+# claims to have been cloud-init'd, that's an upstream cloud-init failure
+# and bootstrap-vps.sh cannot recover the box on its own.
+if ! command -v docker &>/dev/null; then
+  echo "ERROR: docker is not installed. cloud-init should have installed it"
+  echo "       (see terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl"
+  echo "       packages: block). Investigate cloud-init.log on this host."
+  exit 1
+fi
+
+# ── Step 1: Merge SSH authorized_keys into deploy user (append-with-dedup) ──
+# Per deploy#112: original bootstrap did a destructive `cp` of root's
+# authorized_keys over the deploy user's file, wiping the deploy CI key any
+# time an operator added a personal admin key to /root/.ssh/authorized_keys
+# and then re-ran bootstrap.
+#
+# Cloud-init seeds both /root/.ssh/authorized_keys AND
+# /home/deploy/.ssh/authorized_keys with the same ${ssh_public_key} on
+# first boot — so this merge is a no-op on a fresh cloud-init box. Its
+# residual value is for operators who add personal admin keys to
+# /root/.ssh/authorized_keys post-provision and want them propagated to
+# deploy without losing the existing deploy authorized keys.
 #
 # Fix: append each root key to deploy's file only if its fingerprint isn't
-# already present. Idempotent across any number of re-runs; preserves the
-# deploy CI key and any keys an operator has already added to deploy directly.
-# Owner's manual unblock recipe (`cat key.pub | ssh prod 'tee -a ...'`) is
-# the same shape — append, not overwrite.
-echo "==> [3/7] Setting up SSH for deploy user..."
+# already present. Idempotent across any number of re-runs.
+echo "==> [1/5] Merging /root/.ssh/authorized_keys → deploy (idempotent)..."
 DEPLOY_AUTH_KEYS="/home/$DEPLOY_USER/.ssh/authorized_keys"
 mkdir -p "/home/$DEPLOY_USER/.ssh"
 touch "$DEPLOY_AUTH_KEYS"
@@ -95,9 +112,6 @@ ssh_key_fp() {
 }
 
 if [ -f /root/.ssh/authorized_keys ]; then
-  # Build the set of fingerprints already authorized for deploy. We fingerprint
-  # each line individually rather than passing the whole file to `ssh-keygen -lf`
-  # because that bails on the first malformed line.
   declare -A DEPLOY_FPS=()
   while IFS= read -r existing_line; do
     case "$existing_line" in ''|\#*) continue ;; esac
@@ -110,8 +124,6 @@ if [ -f /root/.ssh/authorized_keys ]; then
   while IFS= read -r root_line; do
     case "$root_line" in ''|\#*) continue ;; esac
     fp=$(ssh_key_fp "$root_line")
-    # Malformed line in root's file — skip rather than copy garbage into
-    # deploy's authorized_keys.
     [ -z "$fp" ] && continue
     if [ -n "${DEPLOY_FPS[$fp]:-}" ]; then
       skipped=$((skipped + 1))
@@ -126,43 +138,47 @@ if [ -f /root/.ssh/authorized_keys ]; then
   chmod 600 "$DEPLOY_AUTH_KEYS"
   echo "    Merged root authorized_keys → deploy: $added added, $skipped already present."
 else
-  echo "    WARNING: /root/.ssh/authorized_keys not found."
-  echo "    You'll need to manually add your public key to $DEPLOY_AUTH_KEYS"
+  echo "    /root/.ssh/authorized_keys not found — nothing to merge (expected on heavily-locked-down hosts)."
 fi
 
-# ── Step 3.5: git safe.directory exceptions ────────────────────────────────
+# ── Step 2: git safe.directory exceptions ──────────────────────────────────
 # Allow root to operate on repos owned by the deploy user (git 2.35+
-# CVE-2022-24765 mitigation). Step 4's `git fetch && git reset --hard` runs
-# as root inside $INSTALL_DIR, which gets chowned to $DEPLOY_USER at the end
-# of Step 4 on first-run; every subsequent re-run hits the ownership-mismatch
-# refusal without these exceptions. Aux-repo dirs are listed too because the
-# same hazard applies if/when bootstrap evolves to git-operate on them. See
-# deploy#113. Runs after Step 1 (git installed) and before Step 4 (first git
-# call) — the `${AUX_REPOS[@]/#//opt/}` form prefixes each entry with /opt/.
-echo "==> [3.5/7] Adding git safe.directory exceptions..."
+# CVE-2022-24765 mitigation). Step 3's `git fetch && git reset --hard` runs
+# as root inside $INSTALL_DIR, which gets chowned to $DEPLOY_USER; every
+# subsequent re-run hits the ownership-mismatch refusal without these
+# exceptions. Aux-repo dirs are listed too because the same hazard applies
+# if/when this script evolves to git-operate on them. See deploy#113.
+# Runs before Step 3 (first git call) — the `${AUX_REPOS[@]/#//opt/}`
+# form prefixes each entry with /opt/.
+echo "==> [2/5] Adding git safe.directory exceptions..."
 for dir in "$INSTALL_DIR" "${AUX_REPOS[@]/#//opt/}"; do
   git config --global --add safe.directory "$dir"
 done
 
-# ── Step 4: Clone the repository ────────────────────────────────────────────
-echo "==> [4/7] Cloning repository to $INSTALL_DIR..."
+# ── Step 3: Refresh the deploy repo (idempotent) ───────────────────────────
+# Cloud-init's runcmd already clone-or-skips this on first boot. On
+# subsequent runs we fetch + reset to keep an existing checkout current.
+# Doubles as recovery if the working tree drifted from a manual edit.
+echo "==> [3/5] Refreshing $INSTALL_DIR (idempotent)..."
 if [ -d "$INSTALL_DIR/.git" ]; then
   echo "    Repository already exists, pulling latest..."
   cd "$INSTALL_DIR" && git fetch origin main && git reset --hard origin/main
 else
   git clone "$REPO_URL" "$INSTALL_DIR"
 fi
-chown -R $DEPLOY_USER:$DEPLOY_USER "$INSTALL_DIR"
+chown -R "$DEPLOY_USER:$DEPLOY_USER" "$INSTALL_DIR"
 
-# ── Step 4.5: Pre-provision auxiliary repo directories ─────────────────────
-# /opt/ is root-owned by default, so the deploy user can't `git clone` into it
-# without these dirs existing first with the right ownership. The deploy
-# workflow (.github/workflows/deploy-isnad-graph.yml) clone-or-pulls into each
-# of these. To add a new repo to the deploy pipeline: append it to AUX_REPOS
-# (declared at the top of this script alongside INSTALL_DIR — that placement
-# also feeds the safe.directory loop), re-run this bootstrap script
-# (idempotent), done. See deploy#108 for context.
-echo "==> [4.5/7] Pre-provisioning auxiliary repo directories under /opt/..."
+# ── Step 4: Pre-provision auxiliary repo directories under /opt/ ───────────
+# /opt/ is root-owned by default, so the deploy user can't `git clone` into
+# it without these dirs existing first with the right ownership. The deploy
+# workflow (.github/workflows/deploy-isnad-graph.yml) clone-or-pulls into
+# each of these.
+#
+# CLOUD-INIT GAP (#163): cloud-init.yaml.tpl does NOT currently create
+# these dirs — until that gap is closed, this script is the canonical place
+# they live. To add a new repo to the deploy pipeline: append it to
+# AUX_REPOS at the top of this script, re-run (idempotent).
+echo "==> [4/5] Pre-provisioning auxiliary repo directories under /opt/..."
 for repo in "${AUX_REPOS[@]}"; do
   dir="/opt/$repo"
   if [ ! -d "$dir" ]; then
@@ -171,115 +187,37 @@ for repo in "${AUX_REPOS[@]}"; do
   else
     echo "    Exists  $dir"
   fi
-  chown $DEPLOY_USER:$DEPLOY_USER "$dir"
+  chown "$DEPLOY_USER:$DEPLOY_USER" "$dir"
 done
 echo "    Auxiliary repo dirs ready."
 
-# ── Step 5: Create production .env ──────────────────────────────────────────
-echo "==> [5/7] Creating production .env..."
-ENV_FILE="$INSTALL_DIR/.env"
-if [ -f "$ENV_FILE" ]; then
-  echo "    .env already exists, skipping. Edit manually if needed:"
-  echo "    nano $ENV_FILE"
-else
-  cat > "$ENV_FILE" << 'ENVEOF'
-# =============================================================================
-# noorinalabs-isnad-graph production environment
-# Fill in all values marked CHANGE-ME before starting the stack.
-# =============================================================================
-
-# Neo4j [REQUIRED]
-NEO4J_URI=bolt://neo4j:7687
-NEO4J_USER=CHANGE-ME
-NEO4J_PASSWORD=CHANGE-ME
-
-# PostgreSQL [REQUIRED]
-POSTGRES_USER=CHANGE-ME
-POSTGRES_PASSWORD=CHANGE-ME
-POSTGRES_DB=isnad_graph
-
-# Redis [REQUIRED]
-REDIS_URL=redis://:CHANGE-ME@redis:6379/0
-REDIS_PASSWORD=CHANGE-ME
-
-# Grafana [REQUIRED]
-GRAFANA_ADMIN_USER=admin
-GRAFANA_ADMIN_PASSWORD=CHANGE-ME
-GRAFANA_ROOT_URL=https://isnad.noorinalabs.com/grafana
-
-# CORS
-CORS_ORIGINS=["https://isnad.noorinalabs.com"]
-
-# Logging
-LOG_LEVEL=INFO
-LOG_FORMAT=json
-
-# Rate Limiting
-RATE_LIMIT_REQUESTS_PER_MINUTE=120
-RATE_LIMIT_WINDOW_SECONDS=60
-
-# Paths
-DATA_RAW_DIR=./data/raw
-DATA_STAGING_DIR=./data/staging
-DATA_CURATED_DIR=./data/curated
-
-# Backblaze B2 — backup credentials [REQUIRED for backup timer]
-# Consumed by scripts/backup.sh:59-61 which uses `${VAR:?...}` fail-fast.
-# Scope: read+write+delete on the isnad-graph-backups bucket only (separate
-# from PIPELINE_B2_* ingest scope and TF_STATE_B2_* terraform backend scope).
-# The deploy-{stg,prod}.yml workflows populate these from BACKUP_B2_* GH
-# secrets (writing empty strings when unset, so backup.sh fails fast at
-# preflight); manual operators bootstrapping a new VPS must fill these in
-# by hand. See deploy#188 / #191.
+# ── Step 5: Install backup systemd timer + persistent staging dir ──────────
+# CLOUD-INIT GAP (#163): cloud-init does NOT install the systemd backup
+# units. Until that gap is closed, the timer + tmpfiles.d staging dir +
+# failure-marker unit are installed here.
 #
-# IMPORTANT: leave B2_KEY_ID and B2_APP_KEY EMPTY (not "CHANGE-ME") at
-# bootstrap. The ${VAR:?} preflight in backup.sh treats unset and empty
-# identically; a literal "CHANGE-ME" satisfies :? and would let backup.sh
-# proceed to rclone, which then fails with an opaque B2 401. Empty values
-# give the operator the actually-useful "B2_KEY_ID must be set" error.
-B2_KEY_ID=
-B2_APP_KEY=
-B2_BUCKET=isnad-graph-backups
-ENVEOF
-  chmod 600 "$ENV_FILE"
-  chown $DEPLOY_USER:$DEPLOY_USER "$ENV_FILE"
-  echo ""
-  echo "    ╔═══════════════════════════════════════════════════════╗"
-  echo "    ║  IMPORTANT: Edit $ENV_FILE before starting!          ║"
-  echo "    ║  Replace all CHANGE-ME values with real credentials. ║"
-  echo "    ╚═══════════════════════════════════════════════════════╝"
-  echo ""
-  echo "    nano $ENV_FILE"
-  echo ""
-fi
-
-# ── Step 6: Install rclone for backups ──────────────────────────────────────
-echo "==> [6/7] Installing rclone for backups..."
-if command -v rclone &>/dev/null; then
-  echo "    rclone already installed: $(rclone version --check | head -1)"
-else
-  curl -sL https://rclone.org/install.sh | bash > /dev/null 2>&1
-  echo "    rclone installed: $(rclone version --check 2>/dev/null | head -1 || echo 'installed')"
-fi
-
-# ── Step 7: Install backup systemd timer + persistent staging dir ───────────
-echo "==> [7/7] Installing backup timer..."
+# .env note: the CI deploy workflow (deploy-isnad-graph.yml) writes
+# /opt/noorinalabs-deploy/.env fresh from GH Action secrets on every push,
+# so we no longer write a CHANGE-ME stub here. For first-time MANUAL
+# bring-ups (no CI yet), copy compose/env.example and edit by hand:
+#   cp $INSTALL_DIR/compose/env.example $INSTALL_DIR/.env && chmod 600 $INSTALL_DIR/.env
+echo "==> [5/5] Installing backup timer..."
 if [ -f "$INSTALL_DIR/systemd/isnad-backup.service" ]; then
-  # Install the unit + timer + the OnFailure=-target failure-marker unit.
   install -m 644 "$INSTALL_DIR/systemd/isnad-backup.service"               /etc/systemd/system/
   install -m 644 "$INSTALL_DIR/systemd/isnad-backup.timer"                 /etc/systemd/system/
   install -m 644 "$INSTALL_DIR/systemd/isnad-backup-failure-marker.service" /etc/systemd/system/
 
-  # Provision the persistent staging directory via tmpfiles.d. Without this,
-  # the unit's ReadWritePaths=/var/lib/noorinalabs-backups would fail the
-  # mount-namespace setup with status=226/NAMESPACE before ExecStart fires
-  # — the original deploy#121 Bug A failure mode against /tmp/isnad-backups.
+  # Persistent staging dir via tmpfiles.d. Without this, the unit's
+  # ReadWritePaths=/var/lib/noorinalabs-backups fails the mount-namespace
+  # setup with status=226/NAMESPACE before ExecStart fires — original
+  # deploy#121 Bug A failure mode against /tmp/isnad-backups.
   install -m 644 "$INSTALL_DIR/systemd/tmpfiles.d/noorinalabs-backups.conf" /etc/tmpfiles.d/
   systemd-tmpfiles --create /etc/tmpfiles.d/noorinalabs-backups.conf
 
-  # Provision the node-exporter textfile-collector directory so the
-  # failure-marker unit can drop *.prom files there. Idempotent: install -d
-  # is a no-op when the directory already exists with the right mode.
+  # node-exporter textfile-collector PARENT directory for failure-marker
+  # *.prom files. cloud-init creates the textfile_collector SUBDIR
+  # (/var/lib/node_exporter/textfile_collector); `install -d` is idempotent
+  # so this remains safe on fresh cloud-init hosts.
   install -d -m 0755 /var/lib/node_exporter
 
   systemctl daemon-reload
@@ -289,32 +227,37 @@ if [ -f "$INSTALL_DIR/systemd/isnad-backup.service" ]; then
   echo "    Persistent staging dir provisioned: /var/lib/noorinalabs-backups (mode 0700, root)."
   echo "    Start with: systemctl start isnad-backup.timer"
 else
-  echo "    Backup systemd files not found, skipping."
+  echo "    Backup systemd files not found, skipping (did the repo refresh in Step 3 succeed?)."
 fi
 
 # ── Done ────────────────────────────────────────────────────────────────────
 echo ""
 echo "============================================="
-echo "  Bootstrap complete!"
+echo "  Bootstrap (residual) complete!"
 echo "============================================="
 echo ""
+echo "What this script did NOT do (cloud-init already handles it on fresh boxes):"
+echo "  - Install Docker / docker-compose / docker-buildx / git / curl / rclone / jq"
+echo "  - Create the 'deploy' user, configure sudo, add to docker group"
+echo "  - Seed root + deploy authorized_keys with the per-env ssh_public_key"
+echo "  - Install fail2ban, ufw, unattended-upgrades"
+echo "  - Disable root SSH password login"
+echo "  - Write /opt/noorinalabs-deploy/.env.user-service from Terraform vars"
+echo "  - Write /home/deploy/.docker/config.json (GHCR auth) when ghcr_auth_b64 set"
+echo ""
 echo "Next steps:"
-echo "  1. Edit the .env file with your production credentials:"
-echo "     nano $ENV_FILE"
+echo "  1. (manual non-CI bring-ups only) Stage .env:"
+echo "       cp $INSTALL_DIR/compose/env.example $INSTALL_DIR/.env"
+echo "       chmod 600 $INSTALL_DIR/.env && nano $INSTALL_DIR/.env"
+echo "     CI deploy workflows write .env fresh from GH secrets on every push."
 echo ""
 echo "  2. Start the stack as the deploy user (services are GHCR-only — no local builds):"
-echo "     su - $DEPLOY_USER"
-echo "     cd $INSTALL_DIR"
-echo "     docker login ghcr.io -u noorinalabs --password-stdin <<< \"\$GH_PACKAGES_TOKEN\""
-echo "     docker compose -f compose/docker-compose.prod.yml --env-file .env pull"
-echo "     docker compose -f compose/docker-compose.prod.yml --env-file .env up -d"
+echo "       su - $DEPLOY_USER"
+echo "       cd $INSTALL_DIR"
+echo "       docker compose -f compose/docker-compose.prod.yml --env-file .env pull"
+echo "       docker compose -f compose/docker-compose.prod.yml --env-file .env up -d"
 echo ""
-echo "  3. Verify:"
-echo "     curl http://localhost:8000/health"
+echo "  3. Verify: curl http://localhost:8000/health"
 echo ""
-echo "  4. Add VPS_HOST variable in GitHub repo settings:"
-echo "     Settings → Variables → New: VPS_HOST = isnad.noorinalabs.com"
-echo ""
-echo "  5. Start the backup timer:"
-echo "     systemctl start isnad-backup.timer"
+echo "  4. Start the backup timer: systemctl start isnad-backup.timer"
 echo ""


### PR DESCRIPTION
## Summary
- `scripts/bootstrap-vps.sh` reduced from 321 → 263 lines: deleted Steps 1 (apt packages), 2 (deploy user creation), and 6 (rclone install) — all now covered by `terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl` on first boot. Residual scope (SSH key merge, `safe.directory`, idempotent repo refresh, aux-repo dirs, systemd backup timer) renumbered to 5 steps with a loud header restricting use to pre-cloud-init VPSes or cloud-init-gap refreshers.
- Added preflight assertions for `deploy` user and `docker` binary — script now exits fast on a host that should have been cloud-init'd but wasn't (no silent half-bootstrap).
- Dropped the inline 70-line `.env` CHANGE-ME stub. CI writes `.env` fresh from GH secrets each push, cloud-init writes `.env.user-service` from Terraform vars; manual operators are pointed at `compose/env.example` in the Done banner instead.
- Reference sweep updated: `RUNBOOK.md` (Build § Provision a new VPS), `docs/architecture.md` (Bootstrap section + scripts/ tree comment), `docs/runbooks/new-service-deploy-checklist.md` (Section 3 SSH-key citation). All three now name `cloud-init.yaml.tpl` as the primary bootstrap path with `bootstrap-vps.sh` as the residual.
- **Parent-ontology update needed for `ontology/repos/deploy.yaml § scripts.bootstrap_vps`: YES** — `ontology/repos/deploy.yaml` line 165 still describes `scripts/bootstrap-vps.sh` without the "residual / cloud-init-gap" qualifier. Cannot edit the parent ontology from a deploy worktree; orchestrator to file a follow-up.

## Audit findings

Audit performed on wave-11 HEAD (a23ad3a) against `terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl`.

| Block | bootstrap-vps.sh lines (pre-PR) | cloud-init coverage | Action |
|---|---|---|---|
| `DEBIAN_FRONTEND=noninteractive` export | 1–22 | cloud-init `apt: conf:` sets `--force-confdef/--force-confold`; runs noninteractive by default | Kept harmlessly for re-run safety |
| Step 1 — apt install docker.io / docker-compose-v2 / docker-buildx / git / curl + `systemctl enable docker` | 45–58 | `packages:` block + `runcmd: systemctl enable/start docker` | **DELETED** |
| Step 2 — `adduser deploy` + `usermod -aG docker` | 60–68 | `users:` block creates `deploy` with `groups: docker, sudo` + NOPASSWD sudo | **DELETED** |
| Step 3 — Idempotent merge `/root/.ssh/authorized_keys` → `/home/deploy/.ssh/authorized_keys` with fingerprint dedup (fix for #112) | 70–131 | cloud-init seeds BOTH root + deploy authorized_keys with the same `${ssh_public_key}`. Operator-appended keys post-provision are NOT re-synced — that's the historical merge purpose | **KEPT** — residual for re-runs + post-provision admin-key adds |
| Step 3.5 — `git config --global --add safe.directory` for `/opt/noorinalabs-deploy` + aux repos | 133–145 | NOT in cloud-init | **KEPT** — residual for re-runs / older boxes |
| Step 4 — `git clone` or `git fetch && git reset --hard origin/main` into `/opt/noorinalabs-deploy` | 147–155 | runcmd: `git clone … \|\| true` + chown on first boot | **KEPT** — idempotent refresh for re-runs / manual operator pulls |
| Step 4.5 — `mkdir + chown deploy:deploy` for `/opt/noorinalabs-isnad-graph`, `/opt/noorinalabs-design-system` | 157–176 | NOT in cloud-init (genuine gap — see followup #1) | **KEPT** |
| Step 5 — Write `/opt/noorinalabs-deploy/.env` CHANGE-ME stub for isnad-graph stack | 178–254 | NOT in cloud-init (CI workflow writes `.env` fresh from GH secrets each push) | **DELETED** — replaced with banner pointing at `compose/env.example` |
| Step 6 — `curl … rclone/install.sh \| bash` | 256–263 | `rclone` is in cloud-init `packages:` | **DELETED** |
| Step 7 — Install isnad-backup.{service,timer} + failure-marker + tmpfiles.d, provision `/var/lib/node_exporter`, `systemctl enable isnad-backup.timer` | 265–293 | cloud-init creates `/var/lib/node_exporter/textfile_collector` (subdir, deploy:deploy 0755). cloud-init does NOT install the systemd backup units (genuine gap — see followup #2) | **KEPT** |
| "Done" / next-steps echoes | 295–321 | n/a | **REWRITTEN** — shorter banner keyed to residual scope; explicit list of what cloud-init handles |

### Cloud-init gaps surfaced (NOT in scope for this PR — orchestrator-side follow-ups recommended)

1. **Aux-repo dir pre-provisioning** — cloud-init should `mkdir -p` + `chown deploy:deploy` `/opt/noorinalabs-isnad-graph` and `/opt/noorinalabs-design-system`. Currently lives ONLY in bootstrap-vps.sh Step 4 (renumbered).
2. **Systemd backup timer installation** — cloud-init should install `isnad-backup.{service,timer}`, `isnad-backup-failure-marker.service`, `tmpfiles.d/noorinalabs-backups.conf`, and `systemctl enable isnad-backup.timer`. Currently lives ONLY in bootstrap-vps.sh Step 5 (renumbered).
3. **safe.directory aux-repo exceptions** — if (1) is fixed, cloud-init should also add the `git config --global --add safe.directory` entries.

These three gaps mean a strict "cloud-init only, no bootstrap-vps.sh" provisioning would deploy the stack but **not** have aux-repo dirs ready for the next deploy workflow run, and **not** have the backup timer enabled. Both are silent failures that don't surface until first-pull / first-backup-window.

### Relationship to existing closed issues

- **#112** (`fix(bootstrap): SSH key copy to deploy user is destructive overwrite`) — already closed. The fix it introduced is preserved in this PR as Step 1 of the new numbering (append-with-fingerprint-dedup merge).
- **#122** (`tech-debt: bootstrap-vps.sh:191 still echoes --build in first-run hint`) — already closed. The whole `--build` echo block (old Steps 5-end) is gone; the new Done banner uses `docker compose … pull` then `up -d` with no `--build`.

DO NOT close #112 / #122 — already closed. Checked above per issue body instruction.

## Test plan

- [x] `bash -n scripts/bootstrap-vps.sh` — syntax check passes (263 lines)
- [x] `git grep -n bootstrap-vps` returns only intentional references (RUNBOOK.md, docs/architecture.md, docs/runbooks/new-service-deploy-checklist.md, the script's own header, the cloud-init.yaml.tpl comment crediting the apt-conf shape source)
- [x] cloud-init.yaml.tpl still provisions Docker, docker-compose-v2, docker-buildx, git, curl, fail2ban, ufw, unattended-upgrades, rclone, jq, deploy user with NOPASSWD sudo, root+deploy SSH keys, GHCR auth (conditional), `.env.user-service`, root SSH password disable, ufw rules, repo clone, node_exporter textfile_collector dir — verified by re-reading the template in full
- [ ] (manual, post-merge) provisioning a fresh stg VPS via cloud-init alone succeeds for the stack itself (will be exposed via aux-repo-dir + backup-timer gaps if followups (1) and (2) aren't closed first; this PR documents that explicitly)
- [ ] (manual, post-merge) running the reduced script on the existing prod VPS is a no-op apart from the safe.directory + repo-refresh + backup-timer-reload steps

Closes #163

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
