### PR TITLE
security(caddy): block /metrics on users.{base} vhost

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -164,6 +164,17 @@ users.{$BASE_DOMAIN} {
         reverse_proxy user-service:8000
     }
 
+    # Metrics — not publicly proxied; Prometheus scrapes user-service:8000
+    # directly via the Docker backend network (see infra/prometheus.yml,
+    # scrape config added in deploy#384). Without this block the catch-all
+    # below would proxy /metrics to user-service, exposing request volumes,
+    # latency histograms, the full route inventory, and error rates to the
+    # open internet (recon-useful). Mirrors the isnad.{$BASE_DOMAIN} block.
+    # MUST precede the catch-all `handle`. (deploy#386, us#124/#137 hard-dep)
+    handle /metrics {
+        respond 403
+    }
+
     # Default — catch-all to user-service for any unmapped path on this
     # vhost. The vhost is purely an API surface post-#247 (OAuth callback
     # redirects cross-origin to isnad.{$BASE_DOMAIN}/auth/callback rather


### PR DESCRIPTION
## Summary

Closes #386.

user-service's Prometheus `/metrics` endpoint (us#124/#137) is publicly reachable through the `users.{$BASE_DOMAIN}` Caddy vhost: the vhost ends in a catch-all `handle { reverse_proxy user-service:8000 }` with **no `/metrics` handler**, so `https://users.{base}/metrics` proxies straight to user-service. That exposes request volumes, latency histograms, the full route inventory, and error rates to the open internet (recon-useful).

The pre-existing `handle /metrics { respond 403 }` is on the **`isnad.{$BASE_DOMAIN}`** vhost only (which fronts isnad-graph `api:8000`) — it does not cover this path.

### Change

Add `handle /metrics { respond 403 }` to the `users.{$BASE_DOMAIN}` vhost, placed **before** the catch-all `handle` so it takes precedence. Mirrors the existing `isnad.*` block. 11-line, single-file diff (`caddy/Caddyfile`).

### Does not break internal scraping

Prometheus scrapes `user-service:8000/metrics` **container-to-container over the Docker backend network** (companion deploy#384), never through Caddy — the same pattern as the existing `api:8000` scrape target in `infra/prometheus/prometheus.{stg,prod}.yml`. This Caddy block only affects the public HTTP path; the internal Docker-DNS path is untouched. Coordinated with Nurul Hakim (deploy#384).

## Test Plan

**Done at PR time:**
- [x] `caddy validate --config caddy/Caddyfile --adapter caddyfile` (caddy v2.8.4, `BASE_DOMAIN` set) → **"Valid configuration"** (config adapts to JSON cleanly).
- [x] Diff is minimal (11 insertions, 4-space indent matching the file's existing style). NOTE: `caddy fmt` prefers tabs, but the entire committed Caddyfile uses 4-space indentation — reformatting is out of scope for this security fix and would produce a whole-file diff. There is no `caddy fmt`/validate CI gate in this repo, so the fmt-style warning is non-blocking.
- [x] Confirmed `users.*` vhost has no other `/metrics` handler and the new block precedes the catch-all.

**Post-merge runtime verification (runtime-gated — needs a deployed stack):**
- [ ] After stg deploy: `curl -sSI https://users.stg.noorinalabs.com/metrics` → **403** (publicly blocked).
- [ ] Internal scrape still returns 200: confirm Prometheus' `user-service:8000` target (deploy#384) is `up` in the stg Prometheus targets page — proves the container-to-container path is unaffected.
- [ ] Same two checks on prod after promote.

## Dependency note

Hard prerequisite for shipping us#124/#137 to **prod** — us PR #137 must not reach prod until this 403 lands (per #386). Pairs with deploy#384 (Nurul) for the internal scrape config.

Co-Authored-By: Nino Kavtaradze <parametrization+Nino.Kavtaradze@gmail.com>
Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
