### PR TITLE
tech-debt(terraform): plan-time non-empty validation on required vars (#346)

### DIFF
--- a/terraform/BACKEND.md
+++ b/terraform/BACKEND.md
@@ -47,6 +47,44 @@ The classic failure mode (which directly motivated this doc — see deploy#23 an
 
 **Use the plural `endpoints = { s3 = ... }` form everywhere. tflint's terraform-recommended preset (wired in `.github/workflows/terraform.yml`'s `tflint` job as of deploy#23) catches mismatches at PR-time.**
 
+## Required variables must not be empty (plan-time guard)
+
+**Every required variable (no `default`) MUST carry a non-empty `validation` block so that emptiness fails at `terraform plan` in CI — never at `apply` against the live provider.**
+
+```hcl
+variable "noorinalabs_net_zone_id" {
+  description = "Cloudflare Zone ID for noorinalabs.net (canonical-domain redirect target zone)."
+  type        = string
+  validation {
+    condition     = length(trimspace(var.noorinalabs_net_zone_id)) > 0
+    error_message = "noorinalabs_net_zone_id must not be empty — set repo Actions variable CLOUDFLARE_NOORINALABS_NET_ZONE_ID."
+  }
+}
+```
+
+The `error_message` MUST name the **source** (the repo Actions secret/variable or env-protected secret that feeds the `TF_VAR_*`) so a CI failure tells the operator exactly what to set.
+
+The classic failure mode this guards against (deploy#346; originating PR #344 partial prod apply, 2026-05-20):
+
+1. A variable is declared *required* (no `default`), but is wired in CI from a repo Actions variable that was never created — so `TF_VAR_…` resolves to an **empty string**.
+2. An empty string still satisfies "required" — Terraform errors only on an *unset* required variable, not an empty-but-set one.
+3. `terraform plan` passes clean in CI; the gap bites only at `apply`, where the provider rejects the malformed call (an empty `noorinalabs_net_zone_id` produced `/zones//rulesets` → "Could not route … perhaps your object identifier is invalid?").
+4. Result: a partial prod apply on a class of error a plan-time guard would have caught in the PR.
+
+Note: `terraform validate -backend=false` (the CI `validate` job, which passes no vars) does **not** evaluate `validation` conditions — so adding these blocks does not break the no-vars validate job. They fire at `plan`/`apply`, exactly where the empty value would otherwise slip through.
+
+### Exemption — CI-wired vars that resolve to `default=""` in real plans
+
+A small set of credential/config variables carry `default = ""` and are intentionally empty in real CI plans/applies — a hard non-empty guard on them would break the existing green `plan` job (which does not thread them in as `TF_VAR_*`). These are exempt; document which and why in the variable's `description`. Current exemptions:
+
+| Variable(s) | Why exempt |
+|---|---|
+| `ghcr_auth_b64`, `user_postgres_password`, `user_redis_password`, `user_service_jwt_secret` (hetzner env roots + `hetzner-vps` module) | Never wired as `TF_VAR_*` in the hetzner `plan`/`apply` jobs (only `TF_VAR_hcloud_token` is); consumed as cloud-init template fields that tolerate empty. The module's `user_*` keep their `== "" \|\| length >= N` allow-empty validation. |
+| `deploy_ssh_public_key_path`, `root_ssh_public_key_path` (hetzner env roots + module) | Carry meaningful checked-in-pubkey defaults so cold-rebuild/CI provisions without an operator-local path (ADR 0006). |
+| `net_redirect_ruleset_id`, `org_redirect_ruleset_id` (cloudflare) | CI-discovered at plan/apply time; `default=""` so the no-var `validate` job parses. |
+
+Any new exemption requires an explicit rationale in the variable's `description`.
+
 ## Required CI credentials
 
 The four root modules all read auth from the same env-var pair:
@@ -67,7 +105,8 @@ One bucket, separate state keys keeps the `terraform_remote_state` data sources 
 1. Create `terraform/<module>/versions.tf` (or `backend.tf`) with the block above; pick a unique state key.
 2. Add the module path to `.github/workflows/terraform.yml`'s `validate`, `tflint`, and `plan-<module>` / `apply-<module>` jobs.
 3. Wire any per-module provider creds via `TF_VAR_*` in the workflow `env:` block.
-4. If the new module needs to read sibling state, use `data "terraform_remote_state"` pointing at the same bucket — no extra auth needed.
+4. Add a non-empty `validation` block to every required (no-`default`) variable, with a source-naming `error_message` (see "Required variables must not be empty" above). Document any `default=""` exemption in the variable's `description`.
+5. If the new module needs to read sibling state, use `data "terraform_remote_state"` pointing at the same bucket — no extra auth needed.
 
 ## Pre-existing checkov skips
 

--- a/terraform/backblaze/variables.tf
+++ b/terraform/backblaze/variables.tf
@@ -2,12 +2,22 @@ variable "b2_application_key_id" {
   description = "Backblaze B2 master application key ID (for provider auth; create in B2 console)"
   type        = string
   sensitive   = true
+
+  validation {
+    condition     = length(trimspace(var.b2_application_key_id)) > 0
+    error_message = "b2_application_key_id must not be empty — set repo Actions secret B2_MASTER_KEY_ID (wired as TF_VAR_b2_application_key_id in the Plan/Apply (backblaze) jobs)."
+  }
 }
 
 variable "b2_application_key" {
   description = "Backblaze B2 master application key (for provider auth; create in B2 console)"
   type        = string
   sensitive   = true
+
+  validation {
+    condition     = length(trimspace(var.b2_application_key)) > 0
+    error_message = "b2_application_key must not be empty — set repo Actions secret B2_MASTER_APP_KEY (wired as TF_VAR_b2_application_key in the Plan/Apply (backblaze) jobs)."
+  }
 }
 
 variable "bucket_name" {

--- a/terraform/cloudflare/variables.tf
+++ b/terraform/cloudflare/variables.tf
@@ -2,11 +2,21 @@ variable "cloudflare_api_token" {
   description = "Cloudflare API token with Zone:DNS:Edit, Zone:Zone Settings:Edit, Zone:Zone:Read."
   type        = string
   sensitive   = true
+
+  validation {
+    condition     = length(trimspace(var.cloudflare_api_token)) > 0
+    error_message = "cloudflare_api_token must not be empty — set repo Actions secret CLOUDFLARE_API_TOKEN (wired as TF_VAR_cloudflare_api_token in the Plan/Apply (cloudflare) jobs)."
+  }
 }
 
 variable "cloudflare_zone_id" {
   description = "Cloudflare Zone ID for noorinalabs.com."
   type        = string
+
+  validation {
+    condition     = length(trimspace(var.cloudflare_zone_id)) > 0
+    error_message = "cloudflare_zone_id must not be empty — set repo Actions variable CLOUDFLARE_ZONE_ID (wired as TF_VAR_cloudflare_zone_id in the Plan/Apply (cloudflare) jobs)."
+  }
 }
 
 # Defensive-TLD zone IDs — `.net` and `.org` are dark zones owned for
@@ -17,11 +27,21 @@ variable "cloudflare_zone_id" {
 variable "noorinalabs_net_zone_id" {
   description = "Cloudflare Zone ID for noorinalabs.net (canonical-domain redirect target zone)."
   type        = string
+
+  validation {
+    condition     = length(trimspace(var.noorinalabs_net_zone_id)) > 0
+    error_message = "noorinalabs_net_zone_id must not be empty — set repo Actions variable CLOUDFLARE_NOORINALABS_NET_ZONE_ID (wired as TF_VAR_noorinalabs_net_zone_id in the Plan/Apply (cloudflare) jobs). An empty zone id produced the malformed /zones//rulesets call in the PR #344 partial prod apply."
+  }
 }
 
 variable "noorinalabs_org_zone_id" {
   description = "Cloudflare Zone ID for noorinalabs.org (canonical-domain redirect target zone)."
   type        = string
+
+  validation {
+    condition     = length(trimspace(var.noorinalabs_org_zone_id)) > 0
+    error_message = "noorinalabs_org_zone_id must not be empty — set repo Actions variable CLOUDFLARE_NOORINALABS_ORG_ZONE_ID (wired as TF_VAR_noorinalabs_org_zone_id in the Plan/Apply (cloudflare) jobs). An empty zone id produced the malformed /zones//rulesets call in the PR #344 partial prod apply."
+  }
 }
 
 variable "domain" {

--- a/terraform/hetzner/envs/prod/variables.tf
+++ b/terraform/hetzner/envs/prod/variables.tf
@@ -2,6 +2,11 @@ variable "hcloud_token" {
   description = "Hetzner Cloud API token."
   type        = string
   sensitive   = true
+
+  validation {
+    condition     = length(trimspace(var.hcloud_token)) > 0
+    error_message = "hcloud_token must not be empty — set the HCLOUD_TOKEN secret in the 'production' environment (wired as TF_VAR_hcloud_token in the Plan/Apply (hetzner/prod) jobs)."
+  }
 }
 
 variable "deploy_ssh_public_key_path" {

--- a/terraform/hetzner/envs/stg/variables.tf
+++ b/terraform/hetzner/envs/stg/variables.tf
@@ -2,6 +2,11 @@ variable "hcloud_token" {
   description = "Hetzner Cloud API token."
   type        = string
   sensitive   = true
+
+  validation {
+    condition     = length(trimspace(var.hcloud_token)) > 0
+    error_message = "hcloud_token must not be empty — set the HCLOUD_TOKEN secret in the 'staging' environment (wired as TF_VAR_hcloud_token in the Plan/Apply (hetzner/stg) jobs)."
+  }
 }
 
 variable "deploy_ssh_public_key_path" {

--- a/terraform/hetzner/modules/hetzner-vps/variables.tf
+++ b/terraform/hetzner/modules/hetzner-vps/variables.tf
@@ -11,6 +11,11 @@ variable "env" {
 variable "server_type" {
   description = "Hetzner Cloud server type (e.g., cpx21, cpx41)."
   type        = string
+
+  validation {
+    condition     = length(trimspace(var.server_type)) > 0
+    error_message = "server_type must not be empty — set it in the module call from the env root (terraform/hetzner/envs/<env>/main.tf, e.g. server_type = \"cpx41\")."
+  }
 }
 
 variable "location" {


### PR DESCRIPTION
## Summary

Closes #346. Establishes plan-time fail-fast for the **empty-required-variable** class: a required TF variable (no `default`) is satisfied by an empty STRING — TF errors only on an *unset* required var, not an empty-but-set one. That let an empty `noorinalabs_net_zone_id` pass `terraform plan` clean in CI and only break at `apply` against Cloudflare (`/zones//rulesets`), causing the PR #344 partial prod apply (2026-05-20).

Adds `length(trimspace(var.X)) > 0` validation blocks — mirroring the existing `env` / `user_*` prior art in `hetzner-vps/variables.tf` — to every **required (no-default)** variable across all roots/modules. Each `error_message` names the source (repo Actions secret/var or env-protected secret) that feeds the variable, so a CI failure is self-diagnosing.

## Variables guarded

| Root | Variables |
|------|-----------|
| `terraform/backblaze` | `b2_application_key_id`, `b2_application_key` |
| `terraform/cloudflare` | `cloudflare_api_token`, `cloudflare_zone_id`, `noorinalabs_net_zone_id`, `noorinalabs_org_zone_id` |
| `terraform/hetzner/envs/stg` | `hcloud_token` |
| `terraform/hetzner/envs/prod` | `hcloud_token` |
| `terraform/hetzner/modules/hetzner-vps` | `server_type` |

## Variables deliberately NOT guarded (audited — meaningful empty default)

Guarding these would **break the existing green hetzner Plan CI job**, violating #346's own "existing Plan jobs still green" criterion:

- `ghcr_auth_b64`, `user_postgres_password`, `user_redis_password`, `user_service_jwt_secret` — never wired as `TF_VAR_*` in the hetzner Plan **or** Apply jobs (only `TF_VAR_hcloud_token` is). They resolve to `default = ""` in every real CI plan/apply and are consumed as cloud-init template fields that tolerate empty. The module's existing `user_*` validations keep their `== "" || length >= N` (allow-empty) shape for the same reason.
- `deploy_ssh_public_key_path`, `root_ssh_public_key_path` (per #351 SSH split — these replaced the old single `ssh_public_key_path`) — carry meaningful checked-in-pubkey defaults so cold-rebuild/CI provisions without an operator-local path.
- `net_redirect_ruleset_id`, `org_redirect_ruleset_id` — CI-discovered, intentionally `default = ""` so the no-var `validate` job parses.

## Evidence the guard fires at plan-time

Empirically verified with a local-backend override (then reverted) on the cloudflare root — an empty `noorinalabs_net_zone_id` (the exact #344 var) now errors at `terraform plan`:

```
Error: Invalid value for variable
  on variables.tf line 27, in variable "noorinalabs_net_zone_id":
    var.noorinalabs_net_zone_id is ""
noorinalabs_net_zone_id must not be empty — set repo Actions variable
CLOUDFLARE_NOORINALABS_NET_ZONE_ID ... An empty zone id produced the
malformed /zones//rulesets call in the PR #344 partial prod apply.
```

Also confirmed `terraform validate -backend=false` does **not** evaluate validation conditions (TF 1.14), so the CI `Validate` job — which passes no vars — stays green for all five roots.

## Validation run locally

- `terraform fmt -check -recursive terraform/` — clean
- `terraform validate` — Success in all five roots (backblaze, cloudflare, hetzner/envs/stg, hetzner/envs/prod, hetzner-vps module)

## Out of scope / follow-up

The #346 acceptance criterion "document the general no-empty-required-vars rule in terraform docs / CLAUDE.md infra conventions" is **deferred** — my spawn brief scoped me to `terraform/**/variables.tf` only (no CLAUDE.md / docs edits). Flagging for the team lead to route the doc-codification as a small follow-up.

The Cloudflare API-token ruleset-scope gap (`Authentication error (10000)`) remains a separate operational issue per #346.

TechDebt: removes — closes the empty-required-var plan/apply gap class.
