### PR TITLE
security(bootstrap): exclude canonical root key from root→deploy merge (Refs #352)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -55,3 +55,36 @@ residual case of personal admin keys added to root post-provision).
 
 See also: `bootstrap-vps.sh` Step 1 inline comments, #112 (parent foot-gun),
 PR #287 (the dedup fix).
+
+## Canonical root key is excluded from the merge (ADR 0006, #352)
+
+ADR 0006 splits SSH access into per-env **and** per-role keys: the root key
+authorizes `root` only, the deploy key authorizes `deploy` only. The Step 1
+merge above must therefore **never** copy the canonical per-env root key into
+the deploy user — doing so would re-authorize the root key for `deploy` and
+erode the role separation the split exists to create.
+
+To make the merge honour that, supply the canonical root pubkey so the script
+can fingerprint-match and skip it. Set **one** of these before running
+`bootstrap-vps.sh`:
+
+| Variable | Value |
+|---|---|
+| `CANONICAL_ROOT_PUBKEY` | the root pubkey line itself (e.g. `ssh-ed25519 AAAA… root@prod`) — the same `${root_ssh_public_key}` cloud-init seeded for this env |
+| `CANONICAL_ROOT_PUBKEY_FILE` | path to a file whose first non-comment line is that pubkey |
+
+```bash
+CANONICAL_ROOT_PUBKEY="$(cat ~/.ssh/noorinalabs_prod_root.pub)" \
+  ./bootstrap-vps.sh
+```
+
+With it set, Step 1's summary line reports `… N canonical-root excluded
+(ADR 0006)`, and only **operator-personal** admin keys added to root
+post-provision flow into deploy. **If neither variable is set**, the script
+preserves the legacy merge-everything behaviour but prints a loud `WARNING
+(ADR 0006)` — on a role-separated box, always pass the canonical root key.
+
+This is the residual/legacy bootstrap path only — fresh Terraform-provisioned
+boxes are fully cloud-init'd and never need this merge. Nothing automated calls
+`bootstrap-vps.sh` (whole-tree grep at HEAD); this exclusion hardens the manual
+path so it cannot quietly undo the ADR 0006 split.

--- a/scripts/bootstrap-vps.sh
+++ b/scripts/bootstrap-vps.sh
@@ -105,17 +105,29 @@ fi
 # /root/.ssh/authorized_keys post-provision and want them reachable from the
 # deploy user too. Idempotent append-with-fingerprint-dedup (#287).
 #
-# CAUTION (ADR 0006): this merge copies EVERY root authorized_keys line into
-# deploy, including the canonical per-env ROOT key — which re-authorizes the
-# root key for the deploy user and partially erodes the per-role separation
-# the split exists to create. The behavior is retained for now because this
-# is the legacy/residual bootstrap path (fresh boxes are fully cloud-init'd
-# and should not need it), but whether to exclude the canonical root key from
-# the merge is tracked as an ADR-0006 follow-up. Do not rely on this merge as
-# part of the role-separation guarantee.
+# ADR 0006 role separation (#352): this merge must NOT copy the canonical
+# per-env ROOT key into the deploy user. The whole point of the split is that
+# the root key authorizes root ONLY and the deploy key authorizes deploy ONLY.
+# Previously this loop copied EVERY /root/.ssh/authorized_keys line into deploy,
+# including the cloud-init-seeded canonical root key — re-authorizing root for
+# deploy and partially eroding the separation. We now exclude the canonical root
+# key by fingerprint so ONLY operator-personal admin keys (added to root post-
+# provision) flow into deploy.
 #
-# Fix (#287): append each root key to deploy's file only if its fingerprint
-# isn't already present. Idempotent across any number of re-runs.
+# Identifying the canonical root key: the operator supplies it out-of-band so
+# this on-box script can fingerprint-match and skip it. Set ONE of:
+#   CANONICAL_ROOT_PUBKEY       — the pubkey line itself (e.g. "ssh-ed25519 AAA... root@prod")
+#   CANONICAL_ROOT_PUBKEY_FILE  — path to a file containing that pubkey line
+# This is the same ${root_ssh_public_key} cloud-init seeded for this env (see
+# terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl write_files). When
+# neither is set, the script PRESERVES the legacy behavior (merge everything)
+# but prints a loud warning — on a role-separated box the operator should always
+# pass it. Do not rely on this merge as part of the role-separation guarantee
+# unless the canonical root key is supplied.
+#
+# Residual value of the merge (post-exclusion): operators who add PERSONAL admin
+# keys to /root/.ssh/authorized_keys post-provision and want them reachable from
+# the deploy user too. Idempotent append-with-fingerprint-dedup (#287).
 echo "==> [1/4] Merging /root/.ssh/authorized_keys → deploy (idempotent)..."
 DEPLOY_AUTH_KEYS="/home/$DEPLOY_USER/.ssh/authorized_keys"
 mkdir -p "/home/$DEPLOY_USER/.ssh"
@@ -131,6 +143,29 @@ ssh_key_fp() {
   echo "$1" | ssh-keygen -lf - 2>/dev/null | awk '{print $2}' || true
 }
 
+# Resolve the canonical root key's fingerprint (the line to EXCLUDE from the
+# merge per ADR 0006). Empty when the operator did not supply it.
+CANONICAL_ROOT_FP=""
+canonical_root_line=""
+if [ -n "${CANONICAL_ROOT_PUBKEY:-}" ]; then
+  canonical_root_line="$CANONICAL_ROOT_PUBKEY"
+elif [ -n "${CANONICAL_ROOT_PUBKEY_FILE:-}" ]; then
+  if [ -f "$CANONICAL_ROOT_PUBKEY_FILE" ]; then
+    # First non-empty, non-comment line of the supplied pubkey file.
+    canonical_root_line=$(grep -vE '^[[:space:]]*($|#)' "$CANONICAL_ROOT_PUBKEY_FILE" | head -n1)
+  else
+    echo "ERROR: CANONICAL_ROOT_PUBKEY_FILE='$CANONICAL_ROOT_PUBKEY_FILE' not found." >&2
+    exit 1
+  fi
+fi
+if [ -n "$canonical_root_line" ]; then
+  CANONICAL_ROOT_FP=$(ssh_key_fp "$canonical_root_line")
+  if [ -z "$CANONICAL_ROOT_FP" ]; then
+    echo "ERROR: supplied canonical root pubkey is not a valid SSH public key line." >&2
+    exit 1
+  fi
+fi
+
 if [ -f /root/.ssh/authorized_keys ]; then
   declare -A DEPLOY_FPS=()
   while IFS= read -r existing_line; do
@@ -139,12 +174,25 @@ if [ -f /root/.ssh/authorized_keys ]; then
     [ -n "$fp" ] && DEPLOY_FPS["$fp"]=1
   done < "$DEPLOY_AUTH_KEYS"
 
+  if [ -z "$CANONICAL_ROOT_FP" ]; then
+    echo "    WARNING (ADR 0006): canonical root pubkey not supplied"
+    echo "    (set CANONICAL_ROOT_PUBKEY or CANONICAL_ROOT_PUBKEY_FILE). Merging"
+    echo "    ALL root keys including the canonical root key — this re-authorizes"
+    echo "    the root key for the deploy user and erodes per-role separation."
+  fi
+
   added=0
   skipped=0
+  excluded=0
   while IFS= read -r root_line; do
     case "$root_line" in ''|\#*) continue ;; esac
     fp=$(ssh_key_fp "$root_line")
     [ -z "$fp" ] && continue
+    # ADR 0006: never propagate the canonical per-env root key into deploy.
+    if [ -n "$CANONICAL_ROOT_FP" ] && [ "$fp" = "$CANONICAL_ROOT_FP" ]; then
+      excluded=$((excluded + 1))
+      continue
+    fi
     if [ -n "${DEPLOY_FPS[$fp]:-}" ]; then
       skipped=$((skipped + 1))
     else
@@ -156,7 +204,7 @@ if [ -f /root/.ssh/authorized_keys ]; then
 
   chown "$DEPLOY_USER:$DEPLOY_USER" "$DEPLOY_AUTH_KEYS"
   chmod 600 "$DEPLOY_AUTH_KEYS"
-  echo "    Merged root authorized_keys → deploy: $added added, $skipped already present."
+  echo "    Merged root authorized_keys → deploy: $added added, $skipped already present, $excluded canonical-root excluded (ADR 0006)."
 else
   echo "    /root/.ssh/authorized_keys not found — nothing to merge (expected on heavily-locked-down hosts)."
 fi


### PR DESCRIPTION
## Summary

ADR 0006 follow-up (flagged in-code + in PR #351's body). `scripts/bootstrap-vps.sh` Step 1 merged **every** `/root/.ssh/authorized_keys` line into the `deploy` user — including the **canonical per-env ROOT key** cloud-init seeds. That re-authorized the root key for `deploy` and partially eroded the per-role separation ADR 0006 establishes (root key authorizes `root` only; deploy key authorizes `deploy` only).

## Fix

Exclude the canonical root key from the merge **by fingerprint**. The operator supplies it out-of-band so the on-box script can match and skip it — set one of:

| Variable | Value |
|---|---|
| `CANONICAL_ROOT_PUBKEY` | the pubkey line itself (same `${root_ssh_public_key}` cloud-init seeded for the env) |
| `CANONICAL_ROOT_PUBKEY_FILE` | path to a file holding that pubkey line |

Only operator-**personal** admin keys added to root post-provision now flow into deploy (the merge's sole residual purpose). When neither variable is set, the script preserves the legacy merge-everything behaviour but prints a loud `WARNING (ADR 0006)`. Step 1's summary now also reports `N canonical-root excluded (ADR 0006)`.

`scripts/README.md` gains a "Canonical root key is excluded from the merge (ADR 0006, #352)" section documenting the variables and behaviour.

## Scope / not-a-regression

Per PR #351 reviewers (Weronika Zielinska, Aisha Idrissi): this is the **legacy/manual bootstrap path only**. Fresh boxes are fully cloud-init'd (the template authorizes each role's key independently), and nothing automated invokes `bootstrap-vps.sh` (whole-tree grep at HEAD). This hardens the manual path so it cannot quietly undo the ADR 0006 split.

## Validation (PR-time)

- `bash -n scripts/bootstrap-vps.sh` → clean.
- `shellcheck scripts/bootstrap-vps.sh` → clean (no findings).
- **Merge-exclusion logic functionally tested** with three real `ed25519` keys (canonical-root, operator-personal, deploy): canonical-root **excluded**, operator-personal **merged**, deploy key **preserved**. `RESULT: added=1 skipped=0 excluded=1`.

## Runtime-gated — post-merge Test Plan

The full Step-1 run executes as `root` on a VPS against real `/root/.ssh/authorized_keys` and `/home/deploy/.ssh/authorized_keys`; that end-to-end path is **not** PR-time executable. The merge *logic* is unit-validated above. Post-merge, on the next manual bootstrap of a role-separated box, run with `CANONICAL_ROOT_PUBKEY="$(cat ~/.ssh/noorinalabs_<env>_root.pub)"` and confirm the summary reports the canonical-root exclusion and `/home/deploy/.ssh/authorized_keys` does not contain the root key.

## ADR conformance

Implements **to** ADR 0006's role-separation intent (Accepted, supersedes 0003). No ADR change.

Refs #352
