### PR TITLE
ci(python): ruff + mypy gate for scripts/ + workflows/scripts/ (Refs noorinalabs-main#326)

### DIFF
--- a/.github/workflows/compose-validate.yml
+++ b/.github/workflows/compose-validate.yml
@@ -105,6 +105,56 @@ jobs:
           done
           exit "$fail"
 
+  python-lint:
+    # noorinalabs-main#326: deploy's own Python tooling — the standalone
+    # scripts under scripts/ and .github/workflows/scripts/ — had NO ruff/mypy
+    # gate. hooks-lint.yml only lints .claude/hooks/*.py (none in this
+    # dispatcher-style child, so it skips), and the shellcheck job above is
+    # *.sh-only. So check_tf_apply_locking.py / env-inventory.py /
+    # cold_rebuild_static_checks.py were ungated despite being CI-critical
+    # (the TF-apply-lock regression guard and the cold-rebuild shape guards
+    # run from these). This job is the missing Python floor, mirroring
+    # hooks-lint.yml's ruff/mypy pattern. Pinned to ruff 0.11.6 — the same
+    # version the .pre-commit-config.yaml mirror + org rollout ship — so local
+    # `pre-commit` and CI run the identical tool (#327 fail-fast parity).
+    # integration-tests/ is out of scope here: it is pytest-gated by
+    # integration-tests.yml and carries its own dev-deps/config.
+    name: ruff + mypy (scripts)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Discover Python scripts
+        id: discover
+        shell: bash
+        run: |
+          mapfile -t files < <(find scripts .github/workflows/scripts -type f -name '*.py' 2>/dev/null)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No Python scripts found — nothing to lint."
+            echo "found=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          printf '%s\n' "${files[@]}"
+          echo "found=1" >> "$GITHUB_OUTPUT"
+      - name: Install ruff + mypy (pinned)
+        if: steps.discover.outputs.found == '1'
+        # ruff 0.11.6 matches .pre-commit-config.yaml's ruff-pre-commit rev and
+        # the org rollout pin. types-PyYAML supplies the stubs for
+        # check_tf_apply_locking.py's `import yaml` so mypy doesn't trip on
+        # import-untyped (which --ignore-missing-imports does NOT suppress).
+        run: pip install ruff==0.11.6 mypy types-PyYAML
+      - name: Ruff lint (scripts)
+        if: steps.discover.outputs.found == '1'
+        run: ruff check scripts .github/workflows/scripts
+      - name: Ruff format --check (scripts)
+        if: steps.discover.outputs.found == '1'
+        run: ruff format --check scripts .github/workflows/scripts
+      - name: Mypy type check (scripts)
+        if: steps.discover.outputs.found == '1'
+        run: mypy scripts .github/workflows/scripts --ignore-missing-imports --no-error-summary
+
   passlist-drift:
     # deploy#97: catch drift between compose's :?-required vars and the
     # deploy-stg/deploy-prod env_keys passlists at PR-review time, before

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,30 +55,37 @@ repos:
       - id: actionlint
         name: actionlint
 
-  # --- Python lint/format for .claude/hooks (mirrors hooks-lint.yml) ---
-  # Pinned to ruff 0.11.6 (the org rollout pin). Scoped to .claude/hooks/ and
-  # no-op today (no hooks present); present for CI parity + future-proofing.
+  # --- Python lint/format (mirrors hooks-lint.yml + compose-validate.yml) ---
+  # Pinned to ruff 0.11.6 (the org rollout pin). Scoped to the repo's Python:
+  #   * .claude/hooks/ ............ mirrors hooks-lint.yml (no-op today; no hooks)
+  #   * scripts/ + .github/workflows/scripts/ .. mirrors compose-validate.yml's
+  #     python-lint job (noorinalabs-main#326) so local pre-commit catches the
+  #     same ruff drift CI does (#327 fail-fast parity).
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.6
     hooks:
       - id: ruff-format
         name: ruff-format
-        files: ^\.claude/hooks/.*\.py$
+        files: ^(\.claude/hooks/|scripts/|\.github/workflows/scripts/).*\.py$
       - id: ruff
         name: ruff-lint
         args: [--fix]
-        files: ^\.claude/hooks/.*\.py$
+        files: ^(\.claude/hooks/|scripts/|\.github/workflows/scripts/).*\.py$
 
   # --- Local hooks ---
   - repo: local
     hooks:
-      # mypy over .claude/hooks (mirrors hooks-lint.yml typecheck job). Heavier,
-      # so pre-push. always_run with the wrapper no-op'ing when the directory is
-      # empty, matching the CI job's skip-when-no-hooks guard.
-      - id: mypy-hooks
+      # mypy over .claude/hooks (mirrors hooks-lint.yml) + scripts/ and
+      # .github/workflows/scripts/ (mirrors compose-validate.yml's python-lint
+      # job, noorinalabs-main#326). Heavier, so pre-push. The .claude/hooks/
+      # arm no-ops when empty (matches the CI skip-when-no-hooks guard); the
+      # scripts arm always runs since those dirs are always present. types-PyYAML
+      # is needed for check_tf_apply_locking.py's `import yaml` — install it in
+      # your pre-commit env (`pip install types-PyYAML`) so mypy matches CI.
+      - id: mypy-python
         name: mypy (pre-push)
         entry: |-
-          bash -c 'shopt -s nullglob; files=(.claude/hooks/*.py); if [ ${#files[@]} -eq 0 ]; then echo "No hooks present, skipping mypy."; exit 0; fi; mypy .claude/hooks/ --ignore-missing-imports --no-error-summary'
+          bash -c 'shopt -s nullglob; targets=(scripts .github/workflows/scripts); hooks=(.claude/hooks/*.py); if [ ${#hooks[@]} -gt 0 ]; then targets+=(.claude/hooks); fi; mypy "${targets[@]}" --ignore-missing-imports --no-error-summary'
         language: system
         pass_filenames: false
         always_run: true

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,21 @@
+# Ruff config for noorinalabs-deploy's Python tooling.
+#
+# Added with the python-lint CI gate (noorinalabs-main#326). Deploy previously
+# had NO ruff config, so a bare CI `ruff` run fell back to defaults (88-col)
+# while the scripts were authored to the org-standard 100-col (the parent
+# noorinalabs-main/pyproject.toml + every sibling repo). Pinning line-length
+# here makes CI and local pre-commit agree AND keeps deploy's Python formatted
+# the same as the rest of the org — without reformatting working scripts to a
+# narrower width that diverges from every sibling.
+#
+# Kept deliberately minimal: line-length + target + the lint rule-set the org
+# baseline uses (E/F/W/I). Mirror the parent if that baseline widens.
+target-version = "py312"
+line-length = 100
+
+# Worktree dirs are scratch checkouts of other branches — never lint/format
+# these (matches isnad-graph's ruff config).
+extend-exclude = [".claude/worktrees"]
+
+[lint]
+select = ["E", "F", "W", "I"]


### PR DESCRIPTION
## What

Adds a `python-lint` job (ruff check + ruff format --check + mypy) to `compose-validate.yml` covering deploy's own Python tooling under `scripts/` and `.github/workflows/scripts/`, and broadens the `.pre-commit-config.yaml` ruff/mypy scope to the same dirs.

`Refs noorinalabs-main#326`

## Why

Aino's org-wide CI-green audit (noorinalabs-main#326) found deploy had **no ruff/mypy gate on its own Python**:
- `hooks-lint.yml` lints only `.claude/hooks/*.py` — and deploy is a dispatcher-style child with no hooks, so that job *skips*.
- `compose-validate.yml`'s `shellcheck` job is `*.sh`-only.

That left three CI-critical scripts ungated:
- `scripts/check_tf_apply_locking.py` — the ADR 0005 / #334 TF-apply-lock regression guard
- `scripts/env-inventory.py`
- `.github/workflows/scripts/cold_rebuild_static_checks.py` — the cold-rebuild shape guards

Shell (`compose-validate.yml shellcheck`), Terraform (`terraform.yml`), and `integration-tests/` (pytest via `integration-tests.yml`) were already gated — Python was the one hole.

## Changes

1. **`.github/workflows/compose-validate.yml`** — new `python-lint` job. `find`-discovers `*.py` under `scripts/` + `.github/workflows/scripts/` (skip-clean if none), pins **ruff 0.11.6** (matches the `.pre-commit-config.yaml` mirror + org rollout), installs `types-PyYAML` for the mypy step, runs `ruff check` / `ruff format --check` / `mypy --ignore-missing-imports`. Mirrors `hooks-lint.yml`'s pattern. The job sits alongside the existing `shellcheck` job and rides its `scripts/**` + `.github/workflows/**` triggers.
2. **`.pre-commit-config.yaml`** — broadens the ruff `files:` globs and the mypy local-hook to the same dirs so local `pre-commit` catches the same drift CI does (#327 fail-fast parity). The `.claude/hooks/` arm still no-ops when empty.

## Verification

**Verified at PR-time (mechanic):**
- `ruff check` / `ruff format --check` / `mypy --ignore-missing-imports` all clean on the three scripts — this is a pure regression guard, **no script code changed**.
- The one mypy snag (`import yaml` → `import-untyped`, which `--ignore-missing-imports` does NOT suppress for an installed-but-unstubbed lib) is resolved by installing `types-PyYAML` in the job; verified mypy exits 0 with it.
- `actionlint` clean on the modified workflow (shellcheck on PATH so the embedded integration runs).
- **Pre-commit ⇄ CI sync-drift gate passes** (`python3 .claude/lib/pre_commit_ci_sync.py .` → OK): no new kind introduced — ruff/mypy were already balanced; this only widens scope. `gitleaks` remains stricter-local (informational).
- Sync-gate unit tests: 11 passed.

**Runtime-gated:** none — this is a static-analysis CI job; its behavior is fully exercised by the local runs above.

## Reviewers

Aisha Idrissi (peer) + Nino Kavtaradze (secondary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Update: ruff.toml added

First CI run surfaced that deploy had **no ruff config**, so a bare CI `ruff` run fell back to defaults (88-col) while the two longer scripts were authored to the org-standard **100-col** (the parent `noorinalabs-main/pyproject.toml` + every sibling repo). Added a minimal `ruff.toml` (`line-length=100`, `E/F/W/I` select, `.claude/worktrees` exclude per isnad-graph) so CI and local pre-commit agree and deploy stays formatted like the rest of the org — rather than reformatting working scripts to a narrower width. CI now all-green at HEAD `b50f162` incl. the new `ruff + mypy (scripts)` job.