### PR TITLE
fix(db-migrate): preserve resolved IMAGE_TAG across VPS .env sourcing (#367)

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -130,9 +130,16 @@ jobs:
               echo "       The deploy workflow has never written env-file here, or it was removed."
               exit 1
             fi
+            # The VPS .env carries an IMAGE_TAG for docker-compose's runtime,
+            # but it can be stale (a prior deploy's tag, possibly GC'd). The
+            # tag this gate must pull is the workflow-resolved one (step `tag`,
+            # defaults to <env>-latest). Preserve it across the sourcing so the
+            # .env's IMAGE_TAG does not clobber the resolved pull tag (#367).
+            WANT_TAG="$IMAGE_TAG"
             set -a
             . ./.env
             set +a
+            IMAGE_TAG="$WANT_TAG"
 
             # Log into GHCR so we can pull the user-service image this gate
             # runs alembic from. The trap logs out at end-of-run so no


### PR DESCRIPTION
## The bug (staging deploys wedged)

The alembic pre-deploy gate in `db-migrate.yml` resolves the image tag to pull (step `tag`, defaults to `<env>-latest`) and injects it as `IMAGE_TAG`. The gate then sources the VPS `.env` for DB creds:

```bash
set -a
. ./.env
set +a
```

That `.env` **also** carries an `IMAGE_TAG` (`write-deploy-env` always writes one for docker-compose's runtime). The sourcing **clobbers** the workflow-resolved `IMAGE_TAG` with the stale `.env` value, so the gate builds `IMAGE=...:stg-<old-short>` — often a GC'd tag. The pull 404s -> migrate fails -> deploy is skipped -> `.env` is never refreshed -> the stale tag persists. A self-perpetuating wedge.

## The fix

Capture the workflow-resolved tag before sourcing and restore it immediately after `set +a`, before the `IMAGE=` construction:

```bash
WANT_TAG="$IMAGE_TAG"
set -a
. ./.env
set +a
IMAGE_TAG="$WANT_TAG"
```

The `.env`'s `IMAGE_TAG` is for docker-compose's runtime, not the gate's pull tag — so preserving the resolved tag is correct. Diff is +7 lines (a 5-line comment + the capture/restore).

## Coverage — stg AND prod

`db-migrate.yml` is a reusable workflow. I confirmed the callers:
- **stg**: `deploy-stg.yml` (job `migrate`) -> `db-migrate.yml`
- **prod**: `promote.yml` (job `migrate-prod`, `env: prod`) -> the **same** `db-migrate.yml`

So this single fix covers both stg and prod — both VPS `.env`s have the identical clobber. `db-migrate-ci-gate.yml` is a separate runner-side CI lint gate (`runs-on: ubuntu-latest`, no VPS `.env` sourcing) and is unaffected; no change needed there.

## Validation
- `actionlint` (1.7.7, with `shellcheck` 0.10.0 on PATH for the embedded `run:` block lint) passes clean on `db-migrate.yml`.
- Variable chain checked: `IMAGE_TAG` (injected) -> `WANT_TAG` (read) -> restore -> `IMAGE=` (used); no unused-var.

## Post-merge verification (this is runtime-gated)
The clobber only manifests against the **live VPS `.env`**, so CI cannot fully exercise it. **Live acceptance = a successful staging deploy after merge**: the next deploy trigger runs the gate with the fix, pulls `<env>-latest`, migrates, and the deploy step then rewrites `.env` with a fresh `IMAGE_TAG` — breaking the cycle.

- [ ] Post-merge: confirm a staging deploy succeeds (gate pulls `stg-latest`, migrate passes, deploy proceeds).
- [ ] Confirm the refreshed `.env` on the stg VPS carries a current `IMAGE_TAG`.

Refs #367 (closes after a verified-live staging deploy, not on merge)

TechDebt: none