### PR TITLE
compose: pass user-service DB/Redis as component env vars (completes us#65)

### DIFF
--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -362,6 +362,13 @@ services:
     # deploy#403). DATABASE_HOST set ⇒ the app builds the URL via
     # sqlalchemy.URL.create (password URL-encoded); DATABASE_DRIVER preserves the
     # asyncpg scheme matching the SSH alembic gate in db-migrate.yml (post-#236).
+    #
+    # DATABASE_URL is ALSO retained (rollback safety — Aisha, deploy#403 review):
+    # rollback.yml only rewrites the image tag against the CURRENT compose, so a
+    # rollback to a pre-us#151 image (which reads only DATABASE_URL) must still
+    # find it here, or it falls back to the in-image localhost default and bricks.
+    # The new image ignores DATABASE_URL whenever DATABASE_HOST is set, so keeping
+    # both is strictly safe in both the forward and rollback directions.
     environment:
       - DATABASE_HOST=user-postgres
       - DATABASE_PORT=5432
@@ -369,6 +376,7 @@ services:
       - DATABASE_USER=${USER_POSTGRES_USER:?USER_POSTGRES_USER must be set}
       - DATABASE_PASSWORD=${USER_POSTGRES_PASSWORD:?USER_POSTGRES_PASSWORD must be set}
       - DATABASE_NAME=${USER_POSTGRES_DB:?USER_POSTGRES_DB must be set}
+      - DATABASE_URL=postgresql+asyncpg://${USER_POSTGRES_USER:?USER_POSTGRES_USER must be set}:${USER_POSTGRES_PASSWORD:?USER_POSTGRES_PASSWORD must be set}@user-postgres:5432/${USER_POSTGRES_DB:?USER_POSTGRES_DB must be set}
     # `alembic upgrade head` matches the SSH gate's invocation. The
     # heads-count belt-and-suspenders check from db-migrate.yml is not
     # repeated here — that check guards CI-time migrations-DAG correctness
@@ -396,15 +404,23 @@ services:
     read_only: true
     tmpfs:
       - /tmp:size=256M
-    # DB + Redis passed as discrete component vars, not interpolated URLs
-    # (deploy#403, completes us#65). The app builds the connection URLs in-process
-    # via Settings.effective_{database,redis}_url (us#151), URL-encoding the
-    # password — so a USER_*_PASSWORD secret containing `/ + = @ : #` can no longer
-    # corrupt the URL authority and crash urlparse at startup. The component path
-    # engages only when DATABASE_HOST / REDIS_HOST are set (else the app falls back
-    # to the verbatim DATABASE_URL / REDIS_URL local-dev defaults), so setting the
-    # HOST vars here is what activates the fix. Internal compose-network ports:
-    # user-postgres listens on 5432, user-redis on 6379 (host-published 5433/6380).
+    # DB + Redis passed as discrete component vars (deploy#403, completes us#65).
+    # The app builds the connection URLs in-process via
+    # Settings.effective_{database,redis}_url (us#151), URL-encoding the password —
+    # so a USER_*_PASSWORD secret containing `/ + = @ : #` can no longer corrupt the
+    # URL authority and crash urlparse at startup. The component path engages only
+    # when DATABASE_HOST / REDIS_HOST are set, so setting the HOST vars here is what
+    # activates the fix. Internal compose-network ports: user-postgres listens on
+    # 5432, user-redis on 6379 (host-published 5433/6380).
+    #
+    # DATABASE_URL / REDIS_URL are ALSO retained (rollback safety — Aisha,
+    # deploy#403 review): rollback.yml only rewrites the image tag against the
+    # CURRENT compose, so a rollback to a pre-us#151 image (which reads only the
+    # URLs) must still find them here, or it falls back to the in-image localhost
+    # defaults and bricks the container exactly when rollback is needed. The new
+    # image ignores the URLs whenever HOST is set, so keeping both is strictly safe
+    # in both the forward and rollback directions; the only cost is a few extra env
+    # keys (the passlist-drift gate tolerates extras).
     environment:
       - DATABASE_HOST=user-postgres
       - DATABASE_PORT=5432
@@ -412,10 +428,12 @@ services:
       - DATABASE_USER=${USER_POSTGRES_USER:?USER_POSTGRES_USER must be set}
       - DATABASE_PASSWORD=${USER_POSTGRES_PASSWORD:?USER_POSTGRES_PASSWORD must be set}
       - DATABASE_NAME=${USER_POSTGRES_DB:?USER_POSTGRES_DB must be set}
+      - DATABASE_URL=postgresql+asyncpg://${USER_POSTGRES_USER:?USER_POSTGRES_USER must be set}:${USER_POSTGRES_PASSWORD:?USER_POSTGRES_PASSWORD must be set}@user-postgres:5432/${USER_POSTGRES_DB:?USER_POSTGRES_DB must be set}
       - REDIS_HOST=user-redis
       - REDIS_PORT=6379
       - REDIS_DB=0
       - REDIS_PASSWORD=${USER_REDIS_PASSWORD:?USER_REDIS_PASSWORD must be set}
+      - REDIS_URL=redis://:${USER_REDIS_PASSWORD:?USER_REDIS_PASSWORD must be set}@user-redis:6379/0
       - JWT_PRIVATE_KEY=${JWT_PRIVATE_KEY:?JWT_PRIVATE_KEY must be set}
       - JWT_PUBLIC_KEY=${JWT_PUBLIC_KEY:?JWT_PUBLIC_KEY must be set}
       - CORS_ORIGINS=["https://isnad.${BASE_DOMAIN}","https://${BASE_DOMAIN}"]

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -134,6 +134,13 @@ services:
       # NEO4J_USER must be "neo4j" — Neo4j requires the admin account to use this name
       - NEO4J_USER=neo4j
       - NEO4J_PASSWORD=${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set}
+      # DEFERRED (deploy#403): PG_DSN / REDIS_URL stay as interpolated URLs here
+      # because isnad-graph-api has no app-side connection-component support yet —
+      # tracked in ig#956 (sibling of us#65). Switching to DATABASE_* / REDIS_*
+      # components requires that app change to land first; doing it here now would
+      # feed the api env vars it does not read. Convert in lockstep when ig#956
+      # ships. (Same URL-unsafe-password latent risk as us#65, lower urgency:
+      # POSTGRES_PASSWORD / REDIS_PASSWORD are not currently URL-special.)
       - PG_DSN=postgresql://${POSTGRES_USER:?POSTGRES_USER must be set}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/${POSTGRES_DB:?POSTGRES_DB must be set}
       - REDIS_URL=redis://:${REDIS_PASSWORD:?REDIS_PASSWORD must be set}@redis:6379/0
       - AUTH_GOOGLE_CLIENT_ID=${AUTH_GOOGLE_CLIENT_ID:-}
@@ -348,10 +355,20 @@ services:
   user-service-migrate:
     image: ghcr.io/noorinalabs/noorinalabs-user-service:${USER_SERVICE_IMAGE_TAG:-latest}
     # asyncpg driver — alembic/env.py is async (create_async_engine +
-    # asyncio.run). Same scheme as the runtime user-service DATABASE_URL
-    # and the SSH alembic gate in db-migrate.yml (post-#236).
+    # asyncio.run). alembic/env.py resolves the URL via
+    # Settings.effective_database_url (us#151), so the migrate container needs
+    # the SAME component vars as the runtime user-service — otherwise it hits
+    # the identical urlparse crash on a URL-unsafe USER_POSTGRES_PASSWORD (us#65,
+    # deploy#403). DATABASE_HOST set ⇒ the app builds the URL via
+    # sqlalchemy.URL.create (password URL-encoded); DATABASE_DRIVER preserves the
+    # asyncpg scheme matching the SSH alembic gate in db-migrate.yml (post-#236).
     environment:
-      - DATABASE_URL=postgresql+asyncpg://${USER_POSTGRES_USER:?USER_POSTGRES_USER must be set}:${USER_POSTGRES_PASSWORD:?USER_POSTGRES_PASSWORD must be set}@user-postgres:5432/${USER_POSTGRES_DB:?USER_POSTGRES_DB must be set}
+      - DATABASE_HOST=user-postgres
+      - DATABASE_PORT=5432
+      - DATABASE_DRIVER=postgresql+asyncpg
+      - DATABASE_USER=${USER_POSTGRES_USER:?USER_POSTGRES_USER must be set}
+      - DATABASE_PASSWORD=${USER_POSTGRES_PASSWORD:?USER_POSTGRES_PASSWORD must be set}
+      - DATABASE_NAME=${USER_POSTGRES_DB:?USER_POSTGRES_DB must be set}
     # `alembic upgrade head` matches the SSH gate's invocation. The
     # heads-count belt-and-suspenders check from db-migrate.yml is not
     # repeated here — that check guards CI-time migrations-DAG correctness
@@ -379,9 +396,26 @@ services:
     read_only: true
     tmpfs:
       - /tmp:size=256M
+    # DB + Redis passed as discrete component vars, not interpolated URLs
+    # (deploy#403, completes us#65). The app builds the connection URLs in-process
+    # via Settings.effective_{database,redis}_url (us#151), URL-encoding the
+    # password — so a USER_*_PASSWORD secret containing `/ + = @ : #` can no longer
+    # corrupt the URL authority and crash urlparse at startup. The component path
+    # engages only when DATABASE_HOST / REDIS_HOST are set (else the app falls back
+    # to the verbatim DATABASE_URL / REDIS_URL local-dev defaults), so setting the
+    # HOST vars here is what activates the fix. Internal compose-network ports:
+    # user-postgres listens on 5432, user-redis on 6379 (host-published 5433/6380).
     environment:
-      - DATABASE_URL=postgresql+asyncpg://${USER_POSTGRES_USER:?USER_POSTGRES_USER must be set}:${USER_POSTGRES_PASSWORD:?USER_POSTGRES_PASSWORD must be set}@user-postgres:5432/${USER_POSTGRES_DB:?USER_POSTGRES_DB must be set}
-      - REDIS_URL=redis://:${USER_REDIS_PASSWORD:?USER_REDIS_PASSWORD must be set}@user-redis:6379/0
+      - DATABASE_HOST=user-postgres
+      - DATABASE_PORT=5432
+      - DATABASE_DRIVER=postgresql+asyncpg
+      - DATABASE_USER=${USER_POSTGRES_USER:?USER_POSTGRES_USER must be set}
+      - DATABASE_PASSWORD=${USER_POSTGRES_PASSWORD:?USER_POSTGRES_PASSWORD must be set}
+      - DATABASE_NAME=${USER_POSTGRES_DB:?USER_POSTGRES_DB must be set}
+      - REDIS_HOST=user-redis
+      - REDIS_PORT=6379
+      - REDIS_DB=0
+      - REDIS_PASSWORD=${USER_REDIS_PASSWORD:?USER_REDIS_PASSWORD must be set}
       - JWT_PRIVATE_KEY=${JWT_PRIVATE_KEY:?JWT_PRIVATE_KEY must be set}
       - JWT_PUBLIC_KEY=${JWT_PUBLIC_KEY:?JWT_PUBLIC_KEY must be set}
       - CORS_ORIGINS=["https://isnad.${BASE_DOMAIN}","https://${BASE_DOMAIN}"]


### PR DESCRIPTION
## Summary

Completes us#65. user-service PR #151 (merged to the us wave branch) added separate connection-component env vars with backward-compatible fallback to the pre-composed URLs. The prod crash isn't actually fixed until compose passes the **components** instead of interpolating a URL-unsafe `${USER_REDIS_PASSWORD}` / `${USER_POSTGRES_PASSWORD}` into a URL. This converts the user-service compose env to do that.

The app builds the connection URLs in-process via `Settings.effective_database_url` / `effective_redis_url` (us#151), URL-encoding the password (`sqlalchemy.URL.create` / `urllib.parse.quote`), so a password containing `/ + = @ : #` can no longer corrupt the URL authority and crash `urlparse` at startup. The component path engages only when `DATABASE_HOST` / `REDIS_HOST` are set — so setting the HOST vars is what activates the fix.

### Changes (`compose/docker-compose.prod.yml`)
- **`user-service`** (runtime): **adds** `DATABASE_HOST/PORT/DRIVER/USER/PASSWORD/NAME` + `REDIS_HOST/PORT/DB/PASSWORD` while **retaining** `DATABASE_URL` / `REDIS_URL` (see Rollback safety below).
- **`user-service-migrate`**: **adds** the same `DATABASE_*` components while **retaining** `DATABASE_URL`. `alembic/env.py` resolves its URL via the **same** `Settings.effective_database_url` (verified at the us wave branch head), so the migrate container has the identical crash risk and must convert too. (No Redis — migrations don't use it.)
- Both the component vars and the retained URLs **reuse the existing secrets** (`USER_POSTGRES_USER/PASSWORD/DB`, `USER_REDIS_PASSWORD`) — no new secrets, no `env_keys` passlist change.

### Rollback safety — DATABASE_URL / REDIS_URL retained (Aisha, review must-fix)
The component path engages only when `DATABASE_HOST` / `REDIS_HOST` are set, so the **new** image ignores the retained URLs and the us#65 fix still applies on the forward path. The URLs are kept because `rollback.yml` checks out the **current** compose and only rewrites the image tag — so an image rollback to a **pre-us#151** user-service (which reads only `DATABASE_URL` / `REDIS_URL`) must still find them in compose, or it falls back to the in-image localhost defaults and bricks both containers exactly when rollback is needed. Keeping both forms is strictly safe in both directions; the only cost is a few extra env keys, which the passlist-drift gate tolerates.

### isnad-graph api — explicitly DEFERRED (AC #2)
`api`'s `PG_DSN` / `REDIS_URL` **stay as interpolated URLs**: isnad-graph-api has no app-side connection-component support yet (tracked in **ig#956**, the us#65 sibling, confirmed OPEN). Feeding it `DATABASE_*` / `REDIS_*` now would set env it doesn't read. An in-file comment marks the deferral; convert in lockstep when ig#956 ships. Lower urgency than us#65: `POSTGRES_PASSWORD` / `REDIS_PASSWORD` are not currently URL-special.

### Single shared compose file
Staging and prod both deploy from `compose/docker-compose.prod.yml` (`deploy-stg.yml` uses it with a stg `.env`), so this one edit covers **both** environments — there is no separate staging compose file in the repo.

### Sequencing — no breakage window (forward OR rollback)
This change only takes effect on staging/prod when the wave branch merges to `main` AND a deploy runs.
- **Forward, either merge/deploy order:** before this lands the old URL env still works; after, the new image's component path takes over (the us-side keeps the verbatim URL fallback used when the HOST vars are unset). No window.
- **Rollback:** because compose now ships **both** the component vars AND `DATABASE_URL` / `REDIS_URL` (same secrets), an image rollback to any tag — pre- or post-us#151 — finds the env it reads: a new image uses the components, an old image uses the retained URLs. No window in the rollback direction either.

## Test Plan

**PR-time (done):**
- [x] YAML parses cleanly (24 services); user-service has both `DATABASE_*`/`REDIS_*` components AND the retained `DATABASE_URL`/`REDIS_URL`; user-service-migrate has the `DATABASE_*` components + retained `DATABASE_URL` and no Redis (confirmed programmatically post-fixup).
- [x] Replicated the `compose-validate` CI job's env materialization (`.env.example` + the workflow's CI placeholders incl. `BASE_DOMAIN`/`KAFKA_CLUSTER_ID`) and ran compose-style `${VAR:?}` / `${VAR:-}` interpolation: **all required vars resolve, zero unresolved**, and the substituted document is valid YAML (mirrors `docker compose config --quiet`). Docker is unavailable in the dev WSL distro, so the real `docker compose config` runs in CI.
- [x] Ran the repo's exact **passlist-drift** inline check against the edited file → **OK**; the required-var set is unchanged (all 4 `USER_*` vars still present, no new required vars).
- [x] Resolved user-service component values verified: `DATABASE_HOST=user-postgres` `:5432`, `REDIS_HOST=user-redis` `:6379` `/0` (internal compose-network ports; host-published 5433/6380).

**Runtime (runtime-gated — needs a deployed stack):**
- [ ] After stg deploy: `user-service` and `user-service-migrate` start clean against the real `USER_*` secrets (AC #3) — proves the URL-encoding path works with the production password.
- [ ] Confirm Prometheus `user-service:8000` target stays `up` (companion deploy#384, merged).
- [ ] Same checks on prod after promote.

Closes #403
Refs us#65, us#151, ig#956

Co-Authored-By: Nurul Hakim <parametrization+Nurul.Hakim@gmail.com>
Co-Authored-By: Claude <noreply@anthropic.com>

