### PR TITLE
test(verify): fast stg smoke battery, wired as verify-stg fast-fail gate (Refs #379)

### DIFF
--- a/.github/workflows/verify-deploy.yml
+++ b/.github/workflows/verify-deploy.yml
@@ -113,6 +113,57 @@ jobs:
           path: noorinalabs-deploy
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
+      # ── Fast-fail smoke gate (deploy#379, P3 #8 stg arm) ──────────────
+      # The stg counterpart to verify-prod's smoke battery. Runs FIRST so
+      # a plainly-unreachable stg stack (Caddy down, a vhost not routing,
+      # the auth plane dead) fails the job in ~30s instead of paying the
+      # remote integration suite's ~10–30min wall-clock only to fail at the
+      # end. It is a pre-flight probe, NOT a replacement for the suite —
+      # set -e propagates the script's exit 1, so a smoke FAIL short-
+      # circuits the job (the suite step below never runs) and, exactly
+      # like a suite failure, results in stg-verify-result=failure, which
+      # promote.yml hard-blocks prod-promote on (deploy#179/#199). The
+      # report-upload + summary steps below are `if: always()` so the
+      # smoke table still surfaces even when this step fails.
+      #
+      # ISNAD_BASE_URL / USER_SERVICE_BASE_URL come from the job-level env
+      # (the stg public URLs). LANDING_BASE_URL is stg-specific: stg's
+      # landing is the apex stg.noorinalabs.com (vs prod's noorinalabs.com),
+      # so it's set here rather than at job level. The script defaults to
+      # the same values if the env is unset (see scripts/verify_stg_smoke.sh).
+      - name: Run stg smoke battery (fast-fail gate)
+        working-directory: noorinalabs-deploy
+        env:
+          LANDING_BASE_URL: https://stg.noorinalabs.com
+          SMOKE_REPORT: smoke-report.md
+        run: |
+          set -o pipefail
+          chmod +x scripts/verify_stg_smoke.sh
+          ./scripts/verify_stg_smoke.sh 2>&1 | tee smoke-output.txt
+
+      - name: Upload stg smoke output
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: verify-stg-smoke-output
+          path: |
+            noorinalabs-deploy/smoke-output.txt
+            noorinalabs-deploy/smoke-report.md
+          retention-days: 14
+
+      - name: Append stg smoke report to job summary
+        if: always()
+        run: |
+          if [ -f noorinalabs-deploy/smoke-report.md ]; then
+            cat noorinalabs-deploy/smoke-report.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "## Stg smoke — gate did not produce a report"
+              echo ""
+              echo "_smoke-report.md not produced; see verify-stg-smoke-output artifact._"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       # run-tests.sh in RUN_MODE=remote (#178 / PR #202) skips compose
       # stack-up entirely, builds the runner image from Dockerfile.runner,
       # and `docker run`s it against the env-supplied stg URLs. The

--- a/scripts/verify_stg_smoke.sh
+++ b/scripts/verify_stg_smoke.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# verify_stg_smoke.sh — Staging post-deploy smoke battery (<5min budget).
+#
+# The staging-arm counterpart to verify_prod_smoke.sh (deploy#379, P3 #8
+# stg arm / sub of main#329). Intentionally a near-clone of the prod
+# battery: the same six route-reachability checks, the same JSON-shape
+# assertions, the same markdown report shape — only the target URLs and
+# the runtime budget differ. Keeping the two scripts structurally
+# symmetric is deliberate so a reviewer can diff them and confirm parity
+# at a glance; if a check changes on one side it should change on the
+# other (the prod script is the canonical reference — keep them in sync).
+#
+# Why a separate stg *smoke* battery at all (we already have verify-stg's
+# integration suite): the integration suite is the heavy (~10–30min),
+# hermetic-or-remote correctness gate whose result blocks prod-promote
+# (deploy#179/#199). This battery is the fast (<5min) fail-fast probe
+# that runs FIRST in the verify-stg job — if the stg stack is plainly
+# unreachable (Caddy down, a vhost not routing, the auth plane dead) we
+# surface that in seconds instead of paying the full suite's wall-clock
+# only to fail at the end. It is a pre-flight, not a replacement.
+#
+# Like the prod battery, this script does NOT mint real auth tokens. The
+# full login+refresh flow is exercised by the integration suite that runs
+# after this gate in the same verify-stg job.
+#
+# Checks (mirror of verify_prod_smoke.sh):
+#   1. isnad-graph /health    → HTTP 200, JSON .status in {healthy,degraded,ok}
+#   2. user-service /health   → HTTP 200 (via Caddy /api/v1/user-service/health)
+#   3. landing /              → HTTP 200
+#   4. /api/v1/narrators?limit=1 → HTTP 401 + JSON-shaped body (proves
+#                                  user-service auth is in the path, not
+#                                  Caddy bypass returning plaintext)
+#   5. /.well-known/jwks.json → HTTP 200 + valid JWKS shape (.keys[])
+#   6. /auth/oauth/google/login → HTTP 200 + JSON .authorization_url
+#                                  pointing at accounts.google.com
+#                                  (proves user-service OAuth wiring
+#                                  alive: env client_id, PKCE generator,
+#                                  Redis state-store all reachable).
+#                                  Hit on USER_SERVICE_BASE_URL directly
+#                                  for honest attribution — see #256.
+#
+# Env (stg topology — BASE_DOMAIN=stg.noorinalabs.com, deploy-stg.yml:158):
+# the Caddyfile is env-templated by {$BASE_DOMAIN}, so stg's vhosts are
+# the prod vhosts with the stg base domain. frontend + isnad-graph API
+# live on `isnad.stg.noorinalabs.com`; the pure user-service API surface
+# lives on `users.stg.noorinalabs.com` (same canonical-vs-dual-bound auth
+# plane split as prod, #220/#245); landing is the apex `stg.noorinalabs.com`.
+#   ISNAD_BASE_URL          (default: https://isnad.stg.noorinalabs.com)
+#   USER_SERVICE_BASE_URL   (default: https://users.stg.noorinalabs.com —
+#                            canonical pure user-service API surface)
+#   LANDING_BASE_URL        (default: https://stg.noorinalabs.com — apex)
+#   SMOKE_REPORT            Path to write GH-summary-formatted markdown
+#                           (default: smoke-report.md)
+#   TIMEOUT                 Per-check curl timeout, seconds (default: 5)
+
+set -euo pipefail
+
+ISNAD_BASE_URL="${ISNAD_BASE_URL:-https://isnad.stg.noorinalabs.com}"
+USER_SERVICE_BASE_URL="${USER_SERVICE_BASE_URL:-https://users.stg.noorinalabs.com}"
+LANDING_BASE_URL="${LANDING_BASE_URL:-https://stg.noorinalabs.com}"
+SMOKE_REPORT="${SMOKE_REPORT:-smoke-report.md}"
+TIMEOUT="${TIMEOUT:-5}"
+
+# Runtime budget: 5 minutes. Looser than prod's 60s because stg runs on a
+# smaller box (CPX21 vs CPX41) and may be mid-deploy-settle when this
+# fires; the point is fast-fail vs the integration suite's ~10–30min, not
+# a sub-minute SLA. Six checks at a 5s per-check curl timeout is ~30s
+# worst case anyway — the 300s ceiling is generous headroom, not a target.
+BUDGET_MS=300000
+
+# Result tracking ----------------------------------------------------
+PASS=0
+FAIL=0
+ROWS=()           # markdown table rows
+START_NS="$(date +%s%N)"
+
+record() {
+  # record <name> <pass|fail> <time_ms> <detail>
+  local name="$1" status="$2" time_ms="$3" detail="$4"
+  if [ "$status" = "pass" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS [${time_ms}ms]: $name — $detail"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL [${time_ms}ms]: $name — $detail"
+  fi
+  ROWS+=("| $name | ${status^^} | ${time_ms}ms | $detail |")
+}
+
+SMOKE_BODY="/tmp/stg_smoke_body.$$"
+trap 'rm -f "$SMOKE_BODY"' EXIT
+
+# http_check <url> → "<http_code> <time_total_seconds>" on stdout,
+# response body written to $SMOKE_BODY.
+http_check() {
+  curl -sS -o "$SMOKE_BODY" \
+       -w '%{http_code} %{time_total}' \
+       --max-time "$TIMEOUT" \
+       "$1" 2>/dev/null || echo "000 0"
+}
+
+read_body() {
+  cat "$SMOKE_BODY" 2>/dev/null || echo ""
+}
+
+ms_from_secs() {
+  awk -v t="$1" 'BEGIN { printf("%d", t * 1000) }'
+}
+
+# --- 1. isnad-graph /health -----------------------------------------
+{
+  read -r code secs <<<"$(http_check "${ISNAD_BASE_URL}/health")"
+  body="$(read_body)"
+  ms="$(ms_from_secs "$secs")"
+  if [ "$code" = "200" ]; then
+    if echo "$body" | jq -e '.status' >/dev/null 2>&1; then
+      st="$(echo "$body" | jq -r '.status')"
+      case "$st" in
+        healthy|degraded|ok) record "isnad /health" pass "$ms" "status=$st" ;;
+        *)                   record "isnad /health" fail "$ms" "unexpected status=$st" ;;
+      esac
+    else
+      # Caddy could in principle return 200 with non-JSON; treat as fail
+      # because the API is supposed to answer here.
+      record "isnad /health" fail "$ms" "HTTP 200 but body is not JSON-shaped"
+    fi
+  else
+    record "isnad /health" fail "$ms" "HTTP $code (expected 200)"
+  fi
+}
+
+# --- 2. user-service /health (via Caddy rewrite) --------------------
+{
+  read -r code secs <<<"$(http_check "${ISNAD_BASE_URL}/api/v1/user-service/health")"
+  ms="$(ms_from_secs "$secs")"
+  if [ "$code" = "200" ]; then
+    record "user-service /health" pass "$ms" "HTTP 200 via Caddy rewrite"
+  else
+    record "user-service /health" fail "$ms" "HTTP $code (expected 200)"
+  fi
+}
+
+# --- 3. landing root ------------------------------------------------
+{
+  read -r code secs <<<"$(http_check "${LANDING_BASE_URL}/")"
+  ms="$(ms_from_secs "$secs")"
+  if [ "$code" = "200" ]; then
+    record "landing /" pass "$ms" "HTTP 200"
+  else
+    record "landing /" fail "$ms" "HTTP $code (expected 200)"
+  fi
+}
+
+# --- 4. narrator query (expect 401 + JSON body) ---------------------
+# The JSON-shape check matters: a misconfigured Caddy returning plaintext
+# "401 Unauthorized" from the proxy itself would still pass an HTTP-only
+# check but means user-service is not actually responding (Bereket note).
+{
+  read -r code secs <<<"$(http_check "${ISNAD_BASE_URL}/api/v1/narrators?limit=1")"
+  body="$(read_body)"
+  ms="$(ms_from_secs "$secs")"
+  if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+    if echo "$body" | jq -e '.detail or .error or .message' >/dev/null 2>&1; then
+      record "narrator /api/v1/narrators" pass "$ms" "HTTP $code + JSON body (auth path live)"
+    else
+      record "narrator /api/v1/narrators" fail "$ms" "HTTP $code but body is not JSON — proxy may be answering instead of API"
+    fi
+  else
+    record "narrator /api/v1/narrators" fail "$ms" "HTTP $code (expected 401/403 unauth)"
+  fi
+}
+
+# --- 5. JWKS endpoint -----------------------------------------------
+{
+  read -r code secs <<<"$(http_check "${ISNAD_BASE_URL}/.well-known/jwks.json")"
+  body="$(read_body)"
+  ms="$(ms_from_secs "$secs")"
+  if [ "$code" = "200" ] && echo "$body" | jq -e '.keys | length > 0' >/dev/null 2>&1; then
+    nkeys="$(echo "$body" | jq -r '.keys | length')"
+    record "jwks.json" pass "$ms" "HTTP 200, $nkeys key(s)"
+  elif [ "$code" = "200" ]; then
+    record "jwks.json" fail "$ms" "HTTP 200 but missing/empty .keys array"
+  else
+    record "jwks.json" fail "$ms" "HTTP $code (expected 200)"
+  fi
+}
+
+# --- 6. /auth/oauth/google/login (expect 200 + JSON authorization_url) ----
+# user-service exposes GET /auth/oauth/{provider}/login (see
+# user-service/src/app/routers/auth.py:269) which returns
+# OAuthLoginResponse — a JSON body with `authorization_url` pointing at
+# the OAuth provider. It is NOT a 302 redirect; the SPA reads the JSON
+# and navigates the browser. A 200 + .authorization_url containing the
+# expected provider domain proves the wiring (provider client_id env
+# present, PKCE generation working, Redis state-store reachable).
+#
+# We hit ${USER_SERVICE_BASE_URL} directly rather than ${ISNAD_BASE_URL}
+# so attribution is honest (deploy#256 caveat 4): /auth/* is dual-bound
+# on isnad.* + users.* during the absolute-URL frontend cutover (#245
+# phase 2), but the canonical user-service vhost is users.*.
+{
+  read -r code secs <<<"$(http_check "${USER_SERVICE_BASE_URL}/auth/oauth/google/login")"
+  body="$(read_body)"
+  ms="$(ms_from_secs "$secs")"
+  if [ "$code" = "200" ]; then
+    if echo "$body" | jq -e '.authorization_url' >/dev/null 2>&1; then
+      auth_url="$(echo "$body" | jq -r '.authorization_url')"
+      if echo "$auth_url" | grep -qiE 'accounts\.google\.com|google\.com/o/oauth'; then
+        host="$(echo "$auth_url" | sed -E 's|^https?://([^/]+).*|\1|')"
+        record "/auth/oauth/google/login wiring" pass "$ms" "HTTP 200 + .authorization_url → $host"
+      else
+        host="$(echo "$auth_url" | sed -E 's|^https?://([^/]+).*|\1|')"
+        record "/auth/oauth/google/login wiring" fail "$ms" "HTTP 200 but .authorization_url host=$host (expected accounts.google.com)"
+      fi
+    else
+      record "/auth/oauth/google/login wiring" fail "$ms" "HTTP 200 but body missing .authorization_url"
+    fi
+  else
+    record "/auth/oauth/google/login wiring" fail "$ms" "HTTP $code (expected 200)"
+  fi
+}
+
+# --- Summary --------------------------------------------------------
+END_NS="$(date +%s%N)"
+TOTAL_MS=$(( (END_NS - START_NS) / 1000000 ))
+TOTAL=$((PASS + FAIL))
+
+echo ""
+echo "==> Stg smoke summary: $PASS/$TOTAL passed, total ${TOTAL_MS}ms"
+
+# Markdown report for $GITHUB_STEP_SUMMARY
+{
+  echo "## Stg Smoke Results"
+  echo ""
+  echo "| Check | Result | Time | Detail |"
+  echo "|-------|--------|------|--------|"
+  for row in "${ROWS[@]}"; do
+    echo "$row"
+  done
+  echo ""
+  echo "**Totals:** ${PASS}/${TOTAL} passed — total runtime **${TOTAL_MS}ms** (budget: <${BUDGET_MS}ms)"
+  if [ "$TOTAL_MS" -gt "$BUDGET_MS" ]; then
+    echo ""
+    echo "> WARNING: total runtime exceeded the ${BUDGET_MS}ms budget defined in deploy#379."
+  fi
+} > "$SMOKE_REPORT"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo "RESULT: FAILED — $FAIL/$TOTAL checks did not pass"
+  exit 1
+fi
+
+echo "RESULT: ALL SMOKE CHECKS PASSED"
+exit 0


### PR DESCRIPTION
## Summary

Adds the **staging arm** of P3 end-state #8 (post-deploy smoke tests UI+API on stg AND prod). Owner-decided Option B on main#329 (2026-05-31): build a fast, symmetric stg smoke battery mirroring the existing prod one.

- **New `scripts/verify_stg_smoke.sh`** — staging counterpart to `verify_prod_smoke.sh`. Same six route-reachability checks (isnad `/health`, user-service `/health` via Caddy rewrite, landing `/`, `/api/v1/narrators` 401+JSON, `/.well-known/jwks.json`, `/auth/oauth/google/login` wiring), same JSON-shape assertions and markdown-report shape. Only the target URLs (stg vhosts — `BASE_DOMAIN=stg.noorinalabs.com`, per `deploy-stg.yml:158`) and the runtime budget (<5min vs prod's <60s) differ. Kept structurally symmetric so a reviewer can diff the two scripts and confirm parity at a glance.
- **Wired into the `verify-stg` job as a fast-fail gate** that runs FIRST (before the remote integration suite). A plainly-unreachable stg stack fails the job in ~30s (`set -e` propagates the script's `exit 1`) instead of paying the suite's ~10–30min wall-clock only to fail at the end. A smoke FAIL short-circuits the job exactly like a suite failure → `stg-verify-result=failure`, which `promote.yml` hard-blocks prod-promote on (deploy#179/#199). The report-upload + step-summary steps are `if: always()` for parity with `verify-prod`.

### stg URL resolution (load-bearing)
The Caddyfile is env-templated by `{$BASE_DOMAIN}`; stg's vhosts are the prod vhosts with the stg base domain:
- isnad/frontend → `https://isnad.stg.noorinalabs.com` (job env `ISNAD_BASE_URL`)
- user-service (canonical) → `https://users.stg.noorinalabs.com` (job env `USER_SERVICE_BASE_URL`)
- landing (apex) → `https://stg.noorinalabs.com` (set at step level — differs from prod's `noorinalabs.com` apex)

## Verification

**Verified at PR-time (mechanic):**
- `shellcheck scripts/verify_stg_smoke.sh` — clean (prod script also clean; no new findings)
- `actionlint .github/workflows/verify-deploy.yml` — clean (shellcheck on PATH)
- `bash -n` — clean
- **Fail-path dry-run** against unreachable URLs → 6/6 FAIL, `exit 1`, report rendered (proves fast-fail short-circuit mechanic)
- **Success-path dry-run** against a local mock returning expected shapes → 6/6 PASS, `exit 0` (proves jq parsing, status matching, JSON-shape + OAuth-host assertions all correct)

**Runtime-gated (CANNOT verify at PR-time):**
- Live execution against the real stg stack (needs deployed stg URLs + the `staging` environment / secrets). The script defaults already target the correct stg URLs, but a green/red against live stg can only be observed once this is on the wave branch and a stg deploy triggers `verify-stg`.

### Proposed post-merge Test Plan item
After merge to the wave branch, trigger a stg deploy (or `workflow_dispatch` verify-deploy with `target=stg`) and confirm: (1) the smoke gate runs first and emits the `verify-stg-smoke-output` artifact + step-summary table; (2) on a healthy stg stack it reports 6/6 and the integration suite proceeds; (3) a deliberately-induced failure (e.g., stop one container) short-circuits before the suite and yields `stg-verify-result=failure`.

## TechDebt
None added.

Refs #329
Refs #379
