### PR TITLE
ops(grafana): reachable + working login for metrics access (Refs #45)

### DIFF
--- a/compose/.env.example
+++ b/compose/.env.example
@@ -32,6 +32,10 @@ JWT_PUBLIC_KEY=
 # CORS_ORIGINS=["https://isnad.example.com","https://example.com"]
 
 # Observability
+# Grafana admin login (sub-path UI at https://isnad.${BASE_DOMAIN}/grafana —
+# see docs/runbooks/observability.md § Grafana access). User defaults to
+# `admin` if unset; password is required (compose fails fast without it).
+# GRAFANA_ADMIN_USER=admin
 GRAFANA_ADMIN_PASSWORD=changeme
 
 # Per-env config file selection (deploy#263 — Prometheus scrape config split

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -604,7 +604,15 @@ services:
     environment:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD required}
-      GF_SERVER_ROOT_URL: https://isnad-graph.noorinalabs.com/grafana
+      # Sub-path mount behind Caddy on the isnad vhost (caddy/Caddyfile
+      # `handle /grafana/*`). Host MUST match the live Caddy binding —
+      # the legacy `isnad-graph.noorinalabs.com` record was destroyed in
+      # the 2026-05-02 reconciliation (#192/#226) and every other ref
+      # migrated to `isnad.{$BASE_DOMAIN}`; this line was the last hold-out
+      # (dates from initial commit c7642bf) and made Grafana emit
+      # login-redirect / sub-path asset URLs at a dead NXDOMAIN host,
+      # breaking reachability + login (deploy#45).
+      GF_SERVER_ROOT_URL: https://isnad.${BASE_DOMAIN:?BASE_DOMAIN required}/grafana
       GF_SERVER_SERVE_FROM_SUB_PATH: "true"
     expose:
       - "3000"

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -15,7 +15,7 @@ The list of running containers is canonical in
 | Surface | Signal type | Where it lives | Runbook |
 |---|---|---|---|
 | Prometheus | metrics scrape | prod VPS, port 9090 (internal) | per-alert links in `infra/prometheus/alerts.yml` |
-| Grafana | metrics + log visualisation | prod VPS, `/grafana` behind Caddy | n/a (browse + edit in-app) |
+| Grafana | metrics + log visualisation | prod VPS, `/grafana` behind Caddy | [§ Grafana access](#grafana-access) |
 | Loki + Alloy | log aggregation | prod VPS, container-side `docker-socket` scrape | [`log-ingestion.md`](log-ingestion.md) |
 | Alertmanager | alert routing | prod VPS, port 9093 (internal) | [`alertmanager-slack-routing.md`](alertmanager-slack-routing.md) |
 | blackbox-exporter | synthetic probes (HTTP) | prod VPS, container `blackbox-exporter` | [`blackbox-probes.md`](blackbox-probes.md) |
@@ -26,6 +26,86 @@ The synthetic-vs-real-user distinction matters for triage:
 **CWA** answers "what does a real visitor's browser see for p75 LCP?"
 The two are complements, not duplicates — a regression in either signal
 is independently actionable.
+
+---
+
+## Grafana access
+
+### Access URL
+
+Grafana is mounted as a **sub-path** behind Caddy on the isnad vhost:
+
+| Env | URL |
+|---|---|
+| prod | `https://isnad.noorinalabs.com/grafana` |
+| stg | `https://isnad.stg.noorinalabs.com/grafana` |
+
+The host is `isnad.{$BASE_DOMAIN}` — the same vhost that serves the
+isnad-graph frontend/API (`caddy/Caddyfile` → `handle /grafana/*` →
+`reverse_proxy grafana:3000`). It is **not** a dedicated subdomain. The
+legacy `isnad-graph.noorinalabs.com` record that Grafana's
+`GF_SERVER_ROOT_URL` formerly pointed at was destroyed in the
+2026-05-02 reconciliation (#192/#226); `GF_SERVER_ROOT_URL` is now
+templated to `https://isnad.${BASE_DOMAIN}/grafana` so login-redirect
+and sub-path asset URLs resolve to the live host (deploy#45).
+
+Two compose env vars make the sub-path mount work and must stay in
+lockstep with the Caddy route — change one, change all three:
+
+- `GF_SERVER_ROOT_URL: https://isnad.${BASE_DOMAIN}/grafana`
+- `GF_SERVER_SERVE_FROM_SUB_PATH: "true"`
+- `caddy/Caddyfile` → `handle /grafana/*` on the `isnad.{$BASE_DOMAIN}` vhost
+
+### Login
+
+Admin login is provisioned from compose env (`compose/.env`):
+
+- user: `GRAFANA_ADMIN_USER` (defaults to `admin` if unset)
+- password: `GRAFANA_ADMIN_PASSWORD` (required — compose fails fast if unset)
+
+The password is **not** in the repo. On the VPS it lives in
+`compose/.env`, written from the GitHub Actions encrypted secret
+`GRAFANA_ADMIN_PASSWORD` by the deploy workflow. To retrieve it for the
+project owner, read `compose/.env` on the VPS (`grep GRAFANA_ADMIN
+compose/.env`) or rotate it via the GitHub secret + redeploy. There is
+no OAuth integration for Grafana today — admin basic-auth only.
+
+### Dashboards
+
+Provisioned at boot from `infra/grafana/dashboards/` via
+`infra/grafana/provisioning/dashboards/dashboards.yml`. Datasources
+(Prometheus default, Loki) are provisioned from
+`infra/grafana/provisioning/datasources/datasource.yml`. Bundled
+dashboards:
+
+- `api-overview.json` — API latency, request counts, error rates
+- `kafka-pipeline.json` — pipeline worker throughput / lag
+- `blackbox-probes.json` — synthetic HTTP probe results
+
+### Post-merge verification (Test Plan — requires the live stack)
+
+Grafana reachability + working login cannot be verified at PR time — it
+needs the deployed stack with real DNS, TLS, and the admin secret. After
+this change deploys, an operator confirms on the live host:
+
+1. `curl -fsS https://isnad.noorinalabs.com/grafana/api/health` → returns
+   `{"database":"ok",...}` (200). Confirms reachability + sub-path routing.
+2. Open `https://isnad.noorinalabs.com/grafana/login` in a browser →
+   Grafana login page renders with correct CSS/JS (no asset 404s — this
+   is what the `GF_SERVER_ROOT_URL` fix is for; a wrong root URL serves
+   the page but breaks sub-path assets + the post-login redirect).
+3. Log in with `admin` / `GRAFANA_ADMIN_PASSWORD` (from VPS
+   `compose/.env`) → lands on the Grafana home, no redirect loop to a
+   dead host.
+4. Open **Dashboards** → confirm `api-overview`, `kafka-pipeline`, and
+   `blackbox-probes` are present, and that `api-overview` panels render
+   data (datasource wiring is live).
+5. Record the URL + credential-location in the owner hand-off so the
+   project owner can reach metrics.
+
+If step 1 or 2 fails after deploy, check that `BASE_DOMAIN` is set in the
+VPS `compose/.env` and that the `isnad` Caddy vhost is serving (the
+Grafana route is nested under it, not a standalone subdomain).
 
 ---
 


### PR DESCRIPTION
## Summary

Grafana's `GF_SERVER_ROOT_URL` still pointed at `https://isnad-graph.noorinalabs.com/grafana` — the **legacy** Cloudflare record that was destroyed in the 2026-05-02 reconciliation (#192 / #226). Every other reference in the repo migrated to `isnad.{$BASE_DOMAIN}`; this one (from initial commit `c7642bf`) was the last hold-out, so Grafana emitted login-redirect and sub-path asset URLs at a dead NXDOMAIN host — the reachability + login failure #45 describes.

The rest of the Grafana stack was already correct: compose service with admin auth + provisioning mounts, Caddy `handle /grafana/*` route on the isnad vhost, Prometheus + Loki datasources, and 3 provisioned dashboards. The bug was purely the root-URL hostname.

## Changes

- **`compose/docker-compose.prod.yml`** — template `GF_SERVER_ROOT_URL` to `https://isnad.${BASE_DOMAIN}/grafana` so it matches the live Caddy `/grafana/*` route. Required-var shape mirrors the existing `BASE_DOMAIN` gate at line 269.
- **`docs/runbooks/observability.md`** — new **Grafana access** section: per-env access URL, admin-login source (compose `.env` / GH secret, no OAuth), provisioned datasources + dashboards, and a post-merge Test Plan for the runtime-gated checks.
- **`compose/.env.example`** — document optional `GRAFANA_ADMIN_USER` (defaults `admin`) alongside the required password, pointing at the runbook.

## Runtime-gated vs verified

- **Verified (static mechanic):** YAML parses; templating resolves to `https://isnad.noorinalabs.com/grafana`; matches Caddy route + observability runbook; `compose-validate.yml` CI gate covers `docker compose config`.
- **NOT claimed / post-merge Test Plan:** actual HTTP reachability + live login require the deployed stack (real DNS, TLS, admin secret). Documented as a 5-step operator verification in `docs/runbooks/observability.md` § Grafana access. The local docker daemon was unreachable in this env, so no live curl was run — explicitly not claiming live reachability.

## TechDebt

None added.

Refs #45
