### PR TITLE
fix(cloudflare): redirect target_url uses http.request.uri, drop unsupported if/len (Refs #348)

### DIFF
--- a/terraform/cloudflare/redirects.tf
+++ b/terraform/cloudflare/redirects.tf
@@ -83,15 +83,24 @@ resource "cloudflare_ruleset" "canonical_redirect" {
     action_parameters {
       from_value {
         status_code = 301
-        # Dynamic target: concatenate canonical host with the incoming
-        # request's path, and append `?<query>` only when a query string
-        # is present. Cloudflare's `wirefilter` expression dialect supports
-        # `concat()`, `if()`, and the `http.request.uri.{path,query}` fields.
-        # Expression-based `target_url` already covers query preservation,
+        # Dynamic target: concatenate the canonical host with the incoming
+        # request's URI. Cloudflare's `http.request.uri` field is the path
+        # AND query string together (e.g. `/foo?x=1`), so a single concat()
+        # preserves both with no conditional — there is no need to glue path
+        # and query back together by hand.
+        #
+        # The earlier form used `if()`/`len()` and `http.request.uri.{path,
+        # query}`, but Cloudflare's redirect target_url expression language
+        # does NOT support `if()`/`len()` (they are not in the redirect
+        # expression function set). The CF API rejected it at apply time with
+        # "Filter parsing error … unknown identifier" — the plan can't catch
+        # this because CF validates the expression only at apply (#348).
+        #
+        # Expression-based `target_url` covers query preservation inherently,
         # so the separate `preserve_query_string` boolean is intentionally
         # omitted (it applies only to static `target_url.value` redirects).
         target_url {
-          expression = "concat(\"https://noorinalabs.com\", http.request.uri.path, if(len(http.request.uri.query) > 0, concat(\"?\", http.request.uri.query), \"\"))"
+          expression = "concat(\"https://noorinalabs.com\", http.request.uri)"
         }
       }
     }


### PR DESCRIPTION
## Summary

Follow-up to #349. The prod apply (run 26366264633) **successfully imported** both `.net`/`.org` dynamic-redirect phase entrypoints into Terraform state, then **failed** while converging the redirect rule:

```
value expression: Filter parsing error (1:58)
concat("https://noorinalabs.com", http.request.uri.path,
if(len(http.request.uri.query) > 0, concat("?", http.request.uri.query), ...
                                        ^^ unknown identifier
```

**Root cause:** the `target_url` expression (carried over unchanged from the original #166 code) uses `if()` / `len()`, which Cloudflare's **redirect target_url expression language does not support**. Earlier applies never reached expression validation — they died at the "a similar configuration already exists" stage — so this was only exposed once the import let the apply proceed. The plan cannot catch it: CF validates the `target_url` expression **only at apply time**.

## Fix

Cloudflare's `http.request.uri` field is the **path AND query string** together (per the [Ruleset Engine fields reference](https://developers.cloudflare.com/ruleset-engine/rules-language/fields/reference/http.request.uri/) — *"The URI path and query string of the request"*). So a single `concat()` preserves both with no conditional:

```hcl
expression = "concat(\"https://noorinalabs.com\", http.request.uri)"
```

Also rewrote the inline comment block (`redirects.tf`) that previously documented the `if()`/`len()` reasoning, replacing it with the `http.request.uri` rationale and a note that CF rejects `if()`/`len()` in redirect expressions.

## State note (import already done)

The import landed in state during run 26366264633, so the new plan should show **0 to import** — only the in-place `~` change to the rule's `target_url` expression (and description). If the CI discovery step re-runs and the import block re-appears, that is idempotent and harmless (Terraform consults `import {}` only for addresses not yet in state).

## Verification

- `terraform fmt -check -recursive terraform/` — clean
- `terraform validate` (cloudflare, `-backend=false`) — `Success! The configuration is valid.`
- tflint / checkov / actionlint — deferred to CI; confirmed via statusCheckRollup before review.

## Post-merge Test Plan (NOT PR-time acceptance — production environment approval gate)

Behind the `production` environment approval gate, **not** claimed done here:

1. `apply-cloudflare`: rule converges in place — **0 to destroy**, plan shows only the in-place `target_url` change.
2. Live 301 verification: `curl -sI https://noorinalabs.net/some/path?x=1` → `301` to `https://noorinalabs.com/some/path?x=1` (path + query preserved); same for `.org` and plain `http://`.
3. Idempotent re-apply: a second `apply` shows no diff.

`#348` is closed on **verified-live** (post-apply curl), not on merge — hence `Refs`, not `Closes`.

Refs #348
