### PR TITLE
ci: bump Node-20 actions to Node-24 across CI workflows (#364)

### DIFF
--- a/.github/workflows/cold-rebuild-dryrun.yml
+++ b/.github/workflows/cold-rebuild-dryrun.yml
@@ -171,10 +171,10 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up QEMU (for multi-arch fixture)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx (with insecure-registry for local fixture)
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver-opts: |
             network=host

--- a/.github/workflows/db-migrate-ci-gate.yml
+++ b/.github/workflows/db-migrate-ci-gate.yml
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Log in to GHCR (pull user-service image)
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/hooks-lint.yml
+++ b/.github/workflows/hooks-lint.yml
@@ -24,8 +24,8 @@ jobs:
     name: Ruff lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: pip install ruff
@@ -44,8 +44,8 @@ jobs:
     name: Ruff format check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: pip install ruff
@@ -64,8 +64,8 @@ jobs:
     name: Mypy type check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: pip install mypy
@@ -84,8 +84,8 @@ jobs:
     name: Smoke test — hooks compile and exit cleanly
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Verify all hooks compile

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -70,7 +70,7 @@ jobs:
           ref: ${{ steps.sibling-refs.outputs.isnad_graph_ref }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Run integration tests
         working-directory: noorinalabs-deploy/integration-tests

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -175,14 +175,14 @@ jobs:
       landing_digest:      ${{ steps.resolve.outputs.landing_digest }}
     steps:
       - name: Log in to GHCR
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Resolve per-image shorts
         id: resolve
@@ -814,7 +814,7 @@ jobs:
         include: ${{ fromJson(needs.plan.outputs.images_json) }}
     steps:
       - name: Log in to GHCR
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -831,7 +831,7 @@ jobs:
           password: ${{ secrets.GH_PACKAGES_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Resolve source tag
         id: src

--- a/.github/workflows/terraform-lock-smoke.yml
+++ b/.github/workflows/terraform-lock-smoke.yml
@@ -52,7 +52,7 @@ jobs:
         working-directory: terraform/_lock-smoke
     steps:
       - uses: actions/checkout@v6
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "~> 1.6"
       - name: Init (local backend)

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - name: Install PyYAML
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "~> 1.6"
       - name: terraform fmt -check -recursive
@@ -114,7 +114,7 @@ jobs:
         working-directory: ${{ matrix.path }}
     steps:
       - uses: actions/checkout@v6
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "~> 1.6"
       - name: Init (no backend)
@@ -203,7 +203,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_B2_APP_KEY }}
     steps:
       - uses: actions/checkout@v6
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "~> 1.6"
       - name: Init
@@ -255,7 +255,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_B2_APP_KEY }}
     steps:
       - uses: actions/checkout@v6
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "~> 1.6"
       # Discover the existing http_request_dynamic_redirect entrypoint ruleset
@@ -331,7 +331,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_B2_APP_KEY }}
     steps:
       - uses: actions/checkout@v6
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "~> 1.6"
       - name: Init
@@ -393,7 +393,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_B2_APP_KEY }}
     steps:
       - uses: actions/checkout@v6
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "~> 1.6"
       - name: Init
@@ -435,7 +435,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_B2_APP_KEY }}
     steps:
       - uses: actions/checkout@v6
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "~> 1.6"
       # See plan-cloudflare § "Discover redirect ruleset IDs". Same discovery
@@ -495,7 +495,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_B2_APP_KEY }}
     steps:
       - uses: actions/checkout@v6
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "~> 1.6"
       - name: Init

--- a/.github/workflows/verify-deploy.yml
+++ b/.github/workflows/verify-deploy.yml
@@ -155,7 +155,7 @@ jobs:
       # GITHUB_TOKEN scope which includes packages:read for the org).
       - name: Log in to GHCR (for digest resolution)
         if: always() && job.status == 'success'
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -163,7 +163,7 @@ jobs:
 
       - name: Set up Docker Buildx (for digest resolution)
         if: always() && job.status == 'success'
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Resolve per-service stg-latest digests
         id: digests


### PR DESCRIPTION
## Summary

GitHub forces all actions onto Node.js 24 on **2026-06-02**; the prior Node-20-based action majors are deprecated and may break. This bumps every affected pin across the deploy repo's CI workflows so zero Node-20 action majors remain.

**Base: `deployments/phase-3/wave-12`** (the active integration superset of `main`). `main` inherits this via the wave-12 -> main merge, which lands before June 2. Basing on wave-12 (not `main`) is deliberate: `terraform-lock-smoke.yml` and the wave-12 form of `terraform.yml` (with its `setup-python` step) exist only on the wave branch, and basing on `main` would both miss those and risk re-introducing Node-20 when the wave later merges.

### Bumps (8 files, 28 line-edits)
- `hooks-lint.yml`: `actions/checkout@v4`->`@v6`, `actions/setup-python@v5`->`@v6` (x4 each)
- `terraform.yml`: `actions/setup-python@v5`->`@v6` (x1), `hashicorp/setup-terraform@v3`->`@v4` (x8)
- `terraform-lock-smoke.yml`: `hashicorp/setup-terraform@v3`->`@v4` (x1)
- `cold-rebuild-dryrun.yml`: `docker/setup-qemu-action@v3`->`@v4`, `docker/setup-buildx-action@v3`->`@v4`
- `integration-tests.yml`: `docker/setup-buildx-action@v3`->`@v4`
- `db-migrate-ci-gate.yml`: `docker/login-action@v3`->`@v4`
- `promote.yml`: `docker/login-action` + `docker/setup-buildx-action` SHA re-pin to v4 (x2 each)
- `verify-deploy.yml`: `docker/login-action` + `docker/setup-buildx-action` SHA re-pin to v4

### SHA-pinned actions keep their hardening
The two SHA-pinned workflows (`promote.yml`, `verify-deploy.yml`) were re-pinned to the **new major's current commit SHA** with a trailing `# v4` comment — NOT switched to a floating tag:
- `docker/login-action` v4 = `650006c6eb7dba73a995cc03b0b2d7f5ca915bee`
- `docker/setup-buildx-action` v4 = `d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5`

Validated locally: `actionlint` (1.7.7) + `shellcheck` (0.10.0) pass clean on all 8 touched files; a repo-wide grep confirms zero stale Node-20 action pins remain.

## Test plan
- [ ] `lint-workflows` (actionlint) CI gate passes.
- [ ] `hooks-lint`, `terraform`, `terraform-lock-smoke`, `integration-tests`, `cold-rebuild-dryrun`, `db-migrate-ci-gate` jobs run on the new action majors without Node-runtime deprecation warnings.
- [ ] `promote` / `verify-deploy` GHCR login + buildx steps function on the re-pinned v4 SHAs.

Closes #364
Refs noorinalabs/noorinalabs-main#536

TechDebt: none
