### PR TITLE
ops(secrets): secrets inventory + rotation policy (Refs #11)

### DIFF
--- a/docs/runbooks/secret-rotation-policy.md
+++ b/docs/runbooks/secret-rotation-policy.md
@@ -1,0 +1,107 @@
+# Secret rotation policy
+
+Source: [deploy#11](https://github.com/noorinalabs/noorinalabs-deploy/issues/11)
+(ops: Secrets management and rotation).
+Companion: [`../secrets-inventory.md`](../secrets-inventory.md) (the per-secret
+inventory this policy governs).
+
+This is the **policy layer** — *who* owns rotation, *when* each class rotates,
+and *how* the cadence is enforced. The mechanical procedures live in the
+per-secret runbooks the inventory points at; this file does not duplicate them.
+
+## Principles
+
+1. **Per-environment separation is mandatory.** `staging` and `production` hold
+   distinct values for every per-env secret (GitHub Environments). A secret
+   shared across envs must be explicitly justified in the inventory's
+   "Env-separated" column (only account-wide provider creds qualify today).
+2. **Least standing privilege in CI.** Account-grade credentials do not live in
+   CI. The B2 master key is the canonical example — ADR 0004 Decision D bars it
+   from CI; #361 removes the residual wiring. CI gets read-only / bucket-scoped
+   keys; account-grade operations are workstation-only.
+3. **Rotation cost is matched to exposure.** Rare-use, storage-dominated
+   credentials (e.g. the B2 master key) rotate **on-demand**; runtime-exposed
+   shared credentials (e.g. the state-bucket key) rotate on an **annual**
+   cadence + on-demand triggers. See the cadence table below.
+4. **Every rotatable secret has a runbook or a provider path.** No secret should
+   be rotatable only by tribal knowledge. The inventory's "Runbook" column is
+   the audit: a blank there for a non-provider secret is a gap to close.
+
+## Cadence table (derived from the inventory)
+
+| Class | Cadence | Trigger | Procedure |
+|---|---|---|---|
+| B2 state-bucket key | **annual** | calendar (Platform Architect) + on-demand | [`state-key-annual-rotation.md`](state-key-annual-rotation.md) |
+| B2 master key | on-demand | offboarding / suspected compromise | ADR 0004 Decision D (workstation-only) |
+| SSH deploy/root keys | on-demand | offboarding / suspected compromise | [`ssh-key-rotation.md`](ssh-key-rotation.md) |
+| State-resident app secrets (jwt/ghcr/pipeline) | on-demand | the #172 SSE-window defense-in-depth pass | state-resident-secret-rotation runbook ([#193](https://github.com/noorinalabs/noorinalabs-deploy/issues/193)) |
+| DB / cache passwords | on-demand → **target: automated** | compromise; otherwise see § Automated rotation | per-deploy `.env` swap |
+| OAuth / PAT / webhook | provider | provider rotation / expiry | provider console |
+
+## On-demand triggers (apply to every class)
+
+Rotate immediately, regardless of cadence, on any of:
+
+- Operator offboarding (rotate everything that operator held).
+- A secret value appearing in a commit, log, Slack message, or screen share.
+- A provider compromise notification (B2, GitHub, Google, Cloudflare, Hetzner).
+- A drift-detection alarm firing (e.g. deploy#158 `validate-creds`).
+
+## Audit trail
+
+Until a central manager provides one natively (see § Central management):
+
+- **Rotation events** are recorded as a dated line in the relevant runbook's
+  history and in the originating issue (e.g. #126 recorded the 2026-04-30
+  Postgres/Redis rotation; #193 records the Phase-3 pass; #11 holds the
+  running inventory of rotation timestamps).
+- **GitHub Actions secret changes** carry an implicit audit trail in the repo's
+  audit log (org → Settings → Audit log, `action:secret`).
+- **B2 / provider key creation/deletion** is visible in each provider's console
+  activity log.
+
+This is a **distributed** audit trail, not a single pane — its consolidation is
+part of the central-management decision below.
+
+## Automated rotation — target, not yet built
+
+#11's acceptance asks that **at least database passwords have automated
+rotation**. That automation is **runtime-gated** (needs a live state backend,
+real credentials, and a scheduled runner against the production stack) and is
+**not** delivered by this PR. The shape it should take:
+
+- A scheduled GH Actions workflow (or central-manager dynamic secret) that mints
+  a new DB password, updates the GH Environment secret, applies it to the running
+  Postgres/Redis, and redeploys — gated on a green health check, with rollback.
+- Until that exists, DB passwords rotate via the on-demand `.env`-swap path
+  (the #126 pattern). **Filing the automation as its own implementation issue is
+  the next step**; it depends on the central-management choice below.
+
+## Central management — open decision (owner / ADR)
+
+#11 lists four options for *where* secrets live. This is a **security
+architecture decision with real tradeoffs**, and per team convention an
+options-with-tradeoffs choice of this weight is an **owner / ADR call**, not an
+implementer default. This PR deliberately does **not** pick one. The framing,
+for the decision:
+
+| Option | Pros | Cons / cost |
+|---|---|---|
+| **Stay on GH Actions secrets** (status quo + this policy) | zero new infra; native to CI; per-env Environments already give separation | no dynamic secrets; manual rotation; distributed audit trail |
+| **SOPS + age** (encrypt in git, decrypt at deploy) | git-versioned, reviewable, auditable diffs; no SaaS | key-management bootstrap; decrypt-at-deploy wiring; still static secrets |
+| **Doppler / 1Password Secrets Automation** (SaaS) | easy setup; rotation + audit built-in; sync to GH | external dependency + cost; another trust boundary |
+| **HashiCorp Vault** | dynamic secrets, leases, full audit | heavy for current scale; operational burden |
+
+**Recommendation for the decision (not a decision):** at current scale the
+status quo + this policy + SOPS-for-git-resident-config is the lowest-friction
+defensible path; Vault is over-scaled. But the choice is the owner's. When made,
+record it as an ADR and supersede the relevant rows of this policy.
+
+## What this PR delivers vs. defers
+
+- **Delivered (PR-time, static):** the secrets inventory; this rotation policy;
+  per-env-separation principle; cadence table; audit-trail-today description;
+  the central-management decision framing.
+- **Deferred (runtime / decision-gated):** automated DB-password rotation (its
+  own follow-up issue); the central-secrets-manager tool choice (owner/ADR);
+  a consolidated audit pane (falls out of the tool choice).

--- a/docs/secrets-inventory.md
+++ b/docs/secrets-inventory.md
@@ -1,0 +1,110 @@
+# Secrets inventory
+
+Source: [deploy#11](https://github.com/noorinalabs/noorinalabs-deploy/issues/11)
+(ops: Secrets management and rotation).
+Companion: [`runbooks/secret-rotation-policy.md`](runbooks/secret-rotation-policy.md)
+(the policy + cadence + central-management decision this inventory feeds).
+Related: [`env-inventory.md`](env-inventory.md) is the **generated env-var
+reference** (every env-var consumer across all 7 repos, #116); THIS file is the
+curated **secrets** view — owner, rotation cadence, env-separation, and runbook
+per secret. They are different lenses; keep both.
+
+> **Scope:** secrets consumed by the `noorinalabs-deploy` deployment surface
+> (GH Actions Environment/repo secrets + Terraform-injected credentials).
+> Not values — names and metadata only (per deploy#116 scope). Maintain this
+> table by hand when the secret surface changes; it is not auto-generated.
+
+## Current posture (as of this PR)
+
+- Secrets live in **GitHub Actions secrets** (repo-level + per-Environment),
+  surfaced into CI with masking and written to the VPS `.env` (chmod 600) at
+  deploy time over SSH, or injected via Terraform cloud-init `user_data`.
+- **No central secrets manager** (Vault/Doppler/SOPS) — the central-management
+  option is an open **owner decision**, framed in
+  [`secret-rotation-policy.md`](runbooks/secret-rotation-policy.md) § Central
+  management — open decision. This PR does **not** pick a tool.
+- **Env separation:** `staging` and `production` GitHub Environments hold
+  separate values for the per-env secrets; a few account-wide / repo-level
+  credentials are intentionally shared (flagged below).
+
+## Rotation-cadence legend
+
+| Cadence | Meaning |
+|---|---|
+| **annual** | scheduled yearly + on-demand triggers (ADR 0004 Decision C) |
+| **on-demand** | rotate on offboarding / suspected compromise only (no calendar) |
+| **on-deploy** | value re-materialises into `.env` on every deploy; rotate by changing the GH secret + redeploy |
+| **provider** | lifecycle owned by the upstream provider (OAuth app, GitHub PAT) |
+| **manual** | rotate by an operator runbook; no automation yet |
+
+## Inventory
+
+### Terraform / infrastructure credentials
+
+| Secret | Class | Owner role | Env-separated | Rotation | Runbook |
+|---|---|---|---|---|---|
+| `HCLOUD_TOKEN` | Hetzner API token | Infra Manager | shared (account) | on-demand | — (provider console) |
+| `TF_STATE_B2_KEY_ID` / `TF_STATE_B2_APP_KEY` | B2 state-bucket key | Platform Architect | per-env (stg/prod) | **annual** | [`state-key-annual-rotation.md`](runbooks/state-key-annual-rotation.md) |
+| `B2_MASTER_KEY_ID` / `B2_MASTER_APP_KEY` | B2 master key (account-wide) | Platform Architect | shared (per-operator) | on-demand | ADR 0004 Decision D — **must not be in CI** (being retired from CI, see #361) |
+| `CLOUDFLARE_API_TOKEN` | Cloudflare API token | Infra Manager | shared | on-demand | — (provider console) |
+
+### SSH access
+
+| Secret | Class | Owner role | Env-separated | Rotation | Runbook |
+|---|---|---|---|---|---|
+| `DEPLOY_SSH_PRIVATE_KEY` | deploy@VPS private key | Infra Manager | per-env (stg/prod) | on-demand | [`ssh-key-rotation.md`](runbooks/ssh-key-rotation.md) (per-env, per-role — ADR 0006) |
+| *root keys* (`noorinalabs_{stg,prod}_root`) | root@VPS — **never in any GH secret** | Owner | per-env | on-demand | [`ssh-key-rotation.md`](runbooks/ssh-key-rotation.md) |
+
+### Application secrets (state-resident — see #193)
+
+These reach the VPS via Terraform cloud-init `user_data` and are captured in the
+hetzner tfstate; a one-time defense-in-depth rotation is tracked in
+[deploy#193](https://github.com/noorinalabs/noorinalabs-deploy/issues/193)
+(state-resident-secret-rotation runbook lands with that PR).
+
+| Secret | Class | Owner role | Env-separated | Rotation | Notes |
+|---|---|---|---|---|---|
+| `user_service_jwt_secret` | user-service JWT signing secret | Security Eng | per-env | on-demand (highest blast radius — kicks sessions) | #193 |
+| `ghcr_auth_b64` | GHCR pull cred (base64 `user:pat`) | Security Eng | per-env | **provider** (PAT) + on-deploy | #193 |
+| `user_postgres_password` | user-service Postgres | Security Eng | per-env | on-demand | rotated 2026-04-30 (#126) |
+| `user_redis_password` | user-service Redis | Security Eng | per-env | on-demand | rotated 2026-04-30 (#126) |
+
+### Application secrets (deploy-time `.env`)
+
+| Secret | Class | Owner role | Env-separated | Rotation | Notes |
+|---|---|---|---|---|---|
+| `NEO4J_PASSWORD` | isnad-graph Neo4j | Infra Manager | per-env | on-deploy / manual | — |
+| `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` | isnad-graph Postgres | Infra Manager | per-env | on-deploy / manual | `*_DB`/`*_USER` are low-sensitivity |
+| `REDIS_PASSWORD` | isnad-graph Redis | Infra Manager | per-env | on-deploy / manual | — |
+| `USER_POSTGRES_*` / `USER_REDIS_PASSWORD` | user-service stores (deploy `.env` copy) | Security Eng | per-env | on-deploy / manual | rotated 2026-04-30 (#126) |
+| `JWT_PRIVATE_KEY` / `JWT_PUBLIC_KEY` | JWT signing keypair (deploy `.env` path) | Security Eng | per-env | on-demand | distinct from `user_service_jwt_secret` (symmetric, cloud-init path) |
+| `GRAFANA_ADMIN_PASSWORD` | Grafana admin | Observability Eng | per-env | on-deploy / manual | — |
+| `KAFKA_CLUSTER_ID` / `KAFKA_UI_USER` / `KAFKA_UI_PASSWORD` | pipeline Kafka UI | Observability Eng | per-env | on-deploy / manual | `CLUSTER_ID` is config, not secret |
+
+### Storage / backup credentials
+
+| Secret | Class | Owner role | Env-separated | Rotation | Notes |
+|---|---|---|---|---|---|
+| `PIPELINE_B2_KEY` / `PIPELINE_B2_KEY_ID` | pipeline bucket RW key | Security Eng | per-env | on-demand | minted by `terraform/backblaze/`; #193 |
+| `BACKUP_B2_KEY_ID` / `BACKUP_B2_APP_KEY` | backup bucket key | Infra Manager | per-env | on-demand | — |
+| `PIPELINE_B2_*` / `BACKUP_B2_BUCKET` / `*_ENDPOINT` / `*_REGION` | bucket config (not secret) | — | — | n/a | public-ish config, listed for completeness |
+
+### Integration / OAuth / misc
+
+| Secret | Class | Owner role | Env-separated | Rotation | Notes |
+|---|---|---|---|---|---|
+| `AUTH_GOOGLE_CLIENT_ID` / `AUTH_GOOGLE_CLIENT_SECRET` | Google OAuth app | Security Eng | per-env | **provider** | rotate in Google Cloud console |
+| `AUTH_GITHUB_CLIENT_ID` / `AUTH_GITHUB_CLIENT_SECRET` | GitHub OAuth app | Security Eng | per-env | **provider** | rotate in GitHub OAuth app settings |
+| `GH_PACKAGES_TOKEN` | GHCR packages PAT (CI) | Infra Manager | repo-level | **provider** (PAT) | — |
+| `GITHUB_TOKEN` | GH Actions ephemeral token | n/a (per-run) | n/a | per-run (auto) | not operator-rotatable |
+| `SLACK_WEBHOOK_URL` | Alertmanager Slack webhook | Observability Eng | per-env | on-demand | rotate in Slack app config |
+| `STG_TEST_USER_EMAIL` / `STG_TEST_USER_PASSWORD` | staging smoke-test creds | SRE | staging only | on-demand | low sensitivity (test account) |
+
+## Maintenance
+
+Update this table whenever the secret surface changes (a new GH secret, a new
+Terraform-injected credential, a service added/removed). The generated
+[`env-inventory.md`](env-inventory.md) is the cross-check: a `secrets.*`
+reference appearing there but missing here is an inventory gap. The
+[secret-rotation-policy](runbooks/secret-rotation-policy.md) § Cadence table is
+derived from the **Rotation** column above — keep them in sync.


### PR DESCRIPTION
## Summary

Establishes the secrets-management baseline #11 asks for. Delivers the PR-time-buildable Minimum-Viable-Approach items (inventory + per-env-separation + rotation policy) and **frames** the runtime/decision-gated ones (automated rotation, central-manager tool choice, consolidated audit pane) rather than pre-empting an owner decision.

## What this PR delivers

### `docs/secrets-inventory.md`
A curated **secrets** view — distinct from the generated `env-inventory.md` (which is the env-var reference, #116). Enumerates every deploy-surface secret from the **actual** `.github/workflows/` surface (38 `secrets.*` refs) plus Terraform-injected creds, classified with: **owner role · env-separation status · rotation cadence · runbook pointer**. Names + metadata only (no values, per #116 scope).

### `docs/runbooks/secret-rotation-policy.md`
The policy layer:
- Principles: mandatory per-env separation; least standing privilege in CI (the B2-master-key-not-in-CI rule, #361); rotation cost matched to exposure.
- Cadence table (annual / on-demand / on-deploy / provider) derived from the inventory.
- On-demand triggers; the **distributed audit-trail-today** description.
- The **central-management options** (Vault / Doppler / SOPS / status-quo) framed with tradeoffs as an **open owner/ADR decision** — this PR does **not** pick a tool.

## Acceptance criteria (#11) mapping

- [x] **All secrets documented with owner and rotation schedule** — `secrets-inventory.md`.
- [x] **Staging and production use separate credentials** — per-env-separation principle + inventory "Env-separated" column (shared creds explicitly justified).
- [x] **Secrets not logged or exposed in CI** — current posture documented (GH masking + chmod-600 `.env`); names-only inventory.
- [ ] **At least DB passwords have automated rotation** — see Runtime-gated below (deferred to its own follow-up; depends on the central-manager choice).

## Scope split vs #193

#193 is the **one-time** state-resident defense-in-depth rotation; **#11** is the **ongoing posture** (inventory + policy + env separation + audit framing). #193's runbook is referenced here as an **issue link** (it lands on that branch), not a cross-branch file link.

## Runtime / decision-gated — explicitly NOT claimed done

- **Automated DB-password rotation** — needs a live state backend, real credentials, and a scheduled runner against the production stack. Filing as its own implementation issue is the next step; it depends on the central-manager choice. (Until then: on-demand `.env`-swap, the #126 pattern.)
- **Central secrets-manager tool selection** — owner / ADR call; framed, not decided.
- **Consolidated audit pane** — falls out of the tool choice.

## Validation (PR-time)

- All internal file links verified to resolve at wave-13 HEAD.
- Secret surface cross-checked against `grep -hoE 'secrets\.[A-Z0-9_]+' .github/workflows/`.
- No markdownlint gate in the repo.

Refs #11
