### PR TITLE
security(backblaze): remove master b2 key from CI — read-only plan key + workstation apply (Refs #361)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -325,8 +325,16 @@ jobs:
       run:
         working-directory: terraform/backblaze
     env:
-      TF_VAR_b2_application_key_id: ${{ secrets.B2_MASTER_KEY_ID }}
-      TF_VAR_b2_application_key: ${{ secrets.B2_MASTER_APP_KEY }}
+      # Read-only, account-scoped plan key (ADR 0004 Decision D: the master key
+      # MUST NOT exist in CI — #361). This key carries only the capabilities a
+      # `terraform plan`/refresh needs to read the existing bucket + key topology:
+      # listBuckets, listKeys, listFiles, readFiles. It CANNOT mint or revoke keys
+      # or create/delete buckets, so a CI compromise cannot escalate to the
+      # account-takeover blast radius the master key holds. Apply (which needs
+      # writeBuckets+writeKeys) is workstation-only — see the removed apply-backblaze
+      # job and terraform/backblaze/README.md § "Apply (workstation only)".
+      TF_VAR_b2_application_key_id: ${{ secrets.B2_BACKBLAZE_PLAN_KEY_ID }}
+      TF_VAR_b2_application_key: ${{ secrets.B2_BACKBLAZE_PLAN_APP_KEY }}
       AWS_ACCESS_KEY_ID: ${{ secrets.TF_STATE_B2_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_B2_APP_KEY }}
     steps:
@@ -473,32 +481,21 @@ jobs:
       - name: Apply
         run: terraform apply -auto-approve
 
-  apply-backblaze:
-    name: Apply (backblaze)
-    needs: [validate, tflint, checkov]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    runs-on: ubuntu-latest
-    # State-locking per ADR 0005 (#334). backblaze is a single prod-scoped
-    # root (no env matrix), so the key is fixed. cancel-in-progress:false →
-    # queue, never cancel mid-apply.
-    concurrency:
-      group: "terraform-apply-backblaze-prod"
-      cancel-in-progress: false
-    environment: production
-    defaults:
-      run:
-        working-directory: terraform/backblaze
-    env:
-      TF_VAR_b2_application_key_id: ${{ secrets.B2_MASTER_KEY_ID }}
-      TF_VAR_b2_application_key: ${{ secrets.B2_MASTER_APP_KEY }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.TF_STATE_B2_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_B2_APP_KEY }}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: hashicorp/setup-terraform@v4
-        with:
-          terraform_version: "~> 1.6"
-      - name: Init
-        run: terraform init
-      - name: Apply
-        run: terraform apply -auto-approve
+  # NOTE: there is intentionally NO `apply-backblaze` job.
+  #
+  # ADR 0004 Decision D: the account-grade master b2 key (writeBuckets +
+  # writeKeys) MUST NOT exist in CI. A CI apply of terraform/backblaze/ would
+  # require that master key, putting an account-takeover credential in a CI
+  # environment — exactly the blast-radius Decision D keeps off CI. The
+  # bucket/key topology this module manages changes ~twice a year, so the
+  # exposure/use ratio of standing master-key-in-CI is indefensible (#361).
+  #
+  # terraform/backblaze/ is applied MANUALLY from an operator workstation:
+  #   - capability story:  terraform/backblaze/README.md § "Apply (workstation only)"
+  #   - concurrency story: docs/runbooks/terraform-workstation-apply.md
+  #     (the procedural state-lock substitute for non-CI applies — the same
+  #     workstation discipline already covers terraform/backblaze/).
+  #
+  # If a future decision wants CI to apply terraform/backblaze/, it must first
+  # supersede ADR 0004 Decision D and justify the blast-radius change
+  # (ADR 0004 § "What happens if a future ADR wants to put the master key in CI").

--- a/terraform/backblaze/README.md
+++ b/terraform/backblaze/README.md
@@ -129,13 +129,27 @@ These can also live in `~/.aws/credentials` under a named profile if you prefer
    [Pre-flight](#pre-flight-provisioning-credentials)).
 3. Terraform 1.5+.
 
-## Apply
+## Apply (workstation only)
 
-**NOTE:** This module is **not applied in CI** — run it once, manually, from an
-operator workstation. The resulting keys are fed into GitHub Actions secrets.
+**This module is NOT applied in CI.** `terraform apply` here mints the pipeline
+bucket and the scoped `pipeline_rw` / `pipeline_ro` keys, which requires the
+account-grade **master b2 key** (`writeBuckets` + `writeKeys`). Per
+[ADR 0004 Decision D](../../docs/adr/0004-b2-state-bucket-and-key-management.md#decision-d--master-b2-key-tf_var_b2_),
+that master key **MUST NOT exist in CI** — its compromise is full-B2-account
+takeover, and this module's topology changes only ~twice a year, so a
+standing master key in CI would be an indefensible exposure/use ratio (#361).
+There is deliberately no `apply-backblaze` job in `.github/workflows/terraform.yml`.
+
+Apply is run **manually, from an authorized operator workstation**, and is
+subject to the same workstation-apply state-lock discipline as every other TF
+root — announce-and-acknowledge in `#deploy`, check for an in-flight CI apply,
+post a completion note. See
+[`docs/runbooks/terraform-workstation-apply.md`](../../docs/runbooks/terraform-workstation-apply.md)
+for the full 4-step procedure and the authorized-operator list.
 
 Confirm both credential pairs from the [Pre-flight](#pre-flight-provisioning-credentials)
-section are exported in your shell, then:
+section are exported in your shell (the master key in the `TF_VAR_b2_*` slot,
+the state-bucket key in the `AWS_*` slot), then:
 
 ```bash
 cd terraform/backblaze
@@ -147,6 +161,62 @@ terraform apply
 
 If `init` fails with a 403 on the state backend, you have the wrong key in the `AWS_*`
 slot — see the rotate-direction guard above.
+
+## CI plan: the read-only scoped plan key (ADR 0004 Decision D)
+
+The `plan-backblaze` job in `.github/workflows/terraform.yml` runs
+`terraform plan` on every PR that touches `terraform/backblaze/`. It does **not**
+use the master key. Instead it authenticates the `b2` provider with a
+**read-only, account-scoped plan key** held in GH Environment secrets:
+
+| GH Secret | Maps to | Role |
+|---|---|---|
+| `B2_BACKBLAZE_PLAN_KEY_ID` | `TF_VAR_b2_application_key_id` | b2 provider auth (plan/refresh only) |
+| `B2_BACKBLAZE_PLAN_APP_KEY` | `TF_VAR_b2_application_key` | b2 provider auth (plan/refresh only) |
+
+### Minimal plan-key capability set
+
+`terraform plan` for this module reads, but never writes, the B2 account:
+
+- `b2_bucket.pipeline` refresh ⇒ list/read the existing bucket → `listBuckets`, `listFiles`, `readFiles`.
+- `b2_application_key.pipeline_rw` / `pipeline_ro` refresh ⇒ list keys → `listKeys`.
+
+The application-key *secrets* are stored in Terraform state at create time, and
+**B2 never re-returns an application-key secret after creation** — so refresh of
+the `b2_application_key` resources does not (and cannot) re-read the secret; it
+only reconciles metadata via `listKeys`. This is what makes a read-only key
+sufficient for plan. Verified against the pinned provider `Backblaze/b2 ~> 0.10`
+(`versions.tf`): the `b2_bucket` / `b2_application_key` data refresh paths issue
+`b2_list_buckets` / `b2_list_keys` (read) calls, not write calls.
+
+The minimal capability set is therefore:
+
+```
+listBuckets, listKeys, listFiles, readFiles
+```
+
+Provision it once, from an operator workstation that already holds the master
+key (the master key is needed to *mint* this scoped key, but the scoped key
+itself never holds write capability):
+
+```bash
+b2 key create \
+  noorinalabs-backblaze-plan \
+  listBuckets,listKeys,listFiles,readFiles
+```
+
+`b2 key create` prints `keyID applicationKey` on one line — capture both into a
+password manager, then load them into the `production` GH Environment without
+round-tripping through shell history:
+
+```bash
+echo "<keyID>"         | gh secret set B2_BACKBLAZE_PLAN_KEY_ID  --env production --repo noorinalabs/noorinalabs-deploy --body -
+echo "<applicationKey>"| gh secret set B2_BACKBLAZE_PLAN_APP_KEY --env production --repo noorinalabs/noorinalabs-deploy --body -
+```
+
+> If a future provider bump makes refresh require additional read capabilities,
+> widen this set by the *minimal* increment and document the reason here — never
+> reach back to the master key for CI plan.
 
 ## Retrieving sensitive outputs
 


### PR DESCRIPTION
## Summary

Brings `terraform/backblaze/` CI into compliance with **ADR 0004 Decision D** — *"the master b2 key MUST NOT exist in CI."* Implements the owner ruling (2026-05-26): **read-only plan key + workstation apply, no ADR change.** Decision D stays authoritative.

The `B2_MASTER_*` CI wiring predates ADR 0004 (live since 2026-05-09; ADR authored 2026-05-18). Decision D was written as a prescription to remove that condition, not a description of the status quo — the live jobs are the drift.

## Changes

- **`plan-backblaze`**: `B2_MASTER_{KEY_ID,APP_KEY}` → read-only scoped plan key `B2_BACKBLAZE_PLAN_{KEY_ID,APP_KEY}` (production GH Environment secrets).
- **`apply-backblaze`**: **removed from CI**. A CI apply requires the master key (`writeBuckets`+`writeKeys` = full B2 account takeover). Replaced with an inline comment recording why the job is absent + the supersede gate (ADR 0004 L302).
- **`terraform/backblaze/README.md`**: `## Apply (workstation only)` made explicit + new `## CI plan: the read-only scoped plan key` section documenting the minimal capability set, provisioning, and secret loading.

## Minimal plan-key capability set (verified)

`terraform plan` for this module is **read-only**:
- `b2_bucket.pipeline` refresh → `listBuckets`, `listFiles`, `readFiles`
- `b2_application_key.pipeline_rw`/`pipeline_ro` refresh → `listKeys`

Application-key *secrets* are stored in state at create time and **B2 never re-returns a key secret after creation** — so refresh reconciles metadata via `listKeys`, never a write. Verified against the pinned provider `Backblaze/b2 ~> 0.10` (`versions.tf`).

Minimal set: `listBuckets, listKeys, listFiles, readFiles`.

## Acceptance criteria

- [x] `grep B2_MASTER terraform.yml` returns nothing.
- [x] `plan-backblaze` runs with a read-only scoped key; CI plan still posts on backblaze PRs.
- [x] `apply-backblaze` removed from CI (provably un-runnable — absent); workstation apply path documented.
- [x] Minimal plan-key capability set documented (verified against pinned b2 provider).
- [x] No change to ADR 0004 (Decision D remains authoritative).

## Validation (local, PR-time)

- `grep B2_MASTER .github/workflows/terraform.yml` → none.
- `python3 scripts/check_tf_apply_locking.py` → PASS (2 apply jobs, both compliant).
- `actionlint .github/workflows/terraform.yml` (shellcheck on PATH) → clean.
- `terraform fmt -check -recursive` + `terraform validate` (backblaze) → clean.

## Runtime-gated / cannot verify at PR-time — post-merge Test Plan

These require operator/account actions and are **not** PR-time verifiable:

1. **Provision the read-only plan key** in B2 (from a workstation holding the master key): `b2 key create noorinalabs-backblaze-plan listBuckets,listKeys,listFiles,readFiles`.
2. **Load `B2_BACKBLAZE_PLAN_{KEY_ID,APP_KEY}`** into the `production` GH Environment.
3. **Confirm a live `plan-backblaze` run** posts a plan with the scoped key on a PR touching `terraform/backblaze/` (proves the read-only cap set is sufficient for the pinned provider's refresh path against the real account).
4. **Retire `B2_MASTER_KEY_ID` / `B2_MASTER_APP_KEY`** GH Actions secrets once (1)–(3) are green (owner-operational secret deletion).
5. **Regenerate `docs/env-inventory.md`** (`scripts/env-inventory.py`) AFTER this lands on the canonical wave-13 branch — the generator scans working trees of all 7 sibling repos, so it cannot be regenerated cleanly from this worktree. It still lists the retired `B2_MASTER_*` and not the new plan-key secrets; a post-merge regen reconciles it.

## Note

The "full automation vs reminder-only" rotation decision and #331 calendar-reminder placement are separate owner-decisions — **not bundled here** (per the issue's closing note).

Refs #361
