### PR TITLE
tech-debt(infra): implement ADR 0005 state-locking — GH Actions concurrency (#334)

### DIFF
--- a/.github/workflows/terraform-lock-smoke.yml
+++ b/.github/workflows/terraform-lock-smoke.yml
@@ -1,0 +1,64 @@
+# Lock-smoke — ADR 0005 (#334) proof that the apply concurrency-group serializes.
+#
+# This is NOT part of the normal terraform.yml lifecycle. It is dispatched
+# manually (twice in rapid succession) to demonstrate that two runs sharing a
+# concurrency group queue (same key → serialize) while two runs with distinct
+# keys run in parallel (different key → no false serialization).
+#
+# How to exercise (and link the run pair in the #334 PR body):
+#   # same key → the second run shows "pending" (queued) until the first ends
+#   gh workflow run terraform-lock-smoke.yml -f concurrency_key=hetzner-stg -f run_label=same-a
+#   gh workflow run terraform-lock-smoke.yml -f concurrency_key=hetzner-stg -f run_label=same-b
+#   # different key → both run immediately, in parallel
+#   gh workflow run terraform-lock-smoke.yml -f concurrency_key=cloudflare-prod -f run_label=diff
+#
+# The concurrency group below mirrors the SHAPE used by the real apply jobs in
+# terraform.yml: "terraform-apply-<key>". cancel-in-progress:false matches the
+# queue-and-wait (never cancel mid-apply) semantics ADR 0005 § Decision chose.
+
+name: Terraform lock-smoke (ADR 0005)
+
+on:
+  workflow_dispatch:
+    inputs:
+      concurrency_key:
+        description: "Concurrency key suffix (e.g. hetzner-stg, cloudflare-prod). Same value across two dispatches → they serialize."
+        required: true
+        type: string
+      run_label:
+        description: "Label echoed into the apply log to correlate a run with its dispatch."
+        required: false
+        type: string
+        default: "smoke"
+      hold_seconds:
+        description: "Seconds the apply holds so a same-key second run visibly queues."
+        required: false
+        type: string
+        default: "45"
+
+# The serialization mechanism under test. Keyed on the dispatch input so the
+# operator controls same-key vs different-key. Real apply jobs in terraform.yml
+# use the same "terraform-apply-<root>-<env>" shape.
+concurrency:
+  group: "terraform-apply-${{ github.event.inputs.concurrency_key }}"
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: lock-smoke (${{ github.event.inputs.concurrency_key }} / ${{ github.event.inputs.run_label }})
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: terraform/_lock-smoke
+    steps:
+      - uses: actions/checkout@v6
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~> 1.6"
+      - name: Init (local backend)
+        run: terraform init -backend=false
+      - name: Apply
+        run: |
+          terraform apply -auto-approve \
+            -var "run_label=${{ github.event.inputs.run_label }}" \
+            -var "hold_seconds=${{ github.event.inputs.hold_seconds }}"

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -4,11 +4,13 @@ on:
     paths:
       - 'terraform/**'
       - '.github/workflows/terraform.yml'
+      - 'scripts/check_tf_apply_locking.py'
   push:
     branches: [main]
     paths:
       - 'terraform/**'
       - '.github/workflows/terraform.yml'
+      - 'scripts/check_tf_apply_locking.py'
   schedule:
     # Weekly Monday 14:00 UTC — catches rotation-drift that landed
     # between TF-touching PRs. Detection latency: <=7 days regardless
@@ -20,6 +22,24 @@ permissions:
   pull-requests: write
 
 jobs:
+  # Regression guard for ADR 0005 (#334): every `apply*` job in this workflow
+  # must carry a `terraform-apply-*` concurrency group with
+  # cancel-in-progress:false. Catches a future TF root added without the
+  # state-locking stanza — the silent-regression failure ADR 0005's
+  # failure-mode table names. Cheap (no creds), runs on every TF-touching PR.
+  lock-guard:
+    name: State-locking guard (ADR 0005)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install PyYAML
+        run: pip install pyyaml
+      - name: Assert apply jobs carry concurrency group
+        run: python3 scripts/check_tf_apply_locking.py
+
   validate-creds:
     # Detects rotation-drift between the `staging` and `production` GH
     # Environments for shared B2 state-bucket credentials + per-env
@@ -344,6 +364,17 @@ jobs:
     needs: [validate, tflint, checkov]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
+    # State-locking per ADR 0005 (#334): serialize concurrent applies to the
+    # same B2 state file. Keyed per-root, per-env so hetzner/stg and hetzner/prod
+    # (and cloudflare, backblaze) never serialize against each other. The
+    # matrix already runs stg-before-prod via max-parallel:1; this group
+    # additionally serializes across *separate workflow runs* (e.g. two pushes
+    # to main in rapid succession both touching hetzner/stg).
+    # cancel-in-progress:false → a second apply queues; it never cancels an
+    # in-flight apply (mid-apply cancellation risks partial state writes).
+    concurrency:
+      group: "terraform-apply-hetzner-${{ matrix.env }}"
+      cancel-in-progress: false
     strategy:
       fail-fast: false
       # Apply stg first, then prod — never both in parallel. Matches the
@@ -380,6 +411,12 @@ jobs:
     needs: [validate, tflint, checkov, apply]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
+    # State-locking per ADR 0005 (#334). cloudflare is a single prod-scoped
+    # root (no env matrix), so the key is fixed. cancel-in-progress:false →
+    # queue, never cancel mid-apply.
+    concurrency:
+      group: "terraform-apply-cloudflare-prod"
+      cancel-in-progress: false
     environment: production
     defaults:
       run:
@@ -441,6 +478,12 @@ jobs:
     needs: [validate, tflint, checkov]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
+    # State-locking per ADR 0005 (#334). backblaze is a single prod-scoped
+    # root (no env matrix), so the key is fixed. cancel-in-progress:false →
+    # queue, never cancel mid-apply.
+    concurrency:
+      group: "terraform-apply-backblaze-prod"
+      cancel-in-progress: false
     environment: production
     defaults:
       run:

--- a/docs/runbooks/terraform-workstation-apply.md
+++ b/docs/runbooks/terraform-workstation-apply.md
@@ -1,0 +1,118 @@
+# Runbook — workstation `terraform apply` discipline
+
+Source: [deploy#334](https://github.com/noorinalabs/noorinalabs-deploy/issues/334)
+(ADR 0005 implementation).
+Decision: [ADR 0005 — Terraform state-locking on the B2 backend](../adr/0005-terraform-state-locking-on-b2-backend.md).
+Composes with: [ADR 0004 § Decision A2](../adr/0004-b2-state-bucket-and-key-management.md)
+(B2 bucket versioning — the recovery backstop for the unlocked window),
+[state-bucket-lifecycle runbook](state-bucket-lifecycle.md).
+
+## Why this runbook exists
+
+ADR 0005 chose **Option D** — a GitHub Actions `concurrency:` group on the
+Terraform apply jobs — to serialize CI-initiated applies against the shared B2
+state files. That control has one load-bearing gap, named explicitly in the ADR:
+
+> **Operator-workstation apply bypasses the lock.** A `terraform apply` run from
+> an operator's workstation does not participate in GitHub Actions concurrency.
+
+B2's S3-compatible PUT is last-writer-wins; there is no native lock the
+workstation respects (see ADR 0005 § Context for why DynamoDB, `use_lockfile`,
+Postgres, and Consul backends were all rejected). So when a human runs
+`terraform apply` locally, **this procedure is the only thing preventing a
+concurrent-write state corruption.** Follow it every time.
+
+This is procedural protection, not a technical control — the same shape as
+ADR 0004 § Decision D's master-key constraint. It is acceptable because the
+operator class is small, workstation-apply is the exception (CI is the norm),
+and B2 bucket versioning makes the failure recoverable. If the discipline
+fails in practice, that is an ADR 0005 **upgrade trigger** (see below).
+
+## Who may run a workstation apply
+
+The authorized-operator class is the infrastructure roles on the
+`noorinalabs-deploy` team (`.claude/team/roster/`). As of this runbook:
+
+| Operator | Role |
+|---|---|
+| Bereket Tadesse | Infrastructure Manager |
+| Weronika Zielinska | Platform Architect |
+| Aisha Idrissi | SRE Engineer |
+| Lucas Ferreira | SRE Engineer |
+
+Keep this table in sync with the deploy team roster — it is the source of
+truth for who is in the announce-and-acknowledge loop in Step 2. If you are not
+on this list, do not run `terraform apply` from your workstation; open a PR and
+let CI apply.
+
+## The 4-step procedure
+
+Run these in order, every time, for any workstation `terraform apply` against
+`terraform/hetzner/envs/{stg,prod}/`, `terraform/cloudflare/`, or
+`terraform/backblaze/`.
+
+1. **Announce intent in `#deploy` before you apply.** Post the root module and
+   env, e.g. `manual apply incoming: terraform/cloudflare (prod) — adding www
+   CNAME, ETA ~5min`. The announcement is what gives other operators the chance
+   to say "wait, I'm mid-apply."
+
+2. **Wait for acknowledgement from any other active operator.** If another
+   operator is active, wait for an explicit ack before proceeding. **No
+   acknowledgement after 10 minutes = proceed**, and post a follow-up in
+   `#deploy` noting you proceeded on the timeout.
+
+3. **Check the GitHub Actions runs page for the affected root.** Open the
+   [Terraform workflow runs](https://github.com/noorinalabs/noorinalabs-deploy/actions/workflows/terraform.yml).
+   If an `Apply (<root>)` job is mid-run for the root you are about to touch,
+   **wait for it to finish** — the CI apply holds the concurrency group, but
+   your workstation does not respect it, so you must respect it manually.
+
+4. **Post a completion note in `#deploy` after the apply finishes.** e.g.
+   `manual apply done: terraform/cloudflare (prod), no drift`. This closes the
+   loop so the next operator's Step 1 announcement has accurate context.
+
+## If you suspect a concurrent-write corruption
+
+Symptoms: a `terraform plan` immediately after an apply shows unexpected drift
+(resources you just created appear as "to add" again), a `taint` cascade, or a
+partial apply that left resources live but absent from state. The B2 bucket
+version count for the affected `*.tfstate` object showing two writes seconds
+apart is the smoking gun (see [state-bucket-lifecycle](state-bucket-lifecycle.md)
+for the object/version layout).
+
+Recovery path (B2 bucket versioning is enabled per
+[ADR 0004 § Decision A2](../adr/0004-b2-state-bucket-and-key-management.md)):
+
+1. **Stop all applies.** Announce a freeze in `#deploy`; do not let CI or any
+   workstation apply the affected root until recovery is complete.
+2. **Identify the affected state object and its versions.** In the B2 console
+   (or via the S3 API against the `noorinalabs-terraform-state` bucket), list
+   the versions of the affected key — e.g. `cloudflare/terraform.tfstate`,
+   `hetzner/prod.tfstate`. The two rapid writes are the corruption signature.
+3. **Restore the pre-corruption version.** Promote the last-good version of the
+   state object (the one written *before* the racing pair) back to current.
+   Keep the corrupted version — do not delete it; it is evidence and may hold
+   resource IDs the good version lost.
+4. **Plan for drift against real infrastructure.** Run `terraform plan` for the
+   affected root. The plan now reconciles restored-state vs. what is actually
+   live. Expect to see the lost apply's resources as drift.
+5. **Reconcile manually.** Depending on the drift, either `terraform import` the
+   live-but-unstated resources back into state, or `terraform apply` to converge
+   — done by a single operator, with the freeze still in place, following Steps
+   1–4 above for that apply.
+6. **Post a `#deploy` postmortem** and evaluate the ADR 0005 upgrade trigger: a
+   corruption that happened *despite* this discipline means the discipline
+   failed, which ADR 0005 names as the escalation condition to a technical
+   control (Option B — HCP Terraform).
+
+## ADR 0005 upgrade triggers (when procedure is no longer enough)
+
+Per ADR 0005 § Decision, escalate from this procedural control to Option B
+(HCP Terraform native locking) and supersede ADR 0005 if any of:
+
+- The active TF-operator count grows past 3 (this roster already sits at 4 —
+  flag at the next infra review whether the coordination cost warrants the
+  upgrade now).
+- Workstation-apply moves from "exception" to "weekly or more."
+- A workstation-apply incident corrupts state even with this discipline in place.
+- A new TF root with a higher state-corruption blast radius lands.

--- a/scripts/check_tf_apply_locking.py
+++ b/scripts/check_tf_apply_locking.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Regression guard for ADR 0005 (#334) Terraform state-locking.
+
+Every Terraform *apply* job in .github/workflows/terraform.yml MUST carry a
+`concurrency:` block so concurrent applies to the same B2 state file serialize
+(ADR 0005 § Decision, Option D). A new TF root added without the stanza
+silently regresses to unlocked state — the failure ADR 0005's failure-mode
+table calls out ("a future PR adds a new TF root without the concurrency
+stanza"). This check makes that regression a CI failure instead of a silent gap.
+
+Rules enforced for each job whose id starts with `apply`:
+  1. Has a `concurrency` mapping (not the string short-form).
+  2. `concurrency.group` contains the `terraform-apply-` prefix.
+  3. `concurrency.cancel-in-progress` is explicitly false (queue, never cancel
+     mid-apply — partial state writes are dangerous).
+
+Exit 0 if all apply jobs comply; exit 1 with a per-job diagnostic otherwise.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+WORKFLOW = Path(__file__).resolve().parent.parent / ".github/workflows/terraform.yml"
+GROUP_PREFIX = "terraform-apply-"
+
+
+def main() -> int:
+    if not WORKFLOW.is_file():
+        print(f"::error::workflow not found: {WORKFLOW}")
+        return 1
+
+    doc = yaml.safe_load(WORKFLOW.read_text())
+    jobs = doc.get("jobs", {})
+    apply_jobs = {jid: spec for jid, spec in jobs.items() if jid.startswith("apply")}
+
+    if not apply_jobs:
+        # No apply jobs today (validate-only posture). Nothing to guard, but
+        # say so loudly so a reviewer notices if this is unexpected.
+        print("note: no `apply*` jobs found in terraform.yml — nothing to guard.")
+        return 0
+
+    failures: list[str] = []
+    for jid, spec in sorted(apply_jobs.items()):
+        conc = spec.get("concurrency")
+        if conc is None:
+            failures.append(f"{jid}: missing `concurrency:` block (ADR 0005 #334).")
+            continue
+        if not isinstance(conc, dict):
+            failures.append(
+                f"{jid}: `concurrency` must be a mapping with group + "
+                f"cancel-in-progress, got short-form string {conc!r}."
+            )
+            continue
+        group = str(conc.get("group", ""))
+        if GROUP_PREFIX not in group:
+            failures.append(
+                f"{jid}: concurrency.group {group!r} must contain "
+                f"{GROUP_PREFIX!r} (per-root, per-env key)."
+            )
+        if conc.get("cancel-in-progress") is not False:
+            failures.append(
+                f"{jid}: concurrency.cancel-in-progress must be explicitly "
+                f"false (queue, never cancel mid-apply); got "
+                f"{conc.get('cancel-in-progress')!r}."
+            )
+
+    if failures:
+        print("::error::Terraform apply locking guard FAILED (ADR 0005 / #334):")
+        for f in failures:
+            print(f"::error::  {f}")
+        print(
+            '::error::Add `concurrency: {group: "terraform-apply-<root>-<env>", '
+            "cancel-in-progress: false}` to each apply job. See "
+            "docs/adr/0005-terraform-state-locking-on-b2-backend.md."
+        )
+        return 1
+
+    print(
+        f"OK: all {len(apply_jobs)} apply job(s) carry a "
+        f"`terraform-apply-*` concurrency group with cancel-in-progress:false."
+    )
+    for jid, spec in sorted(apply_jobs.items()):
+        print(f"  - {jid}: group={spec['concurrency']['group']!r}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/terraform/_lock-smoke/main.tf
+++ b/terraform/_lock-smoke/main.tf
@@ -1,0 +1,55 @@
+# Lock-smoke root — ADR 0005 (#334) concurrency-group serialization proof.
+#
+# This root exists ONLY to exercise the GitHub Actions `concurrency:` group
+# that protects real Terraform applies (see .github/workflows/terraform-lock-smoke.yml).
+# It provisions NO real infrastructure: a single `null_resource` runs a local
+# `sleep` so a same-key second run observably queues behind the first, and a
+# different-key run observably parallelizes.
+#
+# Local backend on purpose — no B2 state, no credentials, no provider auth.
+# Not wired into the terraform.yml validate/tflint/plan/apply matrices; it is
+# only ever run by the dedicated lock-smoke workflow.
+
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
+  }
+}
+
+variable "hold_seconds" {
+  description = "Seconds the apply holds, so a same-concurrency-key second run visibly queues behind the first."
+  type        = number
+  default     = 45
+}
+
+variable "run_label" {
+  description = "Free-form label echoed into the apply log to correlate a run with its workflow dispatch (e.g. same-key-a / same-key-b / different-key)."
+  type        = string
+  default     = "unlabelled"
+
+  validation {
+    condition     = length(trimspace(var.run_label)) > 0
+    error_message = "run_label must not be empty."
+  }
+}
+
+resource "null_resource" "lock_smoke" {
+  # Re-run on every apply so two dispatched runs both do real work and the
+  # second cannot short-circuit as a no-op.
+  triggers = {
+    run_label = var.run_label
+    timestamp = timestamp()
+  }
+
+  provisioner "local-exec" {
+    command = "echo \"lock-smoke apply START label=${var.run_label} at $(date -u +%FT%TZ)\"; sleep ${var.hold_seconds}; echo \"lock-smoke apply END   label=${var.run_label} at $(date -u +%FT%TZ)\""
+  }
+}
+
+output "run_label" {
+  value = var.run_label
+}


### PR DESCRIPTION
## Summary

Closes #334. Implements **ADR 0005** (`docs/adr/0005-terraform-state-locking-on-b2-backend.md`) — **Option D**: a GitHub Actions `concurrency:` group on the Terraform apply jobs, paired with a workstation-apply discipline runbook. B2's S3-compatible PUT is last-writer-wins and offers no native lock (DynamoDB / `use_lockfile` / `pg` / `consul` backends all rejected in the ADR), so two concurrent applies to the same `*.tfstate` silently corrupt state. The concurrency group closes that window for CI-initiated applies.

## Deliverables

### 1. Concurrency stanza on all apply jobs (`terraform.yml`)

Per-root, per-env key so unrelated roots never serialize against each other:

| Apply job | Concurrency group |
|---|---|
| `apply` (hetzner) | `terraform-apply-hetzner-${{ matrix.env }}` |
| `apply-cloudflare` | `terraform-apply-cloudflare-prod` |
| `apply-backblaze` | `terraform-apply-backblaze-prod` |

All `cancel-in-progress: false` — a second apply queues behind the first; it never cancels an in-flight apply (mid-apply cancellation risks partial state writes), matching ADR 0005 § Decision § Specifics.

> Note on the key: the ADR's literal `${{ matrix.root }}-${{ matrix.env }}` doesn't apply verbatim at HEAD — only the hetzner `apply` job has an `env` matrix; `cloudflare`/`backblaze` are single prod-scoped roots with no matrix. So their keys are fixed literals (`-cloudflare-prod` / `-backblaze-prod`) while hetzner uses `matrix.env`. The intent (per-root, per-env granularity) is preserved.

### 2. Workstation-apply discipline runbook

`docs/runbooks/terraform-workstation-apply.md` — the load-bearing gap in Option D is that a workstation `terraform apply` bypasses GH Actions concurrency. The runbook codifies:
- The **4-step Slack procedure**: announce intent in `#deploy` → wait for ack (10-min timeout = proceed + log) → check the GHA runs page for a mid-apply on that root → post a completion note.
- The **authorized-operator roster** (Bereket Tadesse, Weronika Zielinska, Aisha Idrissi, Lucas Ferreira — the deploy infra roles), with a note to keep it synced to the team roster.
- The **corruption-recovery path**: freeze → identify the racing B2 versions → restore the pre-corruption version → `terraform plan` for drift → manual reconcile → postmortem + upgrade-trigger evaluation.

### 3. CI smoke test

- `terraform/_lock-smoke/` — a `null_resource` + `sleep` (local backend, no creds, no real infra), so a same-key second run observably queues and a different-key run observably parallelizes.
- `.github/workflows/terraform-lock-smoke.yml` — `workflow_dispatch` with a `concurrency_key` input; its `concurrency.group` mirrors the real apply-job shape (`terraform-apply-<key>`, `cancel-in-progress: false`). Not wired into the `terraform.yml` matrices.
- **Smoke run pair — post-merge Test Plan item (cannot run pre-merge).** GitHub only registers a `workflow_dispatch` workflow once it exists on the **default branch**, so `gh workflow run terraform-lock-smoke.yml` returns 404 against this feature branch (verified: the workflow does not appear in `gh workflow list --all`). The smoke mechanism is proven as far as a PR can prove it — `terraform validate` passes on `_lock-smoke/`, `actionlint` is clean on the workflow, and the `concurrency.group` syntax matches the real apply jobs. The live serialize/parallelize run-pair is a **post-merge** step (same shape as a runtime-acceptance gate):

  ```bash
  # same key → second run shows "pending"/queued until the first ends
  gh workflow run terraform-lock-smoke.yml -f concurrency_key=hetzner-stg -f run_label=same-a -f hold_seconds=40
  gh workflow run terraform-lock-smoke.yml -f concurrency_key=hetzner-stg -f run_label=same-b -f hold_seconds=40
  # different key → both run immediately, in parallel
  gh workflow run terraform-lock-smoke.yml -f concurrency_key=cloudflare-prod -f run_label=diff -f hold_seconds=40
  ```
  Inspect the run queue: the two `hetzner-stg` runs serialize; the `cloudflare-prod` run starts in parallel. I'll dispatch and link the run pair once this is on `deployments/phase-3/wave-12` (or flag for whoever merges to run it).

### 4. Regression guard — chose the LINT job (not CODEOWNERS)

`scripts/check_tf_apply_locking.py`, wired as the `lock-guard` CI job, parses `terraform.yml` and asserts every `apply*` job carries a `terraform-apply-*` concurrency group with `cancel-in-progress: false`.

**Why lint over CODEOWNERS:** the ADR's failure-mode table names "a future PR adds a new TF root without the `concurrency:` stanza" as the silent-regression risk. A lint is a *technical control* — it fails CI even for a new root added in a PR that no Platform Architect happens to review, and catches drift in otherwise-untouched files. CODEOWNERS only protects if the required reviewer notices the omission. Lint is the enforcement-hierarchy-preferred mechanism (technical gate > review-process gate). Negative-tested: stripping a stanza makes the guard exit 1 with a per-job diagnostic.

### 5. Ontology (separate repo)

Deliverable 5 (`ontology/repos/deploy.yaml` § `ci.terraform.locking_mechanism: "gh-actions-concurrency-group"` + ADR ref) lands in the parent `noorinalabs-main` repo where the ontology lives — it is **not** part of this deploy-repo branch. Committed there separately.

## Validation

- `lock-guard` (`scripts/check_tf_apply_locking.py`) — passes for all 3 apply jobs; negative-tested (exits 1 when a stanza is removed).
- `terraform fmt -check -recursive terraform/` — clean.
- `terraform validate` — Success in `terraform/_lock-smoke/`.
- `actionlint` — clean on both `terraform.yml` and `terraform-lock-smoke.yml` (shellcheck integration active).
- `ruff check` + `ruff format --check` — clean on the guard script.

## Regression-guard choice (for reviewers)

LINT job (`lock-guard`), per the rationale in §4 above. Flagging explicitly since the issue asked the implementer to pick and document.

TechDebt: removes — closes the unlocked-concurrent-apply state-corruption window for CI-initiated applies.

