### PR TITLE
feat(compose): dedicated egress network; swap user-service off frontend (#140)

### DIFF
--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -410,12 +410,15 @@ services:
         max-size: "10m"
         max-file: "5"
     networks:
-      # frontend is non-internal — gives user-service outbound egress for OAuth
-      # provider calls (Google, GitHub, etc.). backend + user-backend are internal
-      # for DB isolation. See deploy#138.
+      # egress is non-internal — gives user-service outbound reach for OAuth
+      # provider calls (Google, GitHub, etc.). Caddy reaches user-service for
+      # inbound over the shared `backend` network (caddy is on backend+frontend),
+      # so user-service does NOT need `frontend` for inbound — it was only ever
+      # on `frontend` for egress (deploy#138). backend + user-backend stay
+      # internal for DB isolation. Swapped frontend→egress per deploy#140.
       - backend
       - user-backend
-      - frontend
+      - egress
     command: /app/.venv/bin/uvicorn src.app.main:create_app --factory --host 0.0.0.0 --port 8000 --workers 2
     restart: unless-stopped
 
@@ -569,7 +572,14 @@ services:
       timeout: 5s
       retries: 5
     networks:
+      # backend for scrape/UI; egress for outbound to alert receivers. The Slack
+      # webhook is already wired (api_url_file → secrets.SLACK_WEBHOOK_URL), so the
+      # moment a real webhook URL is set, alertmanager must resolve hooks.slack.com.
+      # Adding egress proactively avoids the silent DNS-failure-on-alert mode that
+      # bit user-service. PagerDuty/SMTP receivers (per #127) get egress for free.
+      # See deploy#140.
       - backend
+      - egress
     restart: unless-stopped
     deploy:
       resources:
@@ -1009,6 +1019,13 @@ networks:
   user-backend:
     driver: bridge
     internal: true
+  # Outbound-only to the public internet (NOT internal). For services that need
+  # to reach external hosts (OAuth providers, Slack/PagerDuty webhooks, SMTP)
+  # but have NO public-facing inbound traffic. Keeps `frontend` semantically
+  # limited to "public-facing via Caddy" rather than overloading it as the
+  # catch-all egress path. See deploy#140 (Option A).
+  egress:
+    driver: bridge
 
 volumes:
   neo4j_data:


### PR DESCRIPTION
## Summary

Implements **Option A** from #140 — a dedicated `egress` bridge network for services that need outbound reach to the public internet but have no public-facing inbound traffic. This stops `frontend` from being overloaded as the catch-all egress path (its semantic stays "public-facing via Caddy").

## Changes (`compose/docker-compose.prod.yml`)

1. **New `egress: { driver: bridge }` network.** Outbound-only, NOT internal. `backend` and `user-backend` remain `internal: true` (untouched).
2. **user-service: `frontend` → `egress`.** Networks are now `backend`, `user-backend`, `egress`.
3. **alertmanager: added `egress`** alongside `backend` — proactively, before real receivers break.

## user-service `frontend` membership: swap, not keep+add

I verified user-service's `frontend` membership is **purely egress**, not Caddy-inbound, before swapping:

- **Caddyfile**: every route to user-service is `reverse_proxy user-service:8000` — same form as `reverse_proxy api:8000`.
- **caddy** service is on `backend` + `frontend`; **api** is on `backend` + `frontend`; **user-service** was on `backend` + `user-backend` + `frontend`.
- Caddy → api inbound resolves over the **shared `backend`** network (api isn't reachable any other way that caddy shares). Caddy → user-service resolves the same way — over `backend`, which both share.
- The `frontend` membership on user-service was added in deploy#138 **solely for OAuth outbound egress** (the inline comment said as much). It carried no inbound role.

Therefore: **swap is safe.** Removing `frontend` and adding `egress` preserves caddy→user-service inbound (over `backend`) and restores proper egress semantics. The React `frontend` service stays on `frontend`-only (that one genuinely is Caddy-facing).

## alertmanager: not as latent as #140 framed — webhook is already wired

While auditing I found the alertmanager block already wires the Slack webhook via `api_url_file` → `/etc/alertmanager/slack_webhook_url`, populated from `${{ secrets.SLACK_WEBHOOK_URL }}` by the deploy workflow (placeholder `<unset>` until the secret is set). So this is **one secret-set away** from the exact DNS-failure-on-alert mode that bit user-service — adding `egress` now closes it. PagerDuty/SMTP receivers (per #127) get egress for free.

## Validation

- Docker is unavailable in this WSL distro, so I could not run `docker compose config` locally. CI's `compose-config` job covers it.
- Local YAML-level validation (parse + every service network ref resolves + egress non-internal + backend/user-backend still internal + user-service on egress-not-frontend + alertmanager on egress): **all assertions pass.**
- No env-var changes → no `passlist-drift` impact.

## Runtime gate (post-merge operational step)

The compose change is PR-deliverable and validated at parse level; the **live network restructure on the running stack requires a redeploy**. Post-merge: redeploy prod so user-service and alertmanager attach to the new `egress` network (and detach user-service from `frontend`). This PR delivers compose correctness, not a live apply.

## Deferred — parent-repo ontology (NOT in this PR)

#140's acceptance also asks to update `ontology/repos/deploy.yaml`'s networks block. That file lives in the **parent `noorinalabs-main` repo**, not here, so it cannot ride this deploy PR. Flagged to the team lead for batching with other pending parent-ontology sync. Needed change: add to the networks block —

```yaml
egress: { internal: false, description: "Outbound-only to public internet — OAuth/webhook/SMTP egress for services with no inbound (user-service, alertmanager). See deploy#140." }
```

and update the `user-service` / `alertmanager` membership notes accordingly.

## Tech Debt

TechDebt: removes — eliminates the `frontend`-network egress overload and pre-empts the alertmanager silent-DNS-failure landmine described in #140.

Closes #140
