### PR TITLE
infra(cutover): finish isnad-graph→isnad hostname migration — straggler config + doc sweep (Refs #156)

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -212,7 +212,7 @@ gh workflow run verify-deploy.yml -f target=stg
 gh workflow run verify-deploy.yml -f target=prod
 
 # Legacy operator script — use only if Actions is unreachable
-SITE_URL=https://isnad-graph.noorinalabs.com ./scripts/verify_deployment.sh --skip-workflow
+SITE_URL=https://isnad.noorinalabs.com ./scripts/verify_deployment.sh --skip-workflow
 ```
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -221,7 +221,7 @@ Defined in `compose/docker-compose.prod.yml`. The stack runs 13 services under t
 
 ## Caddy Configuration
 
-Defined in `caddy/Caddyfile`. Caddy serves as the TLS-terminating reverse proxy for `isnad-graph.noorinalabs.com`.
+Defined in `caddy/Caddyfile`. Caddy serves as the TLS-terminating reverse proxy for `isnad.noorinalabs.com` (frontend + isnad-graph API) and `users.noorinalabs.com` (user-service auth plane). The legacy `isnad-graph.noorinalabs.com` hostname was retired in the deploy#156 cutover.
 
 ### Routing
 
@@ -339,16 +339,17 @@ actually verified).
 ### Prod verify — smoke battery (<60s)
 
 Job: `verify-prod`. Runs `scripts/verify_prod_smoke.sh` against the live
-prod URLs. Defaults reflect today's prod Caddy
-(`isnad-graph.noorinalabs.com` per `caddy/Caddyfile:18`); will be updated
-to `isnad.*` / `users.*` when the deploy#156 cutover lands. Checks:
+prod URLs. Defaults reflect prod Caddy post-cutover
+(`isnad.noorinalabs.com` per `caddy/Caddyfile:18`, with the auth plane on
+`users.noorinalabs.com`) — the deploy#156 hostname cutover has landed and the
+legacy `isnad-graph.noorinalabs.com` record is retired. Checks:
 
-1. `isnad-graph.noorinalabs.com/health` — HTTP 200, JSON `.status`
-2. `isnad-graph.noorinalabs.com/api/v1/user-service/health` — HTTP 200 (Caddy rewrite)
+1. `isnad.noorinalabs.com/health` — HTTP 200, JSON `.status`
+2. `isnad.noorinalabs.com/api/v1/user-service/health` — HTTP 200 (Caddy rewrite)
 3. `noorinalabs.com/` — HTTP 200 (landing)
-4. `isnad-graph.noorinalabs.com/api/v1/narrators?limit=1` — HTTP 401 + JSON-shaped body (proves user-service answers, not Caddy bypass)
-5. `isnad-graph.noorinalabs.com/.well-known/jwks.json` — HTTP 200 with `.keys[]` populated
-6. `isnad-graph.noorinalabs.com/auth/login` — HTTP 3xx redirect to OAuth provider (route reachability only — no creds in prod)
+4. `isnad.noorinalabs.com/api/v1/narrators?limit=1` — HTTP 401 + JSON-shaped body (proves user-service answers, not Caddy bypass)
+5. `isnad.noorinalabs.com/.well-known/jwks.json` — HTTP 200 with `.keys[]` populated
+6. `isnad.noorinalabs.com/auth/login` — HTTP 3xx redirect to OAuth provider (route reachability only — no creds in prod)
 
 Failure semantics: emits `::error::` annotation. There is no auto-rollback
 (no rollback policy currently defined; owner investigates).
@@ -405,7 +406,7 @@ Storage retention: 30 days. Alert rules defined in `infra/prometheus/alerts.yml`
 
 ### Dashboards (Grafana)
 
-- Served at `https://isnad-graph.noorinalabs.com/grafana`
+- Served at `https://isnad.noorinalabs.com/grafana`
 - Pre-provisioned dashboard: `infra/grafana/dashboards/api-overview.json`
 - Datasources provisioned automatically via `infra/grafana/provisioning/datasources/datasource.yml`
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -100,7 +100,7 @@ GitHub Secrets (noorinalabs-deploy, production environment)
 
 | Domain | Record Type | Points To |
 |--------|-------------|-----------|
-| `isnad-graph.noorinalabs.com` | A | VPS public IPv4 (from `terraform output server_ip`) |
-| `isnad-graph.noorinalabs.com` | AAAA | VPS public IPv6 (from `terraform output server_ipv6`) |
+| `isnad.noorinalabs.com` | A | VPS public IPv4 (from `terraform output server_ip`) |
+| `isnad.noorinalabs.com` | AAAA | VPS public IPv6 (from `terraform output server_ipv6`) |
 
 Caddy auto-provisions TLS certificates via ACME (Let's Encrypt). DNS must resolve before the first deploy or TLS provisioning will fail.

--- a/docs/runbooks/deploy-isnad-graph.md
+++ b/docs/runbooks/deploy-isnad-graph.md
@@ -71,7 +71,7 @@ script, not invoked by CI anymore — used by the user-service migration
 runbook):
 
 ```bash
-SITE_URL=https://isnad-graph.noorinalabs.com ./scripts/verify_deployment.sh --skip-workflow
+SITE_URL=https://isnad.noorinalabs.com ./scripts/verify_deployment.sh --skip-workflow
 ```
 
 This broader script checks: site reachability (HTTP 200), API health

--- a/docs/runbooks/user-service-migration.md
+++ b/docs/runbooks/user-service-migration.md
@@ -47,10 +47,10 @@ docker compose -f compose/docker-compose.prod.yml exec user-postgres \
 docker compose -f compose/docker-compose.prod.yml ps --format "table {{.Service}}\t{{.Status}}"
 
 # isnad-graph API
-curl -sf https://isnad-graph.noorinalabs.com/health
+curl -sf https://isnad.noorinalabs.com/health
 
 # user-service
-curl -sf https://isnad-graph.noorinalabs.com/api/v1/user-service/health
+curl -sf https://isnad.noorinalabs.com/api/v1/user-service/health
 ```
 
 ---
@@ -93,17 +93,17 @@ docker compose -f compose/docker-compose.prod.yml exec user-service \
   python -c "import urllib.request; print(urllib.request.urlopen('http://localhost:8000/health').read().decode())"
 
 # Via Caddy (public)
-curl -sf https://isnad-graph.noorinalabs.com/api/v1/user-service/health
+curl -sf https://isnad.noorinalabs.com/api/v1/user-service/health
 ```
 
 ### Verify JWKS endpoint
 
 ```bash
 # JWKS keys are served at the IETF well-known path
-curl -sf https://isnad-graph.noorinalabs.com/.well-known/jwks.json | python3 -m json.tool
+curl -sf https://isnad.noorinalabs.com/.well-known/jwks.json | python3 -m json.tool
 
 # Confirm at least one RSA key is present
-curl -sf https://isnad-graph.noorinalabs.com/.well-known/jwks.json | python3 -c "
+curl -sf https://isnad.noorinalabs.com/.well-known/jwks.json | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
 keys = data.get('keys', [])
@@ -122,25 +122,25 @@ Verify all user-service routes are active and proxying correctly:
 
 ```bash
 # Auth endpoints
-curl -sf -o /dev/null -w "%{http_code}" https://isnad-graph.noorinalabs.com/auth/login
+curl -sf -o /dev/null -w "%{http_code}" https://isnad.noorinalabs.com/auth/login
 
 # User management
-curl -sf -o /dev/null -w "%{http_code}" https://isnad-graph.noorinalabs.com/api/v1/users
+curl -sf -o /dev/null -w "%{http_code}" https://isnad.noorinalabs.com/api/v1/users
 
 # Sessions
-curl -sf -o /dev/null -w "%{http_code}" https://isnad-graph.noorinalabs.com/api/v1/sessions
+curl -sf -o /dev/null -w "%{http_code}" https://isnad.noorinalabs.com/api/v1/sessions
 
 # Subscriptions
-curl -sf -o /dev/null -w "%{http_code}" https://isnad-graph.noorinalabs.com/api/v1/subscriptions
+curl -sf -o /dev/null -w "%{http_code}" https://isnad.noorinalabs.com/api/v1/subscriptions
 
 # Verification
-curl -sf -o /dev/null -w "%{http_code}" https://isnad-graph.noorinalabs.com/api/v1/verification
+curl -sf -o /dev/null -w "%{http_code}" https://isnad.noorinalabs.com/api/v1/verification
 
 # Roles
-curl -sf -o /dev/null -w "%{http_code}" https://isnad-graph.noorinalabs.com/api/v1/roles
+curl -sf -o /dev/null -w "%{http_code}" https://isnad.noorinalabs.com/api/v1/roles
 
 # 2FA
-curl -sf -o /dev/null -w "%{http_code}" https://isnad-graph.noorinalabs.com/api/v1/2fa
+curl -sf -o /dev/null -w "%{http_code}" https://isnad.noorinalabs.com/api/v1/2fa
 ```
 
 Expect `401` or `405` (not `404`) — these indicate the request reached the
@@ -224,13 +224,13 @@ docker compose -f compose/docker-compose.prod.yml exec user-postgres \
 
 ```bash
 # Test login flow (replace with a test account)
-curl -X POST https://isnad-graph.noorinalabs.com/auth/login \
+curl -X POST https://isnad.noorinalabs.com/auth/login \
   -H "Content-Type: application/json" \
   -d '{"email": "<test-user-email>", "password": "<test-password>"}'
 
 # Verify the returned JWT validates against JWKS
 # (use the token from the login response)
-curl -sf https://isnad-graph.noorinalabs.com/.well-known/jwks.json | python3 -c "
+curl -sf https://isnad.noorinalabs.com/.well-known/jwks.json | python3 -c "
 import json, sys
 jwks = json.load(sys.stdin)
 print(f'JWKS has {len(jwks[\"keys\"])} key(s) — JWT validation available')
@@ -283,7 +283,7 @@ docker compose -f compose/docker-compose.prod.yml logs user-service --since 5m 2
 
 ```bash
 # Access Grafana (authenticated)
-# https://isnad-graph.noorinalabs.com/grafana
+# https://isnad.noorinalabs.com/grafana
 
 # Check Prometheus targets are scraping correctly
 curl -sf http://localhost:9090/api/v1/targets | python3 -c "
@@ -351,7 +351,7 @@ docker compose -f compose/docker-compose.prod.yml up -d \
 
 ```bash
 # Confirm isnad-graph auth is working
-curl -X POST https://isnad-graph.noorinalabs.com/api/v1/auth/login \
+curl -X POST https://isnad.noorinalabs.com/api/v1/auth/login \
   -H "Content-Type: application/json" \
   -d '{"email": "<test-user-email>", "password": "<test-password>"}'
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -17,7 +17,7 @@ Common production issues and how to resolve them.
 2. Compare the `AUTH_GOOGLE_CLIENT_ID` / `AUTH_GITHUB_CLIENT_ID` values with what is configured in:
    - [Google Cloud Console](https://console.cloud.google.com/apis/credentials) — OAuth 2.0 Client IDs
    - [GitHub Developer Settings](https://github.com/settings/developers) — OAuth Apps
-3. Verify the OAuth redirect URI matches `https://isnad-graph.noorinalabs.com` in both providers
+3. Verify the OAuth redirect URI matches `https://users.noorinalabs.com/auth/oauth/{provider}/callback` in both providers (see `docs/runbooks/oauth-per-env.md` § Redirect URI conventions — the callback lives on the `users.` user-service host, not the frontend host)
 4. After updating secrets, re-run the deploy workflow to inject the new values into the VPS `.env` file
 
 > Secrets are NOT hot-reloaded. A new deploy is required after any secret change.
@@ -69,7 +69,7 @@ ss -tlnp | grep -E ':(80|443)\b'
 
 **Common causes:**
 
-- **DNS not pointing to VPS:** Caddy needs DNS to resolve to the VPS IP for ACME challenge. Verify: `dig isnad-graph.noorinalabs.com +short`
+- **DNS not pointing to VPS:** Caddy needs DNS to resolve to the VPS IP for ACME challenge. Verify: `dig isnad.noorinalabs.com +short`
 - **Port 80 blocked:** ACME HTTP-01 challenge requires port 80. Check the Hetzner firewall rules.
 - **Rate limiting:** Let's Encrypt has rate limits (50 certs/week per domain). If hit, wait or use the staging ACME server.
 - **Stale Caddy config:** After updating the Caddyfile, restart Caddy: `docker compose -p noorinalabs -f compose/docker-compose.prod.yml restart caddy`


### PR DESCRIPTION
## Summary

Finishes the #156 hostname cutover. The bulk already landed across prior waves — the legacy `isnad-graph.noorinalabs.com` Cloudflare record was destroyed in the 2026-05-02 emergency reconciliation (#226), the Caddyfile already binds `isnad.{$BASE_DOMAIN}` with the auth plane carved to `users.*` (#220), and prometheus blackbox + prod smoke were migrated in #252/#254/#255. **DNS confirms today: `isnad.noorinalabs.com` resolves, `isnad-graph.noorinalabs.com` is NXDOMAIN.** But #156 was never closed and a few stragglers were missed. This PR cleans them up.

## Changes

**Live runtime config (the substantive fix):**
- `compose/docker-compose.prod.yml` — `GF_SERVER_ROOT_URL` was the one remaining live env-var still pointing at the retired host → `https://isnad.noorinalabs.com/grafana`. Grafana is served under `/grafana/*` on the `isnad.*` Caddy block.

**Operator docs (commands that NXDOMAIN against the retired host):**
- `docs/runbooks/user-service-migration.md` — 16 `curl`/`SITE_URL` commands.
- `RUNBOOK.md`, `docs/runbooks/deploy-isnad-graph.md` — `verify_deployment.sh` `SITE_URL`.
- `docs/troubleshooting.md` — `dig` hostname; OAuth redirect-URI line corrected to the actual `users.*` callback host (it had wrongly named the frontend host).
- `docs/dependencies.md` — DNS-requirements table.
- `docs/architecture.md` — Caddy/Grafana serving facts + the `verify-prod` smoke block, which literally self-referenced *"will be updated when the deploy#156 cutover lands."*

**Deliberately left as-is** (correct historical comments, not live config): legacy-host mentions in `infra/prometheus/prometheus.prod.yml`, `terraform/cloudflare/{main,variables}.tf` — all past-tense migration provenance.

## Validation

- compose + prometheus YAML parse clean (`yaml.safe_load`).
- `docker compose config` is CI-gated (docker unavailable locally). The compose change is a single literal-string value — no structural change.

## Operator-gated / NOT in this PR

- OAuth provider console redirect URIs are already on `users.*` (per-env OAuth work) — no console action needed for this PR.
- The legacy host is **already retired at DNS**, so there is no dual-host transition or rollback window left to manage. Once merged, #156's acceptance (new host serves, legacy retired, docs updated) is met; the "tiny follow-up to drop the legacy hostname" the issue anticipated is moot — it's already gone.

TechDebt: none

Refs #156
