### PR TITLE
infra(cloud-init): close 3 bootstrap-vps.sh parity gaps (#328 #329 #330)

### DIFF
--- a/terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl
+++ b/terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl
@@ -196,6 +196,49 @@ runcmd:
   - chown deploy:deploy /var/lib/node_exporter/textfile_collector
   - chmod 0755 /var/lib/node_exporter/textfile_collector
 
+  # Pre-provision aux-repo dirs under /opt/ (#163 followup gap 1/3, deploy#328).
+  # /opt/ is root-owned by default, so the deploy workflow
+  # (.github/workflows/deploy-isnad-graph.yml) `git clone` as the deploy user
+  # fails without these dirs existing first with deploy:deploy ownership.
+  # Mirrors scripts/bootstrap-vps.sh Step 4 (AUX_REPOS); a strictly-cloud-init'd
+  # box now matches a bootstrapped one. Same mkdir+chown shape as the
+  # node_exporter triplet above.
+  - mkdir -p /opt/noorinalabs-isnad-graph
+  - chown deploy:deploy /opt/noorinalabs-isnad-graph
+  - mkdir -p /opt/noorinalabs-design-system
+  - chown deploy:deploy /opt/noorinalabs-design-system
+
+  # Install the systemd backup unit set (#163 followup gap 2/3, deploy#329).
+  # Transcribed from scripts/bootstrap-vps.sh Step 5. The source files live
+  # under /opt/noorinalabs-deploy/systemd/, so this MUST run after the
+  # `git clone .../noorinalabs-deploy` step above (cloud-init runcmd is ordered)
+  # — otherwise the install targets don't exist yet. Without this, backups
+  # never run on a strictly-cloud-init'd box (silent failure; deploy#121 class).
+  # The tmpfiles.d staging dir is created before daemon-reload so the unit's
+  # ReadWritePaths=/var/lib/noorinalabs-backups namespace setup succeeds
+  # (deploy#121 Bug A: 226/NAMESPACE before ExecStart). The failure-marker
+  # unit's .prom output dir (/var/lib/node_exporter/textfile_collector) is
+  # already provisioned by the node_exporter triplet above.
+  - install -m 644 /opt/noorinalabs-deploy/systemd/isnad-backup.service /etc/systemd/system/
+  - install -m 644 /opt/noorinalabs-deploy/systemd/isnad-backup.timer /etc/systemd/system/
+  - install -m 644 /opt/noorinalabs-deploy/systemd/isnad-backup-failure-marker.service /etc/systemd/system/
+  - install -m 644 /opt/noorinalabs-deploy/systemd/tmpfiles.d/noorinalabs-backups.conf /etc/tmpfiles.d/
+  - systemd-tmpfiles --create /etc/tmpfiles.d/noorinalabs-backups.conf
+  - systemctl daemon-reload
+  - systemctl enable isnad-backup.timer
+
+  # Allow root to git-operate on the deploy-owned /opt/ repos (#163 followup
+  # gap 3/3, deploy#330). git 2.35+ (CVE-2022-24765) refuses to run as root
+  # against a deploy-owned working tree with "detected dubious ownership"; any
+  # root-run `git fetch`/`git reset` (e.g. a bootstrap-vps.sh re-run, recovery)
+  # then fails. MUST come after the aux-repo dirs are created above so the paths
+  # exist. `--system` (not `--global`, which is per-user $HOME) because root may
+  # not be the only user invoking git against these from a script. Mirrors
+  # scripts/bootstrap-vps.sh Step 2; git's --add dedups so re-runs are safe.
+  - git config --system --add safe.directory /opt/noorinalabs-deploy
+  - git config --system --add safe.directory /opt/noorinalabs-isnad-graph
+  - git config --system --add safe.directory /opt/noorinalabs-design-system
+
   # Enable automatic security updates
   - systemctl enable unattended-upgrades
   - systemctl start unattended-upgrades


### PR DESCRIPTION
## Summary

PR #327's audit of `scripts/bootstrap-vps.sh` against `cloud-init.yaml.tpl` surfaced **3 parity gaps** that keep a strictly-cloud-init'd VPS from matching a bootstrapped one. All three live in the **same file** (`terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl`, `runcmd:` block), so they ship in **one PR** to avoid self-collision. Added in dependency order:

| Gap | Issue | What | Mirrors |
|---|---|---|---|
| 1/3 | #328 | Pre-provision `/opt/noorinalabs-isnad-graph` + `/opt/noorinalabs-design-system` as `deploy:deploy` | bootstrap Step 4 |
| 2/3 | #329 | Install systemd backup unit set + tmpfiles.d staging dir + `daemon-reload` + `enable isnad-backup.timer` | bootstrap Step 5 |
| 3/3 | #330 | `git config --system --add safe.directory` for the three `/opt/` repos | bootstrap Step 2 |

## Ordering (cloud-init `runcmd:` is sequential)

The three blocks are placed after the existing `git clone .../noorinalabs-deploy` step and the `node_exporter` triplet, in this order:

1. **#328 aux-repo dirs** — `mkdir -p` + `chown deploy:deploy` (same shape as the node_exporter mkdir+chown triplet). The deploy workflow (`.github/workflows/deploy-isnad-graph.yml`) `git clone`s into these as the `deploy` user; `/opt/` is root-owned by default, so this fails without the pre-created dirs.
2. **#329 systemd backup timer** — must come **after** the git-clone step because the unit source files live under `/opt/noorinalabs-deploy/systemd/`. The tmpfiles.d staging dir is created (`systemd-tmpfiles --create`) before any timer fire so the unit's `ReadWritePaths=/var/lib/noorinalabs-backups` namespace setup succeeds (deploy#121 Bug A: `226/NAMESPACE` before ExecStart). The failure-marker unit's `.prom` output dir (`/var/lib/node_exporter/textfile_collector`) is already provisioned by the existing node_exporter triplet, so it's not duplicated. Without this gap closed, **backups never run** on a strictly-cloud-init'd box (silent failure; deploy#121 class).
3. **#330 safe.directory** — must come **after** #328's dir creation (the issue's stated dependency). git 2.35+ (CVE-2022-24765) refuses to run as root against a deploy-owned working tree (`detected dubious ownership`); any root-run `git fetch`/`reset` (bootstrap re-run, recovery) then fails. Uses `--system` (not `--global`, which is per-user `$HOME`) because root may not be the only user invoking git against these paths from a script. git's `--add` dedups, so re-runs are idempotent.

## IMPORTANT — creation-time-only (ADR 0003)

cloud-init `user_data` is **creation-time-only** on Hetzner (`lifecycle { ignore_changes = [user_data] }`, ADR 0003). These `runcmd:` additions take effect on the **next provision/rebuild**, NOT on a live box. Live boxes need `taint`/`replace` per [`docs/runbooks/cloud-init-template-changes.md`](docs/runbooks/cloud-init-template-changes.md), or the equivalent steps applied manually. **This PR delivers template correctness (unit-mechanic), not a live apply** — the per-issue acceptance criteria that require a real provision (fresh-box `git config --system --get-all safe.directory`, first-backup-window B2 upload) are verified at the next rebuild, not by this PR.

## Validation

- `terraform validate` (hetzner-vps module) — **Success**.
- `templatefile(...)` render via `terraform console` — renders to **valid YAML** (top keys intact; 36 `runcmd` entries; all new entries parse as list items: aux-repo mkdir/chown ×2, systemd install ×4 + tmpfiles-create + daemon-reload + enable, safe.directory ×3).
- All four referenced systemd source files exist in `systemd/` (`isnad-backup.service`, `isnad-backup.timer`, `isnad-backup-failure-marker.service`, `tmpfiles.d/noorinalabs-backups.conf`).
- `cold_rebuild_static_checks.py` — terraform/SSH/promote/stg-verify guards all `[OK]`. The sole local `[FAIL]` is the unrelated `db-migrate-pyproject-resolvable` check, which needs the CI-provided sibling user-service `pyproject.toml` (`USER_SERVICE_PYPROJECT=''` not resolvable in a module-only local run) — resolves in CI.

## Follow-up

Once all three gaps land, `scripts/bootstrap-vps.sh` Steps 2/4/5 become no-ops on fresh boxes — bootstrap stays useful only for pre-cloud-init VPSes (decom tracked in #86). Deleting bootstrap entirely is out of scope here.

## Tech debt

**Removes** — closes the three cloud-init/bootstrap parity gaps that PR #327's audit surfaced.

Closes #328
Closes #329
Closes #330

## Reviewers
- Lucas Ferreira (primary)
- Weronika Zielinska (secondary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
