### PR TITLE
fix(caddy): allow connect-src to users.{$BASE_DOMAIN} on isnad.* CSP (deploy#245 step 3)

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -140,7 +140,7 @@ isnad.{$BASE_DOMAIN} {
         X-Frame-Options "DENY"
         X-XSS-Protection "0"
         Referrer-Policy "strict-origin-when-cross-origin"
-        Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'"
+        Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://users.{$BASE_DOMAIN}; frame-ancestors 'none'"
         -Server
     }
 }


### PR DESCRIPTION
## Summary

Add `https://users.{$BASE_DOMAIN}` to the `connect-src` CSP directive on the `isnad.{$BASE_DOMAIN}` vhost. This is step 3 of the deploy#245 phase-2 vhost carve-out — the browser-layer prerequisite for the frontend to issue cross-origin fetches to user-service at `users.*` once the VITE build-arg wiring (sibling isnad-graph PR) ships.

## Why

Frontend code at HEAD already targets `${USER_SERVICE_ORIGIN}/auth/*` and friends (isnad-graph `frontend/src/hooks/useAuth.ts:79-82`, `frontend/src/pages/LoginPage.tsx:11-12`, `frontend/src/api/profile-client.ts:7`, all landed via isnad-graph commit `1a6f2ae`). With the empty-string fallback, fetches resolve same-origin and the existing dual-bind on `isnad.*` (Caddyfile lines 18-103) handles them. Once the prod image bakes `VITE_USER_SERVICE_ORIGIN=https://users.${BASE_DOMAIN}`, fetches go cross-origin and the browser would block them at `connect-src 'self'`.

This PR is behaviorally a no-op today — CSP becomes strictly more permissive on a path nothing exercises yet. It's safe to land alone.

The `users.{$BASE_DOMAIN}` vhost CSP is already locked down separately (`default-src 'none'`, closes #243 via cd07c3e); no change needed there.

## Test plan

- [ ] CI `compose-validate` workflow green (Caddyfile is referenced by docker-compose, but the syntax change is a header value string and doesn't affect compose parsing)
- [ ] Visual inspection of the diff confirms the only change is appending `https://users.{$BASE_DOMAIN}` to `connect-src` on the isnad.* vhost
- [ ] Post-merge: deploy and curl `-I https://isnad.{base}/` to confirm the `Content-Security-Policy` response header includes the new origin
- [ ] Sibling PRs (isnad-graph build-arg + deploy compose CORS extend) follow; combined activation verified by browser-driven login flow on stg

## Refs

- noorinalabs/noorinalabs-deploy#245 (parent issue)
- noorinalabs/noorinalabs-isnad-graph commit 1a6f2ae (step 1)
- noorinalabs/noorinalabs-deploy#243 (users.* CSP lockdown, already merged)

TechDebt: none



---

Note on step 5 (dual-bind drop): blocked on isnad-graph sibling noorinalabs/noorinalabs-isnad-graph#932 (runtime-config.js for env-specific origins) — not on this PR.
