### PR TITLE
security(secrets): state-resident secret rotation runbook — Phase 3 of #172 (Refs #193)

### DIFF
--- a/docs/runbooks/state-resident-secret-rotation.md
+++ b/docs/runbooks/state-resident-secret-rotation.md
@@ -1,0 +1,229 @@
+# Runbook — state-resident secret rotation (defense-in-depth)
+
+Source: [deploy#193](https://github.com/noorinalabs/noorinalabs-deploy/issues/193)
+— Phase 3 of [deploy#172](https://github.com/noorinalabs/noorinalabs-deploy/issues/172).
+Inventory cross-ref: [deploy#11](https://github.com/noorinalabs/noorinalabs-deploy/issues/11)
+(the broader secrets-management posture — update its rotation timestamps after a run here).
+Composes with: [`state-key-annual-rotation.md`](state-key-annual-rotation.md)
+(the **state-bucket key** rotation — a *different* secret class),
+[`terraform-workstation-apply.md`](terraform-workstation-apply.md)
+(the apply discipline every `terraform apply` below must follow).
+
+## Why this runbook exists
+
+Until **2026-04-30T04:30Z** the `noorinalabs-terraform-state` bucket had **no
+server-side encryption at rest** — every Terraform state object was stored
+plaintext for a ~23-day window (since 2026-04-07). Phase 1 + 2 (#172) enabled
+SSE-B2 and deleted all 13 plaintext versions. **This runbook is Phase 3**: a
+one-time **defense-in-depth rotation** of the secrets that were sitting plaintext
+*inside* that state during the exposure window.
+
+> **This is belt-and-suspenders, not incident response.** There is **no evidence
+> of leak** (see #193 § Threat model). If a leak were to come to light
+> retroactively, completing this rotation closes the window. Run it once; it is
+> not a recurring cadence (the recurring cadence lives in #11 / future policy).
+
+### Which secrets, and why they are "state-resident"
+
+Two of the four pending secrets reach the live VPS through **cloud-init
+`user_data`**, which Terraform renders from `local.cloud_init_vars`
+(`terraform/hetzner/modules/hetzner-vps/main.tf`) — so their plaintext value is
+captured in the **hetzner tfstate** on every apply:
+
+| Secret | TF variable | Reaches the box via |
+|---|---|---|
+| `user_service_jwt_secret` | `var.user_service_jwt_secret` | cloud-init `user_data` → hetzner tfstate |
+| `ghcr_auth_b64` | `var.ghcr_auth_b64` | cloud-init `user_data` → hetzner tfstate |
+
+The other two are **B2 application keys** minted by `terraform/backblaze/` (whose
+outputs are `sensitive` and stored in the **backblaze tfstate**), then fed to the
+deploy workflow as GH secrets `PIPELINE_B2_KEY` / `PIPELINE_B2_KEY_ID`:
+
+| Secret | Origin | Reaches the box via |
+|---|---|---|
+| `pipeline_rw_key` | `b2_application_key.pipeline_rw` output | GH secret `PIPELINE_B2_KEY*` → deploy `.env` |
+| `pipeline_ro_key` | `b2_application_key.pipeline_ro` output | GH secret (read consumers) |
+
+> **Already rotated (Phase 3 partial credit, no action here):**
+> `user_postgres_password` and `user_redis_password` (stg + prod) were rotated
+> via [deploy#126](https://github.com/noorinalabs/noorinalabs-deploy/issues/126)
+> on 2026-04-30. The optional `TF_STATE_B2_APP_KEY` rotation is a *separate*
+> class — use [`state-key-annual-rotation.md`](state-key-annual-rotation.md), not
+> this runbook.
+
+## Pre-flight (always)
+
+1. **Confirm SSE-B2 is still active** on the state bucket — rotating into a bucket
+   that has silently lost encryption would re-expose the new values:
+
+   ```bash
+   b2 bucket get noorinalabs-terraform-state \
+     | jq -r '.defaultServerSideEncryption.mode'
+   # expect: SSE-B2
+   ```
+
+   If this is **not** `SSE-B2`, STOP — re-open #172 Phase 1 before rotating.
+
+2. **Confirm zero plaintext versions** remain (Phase 2 invariant):
+
+   ```bash
+   b2 ls --json --recursive --versions b2://noorinalabs-terraform-state \
+     | jq -r '.[] | select(.serverSideEncryption.mode != "SSE-B2") | .fileName'
+   # expect: no output
+   ```
+
+3. **You are an authorized operator** and will follow
+   [`terraform-workstation-apply.md`](terraform-workstation-apply.md) for every
+   `terraform apply` below (announce in `#deploy`, check for in-flight CI apply,
+   completion note). B2 has no native state lock; that discipline is the only
+   thing serializing your apply against CI.
+
+## Rotation order — lowest blast radius first
+
+Run these as **separate units** (separate `#deploy` announcements, separate
+verification). Do **not** bundle them into one apply.
+
+---
+
+### 1. `pipeline_rw_key` / `pipeline_ro_key` (lowest blast radius)
+
+Pipeline workers can be restarted post-rotation; no user-facing impact.
+
+1. **Mint fresh scoped keys.** The `b2_application_key` resources in
+   `terraform/backblaze/main.tf` are *immutable* on capability/scope change —
+   the canonical way to "rotate" is to taint and re-apply so B2 issues new key
+   secrets (apply is workstation-only per
+   [`backblaze/README.md` § Apply](../../terraform/backblaze/README.md#apply)):
+
+   ```bash
+   cd terraform/backblaze
+   terraform taint b2_application_key.pipeline_rw
+   terraform taint b2_application_key.pipeline_ro
+   terraform apply          # mints new secrets; old keys are destroyed
+   ```
+
+2. **Push the new values to GH secrets** (stdin keeps them out of shell history —
+   see `backblaze/README.md` § Retrieving sensitive outputs):
+
+   ```bash
+   terraform output -raw pipeline_rw_key_id | gh secret set PIPELINE_B2_KEY_ID    --repo noorinalabs/noorinalabs-deploy --body -
+   terraform output -raw pipeline_rw_key    | gh secret set PIPELINE_B2_KEY       --repo noorinalabs/noorinalabs-deploy --body -
+   terraform output -raw pipeline_ro_key_id | gh secret set PIPELINE_B2_KEY_ID_RO --repo noorinalabs/noorinalabs-deploy --body -
+   terraform output -raw pipeline_ro_key    | gh secret set PIPELINE_B2_KEY_RO    --repo noorinalabs/noorinalabs-deploy --body -
+   ```
+
+3. **Redeploy** so the VPS `.env` picks up the new keys, then restart workers:
+
+   ```bash
+   gh workflow run deploy-prod.yml --repo noorinalabs/noorinalabs-deploy
+   # (and deploy-stg.yml for staging)
+   ```
+
+4. **Verify:** `b2 list-keys` shows the *new* `noorinalabs-pipeline-rw` /
+   `-ro` key IDs; the old IDs are gone. Pipeline workers come up healthy
+   against the new credentials.
+
+---
+
+### 2. `ghcr_auth_b64` (medium blast radius)
+
+Controls image pulls on the VPS (isnad-graph + user-service stacks).
+
+1. **Generate a fresh GHCR PAT** scoped `read:packages` (+ `write:packages` only
+   if the same token pushes — confirm against the publishing workflow before
+   widening). Base64 the `username:token` pair:
+
+   ```bash
+   NEW_GHCR_B64=$(printf '%s:%s' "<gh-username>" "<new-ghcr-pat>" | base64 -w0)
+   ```
+
+2. **Update the TF variable** (this is the state-resident copy). Set
+   `ghcr_auth_b64` in the **prod** and **stg** workstation tfvars (NOT committed;
+   `terraform.tfvars.example` shows the shape) or export
+   `TF_VAR_ghcr_auth_b64`, then apply each env so cloud-init `user_data` —
+   and the hetzner tfstate — captures the new value:
+
+   ```bash
+   cd terraform/hetzner/envs/prod && terraform apply   # then envs/stg
+   ```
+
+3. **Also update any GH secret** the deploy workflow uses for the pull cred, and
+   **redeploy** so the running box re-authenticates to GHCR:
+
+   ```bash
+   gh workflow run deploy-prod.yml --repo noorinalabs/noorinalabs-deploy
+   ```
+
+4. **Verify:** a redeploy completes a clean image pull (no `denied: ...` /
+   `unauthorized` from ghcr.io in the deploy log); old PAT revoked in GitHub
+   → Settings → Developer settings.
+
+---
+
+### 3. `user_service_jwt_secret` (highest blast radius — schedule a window)
+
+Rotating this **invalidates every live user-service session** — all logged-in
+users are kicked. Schedule for a **low-traffic window** and expect to re-auth on
+your next session.
+
+1. **Generate a new 32-byte URL-safe value** (per the deploy#126 pattern):
+
+   ```bash
+   NEW_JWT=$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')
+   # or: openssl rand -base64 32 | tr '+/' '-_' | tr -d '='
+   ```
+
+2. **Update the TF variable** `user_service_jwt_secret` (prod + stg tfvars or
+   `TF_VAR_user_service_jwt_secret`) and **apply each env** so the new value
+   re-renders into cloud-init and overwrites the state-resident copy:
+
+   ```bash
+   cd terraform/hetzner/envs/prod && terraform apply   # then envs/stg
+   ```
+
+3. **Redeploy user-service** so the running container picks up the new secret
+   (coordinate with the user-service repo deploy if its own pipeline owns the
+   restart):
+
+   ```bash
+   gh workflow run deploy-prod.yml --repo noorinalabs/noorinalabs-deploy
+   ```
+
+4. **Verify:** existing tokens are rejected (401 on a pre-rotation token), a
+   fresh login issues a token signed by the new secret, user-service health is
+   green.
+
+---
+
+### 4. (optional) `TF_STATE_B2_APP_KEY` — use the dedicated runbook
+
+If you also rotate the state-bucket key as part of closing the window, do **not**
+do it here — follow [`state-key-annual-rotation.md`](state-key-annual-rotation.md)
+(it has the atomic stg+prod GH-Environment-secret swap and the "don't disable the
+old key until CI is green" gate). Note it in #11.
+
+## Acceptance (per #193)
+
+- [ ] Each rotated secret has a **fresh value not present** in the pre-2026-04-30
+      state.
+- [ ] Each downstream service **redeploys cleanly**.
+- [ ] A post-rotation `terraform plan` against **each** affected backend reports
+      `No changes` (state consistent with the new secret values):
+
+      ```bash
+      terraform -chdir=terraform/hetzner/envs/prod plan -input=false   # No changes
+      terraform -chdir=terraform/hetzner/envs/stg  plan -input=false   # No changes
+      terraform -chdir=terraform/backblaze         plan -input=false   # No changes
+      ```
+
+- [ ] `b2 ls --json --recursive --versions b2://noorinalabs-terraform-state`
+      shows **zero plaintext versions** throughout (SSE-B2 only).
+- [ ] Rotation timestamps recorded in [deploy#11](https://github.com/noorinalabs/noorinalabs-deploy/issues/11).
+
+## Out of scope
+
+- Post-leak forensics — no leak evidence (see #193 § Threat model).
+- `user_postgres_password` / `user_redis_password` — already rotated (#126).
+- The bucket lifecycle rule and `services.yaml` bucket-name correction — separate
+  W11 issues.
+- The ongoing rotation *policy* / inventory / audit trail — that is [#11](https://github.com/noorinalabs/noorinalabs-deploy/issues/11).

--- a/docs/runbooks/state-resident-secret-rotation.md
+++ b/docs/runbooks/state-resident-secret-rotation.md
@@ -28,12 +28,29 @@ one-time **defense-in-depth rotation** of the secrets that were sitting plaintex
 Two of the four pending secrets reach the live VPS through **cloud-init
 `user_data`**, which Terraform renders from `local.cloud_init_vars`
 (`terraform/hetzner/modules/hetzner-vps/main.tf`) — so their plaintext value is
-captured in the **hetzner tfstate** on every apply:
+captured in the **hetzner tfstate** whenever Terraform writes `user_data`:
 
-| Secret | TF variable | Reaches the box via |
-|---|---|---|
-| `user_service_jwt_secret` | `var.user_service_jwt_secret` | cloud-init `user_data` → hetzner tfstate |
-| `ghcr_auth_b64` | `var.ghcr_auth_b64` | cloud-init `user_data` → hetzner tfstate |
+| Secret | TF variable | On the live box | Captured in |
+|---|---|---|---|
+| `user_service_jwt_secret` | `var.user_service_jwt_secret` | cloud-init `write_files` (user-service env) — **set at first boot only** | hetzner tfstate |
+| `ghcr_auth_b64` | `var.ghcr_auth_b64` | cloud-init `write_files` → `/home/deploy/.docker/config.json` — **set at first boot only** | hetzner tfstate |
+
+> **CRITICAL — `user_data` is `ignore_changes`-masked, so a plain `terraform
+> apply` does NOT re-render these onto an existing box.** `hcloud_server.app`
+> carries `lifecycle { ignore_changes = [ssh_keys, user_data] }`
+> (`modules/hetzner-vps/main.tf`), and Hetzner runs cloud-init exactly **once**
+> at first boot — after that, `user_data` has no effect on the live box no
+> matter what Terraform sends (see
+> [`cloud-init-template-changes.md`](cloud-init-template-changes.md)). The two
+> secrets above therefore reach a *running* box **only** via a
+> **taint/replace** of the server (destroy + recreate). Sections 2 and 3 below
+> use that path. **Do not** rotate these with a bare `terraform apply` — it
+> updates only the tfstate value, leaving the live box serving the OLD secret
+> while you believe you rotated.
+>
+> *(`user_postgres_password` / `user_redis_password` are also cloud-init-seeded,
+> but they were rotated via #126 through the user-service's own path — out of
+> scope here; see the note below.)*
 
 The other two are **B2 application keys** minted by `terraform/backblaze/` (whose
 outputs are `sensitive` and stored in the **backblaze tfstate**), then fed to the
@@ -93,7 +110,7 @@ Pipeline workers can be restarted post-rotation; no user-facing impact.
    `terraform/backblaze/main.tf` are *immutable* on capability/scope change —
    the canonical way to "rotate" is to taint and re-apply so B2 issues new key
    secrets (apply is workstation-only per
-   [`backblaze/README.md` § Apply](../../terraform/backblaze/README.md#apply)):
+   [`backblaze/README.md` § Apply (workstation only)](../../terraform/backblaze/README.md#apply-workstation-only)):
 
    ```bash
    cd terraform/backblaze
@@ -125,9 +142,23 @@ Pipeline workers can be restarted post-rotation; no user-facing impact.
 
 ---
 
-### 2. `ghcr_auth_b64` (medium blast radius)
+### 2. `ghcr_auth_b64` (medium blast radius — server replace)
 
-Controls image pulls on the VPS (isnad-graph + user-service stacks).
+Controls image pulls on the VPS — cloud-init writes it to
+`/home/deploy/.docker/config.json` (`modules/hetzner-vps/cloud-init.yaml.tpl`).
+It is **not** in the deploy workflow `.env` (`deploy-prod.yml` `env_keys` has no
+`ghcr_auth_b64`), so a redeploy does **not** refresh it. Because it is only
+written at first boot and `user_data` is `ignore_changes`-masked, updating the
+state-resident value requires a **server taint/replace** — a bare
+`terraform apply` will update tfstate but leave the live box's
+`/home/deploy/.docker/config.json` on the OLD value.
+
+> **Cheaper alternative (preferred if you only need to rotate the running
+> cred):** edit `/home/deploy/.docker/config.json` on the box directly
+> (`docker login ghcr.io` as the `deploy` user with the new PAT, or rewrite the
+> `auth` blob), then still update the TF variable + tfstate so the next legitimate
+> server-replace doesn't reinstate the old value. A full server replace is only
+> required when you want state and box reconciled in one operation.
 
 1. **Generate a fresh GHCR PAT** scoped `read:packages` (+ `write:packages` only
    if the same token pushes — confirm against the publishing workflow before
@@ -137,34 +168,49 @@ Controls image pulls on the VPS (isnad-graph + user-service stacks).
    NEW_GHCR_B64=$(printf '%s:%s' "<gh-username>" "<new-ghcr-pat>" | base64 -w0)
    ```
 
-2. **Update the TF variable** (this is the state-resident copy). Set
-   `ghcr_auth_b64` in the **prod** and **stg** workstation tfvars (NOT committed;
-   `terraform.tfvars.example` shows the shape) or export
-   `TF_VAR_ghcr_auth_b64`, then apply each env so cloud-init `user_data` —
-   and the hetzner tfstate — captures the new value:
+2. **Update the TF variable** (the state-resident copy). Set `ghcr_auth_b64` in
+   the **prod** and **stg** workstation tfvars (NOT committed;
+   `terraform.tfvars.example` shows the shape) or export `TF_VAR_ghcr_auth_b64`.
 
-   ```bash
-   cd terraform/hetzner/envs/prod && terraform apply   # then envs/stg
-   ```
+3. **Reach the live box.** Either:
+   - **Direct edit (cheaper):** on the box, `sudo -u deploy docker login ghcr.io`
+     with the new PAT (rewrites `/home/deploy/.docker/config.json`), then a
+     plain `terraform apply` to reconcile tfstate to the new variable value
+     (the `user_data` diff is `ignore_changes`-masked, so apply only writes the
+     stored value — it will NOT touch the box); **or**
+   - **Server replace (state + box in one op):** follow the **taint/replace**
+     procedure in
+     [`cloud-init-template-changes.md`](cloud-init-template-changes.md)
+     (snapshot → stg-first → drain prod traffic → DNS-TTL check):
 
-3. **Also update any GH secret** the deploy workflow uses for the pull cred, and
-   **redeploy** so the running box re-authenticates to GHCR:
+     ```bash
+     cd terraform/hetzner/envs/stg   # ALWAYS stg first
+     terraform apply -replace='module.vps.hcloud_server.app' -var-file=terraform.tfvars
+     # verify stg healthy, then repeat for envs/prod
+     ```
 
-   ```bash
-   gh workflow run deploy-prod.yml --repo noorinalabs/noorinalabs-deploy
-   ```
-
-4. **Verify:** a redeploy completes a clean image pull (no `denied: ...` /
-   `unauthorized` from ghcr.io in the deploy log); old PAT revoked in GitHub
-   → Settings → Developer settings.
+4. **Verify:** an image pull on the box authenticates with the new cred
+   (`sudo -u deploy docker pull <a private ghcr image>` succeeds; no
+   `denied`/`unauthorized` from ghcr.io); old PAT revoked in GitHub → Settings →
+   Developer settings. If you replaced the server, also run the
+   `cloud-init-template-changes.md` § Post-replacement checklist.
 
 ---
 
-### 3. `user_service_jwt_secret` (highest blast radius — schedule a window)
+### 3. `user_service_jwt_secret` (highest blast radius — server replace, schedule a window)
 
 Rotating this **invalidates every live user-service session** — all logged-in
 users are kicked. Schedule for a **low-traffic window** and expect to re-auth on
 your next session.
+
+Like `ghcr_auth_b64`, this is a **cloud-init-seeded** secret (user-service env,
+written at first boot) and is **not** in the deploy workflow `.env` —
+`deploy-prod.yml` `env_keys` carries `JWT_PRIVATE_KEY` / `JWT_PUBLIC_KEY` (the
+isnad-graph asymmetric keypair, a *different* secret) but **not**
+`user_service_jwt_secret`. So a redeploy does NOT refresh it, and a bare
+`terraform apply` only rewrites tfstate (the `user_data` diff is
+`ignore_changes`-masked). Reaching the running box requires the **taint/replace**
+path, or a direct on-box rewrite of the user-service env value.
 
 1. **Generate a new 32-byte URL-safe value** (per the deploy#126 pattern):
 
@@ -174,24 +220,31 @@ your next session.
    ```
 
 2. **Update the TF variable** `user_service_jwt_secret` (prod + stg tfvars or
-   `TF_VAR_user_service_jwt_secret`) and **apply each env** so the new value
-   re-renders into cloud-init and overwrites the state-resident copy:
+   `TF_VAR_user_service_jwt_secret`) so the state-resident copy is the new value.
 
-   ```bash
-   cd terraform/hetzner/envs/prod && terraform apply   # then envs/stg
-   ```
+3. **Reach the live box.** Either:
+   - **Direct edit (cheaper, lower blast radius):** update the
+     `user_service_jwt_secret` value in the user-service's env file on the box
+     and restart the user-service container (coordinate with the user-service
+     repo if its own pipeline owns the env injection / restart), then a plain
+     `terraform apply` to reconcile tfstate to the new variable
+     (`ignore_changes` masks the `user_data` diff — apply only stores the
+     value, it will NOT replace the box); **or**
+   - **Server replace (state + box in one op):** follow the **taint/replace**
+     procedure in
+     [`cloud-init-template-changes.md`](cloud-init-template-changes.md)
+     (snapshot → stg-first → drain prod traffic → DNS-TTL check):
 
-3. **Redeploy user-service** so the running container picks up the new secret
-   (coordinate with the user-service repo deploy if its own pipeline owns the
-   restart):
-
-   ```bash
-   gh workflow run deploy-prod.yml --repo noorinalabs/noorinalabs-deploy
-   ```
+     ```bash
+     cd terraform/hetzner/envs/stg   # ALWAYS stg first
+     terraform apply -replace='module.vps.hcloud_server.app' -var-file=terraform.tfvars
+     # verify stg healthy, then repeat for envs/prod
+     ```
 
 4. **Verify:** existing tokens are rejected (401 on a pre-rotation token), a
    fresh login issues a token signed by the new secret, user-service health is
-   green.
+   green. If you replaced the server, also run the
+   `cloud-init-template-changes.md` § Post-replacement checklist.
 
 ---
 
@@ -206,9 +259,15 @@ old key until CI is green" gate). Note it in #11.
 
 - [ ] Each rotated secret has a **fresh value not present** in the pre-2026-04-30
       state.
-- [ ] Each downstream service **redeploys cleanly**.
+- [ ] **The new value reached the LIVE box, not just tfstate** — verified on the
+      box (e.g. pipeline workers authenticate; `/home/deploy/.docker/config.json`
+      holds the new `auth`; a pre-rotation user-service token now 401s). This is
+      the bullet the `ignore_changes`-masked `user_data` makes load-bearing: a
+      green `terraform apply` alone does **not** prove propagation for the
+      cloud-init-seeded secrets (§2, §3).
 - [ ] A post-rotation `terraform plan` against **each** affected backend reports
-      `No changes` (state consistent with the new secret values):
+      `No changes` (state consistent with the new secret values — note this is
+      *necessary but not sufficient*; it confirms tfstate, not the live box):
 
       ```bash
       terraform -chdir=terraform/hetzner/envs/prod plan -input=false   # No changes


### PR DESCRIPTION
## Summary

Phase 3 of [#172](https://github.com/noorinalabs/noorinalabs-deploy/issues/172) — **defense-in-depth rotation** of the four pending secrets that sat plaintext inside the `noorinalabs-terraform-state` bucket during its ~23-day no-SSE-at-rest window (closed 2026-04-30 by #172 Phase 1+2).

**Belt-and-suspenders, not incident response** — no leak evidence (see #193 § Threat model). Run once; not a recurring cadence.

## What this PR delivers (and why it's a runbook, not live rotation)

The actual rotations are **runtime-gated**: they need real B2 application keys, a fresh GHCR PAT, live `terraform apply`s, redeploys, owner coordination, and a low-traffic window for the JWT secret (which kicks every logged-in user). None of that is executable at PR-time from a worktree, and I do **not** claim live rotation.

This PR delivers the **unit-mechanic**: `docs/runbooks/state-resident-secret-rotation.md`, a precise operator runbook capturing the exact sequencing + verification gates from #193, with every command and artifact reference verified against the repo at HEAD.

### Runbook content

- **Why each secret is state-resident** (verified at HEAD): `user_service_jwt_secret` + `ghcr_auth_b64` flow through `local.cloud_init_vars` (`terraform/hetzner/modules/hetzner-vps/main.tf`) into the **hetzner tfstate**; `pipeline_rw/ro` keys are `sensitive` outputs in the **backblaze tfstate**.
- **Pre-flight gates**: SSE-B2 still active + zero plaintext versions.
- **Rotation order, lowest blast radius first**: pipeline keys → `ghcr_auth_b64` → `user_service_jwt_secret` (window-scheduled). Each a separate unit; explicitly **not** bundled.
- **Scope discipline**: defers `TF_STATE_B2_APP_KEY` to the existing `state-key-annual-rotation.md` (different secret class) and the ongoing rotation *policy* to **#11**.

## Validation (PR-time)

- Secret-generation commands functionally tested: `python3 -c 'import secrets; ...token_urlsafe(32)'`, `openssl rand -base64 32 | tr ...`, and `printf '%s:%s' user tok | base64 -w0` round-trips back cleanly.
- All referenced files exist at wave-13 HEAD; the `terraform/backblaze/README.md#apply` anchor resolves at HEAD (the `#apply-workstation-only` rename lands in PR for #361 — used the HEAD-stable anchor here to avoid a broken link at this PR's merge).
- No markdownlint gate in the repo.

## Runtime-gated — post-merge Test Plan

Execute the runbook end-to-end during the rotation window:

1. Pre-flight: `b2 bucket get noorinalabs-terraform-state | jq -r .defaultServerSideEncryption.mode` == `SSE-B2`; zero plaintext versions.
2. Rotate `pipeline_rw_key` / `pipeline_ro_key` (taint + workstation apply on `terraform/backblaze/`, push GH secrets, redeploy, restart workers).
3. Rotate `ghcr_auth_b64` (new PAT, `TF_VAR_ghcr_auth_b64`, apply prod+stg, redeploy, verify clean pull).
4. Rotate `user_service_jwt_secret` in a low-traffic window (new 32-byte value, apply prod+stg, redeploy user-service, verify pre-rotation tokens 401).
5. Acceptance: `terraform plan` == `No changes` on `envs/prod`, `envs/stg`, `backblaze`; zero plaintext versions throughout; record timestamps in **#11**.

## Scope note

Strictly the one-time state-resident rotation of **#193**. The broader secrets-management posture (inventory, ongoing policy, audit trail) is **#11** — handled separately, not bundled.

Refs #193
