### PR TITLE
fix(#407): bump EXPECTED_MERGE_HEAD 0040 -> 0041 to unblock user-service stg deploy

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -7,10 +7,13 @@ name: DB Migrate (user-service alembic)
 #
 # Belt-and-suspenders (deploy#85, per Anya.Kowalczyk 2026-04-23): before
 # `alembic upgrade head`, assert that `alembic heads` reports exactly ONE
-# line containing `0040` — the merge-migration revision introduced by
-# user-service#80. This catches a future migration landing without bumping
-# `down_revision` properly (a silent divergence `alembic upgrade head` alone
-# would mask).
+# line containing the expected head — currently `0041`
+# (`0041_add_subscriptions_user_id_index`, down_revision `0040`; the `0040`
+# merge-migration was introduced by user-service#80). This catches a future
+# migration landing without bumping `down_revision` properly (a silent
+# divergence `alembic upgrade head` alone would mask). Bump EXPECTED_MERGE_HEAD
+# (below) in lockstep whenever user-service adds a migration — deploy#407 was a
+# wedged stg deploy caused by `0041` landing (us#54/#520) without this bump.
 
 on:
   workflow_call:
@@ -67,7 +70,7 @@ jobs:
       # Expected merge-migration revision. Bump this line in the same PR that
       # lands a future alembic merge migration in user-service. A mismatch
       # here means "the migration DAG moved under us" and is a hard stop.
-      EXPECTED_MERGE_HEAD: "0040"
+      EXPECTED_MERGE_HEAD: "0041"
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

Unblocks the wedged `deploy-noorinalabs-user-service` **staging** deploy (live bug — blocks ig#955 and prevents the W1 user-service fixes from reaching stg).

**Root cause:** `db-migrate.yml`'s pre-deploy alembic head-count assertion pins `EXPECTED_MERGE_HEAD: "0040"`, but user-service migration `0041_add_subscriptions_user_id_index` landed on main 2026-06-01 (`312b95b`, #520 recovery of us#54) and ships in `stg-latest`. The lockstep bump was missed, so every post-us#147 deploy hard-stops at the assertion (`alembic heads reports a single head, but it is NOT the expected merge-migration revision '0040'`) **before** `alembic upgrade head` runs → the `deploy` job is skipped. The "Record migration result" step is the faithful messenger (it `exit 1`s because `migrated=false`); the real fault is the stale literal. (Not deploy#367's class — the image pulled fine, no GHCR 404.)

**Fix:** bump `EXPECTED_MERGE_HEAD "0040" → "0041"` (assertion env, line 73) + refresh the header comment to name the current expected head and record the deploy#407 cause.

### Verified head evidence (independent — not trusting the diagnosis blindly)
Read `user-service` `alembic/versions/` at `origin/main`:
- `0041.down_revision = "0040"`; `0040.down_revision = ("0003","0020","0030")` (merge node).
- **No** migration lists `0041` as a `down_revision` → `0041` is the sole leaf = **the single head.** DAG chain is clean.

### No DB cleanup needed
The assertion runs *before* `alembic upgrade head`, so `0041` was never applied — the stg DB is still at `0040` and will apply `0041` normally once the gate is unblocked.

## Test Plan

CI here is path-filtered; the load-bearing validation is **runtime, post-merge** (the assertion only executes in the live deploy job):
- [x] `actionlint` clean on `db-migrate.yml` (shellcheck on PATH — embedded SSH shell linted).
- [x] Independent head verification at user-service origin/main (above).
- [ ] **Post-merge (runtime):** re-run `deploy-noorinalabs-user-service` on **stg** → assertion passes (`1 head, matches 0041`), `deploy` job runs (not skipped).
- [ ] **Post-merge:** confirm `alembic upgrade head` applies `0041` cleanly against the live stg DB (one-line verify — first application of the `subscriptions.user_id` index).
- [ ] **Post-merge:** `Verify Deployment` green.
- [ ] **Post-merge:** re-check ig#955's gate (us#147 fragment-token behavior witnessed live on stg).

## Follow-up (NOT in this PR — scope discipline)
Idris's structural recurrence-prevention recommendation: the hardcoded `EXPECTED_MERGE_HEAD` is a manual cross-repo sync point that drifts every time user-service adds a migration without a matching deploy PR (3rd-ish wedge of this class). Candidate follow-up issue — either (a) derive the expected head from the checked-out user-service source rather than a literal, or (b) a user-service CI gate that fails a migration-adding PR unless deploy's `EXPECTED_MERGE_HEAD` is bumped in lockstep (org pattern: machine-enforce cross-artifact sync, cf. the pre-commit⇄CI sync-drift gate). Not implemented here.

Closes #407

Co-Authored-By: Aisha Idrissi <parametrization+Aisha.Idrissi@gmail.com>
Co-Authored-By: Claude <noreply@anthropic.com>
