### PR TITLE
fix(#395): omit empty required_status_checks rule from ruleset-main.json (API 422s)

### DIFF
--- a/.github/branch-protection/SPEC.md
+++ b/.github/branch-protection/SPEC.md
@@ -52,7 +52,7 @@ A **repository ruleset** targeting `~DEFAULT_BRANCH`, `enforcement: active`:
   (`validate_pr_review`), not formal reviews. A naive "require 1 approval" rule
   would **deadlock every merge**. Reviewer-count enforcement stays with Hook 4.
 
-- **`required_status_checks` is intentionally EMPTY for this repo** — the
+- **`required_status_checks` rule — OMITTED for this repo** — the
   deploy-specific divergence from the user-service pilot. **Every one of
   noorinalabs-deploy's CI workflows is `paths:`-filtered** (terraform.yml,
   compose-validate.yml, hooks-lint.yml, lint-workflows.yml, integration-tests.yml,
@@ -64,13 +64,18 @@ A **repository ruleset** targeting `~DEFAULT_BRANCH`, `enforcement: active`:
   *unconditional*; deploy has no such always-on gate, so requiring any specific
   context here would block unrelated PRs.
 
-  We therefore ship the ruleset with the `required_status_checks` rule present
-  but its list **empty**, which still enforces the `strict` (up-to-date) policy
-  shape without naming a context that can deadlock. The PR-required +
-  no-force-push + no-delete protections — the bulk of #322's intent — are fully
-  active. **The server-side CI-failure-blocks-merge guarantee on deploy is
-  instead carried by the operator-side Hook 4 + `validate_pr_ci_status`
-  ADMIN_MERGE_EXCEPTION gate** until/unless an unconditional CI gate is added.
+  The intent is therefore **no required status check at the ruleset layer**. Note
+  the GitHub REST API **rejects** a `required_status_checks` rule carrying an
+  empty `required_status_checks` array (HTTP 422: "Invalid parameter
+  required_status_checks: Expected at least 1 elements, got 0"), so the rule is
+  **omitted entirely** rather than included-with-`[]`. (An earlier revision
+  shipped the rule present-with-`[]`, which never applied — deploy#395; mirrors
+  the parent-repo correction noorinalabs-main#322 / commit 29cfc88.) The
+  PR-required + no-force-push + no-delete protections — the bulk of #322's
+  intent — are fully active. **The server-side CI-failure-blocks-merge guarantee
+  on deploy is instead carried by the operator-side Hook 4 +
+  `validate_pr_ci_status` ADMIN_MERGE_EXCEPTION gate** until/unless an
+  unconditional CI gate is added.
 
   **If deploy later gains an unconditional (un-path-filtered) PR CI gate**, add
   its job-name context here and to `apply-ruleset.sh`'s read-back, e.g.:

--- a/.github/branch-protection/apply-ruleset.sh
+++ b/.github/branch-protection/apply-ruleset.sh
@@ -22,14 +22,18 @@
 #     principal IS the PR author, so a formal self-approval 422s). Reviewer-count
 #     enforcement stays with Hook 4 (validate_pr_review). A "require 1 approval"
 #     rule would deadlock every merge.
-#   * Required status checks: EMPTY for deploy. Every deploy CI workflow is
-#     paths-filtered, so a `strict` ruleset naming any context would deadlock
+#   * Required status checks: rule OMITTED for deploy. Every deploy CI workflow
+#     is paths-filtered, so a `strict` ruleset naming any context would deadlock
 #     PRs that don't touch that path (the check never runs → its context never
-#     reports). The PR-required + no-force-push + no-delete protections are still
-#     fully active; the CI-blocks-merge guarantee is carried operator-side by
-#     Hook 4 + the ADMIN_MERGE_EXCEPTION gate until deploy gains an unconditional
-#     PR CI gate. When it does, add `{ "context": "<job-name>" }` to
-#     ruleset-main.json's required set (confirm against live check-runs first).
+#     reports). The GitHub REST API also 422s on an empty required_status_checks
+#     array ("Expected at least 1 elements, got 0" — deploy#395), so the rule is
+#     dropped entirely rather than included-with-[]. The PR-required +
+#     no-force-push + no-delete protections are still fully active; the
+#     CI-blocks-merge guarantee is carried operator-side by Hook 4 + the
+#     ADMIN_MERGE_EXCEPTION gate until deploy gains an unconditional PR CI gate.
+#     When it does, ADD a required_status_checks rule with
+#     `{ "context": "<job-name>" }` to ruleset-main.json (confirm against live
+#     check-runs first) — re-introducing the rule, not un-emptying an array.
 #   * Repository-admin always-bypass (actor_id 5) keeps the orchestrator's
 #     --admin wave→main wrapup merges + the charter single-reviewer/doc-sweep/
 #     emergency exceptions working. The hook-side ADMIN_MERGE_EXCEPTION gate

--- a/.github/branch-protection/ruleset-main.json
+++ b/.github/branch-protection/ruleset-main.json
@@ -29,14 +29,6 @@
         "required_reviewers": [],
         "allowed_merge_methods": ["merge", "squash", "rebase"]
       }
-    },
-    {
-      "type": "required_status_checks",
-      "parameters": {
-        "strict_required_status_checks_policy": true,
-        "do_not_enforce_on_create": false,
-        "required_status_checks": []
-      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

The committed `.github/branch-protection/ruleset-main.json` shipped a `required_status_checks` rule with an **empty** `required_status_checks` array. The GitHub REST `/rulesets` endpoint rejects this with HTTP 422 (`Invalid parameter required_status_checks: Expected at least 1 elements, got 0`), so the committed payload **never applied as-is**.

deploy's CI is path-filtered (no unconditional status-check context to require), so the intent is **no required status check at the ruleset layer** — which for the API means the rule must be **omitted entirely**, not included-with-`[]`.

This is a **sync-back**: the live ruleset (id `17139848`) was applied with the rule omitted (`deletion` + `non_fast_forward` + `pull_request` approvals 0 + admin always-bypass). This PR brings the committed JSON in line so a future idempotent `apply-ruleset.sh` re-run **UPDATEs cleanly** instead of 422ing.

Mirrors the parent-repo correction noorinalabs-main#322 / commit `29cfc88`.

### Changes
- `ruleset-main.json` — drop the entire `required_status_checks` rule object (not empty-array it).
- `SPEC.md` — document the API constraint (omit, don't empty) for path-filtered-CI repos.
- `apply-ruleset.sh` — header comment updated to the omit-don't-empty correction; re-add guidance now says "re-introduce the rule" not "un-empty the array".

## Test Plan
- [x] `python3 -m json.tool` validates `ruleset-main.json`.
- [x] Committed rule types now == **live** ruleset `17139848` rule types: `["deletion","non_fast_forward","pull_request"]` (verified via `gh api .../rulesets/17139848`).
- [x] `DRY_RUN=1 ./apply-ruleset.sh` detects the existing ruleset `17139848` and reports the **UPDATE** path (idempotent re-apply confirmed — no 422 shape).
- [ ] Owner-run live `apply-ruleset.sh` UPDATE + read-back (post-merge, owner/admin-gated per SPEC.md — not a PR step).

Closes #395
Refs #322

Co-Authored-By: Aisha Idrissi <parametrization+Aisha.Idrissi@gmail.com>
Co-Authored-By: Claude <noreply@anthropic.com>
