### PR TITLE
fix(compose): extend user-service CORS_ORIGINS to isnad.${BASE_DOMAIN} (deploy#245 step 2)

### DIFF
--- a/compose/.env.example
+++ b/compose/.env.example
@@ -25,7 +25,11 @@ USER_REDIS_PASSWORD=changeme
 JWT_SECRET=changeme
 JWT_PRIVATE_KEY=
 JWT_PUBLIC_KEY=
-CORS_ORIGINS=https://isnad-graph.noorinalabs.com
+# CORS_ORIGINS for user-service is set in docker-compose.prod.yml directly
+# (templated via ${BASE_DOMAIN}). This .env entry is unused at parse time
+# — docker compose only substitutes ${VAR} inside compose YAML, not inside
+# .env values. Kept here as documentation of what user-service accepts.
+# CORS_ORIGINS=["https://isnad.example.com","https://example.com"]
 
 # Observability
 GRAFANA_ADMIN_PASSWORD=changeme

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -371,7 +371,7 @@ services:
       - REDIS_URL=redis://:${USER_REDIS_PASSWORD:?USER_REDIS_PASSWORD must be set}@user-redis:6379/0
       - JWT_PRIVATE_KEY=${JWT_PRIVATE_KEY:?JWT_PRIVATE_KEY must be set}
       - JWT_PUBLIC_KEY=${JWT_PUBLIC_KEY:?JWT_PUBLIC_KEY must be set}
-      - CORS_ORIGINS=["https://isnad-graph.noorinalabs.com"]
+      - CORS_ORIGINS=["https://isnad.${BASE_DOMAIN}","https://${BASE_DOMAIN}"]
       - AUTH_GOOGLE_CLIENT_ID=${AUTH_GOOGLE_CLIENT_ID:-}
       - AUTH_GOOGLE_CLIENT_SECRET=${AUTH_GOOGLE_CLIENT_SECRET:-}
       - AUTH_GITHUB_CLIENT_ID=${AUTH_GITHUB_CLIENT_ID:-}


### PR DESCRIPTION
## Summary

Extend user-service `CORS_ORIGINS` in `compose/docker-compose.prod.yml` to include the actual frontend origins, templated via `${BASE_DOMAIN}` so a single compose file covers stg + prod. This is step 2 of the deploy#245 phase-2 vhost carve-out.

Old: `CORS_ORIGINS=["https://isnad-graph.noorinalabs.com"]` (legacy hostname, retired post-#226).

New: `CORS_ORIGINS=["https://isnad.${BASE_DOMAIN}","https://${BASE_DOMAIN}"]`.

## Why

Browser cross-origin fetches from `https://isnad.{base}` to `https://users.{base}/auth/*` etc. will be rejected by user-service's `CORSMiddleware` (`src/app/middleware/cors.py:11` reads `settings.CORS_ORIGINS`) once the frontend stops falling back to same-origin. Today the empty-string `VITE_USER_SERVICE_ORIGIN` fallback (`frontend/src/hooks/useAuth.ts:79`) plus the transitional dual-bind on `isnad.*` keep fetches same-origin, so this PR is also behaviorally a no-op pending the wider activation. Pre-positioning the correct CORS env keeps the prerequisites lined up.

## Why this template pattern is safe

Mirrors the existing per-env templating already used on the same service:
- `AUTH_OAUTH_REDIRECT_BASE_URL=https://users.${BASE_DOMAIN}` (line 379)
- `AUTH_OAUTH_POST_LOGIN_URL=https://isnad.${BASE_DOMAIN}/auth/callback` (line 380)

Both `deploy-stg.yml` and `deploy-prod.yml` write `BASE_DOMAIN=` to the VPS `.env` via the shared `write-deploy-env` composite (`base_domain` input). Docker compose substitutes `${BASE_DOMAIN}` at parse time from the `.env` file before container env is materialised — identical mechanism to the two existing `AUTH_OAUTH_*` lines.

## .env.example cleanup

The previous `compose/.env.example:28` had `CORS_ORIGINS=https://isnad-graph.noorinalabs.com`, but this entry was dead config: docker compose does NOT substitute `${VAR}` inside `.env` values (substitution only happens inside compose YAML). The runtime value always came from line 374 of `docker-compose.prod.yml`, never from `.env`. Replaced with a comment documenting the actual source-of-truth to prevent operators from chasing the wrong knob.

## Test plan

- [ ] CI `compose-validate` workflow green — confirms `${BASE_DOMAIN}` interpolation parses cleanly with no missing-required-key errors
- [ ] After stg deploy: `docker exec noorinalabs-user-service-1 env | grep CORS_ORIGINS` shows `["https://isnad.stg.noorinalabs.com","https://stg.noorinalabs.com"]`
- [ ] After stg deploy: from a browser-DevTools console at `https://isnad.stg.noorinalabs.com`, issue `fetch('https://users.stg.noorinalabs.com/auth/providers')` — should succeed (200 with `Access-Control-Allow-Origin: https://isnad.stg.noorinalabs.com`)
- [ ] Same after prod deploy with `noorinalabs.com` substituted

## Companion / related PRs

- noorinalabs/noorinalabs-deploy#369 (Caddyfile `connect-src` allows `users.${BASE_DOMAIN}`)
- noorinalabs/noorinalabs-isnad-graph 1a6f2ae (frontend uses `VITE_USER_SERVICE_ORIGIN` — already on main)
- VITE-build-arg wiring is being escalated separately (see PR comment for blocker — single-image-two-envs incompatible with build-time bake)

## Refs

- noorinalabs/noorinalabs-deploy#245
- noorinalabs/noorinalabs-deploy#226 (legacy hostname retirement)
- noorinalabs/noorinalabs-deploy#218 (per-env hostname templating)

TechDebt: none



---

Note on step 5 (dual-bind drop): blocked on isnad-graph sibling noorinalabs/noorinalabs-isnad-graph#932 (runtime-config.js for env-specific origins) — not on this PR.
