### PR TITLE
infra(kafka): migrate broker bitnami → apache/kafka:3.9.2 KRaft (Refs #100)

### DIFF
--- a/compose/.env.example
+++ b/compose/.env.example
@@ -57,7 +57,7 @@ SLACK_WEBHOOK_FILE=slack_webhook_url.secret.example
 
 # Kafka (pipeline messaging, KRaft mode — see infra/kafka/init-topics.sh)
 # Generate KAFKA_CLUSTER_ID once and keep it stable across restarts:
-#   docker run --rm bitnamilegacy/kafka:3.8.0 kafka-storage.sh random-uuid
+#   docker run --rm apache/kafka:3.9.2 /opt/kafka/bin/kafka-storage.sh random-uuid
 KAFKA_CLUSTER_ID=
 KAFKA_UI_USER=admin
 KAFKA_UI_PASSWORD=changeme

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -818,46 +818,65 @@ services:
   # remote access is only via SSH tunnel. Topic creation is handled by the
   # one-shot kafka-init service below.
   kafka:
-    # bitnami/* namespace was sunset Aug 2025; images now live at bitnamilegacy/*.
-    # Same image, same internal paths (/bitnami/kafka, /opt/bitnami/kafka/...) — only
-    # the registry namespace changes. Long-term migration off Bitnami tracked in #100.
-    image: bitnamilegacy/kafka:3.8.0
-    # Must run with GID 0 (root group) — matches the image's default USER directive.
-    # /opt/bitnami/kafka/config is root:root 775; the entrypoint cp's default configs
-    # there on first run and requires group-write via gid=0. Explicit user: 1001:1001
-    # loses that group membership and fails with "Permission denied" on server.properties
-    # — see #124. Long-term migration off Bitnami tracked in #100.
-    user: "1001:0"
+    # Official Apache Kafka image (KRaft-native, no ZooKeeper). Migrated off
+    # Bitnami in #100 — the bitnami/* namespace was sunset Aug 2025 and the
+    # bitnamilegacy/* stopgap is itself on a sunset trajectory. apache/kafka
+    # is the upstream-canonical, Apache-2.0-throughout, smallest standard
+    # image; owner-selected 2026-05-31. Differences from the Bitnami image
+    # that this block reconciles:
+    #   - Env-var convention: KAFKA_CFG_<X> → KAFKA_<X> (no CFG infix; the
+    #     apache/kafka entrypoint translates KAFKA_* directly to server
+    #     properties via KafkaDockerWrapper).
+    #   - Cluster ID: KAFKA_KRAFT_CLUSTER_ID → CLUSTER_ID (consumed by the
+    #     entrypoint's first-boot `kafka-storage format`; the image
+    #     auto-formats the log dir on first start).
+    #   - Data dir: /bitnami/kafka → /var/lib/kafka/data (apache/kafka's
+    #     default log.dirs from /etc/kafka/docker; volume remount below).
+    #   - User: the bitnami gid=0 workaround (#124, /opt/bitnami config
+    #     group-write) no longer applies — apache/kafka runs as its own
+    #     appuser (uid 1000) and owns its config/data dirs, so no explicit
+    #     `user:` override is needed.
+    #   - CLI scripts: /opt/bitnami/kafka/... → /opt/kafka/bin/... (see the
+    #     kafka-init mount + healthcheck below, and infra/kafka/init-topics.sh).
+    image: apache/kafka:3.9.2
     environment:
       # Core KRaft identity
-      KAFKA_CFG_NODE_ID: "1"
-      KAFKA_CFG_PROCESS_ROLES: "controller,broker"
-      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: "1@kafka:9093"
-      # Cluster ID must be stable across restarts — supplied via env (see .env.example).
-      KAFKA_KRAFT_CLUSTER_ID: "${KAFKA_CLUSTER_ID:?KAFKA_CLUSTER_ID must be set (generate once: docker run --rm bitnamilegacy/kafka:3.8.0 kafka-storage.sh random-uuid)}"
+      KAFKA_NODE_ID: "1"
+      KAFKA_PROCESS_ROLES: "controller,broker"
+      KAFKA_CONTROLLER_QUORUM_VOTERS: "1@kafka:9093"
+      # Cluster ID must be stable across restarts — supplied via env (see
+      # .env.example). apache/kafka reads CLUSTER_ID (not the Bitnami
+      # KAFKA_KRAFT_CLUSTER_ID) and formats the log dir with it on first boot.
+      CLUSTER_ID: "${KAFKA_CLUSTER_ID:?KAFKA_CLUSTER_ID must be set (generate once: docker run --rm apache/kafka:3.9.2 /opt/kafka/bin/kafka-storage.sh random-uuid)}"
+      # Persistent log dir — apache/kafka's bundled docker config defaults
+      # log.dirs to /var/lib/kafka/data; set it explicitly so the volume
+      # mount target below is unambiguous and survives any default change.
+      KAFKA_LOG_DIRS: "/var/lib/kafka/data"
       # Listeners (plaintext, internal-only — backend network is docker-internal)
-      KAFKA_CFG_LISTENERS: "INTERNAL://:9092,CONTROLLER://:9093"
-      KAFKA_CFG_ADVERTISED_LISTENERS: "INTERNAL://kafka:9092"
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: "INTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT"
-      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: "CONTROLLER"
-      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: "INTERNAL"
+      KAFKA_LISTENERS: "INTERNAL://:9092,CONTROLLER://:9093"
+      KAFKA_ADVERTISED_LISTENERS: "INTERNAL://kafka:9092"
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "INTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT"
+      KAFKA_CONTROLLER_LISTENER_NAMES: "CONTROLLER"
+      KAFKA_INTER_BROKER_LISTENER_NAME: "INTERNAL"
       # Durability / retention defaults (per-topic retention set by kafka-init)
-      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: "false"
-      KAFKA_CFG_DEFAULT_REPLICATION_FACTOR: "1"
-      KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
-      KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: "1"
-      KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR: "1"
-      KAFKA_CFG_MIN_INSYNC_REPLICAS: "1"
-      KAFKA_CFG_NUM_PARTITIONS: "3"
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+      KAFKA_DEFAULT_REPLICATION_FACTOR: "1"
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: "1"
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: "1"
+      KAFKA_MIN_INSYNC_REPLICAS: "1"
+      KAFKA_NUM_PARTITIONS: "3"
       # JVM heap — small single-node broker
       KAFKA_HEAP_OPTS: "-Xms512m -Xmx1g"
     volumes:
-      - kafka_data:/bitnami/kafka
+      - kafka_data:/var/lib/kafka/data
     expose:
       - "9092"
     healthcheck:
       # kafka-broker-api-versions.sh returns non-zero if the broker isn't accepting connections.
-      test: ["CMD-SHELL", "kafka-broker-api-versions.sh --bootstrap-server kafka:9092 >/dev/null 2>&1 || exit 1"]
+      # apache/kafka ships the CLI scripts under /opt/kafka/bin and does NOT
+      # guarantee them on PATH (unlike Bitnami), so call by absolute path.
+      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server kafka:9092 >/dev/null 2>&1 || exit 1"]
       interval: 15s
       timeout: 10s
       retries: 10
@@ -886,17 +905,18 @@ services:
     # One-shot topic creation. Idempotent: uses --if-not-exists. Exits 0 on success.
     # The service stays in "exited" state after the first successful run and is
     # re-executed whenever compose is brought up — cheap and safe.
-    # bitnamilegacy/* — see broker service comment + #100 for the long-term plan.
-    image: bitnamilegacy/kafka:3.8.0
-    # Must run with GID 0 (root group) — matches the image's default USER directive.
-    # /opt/bitnami/kafka/config is root:root 775; the entrypoint cp's default configs
-    # there on first run and requires group-write via gid=0. Explicit user: 1001:1001
-    # loses that group membership and fails with "Permission denied" on server.properties
-    # — see #124. Long-term migration off Bitnami tracked in #100.
-    user: "1001:0"
+    # apache/kafka — migrated off Bitnami in #100 (see broker service comment).
+    # No gid=0 / config-dir workaround needed here: this service only runs the
+    # init script against the already-running broker; it doesn't write into the
+    # image's config dir. The CLI scripts the init script calls live under
+    # /opt/kafka/bin (handled inside init-topics.sh).
+    image: apache/kafka:3.9.2
+    # Mount under a neutral path (not /opt/bitnami/...) — apache/kafka has no
+    # /opt/bitnami tree. /opt/kafka exists in the image; placing the script
+    # alongside (not inside bin/) keeps it clearly ours.
     volumes:
-      - ../infra/kafka/init-topics.sh:/opt/bitnami/kafka/init-topics.sh:ro
-    entrypoint: ["/bin/bash", "/opt/bitnami/kafka/init-topics.sh"]
+      - ../infra/kafka/init-topics.sh:/opt/kafka/init-topics.sh:ro
+    entrypoint: ["/bin/bash", "/opt/kafka/init-topics.sh"]
     environment:
       KAFKA_BOOTSTRAP: "kafka:9092"
     depends_on:

--- a/docs/pipeline-kafka.md
+++ b/docs/pipeline-kafka.md
@@ -66,7 +66,7 @@ Direct broker access (for `kafka-*.sh` CLI debugging) is possible from the VPS h
 
 ```
 docker compose -f compose/docker-compose.prod.yml exec kafka \
-    kafka-topics.sh --bootstrap-server kafka:9092 --list
+    /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --list
 ```
 
 The broker listener is on the `backend` Docker network (internal). It is not reachable from the host or the public internet.
@@ -76,10 +76,10 @@ The broker listener is on the `backend` Docker network (internal). It is not rea
 `KAFKA_CLUSTER_ID` is required and must remain stable — changing it after the first boot will cause the broker to refuse to start against existing log directories. Generate once at VPS bootstrap time:
 
 ```
-docker run --rm bitnamilegacy/kafka:3.8.0 kafka-storage.sh random-uuid
+docker run --rm apache/kafka:3.9.2 /opt/kafka/bin/kafka-storage.sh random-uuid
 ```
 
-(The `bitnami/*` namespace was sunset Aug 2025; `bitnamilegacy/*` is the same image rebadged. Long-term migration off Bitnami tracked in #100.)
+(The broker runs on the official `apache/kafka` image — migrated off Bitnami in #100. The previous `bitnami/*` namespace was sunset Aug 2025 and the `bitnamilegacy/*` stopgap was itself on a sunset trajectory. The compose service supplies this value to the image as `CLUSTER_ID`, which the entrypoint uses to format the log dir on first boot.)
 
 Store the output in the production `.env` file alongside the other secrets.
 

--- a/infra/kafka/init-topics.sh
+++ b/infra/kafka/init-topics.sh
@@ -15,6 +15,14 @@
 
 set -euo pipefail
 
+# apache/kafka (migrated off Bitnami in #100) ships the CLI scripts under
+# /opt/kafka/bin but does NOT put them on PATH by default. Prepend it so the
+# bare `kafka-topics.sh` / `kafka-configs.sh` / `kafka-broker-api-versions.sh`
+# invocations below resolve. Harmless on any image that already has them on
+# PATH (the dir is simply searched first). The scripts themselves are the
+# Apache-canonical ones, so the command-line flags used below are unchanged.
+export PATH="/opt/kafka/bin:${PATH}"
+
 BOOTSTRAP="${KAFKA_BOOTSTRAP:-kafka:9092}"
 PARTITIONS="${KAFKA_DEFAULT_PARTITIONS:-3}"
 REPLICATION="${KAFKA_REPLICATION_FACTOR:-1}"


### PR DESCRIPTION
## Summary

Migrates the pipeline Kafka broker off the sunset Bitnami image onto the **official `apache/kafka` image** (KRaft-native, no ZooKeeper). Owner-decided on #100 (2026-05-31): `apache/kafka` over the alternatives — Apache-2.0 throughout, smallest standard image (~390 MB), canonical docs, longest-stable trajectory. Pinned **`apache/kafka:3.9.2`** (latest 3.9 patch) to stay on the same major line as the outgoing `bitnamilegacy/kafka:3.8.0` — a 4.x jump on top of the image swap would widen the blast radius unnecessarily.

## Changes (`compose/docker-compose.prod.yml` — `kafka` + `kafka-init`)

| Concern | Bitnami (before) | apache/kafka (after) |
|---|---|---|
| Env-var convention | `KAFKA_CFG_<X>` | `KAFKA_<X>` (no `CFG` infix) |
| Cluster ID env | `KAFKA_KRAFT_CLUSTER_ID` | `CLUSTER_ID` |
| Data dir / volume | `/bitnami/kafka` | `/var/lib/kafka/data` (+ explicit `KAFKA_LOG_DIRS`) |
| Container user | `user: "1001:0"` workaround (#124) | none — image's own `appuser` (uid 1000) owns its dirs |
| CLI scripts | `/opt/bitnami/kafka/...` | `/opt/kafka/bin/...` |

- **Healthcheck**: `kafka-broker-api-versions.sh` → absolute `/opt/kafka/bin/kafka-broker-api-versions.sh` (apache/kafka does not put bin on `PATH`).
- **`infra/kafka/init-topics.sh`**: prepends `/opt/kafka/bin` to `PATH` so the bare `kafka-topics.sh` / `kafka-configs.sh` / `kafka-broker-api-versions.sh` calls resolve. Script body + flags unchanged (Apache-canonical scripts).
- **`kafka-init`**: image + mount/exec path `/opt/bitnami/kafka/init-topics.sh` → `/opt/kafka/init-topics.sh`; dropped the gid=0 override (this service only runs the init script against the live broker, doesn't write the image config dir).
- **`compose/.env.example` + `docs/pipeline-kafka.md`**: uuid-gen command and operator CLI examples repointed to `apache/kafka:3.9.2` / `/opt/kafka/bin/...`; Cluster ID doc notes the value is supplied to the image as `CLUSTER_ID`.

### Unchanged (image-agnostic — verified, not touched)
- **`kafka-ui`** (provectus): configured by broker address (`KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka:9092`), not cluster-ID — no change needed.
- **`kafka-exporter`** (danielqsj): scrapes the broker over the wire protocol on `kafka:9092` — no change needed.
- **Workflow secret passthrough**: the `.env` key `KAFKA_CLUSTER_ID` is unchanged, so `deploy-stg.yml` / `deploy-isnad-graph.yml` secret wiring is untouched.

## Side-effects table (from #100) — resolved for apache/kafka
1. **KRaft cluster ID**: `CLUSTER_ID` env; image auto-runs `kafka-storage format` on first boot. Existing prod/stg log dir holds the old Bitnami-formatted cluster ID → **re-bootstrap required** (wipe `kafka_data` volume). Acceptable per the pipeline design (reprocessing from B2 is the recovery model).
2. **Volume path**: `/bitnami/kafka` → `/var/lib/kafka/data` (done).
3. **Healthcheck**: absolute-path `kafka-broker-api-versions.sh` (done).
4. **init-topics.sh**: PATH-prepend + neutral mount path (done).
5. **JMX/metrics**: unchanged — `kafka-exporter` sidecar (broker-protocol) covers the surface; no JMX env needed (matches docs § Follow-ups "JMX not wired").
6. **`stop_grace_period`**: retained at 30s; apache/kafka's entrypoint handles SIGTERM for clean quorum exit.
7. **Kafka UI cluster-ID passthrough**: N/A — UI uses broker address, not cluster ID.
8. **Operator docs**: `docs/pipeline-kafka.md` § Cluster ID updated.

## Verification

**Verified at PR-time (mechanic):**
- YAML parses cleanly; `kafka`/`kafka-init` blocks structurally correct (image, volume, `CLUSTER_ID`, `KAFKA_LOG_DIRS`, no `user:` override, absolute healthcheck path).
- Env-var renames cross-checked against the **official apache/kafka image docs + container launch script** (`KAFKA_*` translation via `KafkaDockerWrapper`, `CLUSTER_ID`, uid 1000, `/opt/kafka/bin`).
- `shellcheck` + `bash -n` clean on `infra/kafka/init-topics.sh`.
- No CI gate hardcodes the old image string/paths; `compose-validate.yml` (`docker compose config`) + `shellcheck` job both exercise these files.

**Runtime-gated (CANNOT verify at PR-time — no Docker daemon in this env):**
- Live broker bring-up, first-boot storage format with `CLUSTER_ID`, healthcheck pass, and `kafka-init` topic creation against a real `apache/kafka:3.9.2` container.

### Proposed post-merge Test Plan item (stg-first, per #100 owner direction)
After merge to the wave branch, deploy to **stg first** via the auto-deploy chain. KRaft re-bootstrap on stg is low-cost (B2 reprocessing is the recovery model): wipe the stg `kafka_data` volume, confirm (1) the broker formats + reaches healthy, (2) `kafka-init` creates the 5 pipeline topics with correct retention, (3) `kafka-exporter` scrapes + Grafana broker/topic gauges populate, (4) Kafka UI connects read-only. Then promote to prod (same volume-wipe + re-bootstrap).

## TechDebt
None added. (Removes the standing Bitnami-sunset tech-debt this issue tracks; the `user: gid=0` / `#124` workaround is also retired.)

Refs #100
