### PR TITLE
infra(cloudflare): import existing dynamic-redirect rulesets for .net/.org (#348)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -238,6 +238,38 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "~> 1.6"
+      # Discover the existing http_request_dynamic_redirect entrypoint ruleset
+      # ID for each defensive-TLD zone and thread it into the import {} blocks
+      # (imports.tf) via TF_VAR_*. Required because Cloudflare allows only one
+      # entrypoint per phase per zone, so the canonical-redirect rulesets must
+      # adopt the existing entrypoints rather than create new ones (#348). The
+      # IDs are not stored anywhere; the CLOUDFLARE_API_TOKEN that can read
+      # them lives only in CI. Must run before plan (an empty import id errors
+      # at plan time, not just apply).
+      - name: Discover redirect ruleset IDs
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          NET_ZONE_ID: ${{ vars.CLOUDFLARE_NOORINALABS_NET_ZONE_ID }}
+          ORG_ZONE_ID: ${{ vars.CLOUDFLARE_NOORINALABS_ORG_ZONE_ID }}
+        run: |
+          discover() {
+            zone_id="$1"; label="$2"
+            resp=$(curl --silent --show-error --fail-with-body \
+              --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+              "https://api.cloudflare.com/client/v4/zones/${zone_id}/rulesets") || {
+                echo "::error::Failed to list rulesets for ${label} zone ${zone_id}"; echo "${resp}"; exit 1; }
+            id=$(printf '%s' "${resp}" | jq -r \
+              '.result[] | select(.phase=="http_request_dynamic_redirect") | .id' | head -n1)
+            if [ -z "${id}" ] || [ "${id}" = "null" ]; then
+              echo "::error::No http_request_dynamic_redirect entrypoint ruleset found for ${label} zone ${zone_id}."
+              echo "::error::imports.tf assumes one already exists (the reason this PR imports rather than creates — see #348)."
+              exit 1
+            fi
+            echo "Discovered ${label} dynamic-redirect ruleset: ${id}"
+            echo "TF_VAR_${label}_redirect_ruleset_id=${id}" >> "${GITHUB_ENV}"
+          }
+          discover "${NET_ZONE_ID}" net
+          discover "${ORG_ZONE_ID}" org
       - name: Init
         run: terraform init
       - name: Plan
@@ -369,6 +401,36 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "~> 1.6"
+      # See plan-cloudflare § "Discover redirect ruleset IDs". Same discovery
+      # is required on apply: the import {} blocks (imports.tf) reference
+      # TF_VAR_{net,org}_redirect_ruleset_id, and an empty import id errors at
+      # plan-during-apply. After the first apply imports the entrypoints into
+      # state, re-runs are idempotent (Terraform consults import {} only for
+      # resources not yet in state). See #348.
+      - name: Discover redirect ruleset IDs
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          NET_ZONE_ID: ${{ vars.CLOUDFLARE_NOORINALABS_NET_ZONE_ID }}
+          ORG_ZONE_ID: ${{ vars.CLOUDFLARE_NOORINALABS_ORG_ZONE_ID }}
+        run: |
+          discover() {
+            zone_id="$1"; label="$2"
+            resp=$(curl --silent --show-error --fail-with-body \
+              --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+              "https://api.cloudflare.com/client/v4/zones/${zone_id}/rulesets") || {
+                echo "::error::Failed to list rulesets for ${label} zone ${zone_id}"; echo "${resp}"; exit 1; }
+            id=$(printf '%s' "${resp}" | jq -r \
+              '.result[] | select(.phase=="http_request_dynamic_redirect") | .id' | head -n1)
+            if [ -z "${id}" ] || [ "${id}" = "null" ]; then
+              echo "::error::No http_request_dynamic_redirect entrypoint ruleset found for ${label} zone ${zone_id}."
+              echo "::error::imports.tf assumes one already exists (the reason this PR imports rather than creates — see #348)."
+              exit 1
+            fi
+            echo "Discovered ${label} dynamic-redirect ruleset: ${id}"
+            echo "TF_VAR_${label}_redirect_ruleset_id=${id}" >> "${GITHUB_ENV}"
+          }
+          discover "${NET_ZONE_ID}" net
+          discover "${ORG_ZONE_ID}" org
       - name: Init
         run: terraform init
       - name: Apply

--- a/terraform/cloudflare/imports.tf
+++ b/terraform/cloudflare/imports.tf
@@ -1,0 +1,41 @@
+# ===========================================================================
+# Terraform `import` blocks — adopt the existing dynamic-redirect entrypoint
+# rulesets on the `.net` / `.org` zones instead of creating new ones (#348).
+#
+# Cloudflare allows exactly ONE entrypoint ruleset per phase per zone. Both
+# defensive TLDs already have an `http_request_dynamic_redirect` entrypoint,
+# so a plain `create` of `cloudflare_ruleset.canonical_redirect[*]` is
+# rejected by the API:
+#
+#   Error: failed to create ruleset "http_request_dynamic_redirect"
+#   A similar configuration with rules already exists and overwriting will
+#   have unintended consequences.
+#
+# These `import {}` blocks tell Terraform to adopt the existing entrypoint
+# into state and then converge it to the redirect rule defined in
+# redirects.tf — import-then-update, no destroy/recreate, no second entrypoint.
+#
+# Import ID format for the cloudflare v4 provider's zone-scoped ruleset is
+# `zone/<zone_id>/<ruleset_id>`. The ruleset IDs are not committed anywhere;
+# they are discovered at CI time (the "Discover redirect ruleset IDs" step in
+# .github/workflows/terraform.yml) and threaded in via
+# `TF_VAR_{net,org}_redirect_ruleset_id`. Variable interpolation in import-
+# block `id` is supported on Terraform >= 1.6 (versions.tf pins it), and the
+# zone-id + ruleset-id vars are plan-time-known, so this resolves at plan.
+#
+# Removability: once both zones' entrypoints are in state and a clean apply +
+# idempotent re-apply have been observed, these `import {}` blocks (and the
+# CI discovery step + the two ruleset-id vars) can be dropped in a follow-up —
+# Terraform only consults `import {}` for resources not yet in state. Same
+# transitional pattern as moved.tf.
+# ===========================================================================
+
+import {
+  to = cloudflare_ruleset.canonical_redirect["net"]
+  id = "zone/${var.noorinalabs_net_zone_id}/${var.net_redirect_ruleset_id}"
+}
+
+import {
+  to = cloudflare_ruleset.canonical_redirect["org"]
+  id = "zone/${var.noorinalabs_org_zone_id}/${var.org_redirect_ruleset_id}"
+}

--- a/terraform/cloudflare/redirects.tf
+++ b/terraform/cloudflare/redirects.tf
@@ -28,9 +28,19 @@
 #
 # Why C1 (extend this module) and not C2 (new root `terraform/cloudflare-
 # redirects/`): fewer moving parts. Same provider, same backend, same
-# `CLOUDFLARE_API_TOKEN` (token scope already covers all three zones per
-# owner setup in W10). New state in a separate root would add CI matrix
+# `CLOUDFLARE_API_TOKEN`. New state in a separate root would add CI matrix
 # entries and a second `terraform init` for one resource per zone.
+#
+# Token scope: the `CLOUDFLARE_API_TOKEN` was extended to cover the `.net` /
+# `.org` zones (plus Dynamic Redirect edit) in #347 — it did NOT already
+# cover all three zones (the earlier comment here claimed otherwise and was
+# wrong; corrected per #348).
+#
+# Import, not create: each `.net` / `.org` zone already has an
+# `http_request_dynamic_redirect` phase entrypoint ruleset, and Cloudflare
+# permits only one entrypoint per phase per zone. The `cloudflare_ruleset`
+# resources below are therefore IMPORTED (adopting the existing entrypoint)
+# rather than created — see imports.tf and #348.
 # ===========================================================================
 
 locals {

--- a/terraform/cloudflare/redirects.tf
+++ b/terraform/cloudflare/redirects.tf
@@ -56,9 +56,19 @@ locals {
 resource "cloudflare_ruleset" "canonical_redirect" {
   for_each = local.redirect_zones
 
-  zone_id     = each.value
-  name        = "canonical-domain-redirect-${each.key}"
-  description = "301 redirect noorinalabs.${each.key} → noorinalabs.com (path + query preserved)"
+  zone_id = each.value
+  # MUST be "default". A phase ENTRYPOINT ruleset (kind="zone") is named
+  # "default" by Cloudflare convention, and `name` is ForceNew on
+  # cloudflare_ruleset. Since each zone already HAS a "default"
+  # http_request_dynamic_redirect entrypoint (the one we import via
+  # imports.tf), any other name forces a destroy+recreate of the prod
+  # entrypoint instead of an in-place adopt-and-update — which both defeats
+  # the import (#348) and breaks idempotency. With name="default" the import
+  # converges in place: only the rule's description + target_url expression
+  # change to our path/query-preserving redirect. Per-zone labeling lives in
+  # `description` (NOT ForceNew) and on the inner rule below, not in `name`.
+  name        = "default"
+  description = "Canonical-domain 301 redirect entrypoint for noorinalabs.${each.key} → noorinalabs.com (path + query preserved)"
   kind        = "zone"
   phase       = "http_request_dynamic_redirect"
 

--- a/terraform/cloudflare/variables.tf
+++ b/terraform/cloudflare/variables.tf
@@ -30,6 +30,34 @@ variable "domain" {
   default     = "noorinalabs.com"
 }
 
+# Existing dynamic-redirect phase-entrypoint ruleset IDs for the defensive
+# TLDs. Cloudflare allows exactly one entrypoint ruleset per phase per zone,
+# and both `.net` and `.org` already have one — so the canonical-redirect
+# rulesets in redirects.tf must be IMPORTED (adopt the existing entrypoint),
+# not created (see #348). The `import {}` blocks in imports.tf reference these.
+#
+# These IDs are NOT stored anywhere — they are discovered at CI time from the
+# Cloudflare API (`GET /zones/<zone_id>/rulesets` → the entry whose
+# `phase == "http_request_dynamic_redirect"`) and threaded in as `TF_VAR_*`
+# by the discovery step in .github/workflows/terraform.yml.
+#
+# Default "" so that `terraform validate -backend=false` (the CI `validate`
+# job, which runs no discovery and passes no vars) still parses. An empty id
+# is only a problem at PLAN/APPLY time — those jobs (plan-cloudflare,
+# apply-cloudflare) run the discovery step first, so the value is non-empty
+# there. Do not rely on this default anywhere a plan/apply runs.
+variable "net_redirect_ruleset_id" {
+  description = "Existing http_request_dynamic_redirect entrypoint ruleset ID for noorinalabs.net (CI-discovered; see imports.tf)."
+  type        = string
+  default     = ""
+}
+
+variable "org_redirect_ruleset_id" {
+  description = "Existing http_request_dynamic_redirect entrypoint ruleset ID for noorinalabs.org (CI-discovered; see imports.tf)."
+  type        = string
+  default     = ""
+}
+
 # Per-env Hetzner VPS IPs are read from the hetzner env-root tfstates via
 # `data "terraform_remote_state"` in main.tf — no input vars. Eliminates
 # the manual var-passing footgun where cloudflare DNS could drift from a


### PR DESCRIPTION
## Summary

`terraform/cloudflare/redirects.tf` (canonical-domain 301 redirects, #166) cannot **create** its `cloudflare_ruleset.canonical_redirect[*]` resources: each `.net`/`.org` zone already has an `http_request_dynamic_redirect` phase entrypoint ruleset, and Cloudflare permits only one entrypoint per phase per zone. The create is rejected with *"A similar configuration with rules already exists."* This PR makes Terraform **adopt** the existing entrypoints via `import {}` blocks instead of creating new ones — the last P3W11 close-blocker.

## Changes

- **`terraform/cloudflare/imports.tf`** (new) — `import {}` blocks for `canonical_redirect["net"]` and `["org"]`. Import id uses the cloudflare v4 provider's zone-scoped ruleset format `zone/<zone_id>/<ruleset_id>`. Ruleset IDs are threaded in via `TF_VAR_{net,org}_redirect_ruleset_id`; variable interpolation in import-block `id` is supported on Terraform >= 1.6 (pinned in `versions.tf`), and both the zone-id and ruleset-id vars are plan-time-known. Transitional (parallels `moved.tf`) — removable once the entrypoints are in state and a clean + idempotent apply is observed.
- **`terraform/cloudflare/variables.tf`** — new `net_redirect_ruleset_id` / `org_redirect_ruleset_id` (`default = ""`). The empty default keeps the no-vars `validate` job (`terraform validate -backend=false`) green; CI discovery supplies non-empty values for plan/apply, where an empty import id would error at plan time.
- **`.github/workflows/terraform.yml`** — a `Discover redirect ruleset IDs` step in **both** `plan-cloudflare` and `apply-cloudflare`. It queries `GET /zones/<zone_id>/rulesets`, selects the `http_request_dynamic_redirect` entrypoint id via `jq`, and exports `TF_VAR_*` to `$GITHUB_ENV`. The `CLOUDFLARE_API_TOKEN` stays in CI. It runs **before** plan because an empty import id errors at plan, not just apply; it hard-fails with a diagnostic if no entrypoint is found.
- **`terraform/cloudflare/redirects.tf`** — corrected the misleading comment claiming "token scope already covers all three zones per owner setup in W10" (token scope was actually extended in #347, not pre-existing) and documented the import-not-create rationale.

## Why discovery runs in BOTH plan and apply

`import {}` block ids are evaluated at **plan** time. An empty id errors there, so `Plan (cloudflare)` (a PR-time gate) would break if discovery ran apply-only. The `validate` job runs no plan and passes no vars, so the empty default is fine there.

## Idempotency (acceptance criterion)

`import {}` is **config-driven import**: Terraform consults an import block only for a resource address that is **not yet in state**. The first `apply-cloudflare` run binds `canonical_redirect["net"]`/`["org"]` to the discovered entrypoint rulesets and writes them to state. On every subsequent run:

- The resources are now in state, so Terraform **ignores** the import blocks entirely — no re-import is attempted (no "Resource already managed" error, no churn).
- The plan compares the in-state entrypoint against the desired config in `redirects.tf`. Because the first apply already converged the entrypoint to that exact rule (action `redirect`, the `concat(...)` `target_url` expression, `expression = "true"`), a clean re-run shows **no diff**.

So the import blocks are a one-time adoption mechanism, not a recurring operation — they are inert once state exists. This is also why they are safe to delete in a follow-up PR (same transitional pattern as `moved.tf`): with the rulesets already in state, removing the blocks changes nothing. The "no spurious diff, no re-import" check is item 3 of the post-merge Test Plan below.

## Verification

- `terraform fmt -check -recursive terraform/` — clean
- `terraform validate` (cloudflare, `-backend=false`) — `Success! The configuration is valid.` (import blocks + new vars parse)
- `actionlint .github/workflows/terraform.yml` (with shellcheck 0.10 on PATH) — clean
- tflint / checkov: deferred to CI (not installed locally); changes add no new resource attributes, providers, or backend args those scanners gate on. CI run confirms `TFLint (terraform/cloudflare)` + `Checkov` green.

## Post-merge Test Plan (NOT PR-time acceptance — production environment approval gate)

These run after merge, behind the `production` environment approval gate, and are **not** claimed done by this PR:

1. `apply-cloudflare` job: discovery resolves both ruleset IDs → `terraform apply` imports both entrypoints and converges them to the redirect rule (no "already exists" error).
2. Live 301 verification: `curl -sI https://noorinalabs.net/some/path?x=1` → `301` to `https://noorinalabs.com/some/path?x=1` (path + query preserved); same for `.org` and for plain `http://`.
3. Idempotent re-apply: a second `apply` shows no spurious diff and no re-import attempt (see Idempotency section above for the mechanism).

Closes #348
