### PR TITLE
docs(#86): correct architecture.md prod server name; defer teardown-gated manifest rows

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -152,7 +152,7 @@ The `.env` file is ephemeral: recreated fresh on each deployment, written with `
 | Server type | CPX41 (8 vCPU, 16 GB RAM) |
 | OS | Ubuntu 24.04 |
 | Location | Ashburn (`ash`) |
-| Server name | `noorinalabs-isnad-graph-prod` |
+| Server name | `noorinalabs-prod` |
 
 Provisioned via Terraform in `terraform/hetzner/`. The Terraform configuration creates:
 


### PR DESCRIPTION
## Summary

`deploy#86` tracks decommissioning the hand-made `isnad-graph-prod` VPS (system name `noorinalabs-1box-prod`, Hetzner id `124917846`). **The runbook + reference-removal manifest already shipped** in PR #372 (`docs/runbooks/decommission-old-prod-vps.md`, on `main` + this wave base). The two remaining deliverables, per the orchestrator's 2026-05-31 status comment on #86, are:

1. **Operator teardown** of the box — owner/runtime, NOT PR-able.
2. **Reference-removal cleanup PR** applying the manifest dispositions.

This PR delivers the **only manifest row that is safe to apply before the physical teardown**: `docs/architecture.md`'s "Server name" cell described the *current TF-managed* prod box as `noorinalabs-isnad-graph-prod` (the **old** hand-made box's name). The TF module names the prod server `noorinalabs-${var.env}` = `noorinalabs-prod` (`terraform/hetzner/modules/hetzner-vps/main.tf` `local.name_prefix`; ontology `repos/deploy.yaml` agrees: `name: noorinalabs-prod`). That is a present-tense factual error about the live box — correct independent of teardown status.

## Why the rest of the manifest is NOT in this PR (deliberate scope)

The decommission runbook is explicit: the remaining references are gated on the operator's **irreversible** teardown of the hand-made box, which is owner-console work with **no in-repo evidence yet**. Editing them now would "make the repo lie ahead of reality." Confirmed state:

- Cutover (`deploy#156`) is **CLOSED** (PR #380, 2026-05-31) — the hard blocker is lifted.
- But the **physical teardown is not evidenced.** Prod hostnames resolve to Cloudflare-proxied IPs (`172.67.x` / `104.21.x`), so the origin (old box vs new TF box) is not observable externally, and the Hetzner-console deletion is owner-only.

Therefore these manifest rows stay deferred until the operator confirms teardown:

| Manifest row | Why deferred |
|---|---|
| Delete `.github/workflows/deploy-isnad-graph.yml` | It is the legacy single-VPS **rollback path** — safe to remove only once the new box is the *irreversible* prod (post-teardown). |
| `terraform/cloudflare/main.tf` L73–80 comment → past tense | Still factually correct *today* ("currently the hand-made box"). |
| `RUNBOOK.md` L82 bootstrap rationale | Same — old box still live. |
| `terraform/hetzner/README.md` L130/L133 → past tense | Same. |
| `docs/adr/0001-...md` L91/L129 | ADRs are immutable — add a dated "Update" note *after* teardown, do not rewrite history. |
| `ontology/repos/deploy.yaml`, `ontology/services.yaml` | Resolve via `/ontology-rebuild` after teardown + #86 close — not a manual edit. |

## Owner / runtime action items (NOT in this PR — gated, per runbook)

The destructive teardown sequence in `docs/runbooks/decommission-old-prod-vps.md` is operator-driven:

1. Verify the pre-teardown gates (DNS on new TF box, no inbound traffic on old box, a fresh end-to-end backup from the **new** box in B2, observability green).
2. (Optional) Hetzner snapshot of `1box-prod` as a short-lived safety net.
3. **Delete `1box-prod`** (id `124917846` / `87.99.134.161`) from the Hetzner Cloud dashboard — it is outside Terraform, so there is no `terraform destroy`.
4. Workstation hygiene: `ssh-keygen -R 87.99.134.161` + the IPv6, remove any `~/.ssh/config` `Host` block.
5. Once teardown is irreversible, open the **reference-removal cleanup PR** applying the deferred manifest rows above.

`#86` stays **OPEN** as the teardown tracker (per the orchestrator's "do NOT auto-close" note) — hence `Refs #86`, not `Closes`.

## Test Plan

- [x] `docs/architecture.md` change is a single value correction; `noorinalabs-prod` is an established term (stg/prod naming) — no new spell-dict entry needed
- [ ] `docs.yml` (markdownlint + cspell + lychee) — **runs in CI** on this `.md` change

Refs #86

Co-Authored-By: Lucas Ferreira <parametrization+Lucas.Ferreira@gmail.com>
Co-Authored-By: Claude <noreply@anthropic.com>
