### PR TITLE
infra(cloudflare): token-scope preflight + correct .net/.org ruleset auth docs (Refs #347)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -258,6 +258,18 @@ jobs:
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "~> 1.6"
+      # Token-scope preflight (#347). The redirect rulesets on .net/.org need
+      # the token scoped to those zones AND "Zone → Dynamic Redirect → Edit".
+      # Cloudflare validates ruleset writes only at APPLY, so a token missing
+      # that scope passes plan and fails apply with "Authentication error
+      # (10000)". This step turns that into an early, actionable failure by
+      # verifying the token and probing per-zone rulesets read access.
+      - name: Cloudflare token-scope preflight
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          NET_ZONE_ID: ${{ vars.CLOUDFLARE_NOORINALABS_NET_ZONE_ID }}
+          ORG_ZONE_ID: ${{ vars.CLOUDFLARE_NOORINALABS_ORG_ZONE_ID }}
+        run: ../../scripts/cf_token_preflight.sh
       # Discover the existing http_request_dynamic_redirect entrypoint ruleset
       # ID for each defensive-TLD zone and thread it into the import {} blocks
       # (imports.tf) via TF_VAR_*. Required because Cloudflare allows only one
@@ -438,6 +450,16 @@ jobs:
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "~> 1.6"
+      # Token-scope preflight (#347) — same as plan-cloudflare. On the apply
+      # path this is load-bearing: without it the token-scope miss surfaces as
+      # a half-applied prod run ("Authentication error (10000)" on the
+      # .net/.org rulesets after the .com DNS already applied). Fail fast here.
+      - name: Cloudflare token-scope preflight
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          NET_ZONE_ID: ${{ vars.CLOUDFLARE_NOORINALABS_NET_ZONE_ID }}
+          ORG_ZONE_ID: ${{ vars.CLOUDFLARE_NOORINALABS_ORG_ZONE_ID }}
+        run: ../../scripts/cf_token_preflight.sh
       # See plan-cloudflare § "Discover redirect ruleset IDs". Same discovery
       # is required on apply: the import {} blocks (imports.tf) reference
       # TF_VAR_{net,org}_redirect_ruleset_id, and an empty import id errors at

--- a/docs/runbooks/cloudflare-token-scope.md
+++ b/docs/runbooks/cloudflare-token-scope.md
@@ -1,0 +1,115 @@
+# Runbook — `CLOUDFLARE_API_TOKEN` scope for the canonical-redirect rulesets
+
+Source: [deploy#347](https://github.com/noorinalabs/noorinalabs-deploy/issues/347).
+Composes with: [#166](https://github.com/noorinalabs/noorinalabs-deploy/issues/166)
+(canonical-domain redirects), [#348](https://github.com/noorinalabs/noorinalabs-deploy/issues/348)
+(import-not-create + apply-time expression validation),
+[`terraform/cloudflare/redirects.tf`](../../terraform/cloudflare/redirects.tf),
+[`terraform/cloudflare/README.md`](../../terraform/cloudflare/README.md#prerequisites).
+
+## Symptom
+
+`terraform apply` on the `cloudflare` root creates/refreshes the `.com` DNS
+records successfully, then fails when it reaches the `.net` / `.org`
+canonical-redirect rulesets:
+
+```
+cloudflare_ruleset.canonical_redirect["org"]: Creating...
+Error: error creating ruleset canonical-domain-redirect-org
+  Authentication error (10000)
+cloudflare_ruleset.canonical_redirect["net"]: Creating...
+Error: error creating ruleset canonical-domain-redirect-net
+  Authentication error (10000)
+```
+
+No outage results — the `.net`/`.org` redirects simply don't apply, and those
+zones carry no productive traffic. But the apply is half-done and the redirects
+stay un-provisioned until the token is fixed.
+
+## Root cause
+
+`CLOUDFLARE_API_TOKEN` is under-scoped for ruleset management on the defensive
+TLDs. Managing `http_request_dynamic_redirect` entrypoint rulesets needs the
+token to carry **both** of:
+
+1. **Zone Resources** including `noorinalabs.net` and `noorinalabs.org` (not
+   just `noorinalabs.com`). A token scoped to `.com` only authenticates for
+   `.com` operations and returns auth error 10000 for anything on the other
+   zones — which is why the `.com` DNS in the same run succeeds while the
+   `.net`/`.org` rulesets fail.
+2. The **`Zone → Dynamic Redirect → Edit`** permission group. Single
+   Redirects / dynamic-redirect rulesets are managed via the rulesets API;
+   `Zone → DNS → Edit` alone does not authorize ruleset writes.
+
+## Why a clean plan does not catch it
+
+Cloudflare validates ruleset **writes** only at APPLY, not at plan. A token
+missing the scope above passes `terraform plan` and a green PR review, then
+fails `terraform apply` on prod. This is the same plan-vs-apply asymmetry that
+bites the redirect *expression* language (#348) — clean plan, failed apply.
+
+## Preflight guard (automated, #347)
+
+[`scripts/cf_token_preflight.sh`](../../scripts/cf_token_preflight.sh) runs in
+both the `plan-cloudflare` and `apply-cloudflare` jobs of
+[`.github/workflows/terraform.yml`](../../.github/workflows/terraform.yml),
+before the `terraform` steps. It:
+
+1. Verifies the token is valid + active (`GET /user/tokens/verify`).
+2. Probes `GET /zones/<id>/rulesets` for each redirect zone — a non-destructive
+   proxy for "the token covers this zone and can touch the rulesets API."
+
+A miss fails the job early with a pointed `::error::` instead of a half-applied
+prod run. Run it locally the same way:
+
+```bash
+CLOUDFLARE_API_TOKEN=… \
+NET_ZONE_ID="$(…noorinalabs.net zone id)" \
+ORG_ZONE_ID="$(…noorinalabs.org zone id)" \
+  scripts/cf_token_preflight.sh
+```
+
+### Residual apply-gated gap
+
+The preflight proves the token **covers each zone** (zone in Zone Resources +
+rulesets readable). It cannot fully prove the **`Dynamic Redirect → Edit`**
+write permission without mutating prod ruleset state (Cloudflare has no dry-run
+for ruleset PUT). The one case that still surfaces only at apply: token has the
+zone but lacks the Dynamic Redirect *Edit* group specifically. Set both per the
+fix below and that case disappears.
+
+## Fix (owner action — Cloudflare dashboard)
+
+> This is an owner action: the token lives behind the org-level GitHub Actions
+> secret `CLOUDFLARE_API_TOKEN` and editing it requires Cloudflare dashboard
+> access. Mark the PR that lands this runbook as `Refs #347`, not `Closes` —
+> close #347 only after the live re-apply below is green.
+
+1. Cloudflare dashboard → **My Profile → API Tokens** → edit the token behind
+   `CLOUDFLARE_API_TOKEN` (or mint a new one — see README § "How to rotate").
+2. **Permissions** — ensure all of:
+   - `Zone → DNS → Edit`
+   - `Zone → Zone Settings → Edit`
+   - `Zone → Zone → Read`
+   - `Zone → Dynamic Redirect → Edit`  ← the missing one
+3. **Zone Resources** — include `noorinalabs.com`, `noorinalabs.net`,
+   `noorinalabs.org` (or "All zones in account").
+4. If the token value changed, re-set the secret:
+   ```bash
+   gh secret set CLOUDFLARE_API_TOKEN --repo noorinalabs/noorinalabs-deploy
+   ```
+5. Re-run `Apply (cloudflare)` (rerun the failed jobs on the original run, or
+   push a no-op to `main` touching `terraform/**`). The rulesets import
+   idempotently — the `.com` DNS and `stg_www_cname` already in state are
+   untouched.
+
+## Verify (live, post-apply)
+
+```bash
+# Both should 301 to the matching path on .com, preserving path + query.
+curl -sI "https://noorinalabs.net/some/path?x=1" | grep -iE '^location|^HTTP'
+curl -sI "https://noorinalabs.org/some/path?x=1" | grep -iE '^location|^HTTP'
+# Expect: HTTP/.. 301 ... and Location: https://noorinalabs.com/some/path?x=1
+```
+
+Once both return the 301 to `noorinalabs.com`, close #347.

--- a/scripts/cf_token_preflight.sh
+++ b/scripts/cf_token_preflight.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# ===========================================================================
+# cf_token_preflight.sh — verify CLOUDFLARE_API_TOKEN can manage the
+# canonical-domain redirect rulesets on the defensive `.net` / `.org` zones
+# BEFORE `terraform apply` reaches them.
+#
+# Why this exists (#347):
+#   The redirect rulesets in terraform/cloudflare/redirects.tf are
+#   `http_request_dynamic_redirect` entrypoint rulesets on the `.net` and
+#   `.org` zones. Managing them needs the token scoped to BOTH:
+#     - those zones in "Zone Resources", AND
+#     - the "Zone → Dynamic Redirect → Edit" permission group.
+#   A token that only carries `Zone:DNS:Edit` on `.com` (the historical
+#   baseline) authenticates fine for the `.com` DNS records but fails on the
+#   `.net`/`.org` ruleset apply with the opaque Cloudflare error:
+#
+#       Authentication error (10000)
+#
+#   Crucially Terraform/Cloudflare validate ruleset writes only AT APPLY, so a
+#   clean `terraform plan` + green PR review can still fail apply on prod (the
+#   exact P3W11 prod-apply post-mortem behind #347). This script surfaces the
+#   missing scope as an early, actionable CI failure instead.
+#
+# What it checks:
+#   1. Token is valid + active            (GET /user/tokens/verify)
+#   2. Token can authenticate against the rulesets endpoint of EACH redirect
+#      zone (GET /zones/<id>/rulesets) — i.e. the zone is in the token's
+#      Zone Resources and the token can read rulesets. A 10000/9109 here is
+#      the same auth class that bites the apply.
+#
+# What it deliberately does NOT do:
+#   - It cannot fully prove WRITE/Edit on the dynamic-redirect ruleset without
+#     mutating prod state (Cloudflare has no dry-run for ruleset PUT). Read
+#     access on the zone's rulesets is a strong, non-destructive proxy: a
+#     token missing the zone from its Zone Resources fails read too. The
+#     residual gap — token has the zone but lacks the Dynamic Redirect *Edit*
+#     permission group specifically — is documented in the runbook and is the
+#     one apply-gated case that remains. See docs/runbooks/cloudflare-token-scope.md.
+#
+# Usage:
+#   CLOUDFLARE_API_TOKEN=... NET_ZONE_ID=... ORG_ZONE_ID=... \
+#     scripts/cf_token_preflight.sh
+#
+# Emits GitHub Actions `::error::` annotations when run in CI; exits non-zero
+# on any failure so the calling job stops before `terraform apply`.
+# ===========================================================================
+set -euo pipefail
+
+: "${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN must be set}"
+: "${NET_ZONE_ID:?NET_ZONE_ID (noorinalabs.net zone id) must be set}"
+: "${ORG_ZONE_ID:?ORG_ZONE_ID (noorinalabs.org zone id) must be set}"
+
+CF_API="https://api.cloudflare.com/client/v4"
+
+# err — print a GitHub-Actions error annotation when in CI, else a plain line.
+err() {
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    printf '::error::%s\n' "$1" >&2
+  else
+    printf 'ERROR: %s\n' "$1" >&2
+  fi
+}
+
+# cf_get — GET a CF API path, echo the body, return curl's exit status. Does
+# not use --fail so we can inspect `success`/`errors` in the JSON envelope.
+cf_get() {
+  curl --silent --show-error \
+    --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+    --header "Content-Type: application/json" \
+    "${CF_API}$1"
+}
+
+# 1. Token validity + active status.
+verify_resp=$(cf_get "/user/tokens/verify") || {
+  err "Could not reach Cloudflare token-verify endpoint."
+  exit 1
+}
+if [ "$(printf '%s' "${verify_resp}" | jq -r '.success')" != "true" ]; then
+  err "CLOUDFLARE_API_TOKEN failed /user/tokens/verify — the token is invalid, expired, or revoked."
+  err "Fix: mint a new token and re-set the GH secret (see docs/runbooks/cloudflare-token-scope.md)."
+  printf '%s\n' "${verify_resp}" | jq -c '.errors' >&2 || true
+  exit 1
+fi
+token_status=$(printf '%s' "${verify_resp}" | jq -r '.result.status // "unknown"')
+if [ "${token_status}" != "active" ]; then
+  err "CLOUDFLARE_API_TOKEN status is '${token_status}', expected 'active'."
+  exit 1
+fi
+echo "Token verify: OK (status=active)"
+
+# 2. Per-zone rulesets read — proves the zone is in the token's Zone Resources
+#    and the token can touch the rulesets API on it. A miss here is the same
+#    auth class (10000/9109) that fails the apply.
+probe_zone() {
+  zone_id="$1"; label="$2"
+  resp=$(cf_get "/zones/${zone_id}/rulesets")
+  if [ "$(printf '%s' "${resp}" | jq -r '.success')" = "true" ]; then
+    echo "Zone ${label} (${zone_id}): rulesets readable — token covers this zone."
+    return 0
+  fi
+  code=$(printf '%s' "${resp}" | jq -r '.errors[0].code // "?"')
+  msg=$(printf '%s' "${resp}" | jq -r '.errors[0].message // "unknown error"')
+  err "CLOUDFLARE_API_TOKEN cannot read rulesets on the ${label} zone (${zone_id}): [${code}] ${msg}"
+  err "This is the apply-time 'Authentication error (10000)' from #347, caught early."
+  err "Fix: scope the token to the '${label}' zone in Zone Resources AND grant"
+  err "     'Zone → Dynamic Redirect → Edit'. See docs/runbooks/cloudflare-token-scope.md."
+  return 1
+}
+
+fail=0
+probe_zone "${NET_ZONE_ID}" "noorinalabs.net" || fail=1
+probe_zone "${ORG_ZONE_ID}" "noorinalabs.org" || fail=1
+
+if [ "${fail}" -ne 0 ]; then
+  err "Cloudflare token preflight FAILED — not running terraform apply on the redirect zones."
+  exit 1
+fi
+
+echo "Cloudflare token preflight: PASS — token authenticates against .com, .net, .org rulesets."

--- a/terraform/cloudflare/README.md
+++ b/terraform/cloudflare/README.md
@@ -98,7 +98,7 @@ Prod and stg VPS IPs are read automatically from the hetzner per-env Terraform r
 ## Prerequisites
 
 - [Terraform >= 1.6](https://developer.hashicorp.com/terraform/install)
-- `CLOUDFLARE_API_TOKEN` — Cloudflare API token with `Zone:DNS:Edit`, `Zone:Zone Settings:Edit`, `Zone:Zone:Read`
+- `CLOUDFLARE_API_TOKEN` — Cloudflare API token. **Permissions:** `Zone:DNS:Edit`, `Zone:Zone Settings:Edit`, `Zone:Zone:Read`, **and `Zone:Dynamic Redirect:Edit`** (the last is required for the `.net`/`.org` canonical-redirect rulesets — DNS edit alone is insufficient for ruleset management). **Zone Resources:** must cover all three zones — `noorinalabs.com`, `noorinalabs.net`, `noorinalabs.org` (or "All zones in account"). A token scoped to `.com` only authenticates for `.com` DNS but fails the redirect apply with `Authentication error (10000)` — see [token-scope runbook](../../docs/runbooks/cloudflare-token-scope.md) and #347.
 - `cloudflare_zone_id` — Zone ID for `noorinalabs.com` (Cloudflare dashboard → Overview → Zone ID)
 - Backblaze B2 credentials (to read hetzner remote state — same creds as the cloudflare module's own backend)
 
@@ -155,7 +155,8 @@ Root apex A/AAAA records point at `local.prod_vps_ipv4` / `local.prod_vps_ipv6` 
    - `Zone:DNS:Edit`
    - `Zone:Zone Settings:Edit`
    - `Zone:Zone:Read`
-   Scope it to `noorinalabs.com` zone only.
+   - `Zone:Dynamic Redirect:Edit` — required for the `.net`/`.org` canonical-redirect rulesets (#347)
+   Scope it (Zone Resources) to **all three zones** — `noorinalabs.com`, `noorinalabs.net`, `noorinalabs.org` (or "All zones in account"). A `.com`-only token fails the redirect apply with `Authentication error (10000)`; see the [token-scope runbook](../../docs/runbooks/cloudflare-token-scope.md).
 
 2. Update the secret in GitHub:
 


### PR DESCRIPTION
## Summary

Addresses the code/doc-fix portion of #347. The actual `CLOUDFLARE_API_TOKEN` scope change is owner action (token lives behind an org-level GH secret); this PR makes a missing scope fail-fast and corrects the docs that understated the required scope.

The `.net`/`.org` canonical-redirect rulesets need the token scoped to those zones **and** the `Zone → Dynamic Redirect → Edit` permission. Cloudflare validates ruleset writes only at APPLY, so an under-scoped token passes plan + review then fails apply with `Authentication error (10000)` — the P3W11 prod-apply post-mortem behind #347.

## Changes

- **`scripts/cf_token_preflight.sh`** (new) — verifies the token (`/user/tokens/verify`) and probes `GET /zones/<id>/rulesets` for `.net`/`.org` as a non-destructive proxy for "token covers this zone." Emits `::error::` annotations; exits non-zero so the job stops before `terraform apply`. shellcheck + `bash -n` clean (covered by the `compose-validate` shellcheck job, which globs `scripts/**`).
- **`.github/workflows/terraform.yml`** — wires the preflight into `plan-cloudflare` and `apply-cloudflare` before the terraform steps.
- **`terraform/cloudflare/README.md`** — corrects Prerequisites + token-rotation: permissions now include `Zone:Dynamic Redirect:Edit`; Zone Resources must cover all three zones (`.com`/`.net`/`.org`), not `.com` only.
- **`docs/runbooks/cloudflare-token-scope.md`** (new) — symptom, root cause, plan-vs-apply asymmetry, the preflight + its residual gap, owner fix steps, live curl verification.

## Apply-gated / Test Plan (post-merge)

- The token-scope edit is **owner action** (Cloudflare dashboard) — steps in the runbook.
- The preflight proves zone coverage but cannot prove the `Dynamic Redirect → Edit` *write* permission without mutating prod ruleset state (CF has no dry-run for ruleset PUT). That single case remains apply-gated.
- Live verification: `curl -sI https://noorinalabs.{net,org}/p?x=1` should `301` to the matching `.com` path. Close #347 only after that is green.

The misleading "token already covers all three zones" claim in `redirects.tf` was already corrected upstream in #348; this PR covers the remaining doc-scope drift and the preflight checkbox.

TechDebt: none

Refs #347
