### PR TITLE
ci(tf): consolidate Terraform CI workflow + add tflint/checkov coverage (closes #23)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -135,7 +135,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run tflint
-        run: tflint --config="${GITHUB_WORKSPACE}/.tflint.hcl" --recursive=false --format=compact
+        # tflint's --recursive is a bare bool flag (no =value form); default is
+        # non-recursive, which is what we want — each matrix entry runs from a
+        # working-directory scoped to one module. NOTE: actionlint does NOT
+        # validate tflint flag syntax, so when bumping setup-tflint, verify
+        # against `tflint --help` of the pinned version before merge.
+        run: tflint --config="${GITHUB_WORKSPACE}/.tflint.hcl" --format=compact
 
   checkov:
     # Policy / security scan. Runs against the whole terraform/ tree in

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -102,9 +102,66 @@ jobs:
       - name: Validate
         run: terraform validate
 
+  tflint:
+    # Static analysis. Catches the class of bug that motivated this issue:
+    # an `endpoint` (singular, pre-TF 1.6) vs `endpoints` (plural, TF 1.6+)
+    # S3 backend-arg mismatch slipped through `terraform validate` because
+    # the parser treats unknown-but-syntactically-valid args as warnings.
+    # tflint's terraform-recommended preset fails on those. See deploy#23.
+    name: TFLint (${{ matrix.path }})
+    needs: fmt
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        path:
+          - terraform/hetzner/modules/hetzner-vps
+          - terraform/hetzner/envs/stg
+          - terraform/hetzner/envs/prod
+          - terraform/cloudflare
+          - terraform/backblaze
+    defaults:
+      run:
+        working-directory: ${{ matrix.path }}
+    steps:
+      - uses: actions/checkout@v6
+      # Pinned to commit-sha (v6.2.2) per third-party-action integrity
+      # discipline — see ontology feedback_verify_third_party_integrity_claims.
+      - uses: terraform-linters/setup-tflint@b480b8fcdaa6f2c577f8e4fa799e89e756bb7c93  # v6.2.2
+        with:
+          tflint_version: latest
+      - name: Init tflint plugins
+        run: tflint --init --config="${GITHUB_WORKSPACE}/.tflint.hcl"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run tflint
+        run: tflint --config="${GITHUB_WORKSPACE}/.tflint.hcl" --recursive=false --format=compact
+
+  checkov:
+    # Policy / security scan. Runs against the whole terraform/ tree in
+    # a single job (checkov walks the tree itself). Soft-fail false so
+    # any NEW finding blocks the PR; pre-existing findings are skipped
+    # inline via `# checkov:skip=CKV_*` comments in the source files.
+    # See terraform/BACKEND.md § Pre-existing checkov skips.
+    name: Checkov
+    needs: fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      # Pinned to commit-sha (v12.3102.0) per third-party-action integrity
+      # discipline — see ontology feedback_verify_third_party_integrity_claims.
+      - uses: bridgecrewio/checkov-action@4048c972aae68d0b983a48bb3479aab2d877b898  # v12.3102.0
+        with:
+          directory: terraform/
+          framework: terraform
+          soft_fail: false
+          quiet: true
+          output_format: cli
+          skip_results_upload: true
+
   plan:
     name: Plan (hetzner/${{ matrix.env }})
-    needs: validate
+    needs: [validate, tflint, checkov]
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     strategy:
@@ -152,7 +209,7 @@ jobs:
 
   plan-cloudflare:
     name: Plan (cloudflare)
-    needs: validate
+    needs: [validate, tflint, checkov]
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     environment: production
@@ -203,7 +260,7 @@ jobs:
 
   plan-backblaze:
     name: Plan (backblaze)
-    needs: validate
+    needs: [validate, tflint, checkov]
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     environment: production
@@ -247,7 +304,7 @@ jobs:
 
   apply:
     name: Apply (hetzner/${{ matrix.env }})
-    needs: validate
+    needs: [validate, tflint, checkov]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     strategy:
@@ -283,7 +340,7 @@ jobs:
   # cloudflare DNS pointing at the prior IP until the *next* push.
   apply-cloudflare:
     name: Apply (cloudflare)
-    needs: [validate, apply]
+    needs: [validate, tflint, checkov, apply]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     environment: production
@@ -314,7 +371,7 @@ jobs:
 
   apply-backblaze:
     name: Apply (backblaze)
-    needs: validate
+    needs: [validate, tflint, checkov]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     environment: production

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,9 @@
+config {
+  call_module_type = "local"
+  force            = false
+}
+
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}

--- a/terraform/BACKEND.md
+++ b/terraform/BACKEND.md
@@ -1,0 +1,83 @@
+# Terraform backend configuration
+
+Every root module in `terraform/` uses the **same S3-compatible Backblaze B2 bucket** for remote state: `noorinalabs-terraform-state`. Each root module writes to its own `key` so the four state files (`hetzner/stg.tfstate`, `hetzner/prod.tfstate`, `cloudflare/terraform.tfstate`, `backblaze/terraform.tfstate`) never collide.
+
+## Required backend block (TF 1.6+)
+
+```hcl
+terraform {
+  backend "s3" {
+    bucket = "noorinalabs-terraform-state"
+    key    = "<module>/<env>.tfstate"
+    region = "us-east-005"
+    endpoints = {
+      s3 = "https://s3.us-east-005.backblazeb2.com"
+    }
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+  }
+}
+```
+
+The current root modules are:
+
+| Module path | State key |
+|---|---|
+| `terraform/hetzner/envs/stg/` | `hetzner/stg.tfstate` |
+| `terraform/hetzner/envs/prod/` | `hetzner/prod.tfstate` |
+| `terraform/cloudflare/` | `cloudflare/terraform.tfstate` |
+| `terraform/backblaze/` | `backblaze/terraform.tfstate` |
+
+## `endpoints` (plural) vs `endpoint` (singular) — the trap
+
+Terraform's S3 backend grew a **new `endpoints` attribute (plural, map-shape) in v1.6**. The pre-1.6 form used a top-level `endpoint = "<url>"` (singular, string). Both attributes are accepted by the parser to keep older configs working through the deprecation window, but they are **not interchangeable**:
+
+- **`endpoint` (singular)** — pre-1.6 form. Deprecated in 1.6+, removed in a future release. Continues to parse without error today.
+- **`endpoints = { s3 = "<url>" }` (plural)** — 1.6+ form. Required when any other non-default backend behavior is in use; future-proof.
+
+The classic failure mode (which directly motivated this doc — see deploy#23 and the originating PR #22 incident):
+
+1. Operator copies an older example using `endpoint = "<url>"`.
+2. `terraform init` succeeds (parser accepts both forms).
+3. `terraform validate` succeeds (validate doesn't connect anywhere).
+4. CI's `plan` job authenticates against the **default AWS S3 endpoint** instead of B2 — because `endpoint` (singular) was silently demoted to a no-op by the new parser path.
+5. The failure surfaces as a generic AWS auth error during `init` against the wrong endpoint, not as a config-shape error.
+
+**Use the plural `endpoints = { s3 = ... }` form everywhere. tflint's terraform-recommended preset (wired in `.github/workflows/terraform.yml`'s `tflint` job as of deploy#23) catches mismatches at PR-time.**
+
+## Required CI credentials
+
+The four root modules all read auth from the same env-var pair:
+
+| Env var (TF backend reads it) | Source secret name |
+|---|---|
+| `AWS_ACCESS_KEY_ID` | `TF_STATE_B2_KEY_ID` |
+| `AWS_SECRET_ACCESS_KEY` | `TF_STATE_B2_APP_KEY` |
+
+These are set per-GH-Environment (`staging` and `production`) so rotation of the B2 application key only requires updating both env secret slots, not a per-module secret. The `validate-creds` job in `.github/workflows/terraform.yml` probes both envs on every push/PR/Monday-cron to surface rotation drift before any `plan` runs.
+
+## Why all four modules share one bucket
+
+One bucket, separate state keys keeps the `terraform_remote_state` data sources simple. The cloudflare module reads hetzner state via `data "terraform_remote_state" "hetzner_prod"` (see `terraform/cloudflare/main.tf`) using the same B2 auth — no second credential pair to manage. Same for any future module that needs to read VPS IPs or backblaze bucket names from sibling state.
+
+## Adding a new root module — checklist
+
+1. Create `terraform/<module>/versions.tf` (or `backend.tf`) with the block above; pick a unique state key.
+2. Add the module path to `.github/workflows/terraform.yml`'s `validate`, `tflint`, and `plan-<module>` / `apply-<module>` jobs.
+3. Wire any per-module provider creds via `TF_VAR_*` in the workflow `env:` block.
+4. If the new module needs to read sibling state, use `data "terraform_remote_state"` pointing at the same bucket — no extra auth needed.
+
+## Pre-existing checkov skips
+
+The `checkov` job in `.github/workflows/terraform.yml` runs against `terraform/` with `soft_fail: false`, so any **new** finding blocks the PR. Pre-existing findings (if any surface on first CI run) should be skipped inline at the resource level using:
+
+```hcl
+resource "<type>" "<name>" {
+  # checkov:skip=CKV_AWS_xxx: <one-line justification>
+  ...
+}
+```
+
+If a skip is added, document the justification in the inline comment AND in a follow-up issue if the skip represents real tech-debt that should be revisited.


### PR DESCRIPTION
## Summary

Closes deploy#23. Adds the two missing static-analysis gates (tflint + checkov) to the existing Terraform CI workflow, wires them into the plan/apply `needs:` chain so failures actually block apply, and documents the S3-compat backend config the workflow depends on.

### What was actually still open vs the issue body

Issue #23 lists 5 priority items. Items 1 and 2 were **already landed** on `deployments/phase-3/wave-11` before this PR:

| # | Item | Status entering this PR |
|---|------|---|
| 1 | Merge `L.Ferreira/0007-terraform-cicd` content | DONE (`d2a08ef` / `fdfd74e` series) |
| 2 | Add cloudflare module to the workflow | DONE (`2b0b07a` "ci(terraform): wire cloudflare + backblaze into plan/apply matrix (closes #250)") |
| 3 | Add tflint | THIS PR |
| 4 | Add checkov | THIS PR |
| 5 | Document backend config requirements | THIS PR |

`terraform.yml` already has fmt + validate + plan + apply for all 4 root modules (`hetzner/envs/{stg,prod}`, `cloudflare`, `backblaze`) plus the `validate-creds` rotation-drift probe from #158. This PR layers tflint + checkov on top without restructuring existing jobs.

### Changes

| File | What |
|---|---|
| `.github/workflows/terraform.yml` | New `tflint` job (matrix over 5 paths); new `checkov` job (single, scans whole `terraform/` tree); existing plan + apply jobs now `needs: [validate, tflint, checkov]` so lint/policy failures block apply |
| `.tflint.hcl` (new) | Top-level config — terraform-recommended preset, local-module call resolution |
| `terraform/BACKEND.md` (new) | Shared B2 S3-compat backend block, `endpoints` (plural) vs `endpoint` (singular) trap with PR#22 incident history, CI creds map, checkov-skip convention |

### TF baseline

- Terraform version pinned: `~> 1.6` (unchanged — already in `setup-terraform` calls)
- tflint: `terraform-linters/setup-tflint@b480b8fcdaa6f2c577f8e4fa799e89e756bb7c93` (v6.2.2, pinned to commit-sha per `feedback_verify_third_party_integrity_claims`)
- checkov: `bridgecrewio/checkov-action@4048c972aae68d0b983a48bb3479aab2d877b898` (v12.3102.0, same pinning discipline)

### tflint rules in/out

- **In**: terraform-recommended preset only — covers `terraform_deprecated_*`, `terraform_unused_*`, `terraform_required_*`, `terraform_naming_convention`. This is the ruleset that flags the `endpoint`-vs-`endpoints` class of issue (deprecated args → fail).
- **Out**: No provider-specific plugins (aws/azure/gcp) — none of our 4 modules use those providers natively. Hetzner, Cloudflare, and B2 don't ship official tflint plugins, so we rely on core checks only.

### checkov rules in/out

- **In**: All default Terraform-framework checks (`framework: terraform`, `soft_fail: false`).
- **Out**: No baseline-skips committed in this PR — checkov hasn't run against this tree yet in CI. If the first CI run surfaces pre-existing findings (likely on the B2/Cloudflare modules), the follow-up will be to add inline `# checkov:skip=CKV_*: <justification>` per `BACKEND.md` § Pre-existing checkov skips. I deliberately did NOT commit speculative skips for findings I haven't seen yet.

### Cloudflare CI creds — no owner-action needed

Confirmed via `gh secret list` + `gh api .../actions/variables`:
- `CLOUDFLARE_API_TOKEN` (secret) — present since 2026-04-30
- `CLOUDFLARE_ZONE_ID`, `CLOUDFLARE_NOORINALABS_NET_ZONE_ID`, `CLOUDFLARE_NOORINALABS_ORG_ZONE_ID` (vars) — present
- `TF_STATE_B2_KEY_ID`, `TF_STATE_B2_APP_KEY` (secrets) — present
- `HCLOUD_TOKEN`, `B2_MASTER_KEY_ID`, `B2_MASTER_APP_KEY` (secrets) — present

No new secrets need to be provisioned for this PR to function.

## Test plan

### What passes at PR time (PR-author-verifiable)

- [x] `actionlint .github/workflows/terraform.yml` clean (v1.7.7 with shellcheck 0.10.0 on PATH per `feedback_actionlint_needs_shellcheck`)
- [x] `actionlint` clean over the full `.github/workflows/` tree (no regressions on existing workflows)
- [x] Workflow YAML syntax valid; new jobs `tflint` and `checkov` correctly reference matrix paths that exist in the tree
- [x] `needs:` chain updated atomically — all 6 plan/apply jobs include `tflint, checkov` so a lint failure on stg-plan blocks prod-apply via existing causal chain
- [x] `.tflint.hcl` syntax valid (HCL parser-clean — no HCL strict-mode failures)
- [x] `terraform/BACKEND.md` accurately reflects the 4 active backend blocks (verified by grepping `backend "s3"` across `terraform/**/*.tf` — 4 matches, all using plural `endpoints`)
- [x] Both action SHAs verified to resolve against legitimate `terraform-linters/setup-tflint` and `bridgecrewio/checkov-action` releases via `gh api repos/<org>/<repo>/git/ref/tags/<v>` and `action.yml` content inspection — no compromised forks

### What requires CI to actually run (cannot be verified at PR-author-time)

- [ ] `tflint --init --config=.tflint.hcl` succeeds in the runner (plugin install requires network + GITHUB_TOKEN, only available in CI)
- [ ] `tflint` exit code = 0 against each of the 5 module paths (CI-only — first signal that the terraform-recommended preset is happy with our existing code)
- [ ] `checkov` exit code = 0 against `terraform/` (CI-only — likely first surface of pre-existing findings that need inline skips)
- [ ] `plan` + `apply` jobs still gate correctly with the expanded `needs:` chain — requires a green CI run on this branch

### What requires production credentials and cannot be tested at PR time (per `feedback_runtime_gate_scoping`)

- [ ] `terraform plan` actually authenticates against B2 with the rotated `TF_STATE_B2_*` creds — only the CI-run with the production GH Environment can prove this
- [ ] `apply-cloudflare` job still ordered after `apply` (hetzner) with the new tflint/checkov gate inserted — verifiable only on a merge-to-wave-11/main push
- [ ] Real `terraform apply` won't be triggered until this PR merges + a subsequent `terraform/**` change pushes to wave-11/main

## Acceptance checklist (issue #23)

- [x] `terraform.yml` has fmt + validate + plan + apply for both hetzner AND cloudflare AND backblaze modules (pre-existing on wave-11)
- [x] tflint runs on both modules (pinned commit-sha for the action) — matrix over 5 paths
- [x] checkov runs on the terraform/ tree (pinned commit-sha)
- [x] Baseline-skips documented as a CONVENTION in `terraform/BACKEND.md` (no speculative skips committed; see "checkov rules in/out" above for rationale)
- [x] Backend config requirements documented (`endpoints` plural for TF 1.6+ trap explained with PR#22 incident history)
- [x] `actionlint` + `shellcheck` clean on the workflow file (and on the full workflows tree)

## Structured fields

```
Requestor: (TBD — orchestrator will assign)
Requestee: Lucas Ferreira
RequestOrReplied: New
TechDebt: none
```
