### PR TITLE
feat(integration-tests): conftest module-load guard for RUN_MODE=remote against prod (closes #203)

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -81,6 +81,22 @@ Remote mode:
   (so RBAC / sessions / 2FA / subscription flows can run remotely too)
   are downstream follow-up work — see deploy#178 body.
 
+### Two-layer prod-environment guard
+
+The `RUN_MODE=remote` + `ENVIRONMENT in {prod, production}` refusal is
+enforced at **two layers** to cover the case where pytest is invoked
+directly (interactive debugging inside the runner image, future workflows
+that skip `run-tests.sh`, `python -m pytest`, etc.):
+
+| Layer | Where | When it fires | How it aborts |
+|------|------|------|------|
+| Shell | `run-tests.sh` lines ~46-56 | Before pytest starts via the documented entrypoint | `exit 3` |
+| Python | `tests/conftest.py` module-load | At pytest collection time, regardless of invocation path | `RuntimeError` raised before any fixture or test runs |
+
+Both layers check the same predicate (`RUN_MODE=remote` AND
+`ENVIRONMENT in {prod, production}`). If you change one, change the
+other — they are intentionally coupled. See deploy#203.
+
 ## Architecture
 
 - All services run on isolated Docker networks: `backend`, `user-backend`, `testnet`

--- a/integration-tests/run-tests.sh
+++ b/integration-tests/run-tests.sh
@@ -48,6 +48,14 @@ if [[ "$RUN_MODE" == "remote" ]]; then
     # The suite seeds and mutates state via /auth endpoints; running against
     # prod could create test users in the live user-postgres or trip
     # rate-limiters that page oncall.
+    #
+    # DEFENSE IN DEPTH: this shell guard is the fast-fail layer for the
+    # documented entrypoint (this script). The matching Python module-load
+    # guard in `tests/conftest.py` catches direct-pytest invocations that
+    # would otherwise bypass this check (e.g. interactive debug inside the
+    # runner image, future workflow author who skips run-tests.sh). Keep the
+    # two coupled: if you change the predicate here, update conftest.py too.
+    # See deploy#203.
     : "${ENVIRONMENT:=stg}"
     if [[ "$ENVIRONMENT" == "prod" || "$ENVIRONMENT" == "production" ]]; then
         echo "ERROR: refusing to run integration suite against ENVIRONMENT=$ENVIRONMENT." >&2

--- a/integration-tests/tests/conftest.py
+++ b/integration-tests/tests/conftest.py
@@ -44,6 +44,28 @@ import redis.asyncio as aioredis
 # of pytest (e.g. `pytest tests/test_health.py`) inside the runner container
 # still works the same way it always has.
 RUN_MODE = os.environ.get("RUN_MODE", "hermetic")
+
+# Defense-in-depth prod-environment guard. The shell entrypoint
+# `integration-tests/run-tests.sh` already exits 3 on `RUN_MODE=remote
+# ENVIRONMENT={prod,production}` before pytest starts, but a direct
+# `pytest` invocation inside the runner image (interactive debug, future
+# workflow that skips run-tests.sh, `python -m pytest`, etc.) would
+# otherwise reach the auth-mutating fixtures and create real users or
+# trip rate-limiters against prod. Re-check here at module load so the
+# guard fires regardless of how pytest is invoked. See deploy#203 and
+# the matching shell block in run-tests.sh — keep the two coupled.
+_ENVIRONMENT = os.environ.get("ENVIRONMENT", "stg")
+if RUN_MODE == "remote" and _ENVIRONMENT in ("prod", "production"):
+    raise RuntimeError(
+        f"Refusing to run integration suite in remote mode against "
+        f"ENVIRONMENT={_ENVIRONMENT!r}. The suite mutates state via "
+        f"/auth endpoints; running against prod could create real "
+        f"users or trip rate-limiters that page oncall. Set "
+        f"ENVIRONMENT=stg or unset (defaults to 'stg'). This is "
+        f"enforced both by integration-tests/run-tests.sh AND here "
+        f"at module load."
+    )
+
 HERMETIC_ONLY_REASON = (
     "hermetic-only fixture: direct DB/Redis access is not available in "
     "remote mode (stg DBs are not reachable from outside the VPS). Run "
@@ -55,12 +77,8 @@ HERMETIC_ONLY_REASON = (
 # the legacy USER_SERVICE_URL / ISNAD_GRAPH_URL names are the hermetic
 # compose-internal hostnames. run-tests.sh exports both shapes in remote
 # mode so this lookup works either way.
-USER_SERVICE_URL = os.environ.get(
-    "USER_SERVICE_URL", os.environ.get("USER_SERVICE_BASE_URL", "")
-)
-ISNAD_GRAPH_URL = os.environ.get(
-    "ISNAD_GRAPH_URL", os.environ.get("ISNAD_BASE_URL", "")
-)
+USER_SERVICE_URL = os.environ.get("USER_SERVICE_URL", os.environ.get("USER_SERVICE_BASE_URL", ""))
+ISNAD_GRAPH_URL = os.environ.get("ISNAD_GRAPH_URL", os.environ.get("ISNAD_BASE_URL", ""))
 if not USER_SERVICE_URL or not ISNAD_GRAPH_URL:
     raise RuntimeError(
         "USER_SERVICE_URL/USER_SERVICE_BASE_URL and "
@@ -250,8 +268,6 @@ async def seeded_user_factory(
 async def issue_token_for(
     user_service: httpx.AsyncClient, authorization_code: str
 ) -> dict[str, str | int]:
-    r = await user_service.post(
-        "/auth/token", json={"authorization_code": authorization_code}
-    )
+    r = await user_service.post("/auth/token", json={"authorization_code": authorization_code})
     assert r.status_code == 200, f"token issuance failed: {r.status_code} {r.text}"
     return r.json()

--- a/integration-tests/tests/test_conftest_guard.py
+++ b/integration-tests/tests/test_conftest_guard.py
@@ -1,0 +1,136 @@
+"""Tests for the module-load-time prod-environment guard in conftest.py.
+
+The guard refuses `RUN_MODE=remote` + `ENVIRONMENT in {prod, production}`
+at module import time so that direct `pytest` invocations (bypassing
+run-tests.sh) cannot reach the auth-mutating fixtures against prod.
+
+These tests subprocess-import the conftest module with controlled env
+vars and assert on the exit code + stderr. Subprocess isolation is
+required because the guard executes at module load, and the conftest
+is already loaded once in this test process — re-importing it here
+would not re-run the top-level statements.
+
+See deploy#203 for the issue and run-tests.sh for the matching shell
+guard layer.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+CONFTEST_PATH = Path(__file__).parent / "conftest.py"
+
+# Minimum env to satisfy the post-guard URL/DSN checks in conftest. The
+# guard fires BEFORE these are needed, but the passes-through cases need
+# them so the import reaches the bottom of the module without crashing
+# for an unrelated reason.
+_HERMETIC_URLS = {
+    "USER_SERVICE_URL": "http://user-service:8000",
+    "ISNAD_GRAPH_URL": "http://isnad-graph-api:8001",
+    # Hermetic-mode DSN-construction env vars (touched only when
+    # RUN_MODE=hermetic; provided here so hermetic+prod doesn't crash
+    # on missing-env for an unrelated reason).
+    "USER_POSTGRES_USER": "test",
+    "USER_POSTGRES_PASSWORD": "test",
+    "USER_POSTGRES_HOST": "user-postgres",
+    "USER_POSTGRES_PORT": "5432",
+    "USER_POSTGRES_DB": "test",
+    "USER_REDIS_URL": "redis://user-redis:6379/0",
+}
+
+_REMOTE_URLS = {
+    "USER_SERVICE_BASE_URL": "https://auth.stg.noorinalabs.com",
+    "ISNAD_BASE_URL": "https://isnad.stg.noorinalabs.com",
+    "USER_SERVICE_URL": "https://auth.stg.noorinalabs.com",
+    "ISNAD_GRAPH_URL": "https://isnad.stg.noorinalabs.com",
+}
+
+
+def _import_conftest(env_overrides: dict[str, str]) -> subprocess.CompletedProcess:
+    """Run a subprocess that imports conftest.py with the given env, return result."""
+    env = {
+        # PATH so we can find python; PYTHONPATH so the tests/ dir is on
+        # the import path; no pre-existing RUN_MODE/ENVIRONMENT leakage
+        # from the parent test process.
+        "PATH": "/usr/local/bin:/usr/bin:/bin",
+        "PYTHONPATH": str(CONFTEST_PATH.parent),
+        **env_overrides,
+    }
+    return subprocess.run(
+        [sys.executable, "-c", "import conftest"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_remote_against_prod_raises():
+    """RUN_MODE=remote + ENVIRONMENT=prod must abort at module load."""
+    result = _import_conftest(
+        {
+            "RUN_MODE": "remote",
+            "ENVIRONMENT": "prod",
+            **_REMOTE_URLS,
+        }
+    )
+    assert result.returncode != 0, (
+        f"expected non-zero exit; got 0. stdout={result.stdout!r} " f"stderr={result.stderr!r}"
+    )
+    assert (
+        "Refusing to run integration suite in remote mode" in result.stderr
+    ), f"expected guard error in stderr; got: {result.stderr!r}"
+    assert (
+        "ENVIRONMENT='prod'" in result.stderr
+    ), f"expected ENVIRONMENT value echoed in stderr; got: {result.stderr!r}"
+
+
+def test_remote_against_production_raises():
+    """The full `production` alias must also abort — matches shell guard."""
+    result = _import_conftest(
+        {
+            "RUN_MODE": "remote",
+            "ENVIRONMENT": "production",
+            **_REMOTE_URLS,
+        }
+    )
+    assert result.returncode != 0, f"expected non-zero exit; got 0. stderr={result.stderr!r}"
+    assert "Refusing to run integration suite in remote mode" in result.stderr
+    assert "ENVIRONMENT='production'" in result.stderr
+
+
+def test_remote_against_stg_passes_through():
+    """RUN_MODE=remote + ENVIRONMENT=stg must NOT raise the prod guard."""
+    result = _import_conftest(
+        {
+            "RUN_MODE": "remote",
+            "ENVIRONMENT": "stg",
+            **_REMOTE_URLS,
+        }
+    )
+    assert result.returncode == 0, (
+        f"expected clean import; got rc={result.returncode}. " f"stderr={result.stderr!r}"
+    )
+    assert "Refusing to run integration suite" not in result.stderr
+
+
+def test_hermetic_against_prod_passes_through():
+    """RUN_MODE=hermetic must NOT gate on ENVIRONMENT.
+
+    Hermetic mode runs against an ephemeral local stack — there is no
+    real prod to mutate, so ENVIRONMENT=prod is a non-issue here.
+    Gating on it would break a legitimate local-debug pattern.
+    """
+    result = _import_conftest(
+        {
+            "RUN_MODE": "hermetic",
+            "ENVIRONMENT": "prod",
+            **_HERMETIC_URLS,
+        }
+    )
+    assert result.returncode == 0, (
+        f"expected clean import; got rc={result.returncode}. " f"stderr={result.stderr!r}"
+    )
+    assert "Refusing to run integration suite" not in result.stderr


### PR DESCRIPTION
## Summary

Adds a defense-in-depth module-load-time prod-environment guard to `integration-tests/tests/conftest.py`. Closes #203.

The existing shell guardrail in `integration-tests/run-tests.sh` (lines ~46-56) exits 3 when `RUN_MODE=remote` + `ENVIRONMENT in {prod, production}` is passed to the documented entrypoint. But a direct `pytest` invocation in the runner image bypasses it — interactive debugging inside the container, a future workflow author who skips `run-tests.sh`, `python -m pytest`, etc.

The new guard re-checks the same predicate at pytest collection time so the suite refuses to load regardless of invocation path. Placed BEFORE the existing `USER_SERVICE_URL`/`ISNAD_GRAPH_URL` `raise RuntimeError` so the prod-guard error is the one operators see, not a misleading "URL not set" error when both conditions hold simultaneously.

## Changes

- `integration-tests/tests/conftest.py` — module-load guard at the top of the import-time section.
- `integration-tests/run-tests.sh` — cross-reference comment in the existing shell guard block so the two layers stay coupled if the predicate ever evolves.
- `integration-tests/README.md` — new section "Two-layer prod-environment guard" with a table showing where each layer fires and how it aborts.
- `integration-tests/tests/test_conftest_guard.py` (new) — 4 subprocess-isolated tests:
  - `test_remote_against_prod_raises` — RUN_MODE=remote + ENVIRONMENT=prod → guard fires.
  - `test_remote_against_production_raises` — full `production` alias also fires (matches shell guard predicate).
  - `test_remote_against_stg_passes_through` — stg is allowed, no guard fire.
  - `test_hermetic_against_prod_passes_through` — hermetic mode runs against an ephemeral local stack, no real prod to mutate; gating here would break a legitimate local-debug pattern.

## Test plan

- [x] `ruff check` / `ruff format --check` clean on conftest.py + test_conftest_guard.py
- [x] `shellcheck integration-tests/run-tests.sh` clean
- [x] 4 new tests pass locally (`pytest tests/test_conftest_guard.py -v`)
- [x] Direct `python -c "import conftest"` with `RUN_MODE=remote ENVIRONMENT=prod` raises with the correct guard message
- [ ] CI green on PR

## Threat-model notes

The issue body explicitly scoped out a stricter `ENVIRONMENT` allowlist (today `dev`/`local`/etc. are valid free-form values; locking down would be a UX regression). The shell guard uses exact match on `{prod, production}`; this PR matches that exactly so the two layers cannot drift. If a future operational convention adds another prod-aliasing string (e.g. `prd`), update BOTH layers in the same PR — see the cross-reference comments in each file.

Closes #203.
