### PR TITLE
infra(observability): add user-service:8000/metrics scrape to prometheus.{stg,prod}.yml

### DIFF
--- a/infra/prometheus/prometheus.prod.yml
+++ b/infra/prometheus/prometheus.prod.yml
@@ -26,11 +26,23 @@ scrape_configs:
     static_configs:
       - targets: ["postgres-exporter:9187"]
 
-  # user-service stack exporters (deploy#64). user-service:8000/metrics is NOT
-  # scraped here because user-service has no /metrics endpoint yet — tracked
-  # in noorinalabs-user-service#124. user-postgres-exporter IS scraped — it
-  # has been running in compose since the user-service stack extraction and
-  # was silently un-scraped until #64 surfaced the gap.
+  # user-service application metrics (deploy#384, follow-up to
+  # noorinalabs-user-service#124 / PR #137). user-service now exposes
+  # /metrics via prometheus_fastapi_instrumentator (low-cardinality:
+  # handler+method+status, excluded from the OpenAPI schema). This closes
+  # the carve-out documented in #64 — at that time user-service had no
+  # /metrics endpoint, so only user-postgres-exporter was scraped. Scraped
+  # service-to-service over the backend Docker network on :8000; the
+  # endpoint is NOT publicly exposed (the Caddyfile `respond 403`s
+  # /metrics), so Prometheus reaches it directly by container name.
+  - job_name: "user-service"
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["user-service:8000"]
+
+  # user-postgres-exporter (deploy#64) — has been running in compose since
+  # the user-service stack extraction and was silently un-scraped until #64
+  # surfaced the gap.
   - job_name: "user-postgres-exporter"
     static_configs:
       - targets: ["user-postgres-exporter:9187"]

--- a/infra/prometheus/prometheus.stg.yml
+++ b/infra/prometheus/prometheus.stg.yml
@@ -26,8 +26,20 @@ scrape_configs:
     static_configs:
       - targets: ["postgres-exporter:9187"]
 
+  # user-service application metrics (deploy#384, follow-up to
+  # noorinalabs-user-service#124 / PR #137). user-service now exposes
+  # /metrics via prometheus_fastapi_instrumentator (low-cardinality:
+  # handler+method+status, excluded from the OpenAPI schema). Scraped
+  # service-to-service over the backend Docker network on :8000 — the
+  # endpoint is NOT publicly exposed (the Caddyfile `respond 403`s
+  # /metrics), so Prometheus reaches it directly by container name.
+  - job_name: "user-service"
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["user-service:8000"]
+
   # user-service stack exporters (deploy#64). See prometheus.prod.yml for
-  # full rationale on the user-service:8000 carve-out (noorinalabs-user-service#124).
+  # full rationale on the user-service stack carve-out (noorinalabs-user-service#124).
   - job_name: "user-postgres-exporter"
     static_configs:
       - targets: ["user-postgres-exporter:9187"]


### PR DESCRIPTION
## Summary

Adds a `user-service` Prometheus scrape job to both env configs (`infra/prometheus/prometheus.stg.yml` and `prometheus.prod.yml`), scraping `user-service:8000/metrics` over the backend Docker network.

Follow-up to **noorinalabs-user-service#124 / PR #137**, which delivered the `/metrics` endpoint via `prometheus_fastapi_instrumentator` (low-cardinality: handler+method+status, excluded from the OpenAPI schema). AC item 5 of us#124 was a deploy-repo task.

The endpoint is **not publicly exposed** — the Caddyfile `respond 403`s `/metrics` — so Prometheus reaches it service-to-service by container name, not through Caddy. The prod config's prior carve-out comment (#64: "user-service has no /metrics endpoint yet") is updated to reflect closure of that gap.

**Lands with #386** (Nino's Caddy external `/metrics` block). That change does NOT affect this scrape: my scrape is container-to-container on the backend network, not through Caddy.

The new job mirrors the existing `api` job shape (job_name + `metrics_path: /metrics` + a single `static_configs` target), which already passes the `promtool check config` CI gate.

## Test Plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — both files parse cleanly
- [ ] CI `promtool check (rules + config)` gate validates both configs against `prom/prometheus:v3.4.0` (docker not available locally — relied on CI)
- [ ] **Post-merge (runtime-gated, needs deployed stack):** confirm `up{job="user-service"} == 1` in Prometheus and that `user-service:8000/metrics` returns 200 + `text/plain` over the backend network. Live scrape verification could not be done at PR time — it requires the deployed compose stack (per the issue's runtime-gated note).

Closes #384

Co-Authored-By: Nurul Hakim <parametrization+Nurul.Hakim@gmail.com>
Co-Authored-By: Claude <noreply@anthropic.com>
