### PR TITLE
ci(promote): drop single-arch fallback branch — all services emit OCI index (#242)

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -891,35 +891,15 @@ jobs:
           # match, but verifying catches registry bugs or accidental
           # buildx flag drift.
           #
-          # Comparison is shape-aware (#239 fix). When the source is a
-          # multi-arch index/list, `imagetools create` preserves it
-          # identically and we compare top-level manifest digests directly.
-          # When the source is a single-arch v2 manifest (landing-page is
-          # currently the only one), `imagetools create` wraps it in a
-          # NEW index whose digest is necessarily different from the
-          # unwrapped source manifest. In that case we compare the source
-          # digest to the destination index's `manifests[0].digest` —
-          # which IS the wrapped source manifest, so equality means the
-          # retag preserved content even though the surface representation
-          # changed.
+          # All services emit OCI index post-#242 (landing-page PR #75,
+          # isnad-graph + user-service + design-system from prior waves),
+          # so the shape-aware fallback for single-arch v2 manifests is no
+          # longer needed. Direct top-level digest comparison applies
+          # uniformly.
           src=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$IMAGE:$SOURCE_TAG")
-          src_media=$(docker buildx imagetools inspect --format '{{.Manifest.MediaType}}' "$IMAGE:$SOURCE_TAG")
+          ps=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$IMAGE:prod-$SHORT")
+          pl=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$IMAGE:prod-latest")
 
-          if echo "$src_media" | grep -qE 'index|manifest\.list'; then
-            # Multi-arch source — direct top-level comparison.
-            ps=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$IMAGE:prod-$SHORT")
-            pl=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$IMAGE:prod-latest")
-            shape="multi-arch (direct top-level digest comparison)"
-          else
-            # Single-arch source — compare against the wrapped manifest digest
-            # inside the destination index.
-            ps=$(docker buildx imagetools inspect --raw "$IMAGE:prod-$SHORT" | jq -r '.manifests[0].digest')
-            pl=$(docker buildx imagetools inspect --raw "$IMAGE:prod-latest" | jq -r '.manifests[0].digest')
-            shape="single-arch (compare source to destination's manifests[0].digest)"
-          fi
-
-          echo "Source MediaType:    $src_media"
-          echo "Comparison shape:    $shape"
           echo "source digest:       $src"
           echo "prod-<short> digest: $ps"
           echo "prod-latest digest:  $pl"


### PR DESCRIPTION
## Summary

Step 2 of deploy#242 multi-arch standardization. The shape-aware verify-parity branch in `.github/workflows/promote.yml` (added in #239 to handle landing-page's single-arch v2 manifests) is now dead weight: all four services emit OCI image-index artifacts post-Step 1.

- **Step 1**: landing-page PR [#75](https://github.com/noorinalabs/noorinalabs-landing-page/pull/75) merged 2026-05-04 (commit `025249b8`) — switched landing-page workflow to `docker/setup-buildx-action@v3` + `docker/build-push-action@v6` with `platforms: linux/amd64` + `provenance: true`.
- **Runtime evidence**: 4 successful stg-publishes since 2026-05-04; latest image version is shape `application/vnd.oci.image.index.v1+json` with 2 child manifest digests (linux/amd64 platform + provenance attestation) under it.
- **Step 2 (this PR)**: collapse the if/else in promote.yml's verify-parity step. Drop `src_media` probing, drop the `manifests[0].digest` fallback. Direct top-level digest comparison now applies uniformly.

### Diff shape

`.github/workflows/promote.yml`: +7 / -27. Removes the `src_media` variable, the if/else conditional, and the per-branch `shape` log line. Replaces the multi-paragraph "#239 fix" rationale with a brief note explaining why the fallback is no longer needed.

## Test Plan

- [x] `actionlint .github/workflows/promote.yml` — passes locally (shellcheck on PATH per project tooling convention).
- [x] Workflow YAML structure unchanged — only the inline shell logic inside the existing `Verify digest parity` step was simplified. No new steps, no triggers/inputs changed, no permissions changed.
- [ ] CI gates pass (`hooks-lint`, `actionlint`, any other workflow-level checks) — verify via `gh pr view <N> --json statusCheckRollup`.
- [ ] **Runtime acceptance (post-merge, not PR-time)**: next manual prod-promotion run executes verify-parity with the collapsed comparison. All 4 services (isnad-graph, user-service, landing-page, design-system) emit OCI index now, so all three digests (`src`, `ps`, `pl`) should match top-level uniformly. If parity fails for any service, the previous `manifests[0].digest` fallback can be restored via revert; the registry-side retag mechanism itself is unchanged.

## Reviewers

Per charter, 2 reviewers required. Orchestrator will spawn reviewers post-open.

Closes #242

---

<!-- Reviewers: fill in the structured-fields block below per Hook 4. Do not delete the field names. -->
