### PR TITLE
ci(docs): pin actionlint installer to v1.7.12 + SHA256-verify (Refs #578)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -155,13 +155,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Download and verify actionlint
+        env:
+          # Pinned: version + linux_amd64 tarball SHA256 from upstream's
+          # signed release manifest (actionlint_1.7.12_checksums.txt at
+          # https://github.com/rhysd/actionlint/releases/tag/v1.7.12).
+          # `sha256sum -c` aborts the job on mismatch — bytes-on-runner are
+          # exactly what was published at release time. Replaces the prior
+          # `curl|bash` of the unpinned download-actionlint.bash off `main`
+          # (#578): fetching+executing latest-of-main each run is a
+          # supply-chain gap and diverges from the pinned v1.7.12 the
+          # .pre-commit-config.yaml mirror already ships.
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          cd "$RUNNER_TEMP"
+          curl --fail --silent --show-error --location \
+            -o "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" | sha256sum -c -
+          tar -xzf "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" actionlint
+          install -m 0755 actionlint /usr/local/bin/actionlint
+          actionlint -version
       - name: Run actionlint on workflows
         # shellcheck is preinstalled on ubuntu-latest, so actionlint's embedded
         # shellcheck integration runs (per the actionlint-needs-shellcheck
         # discipline) rather than silently skipping — load-bearing for this
         # shell-heavy repo. lint-workflows.yml pins+SHA-verifies actionlint for
         # the workflow-paths trigger; this job is the docs-workflow companion
-        # using the upstream installer so the docs gate is self-contained.
-        run: |
-          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-          ./actionlint -color
+        # using the same pinned installer so the docs gate is self-contained.
+        run: actionlint -color


### PR DESCRIPTION
## What

Pins `docs.yml`'s actionlint installer (deploy slice of the org-wide rollout, `Refs noorinalabs-main#578`).

Replaces the unpinned, no-checksum installer:
```yaml
bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
./actionlint -color
```
with a pinned **download + `sha256sum -c` verify** step (v1.7.12) followed by `actionlint -color` (installs to `/usr/local/bin`, so the `./` prefix is dropped).

## Why

Fetching + executing `download-actionlint.bash` off `main` each run is a supply-chain gap and diverges from the pinned **v1.7.12** the repo's `.pre-commit-config.yaml` mirror already ships. The pinned tarball + checksum gate makes the bytes-on-runner exactly what upstream published at release time.

## Verification

- **SHA256 independently re-verified against upstream** (verify-third-party-integrity discipline): downloaded `actionlint_1.7.12_checksums.txt` from the v1.7.12 release; `linux_amd64` hash is `8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8` — exact match to the pinned value.
- `actionlint` (local, with shellcheck on PATH) clean on the modified `docs.yml`.
- Pre-commit ⇄ CI sync-drift gate passes (no new un-mirrored kind).
- Deploy's actionlint job has **no `-ignore` flags** and **no matrix** (uniform check-run name `Config — Workflow actionlint`), so this swap adds no new required-status-check context and renames nothing.

## Reviewers

Lucas Ferreira (peer) + Nurul Hakim (secondary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
