### PR TITLE
infra(caddy): complete users.{base} carve-out — drop isnad.* dual-bind (Refs #245)

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -16,88 +16,33 @@ www.{$BASE_DOMAIN} {
 }
 
 isnad.{$BASE_DOMAIN} {
-    # User-service routes are ALSO served from this vhost (in addition to
-    # the dedicated users.{$BASE_DOMAIN} block below). The frontend hard-
-    # codes relative URLs (`/auth/oauth/{provider}/login`, `/api/v1/users`,
-    # etc.) — see frontend/src/{hooks/useAuth.ts,pages/LoginPage.tsx} —
-    # so removing these entirely from isnad.* breaks login. Restored
-    # 2026-05-02 mid-emergency-restore as the pragmatic two-phase
-    # migration completion: phase 1 is dual-binding both vhosts (this
-    # state); phase 2 is updating frontend to absolute URLs targeting
-    # users.{$BASE_DOMAIN}, then dropping the user-service routes from
-    # isnad.* (filed as deploy#NNN).
+    # User-service routes are NO LONGER served from this vhost — they live
+    # solely on the dedicated users.{$BASE_DOMAIN} block below. This is
+    # phase 2 of the #220 carve-out (deploy#245), completed once the
+    # frontend stopped hard-coding relative URLs:
+    #   - Phase 1 (2026-05-02 emergency restore): dual-bind user-service
+    #     routes on BOTH isnad.* and users.* so the relative-URL frontend
+    #     kept working after #241 moved the server-side routes.
+    #   - Phase 2 (this state, deploy#245): the frontend now targets
+    #     users.{$BASE_DOMAIN} absolutely — it resolves USER_SERVICE_ORIGIN
+    #     from window.RUNTIME_CONFIG (isnad-graph#932 / ig#934), set to
+    #     https://users.{$BASE_DOMAIN} via compose (USER_SERVICE_ORIGIN).
+    #     So the dual-bind is no longer load-bearing and is dropped here,
+    #     leaving isnad.* a pure frontend + isnad-graph-API surface.
+    # Same-site note: isnad.{base} and users.{base} share the registrable
+    # domain noorinalabs.com, so the user-service refresh/csrf cookies
+    # (httpOnly, SameSite=Lax, host-only on users.*) are still sent on the
+    # frontend's credentialed cross-origin fetch to users.* — Lax blocks
+    # only cross-SITE, and these subdomains are same-site. CORS already
+    # allows isnad.* (compose CORS_ORIGINS), CSP connect-src allows
+    # users.{$BASE_DOMAIN} (header block below).
 
-    # ── User service routes (transitional — see comment above) ──────
-
-    # OAuth post-login redirect target lives on the frontend (React Router
-    # AuthCallbackPage), NOT user-service. Carve out before /auth/* which
-    # goes to user-service. See deploy#133, user-service#67.
+    # OAuth post-login redirect target lives on the FRONTEND (React Router
+    # AuthCallbackPage), NOT user-service — so it STAYS on isnad.*. This is
+    # the one /auth/* path that is not a user-service route. Carve it out
+    # before the isnad-graph /api/* catch-all. See deploy#133, user-service#67.
     handle /auth/callback/* {
         reverse_proxy frontend:80
-    }
-
-    # User service — auth endpoints
-    handle /auth/* {
-        reverse_proxy user-service:8000
-    }
-
-    # User service — JWKS public keys (IETF well-known)
-    handle /.well-known/jwks.json {
-        reverse_proxy user-service:8000
-    }
-
-    # User service — user management API
-    handle /api/v1/users {
-        reverse_proxy user-service:8000
-    }
-    handle /api/v1/users/* {
-        reverse_proxy user-service:8000
-    }
-
-    # User service — session management
-    handle /api/v1/sessions {
-        reverse_proxy user-service:8000
-    }
-    handle /api/v1/sessions/* {
-        reverse_proxy user-service:8000
-    }
-
-    # User service — subscription management
-    handle /api/v1/subscriptions {
-        reverse_proxy user-service:8000
-    }
-    handle /api/v1/subscriptions/* {
-        reverse_proxy user-service:8000
-    }
-
-    # User service — email verification
-    handle /api/v1/verification {
-        reverse_proxy user-service:8000
-    }
-    handle /api/v1/verification/* {
-        reverse_proxy user-service:8000
-    }
-
-    # User service — roles
-    handle /api/v1/roles {
-        reverse_proxy user-service:8000
-    }
-    handle /api/v1/roles/* {
-        reverse_proxy user-service:8000
-    }
-
-    # User service — 2FA (TOTP)
-    handle /api/v1/2fa {
-        reverse_proxy user-service:8000
-    }
-    handle /api/v1/2fa/* {
-        reverse_proxy user-service:8000
-    }
-
-    # User service — health check (rewrite to /health)
-    handle /api/v1/user-service/health {
-        rewrite * /health
-        reverse_proxy user-service:8000
     }
 
     # ── isnad-graph API routes ───────────────────────────────────────

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -188,6 +188,19 @@ services:
     # no Node/npm toolchain, so the previous `npm pack`-based build path was
     # never viable and the CACHEBUST arg (local-build cache buster) went with it.
     image: ghcr.io/noorinalabs/noorinalabs-isnad-graph-frontend:${IMAGE_TAG:-latest}
+    environment:
+      # Runtime origin for the user-service API, consumed by the frontend
+      # container entrypoint (isnad-graph#932 / ig#934): entrypoint.sh runs
+      # `envsubst '${USER_SERVICE_ORIGIN}'` over runtime-config.js.template,
+      # so window.RUNTIME_CONFIG.USER_SERVICE_ORIGIN is this value at runtime.
+      # useAuth.ts / LoginPage.tsx then build absolute AUTH_BASE / USER_BASE /
+      # SESSIONS_BASE against it. This completes deploy#245 phase 2: the
+      # frontend targets users.{$BASE_DOMAIN} directly instead of the empty-
+      # string same-origin fallback the transitional isnad.* dual-bind relied
+      # on (now dropped — see caddy/Caddyfile isnad.{$BASE_DOMAIN} block).
+      # Per-env via ${BASE_DOMAIN} (prod: users.noorinalabs.com,
+      # stg: users.stg.noorinalabs.com).
+      USER_SERVICE_ORIGIN: "https://users.${BASE_DOMAIN}"
     expose:
       - "80"
     read_only: true


### PR DESCRIPTION
## Summary

Completes **phase 2** of the #220 user-service vhost carve-out — the remaining deploy-repo work of #245 (step 5). The frontend stopped hard-coding relative URLs in **isnad-graph#932 / ig#934** (merged to the wave branch): `useAuth.ts` + `LoginPage.tsx` now resolve `USER_SERVICE_ORIGIN` from `window.RUNTIME_CONFIG` (injected by the container entrypoint's `envsubst` over `runtime-config.js.template`) and build **absolute** `AUTH_BASE` / `USER_BASE` / `SESSIONS_BASE`. With that consumer landed, the transitional dual-bind of user-service routes on `isnad.{base}` is no longer load-bearing and is dropped here.

Phase-2 step status going in (verified at wave-13 head):
- Step 1 (frontend absolute URLs) — done in ig#934.
- Step 2 (user-service `CORS_ORIGINS` includes `isnad.{base}`) — already present.
- Step 3 (Caddy CSP `connect-src https://users.{$BASE_DOMAIN}`) — already present.
- Step 4 (cookie domain) — analyzed below; no change needed.
- **Step 5 (drop the isnad.{base} dual-bind) — this PR.**

## Changes

- **`compose/docker-compose.prod.yml`** — add `USER_SERVICE_ORIGIN: "https://users.${BASE_DOMAIN}"` to the **frontend** service env. This is the value ig#934's entrypoint substitutes into `runtime-config.js`; when unset the frontend falls back to same-origin (`''`), so setting it makes the frontend target `users.*` directly. Per-env via `${BASE_DOMAIN}` (prod `users.noorinalabs.com`, stg `users.stg.noorinalabs.com`).
- **`caddy/Caddyfile`** — drop the user-service routes from the `isnad.{$BASE_DOMAIN}` block: `/auth/*` (except `/auth/callback/*`), `/.well-known/jwks.json`, `/api/v1/{users,sessions,subscriptions,verification,roles,2fa}`, and the user-service health rewrite. They remain **fully served** on the dedicated `users.{$BASE_DOMAIN}` block (unchanged — verified all 16 routes still present). `/auth/callback/*` **stays** on `isnad.*` because it is the **frontend** React-Router `AuthCallbackPage` target, not a user-service route. `isnad.*` is now a pure frontend + isnad-graph-API surface.

## Cookie same-site analysis (the step-5 safety question)

Orchestrator-verified against user-service `src/app/routers/auth.py`: the refresh-token + csrf cookies are `httpOnly`, **`SameSite=Lax`**, **host-only** (no `Domain=`), Secure in prod.

`isnad.noorinalabs.com` and `users.noorinalabs.com` share the registrable domain `noorinalabs.com`, so they are **same-site** (SameSite is computed on eTLD+1; subdomains are same-site). `SameSite=Lax` blocks only *cross-site* requests, so the cookies **are** sent on the frontend's credentialed `fetch(users.{base}/auth/token/refresh, {credentials:'include'})`. Host-only scope is fine because, once `USER_SERVICE_ORIGIN=users.{base}`, both login and refresh target `users.*` — cookie set by and sent to the same host. CORS already allows `isnad.*`; CSP `connect-src` already allows `users.{$BASE_DOMAIN}`. So dropping the dual-bind does not break refresh.

## Verification

**Verified at PR-time (mechanic):**
- compose YAML parses; frontend service now carries `USER_SERVICE_ORIGIN`.
- Caddyfile braces balanced (51/51); **0** `user-service:8000` routes remain in the `isnad.{base}` block; the `users.{base}` block retains all 16 user-service routes (nothing lost).
- Passlist-drift gate unaffected — `USER_SERVICE_ORIGIN` is a `${BASE_DOMAIN}`-derived compose value, not a `:?`-required secret, and `BASE_DOMAIN` is already in the deploy `env_keys`.
- `caddy validate` + `docker compose config` run in CI (caddy/docker unavailable in this env).

**Runtime-gated (CANNOT verify at PR-time):** the live cross-origin login + refresh flow against a deployed stack.

## STG-FIRST PROD-PROMOTION GATE (mandatory)

This changes the live auth routing topology. **Deploy to staging first** and confirm both, before any prod promote:
1. **Login works** end-to-end on `isnad.stg.noorinalabs.com` (OAuth + email), with the frontend hitting `users.stg.noorinalabs.com` absolutely (network panel shows no same-origin `/auth/*` calls to `isnad.*`).
2. **Page-reload survives** — reload an authenticated session and confirm the silent refresh (`users.stg.../auth/token/refresh`, `credentials:'include'`) succeeds cross-origin (the `SameSite=Lax` host-only cookie is sent). This is the exact behavior the cookie analysis predicts; it is the load-bearing proof.

**Do NOT promote to prod until stg proves the reload-refresh.** If stg shows the JSON.parse / session-drop symptom, the cookie scope needs a parent-domain (`.noorinalabs.com`) change in user-service first — hold and escalate rather than force prod.

## TechDebt
None added. (Removes the transitional dual-bind tech-debt; `isnad.*` no longer carries a foreign service's routes.)

Refs #245
