### PR TITLE
fix(#414): smoke checks 2+5 probe post-carve-out user-service URLs

### DIFF
--- a/scripts/verify_prod_smoke.sh
+++ b/scripts/verify_prod_smoke.sh
@@ -8,12 +8,14 @@
 #
 # Checks:
 #   1. isnad-graph /health    → HTTP 200, JSON .status in {healthy,degraded,ok}
-#   2. user-service /health   → HTTP 200 (via Caddy /api/v1/user-service/health)
+#   2. user-service /health   → HTTP 200 (USER_SERVICE_BASE_URL/health,
+#                                  direct on the carved-out users.* vhost — #245/#414)
 #   3. landing /              → HTTP 200
 #   4. /api/v1/narrators?limit=1 → HTTP 401 + JSON-shaped body (proves
 #                                  user-service auth is in the path, not
 #                                  Caddy bypass returning plaintext)
-#   5. /.well-known/jwks.json → HTTP 200 + valid JWKS shape (.keys[])
+#   5. /.well-known/jwks.json → HTTP 200 + valid JWKS shape (.keys[]),
+#                                  on USER_SERVICE_BASE_URL (users.* vhost — #245/#414)
 #   6. /auth/oauth/google/login → HTTP 200 + JSON .authorization_url
 #                                  pointing at accounts.google.com
 #                                  (proves user-service OAuth wiring
@@ -22,12 +24,12 @@
 #                                  Hit on USER_SERVICE_BASE_URL directly
 #                                  for honest attribution — see #256.
 #
-# Env (post-cutover topology, #226 + emergency 2026-05-02): frontend +
-# isnad-graph API live on `isnad.noorinalabs.com`; the pure user-service
-# API surface lives on `users.noorinalabs.com`. The auth-plane routes
-# (/auth/*, /.well-known/jwks.json) are dual-bound on both vhosts during
-# the absolute-URL frontend cutover (#245 phase 2), so the script's
-# auth-plane checks currently route via ISNAD_BASE_URL — see check 6:
+# Env (post-#245-carve-out topology): frontend + isnad-graph API live on
+# `isnad.noorinalabs.com`; the pure user-service API surface (health, JWKS,
+# /auth/*, /api/v1/users…) lives on `users.noorinalabs.com`. The #245
+# carve-out (merged e321e9a7) retired the user-service bindings on the
+# isnad vhost, so the user-service checks (2 + 5, and 6) all target
+# USER_SERVICE_BASE_URL directly — see deploy#414:
 #   ISNAD_BASE_URL          (default: https://isnad.noorinalabs.com)
 #   USER_SERVICE_BASE_URL   (default: https://users.noorinalabs.com —
 #                            canonical pure user-service API surface)
@@ -105,12 +107,16 @@ ms_from_secs() {
   fi
 }
 
-# --- 2. user-service /health (via Caddy rewrite) --------------------
+# --- 2. user-service /health ----------------------------------------
+# Post-#245 carve-out: user-service is its own vhost (users.*); the old
+# isnad-vhost rewrite (ISNAD_BASE_URL/api/v1/user-service/health → /health)
+# was retired when the carve-out merged (e321e9a7), so probe the canonical
+# user-service surface directly. See deploy#414.
 {
-  read -r code secs <<<"$(http_check "${ISNAD_BASE_URL}/api/v1/user-service/health")"
+  read -r code secs <<<"$(http_check "${USER_SERVICE_BASE_URL}/health")"
   ms="$(ms_from_secs "$secs")"
   if [ "$code" = "200" ]; then
-    record "user-service /health" pass "$ms" "HTTP 200 via Caddy rewrite"
+    record "user-service /health" pass "$ms" "HTTP 200"
   else
     record "user-service /health" fail "$ms" "HTTP $code (expected 200)"
   fi
@@ -147,8 +153,12 @@ ms_from_secs() {
 }
 
 # --- 5. JWKS endpoint -----------------------------------------------
+# Post-#245 carve-out: JWKS lives on the user-service vhost (users.*); the
+# isnad-vhost binding was retired with the carve-out (it returned an empty
+# .keys array after the move). Probe USER_SERVICE_BASE_URL directly. See
+# deploy#414.
 {
-  read -r code secs <<<"$(http_check "${ISNAD_BASE_URL}/.well-known/jwks.json")"
+  read -r code secs <<<"$(http_check "${USER_SERVICE_BASE_URL}/.well-known/jwks.json")"
   body="$(read_body)"
   ms="$(ms_from_secs "$secs")"
   if [ "$code" = "200" ] && echo "$body" | jq -e '.keys | length > 0' >/dev/null 2>&1; then

--- a/scripts/verify_stg_smoke.sh
+++ b/scripts/verify_stg_smoke.sh
@@ -25,12 +25,14 @@
 #
 # Checks (mirror of verify_prod_smoke.sh):
 #   1. isnad-graph /health    → HTTP 200, JSON .status in {healthy,degraded,ok}
-#   2. user-service /health   → HTTP 200 (via Caddy /api/v1/user-service/health)
+#   2. user-service /health   → HTTP 200 (USER_SERVICE_BASE_URL/health,
+#                                  direct on the carved-out users.* vhost — #245/#414)
 #   3. landing /              → HTTP 200
 #   4. /api/v1/narrators?limit=1 → HTTP 401 + JSON-shaped body (proves
 #                                  user-service auth is in the path, not
 #                                  Caddy bypass returning plaintext)
-#   5. /.well-known/jwks.json → HTTP 200 + valid JWKS shape (.keys[])
+#   5. /.well-known/jwks.json → HTTP 200 + valid JWKS shape (.keys[]),
+#                                  on USER_SERVICE_BASE_URL (users.* vhost — #245/#414)
 #   6. /auth/oauth/google/login → HTTP 200 + JSON .authorization_url
 #                                  pointing at accounts.google.com
 #                                  (proves user-service OAuth wiring
@@ -129,12 +131,16 @@ ms_from_secs() {
   fi
 }
 
-# --- 2. user-service /health (via Caddy rewrite) --------------------
+# --- 2. user-service /health ----------------------------------------
+# Post-#245 carve-out: user-service is its own vhost (users.*); the old
+# isnad-vhost rewrite (ISNAD_BASE_URL/api/v1/user-service/health → /health)
+# was retired when the carve-out merged (e321e9a7), so probe the canonical
+# user-service surface directly. See deploy#414.
 {
-  read -r code secs <<<"$(http_check "${ISNAD_BASE_URL}/api/v1/user-service/health")"
+  read -r code secs <<<"$(http_check "${USER_SERVICE_BASE_URL}/health")"
   ms="$(ms_from_secs "$secs")"
   if [ "$code" = "200" ]; then
-    record "user-service /health" pass "$ms" "HTTP 200 via Caddy rewrite"
+    record "user-service /health" pass "$ms" "HTTP 200"
   else
     record "user-service /health" fail "$ms" "HTTP $code (expected 200)"
   fi
@@ -171,8 +177,12 @@ ms_from_secs() {
 }
 
 # --- 5. JWKS endpoint -----------------------------------------------
+# Post-#245 carve-out: JWKS lives on the user-service vhost (users.*); the
+# isnad-vhost binding was retired with the carve-out (it returned an empty
+# .keys array after the move). Probe USER_SERVICE_BASE_URL directly. See
+# deploy#414.
 {
-  read -r code secs <<<"$(http_check "${ISNAD_BASE_URL}/.well-known/jwks.json")"
+  read -r code secs <<<"$(http_check "${USER_SERVICE_BASE_URL}/.well-known/jwks.json")"
   body="$(read_body)"
   ms="$(ms_from_secs "$secs")"
   if [ "$code" = "200" ] && echo "$body" | jq -e '.keys | length > 0' >/dev/null 2>&1; then


### PR DESCRIPTION
Closes #414

## Problem

The stg smoke battery (`scripts/verify_stg_smoke.sh`) and its prod mirror probed user-service **through the isnad vhost's Caddy rewrites** — routing the deploy#245 carve-out retired when it merged to main (`e321e9a7`, 2026-05-31). The scripts predate the carve-out (#383, P3W13) and weren't in its change-surface, so two checks failed:

| Check | Old probe | Result |
|---|---|---|
| 2: user-service /health | `ISNAD_BASE_URL/api/v1/user-service/health` | 404 |
| 5: JWKS | `ISNAD_BASE_URL/.well-known/jwks.json` | 200, empty `.keys` |

This hard-blocks W1 wrapup's staging-promotion gate (it reads Verify Deployment).

## Fix

Point checks 2 and 5 at the canonical user-service vhost directly (mirrors check 6's existing `USER_SERVICE_BASE_URL` pattern, #256):

- check 2 → `${USER_SERVICE_BASE_URL}/health`
- check 5 → `${USER_SERVICE_BASE_URL}/.well-known/jwks.json`

Applied identically to `verify_stg_smoke.sh` and `verify_prod_smoke.sh` (the two scripts' check-2/check-5 code blocks are byte-identical by design — structural parity preserved). Header comment blocks (checks list + the prod Env note's stale dual-bind framing) updated to the post-carve-out topology.

## Caddyfile disposition (AC item 4)

The carve-out **already removed every user-service handle from the isnad vhost**. On the wave-1 branch the `isnad.{$BASE_DOMAIN}` block is a pure frontend + isnad-graph-API surface (`/auth/callback/*` → frontend, `/api/*`/`/health`/`/status` → api, `/metrics` 403, `/grafana/*`, catch-all → frontend) — verified at HEAD. The `/api/v1/user-service/health` and `/.well-known/jwks.json` handles live on the `users.{$BASE_DOMAIN}` vhost where they belong. There are **no vestigial isnad-vhost user-service handles left to remove**; AC item 4 is satisfied by the carve-out itself, so this PR makes no Caddyfile change. (The issue's cited line numbers ~108-111/~161-165 were from the pre-carve-out file.)

## Verification

Ran the stg battery live against staging (read-only GET probes — safe):

```
ENVIRONMENT=stg RUN_MODE=remote \
  ISNAD_BASE_URL=https://isnad.stg.noorinalabs.com \
  USER_SERVICE_BASE_URL=https://users.stg.noorinalabs.com \
  LANDING_BASE_URL=https://stg.noorinalabs.com \
  ./scripts/verify_stg_smoke.sh

  PASS [131ms]: isnad /health — status=healthy
  PASS [107ms]: user-service /health — HTTP 200
  PASS [94ms]:  landing / — HTTP 200
  PASS [105ms]: narrator /api/v1/narrators — HTTP 401 + JSON body (auth path live)
  PASS [107ms]: jwks.json — HTTP 200, 1 key(s)
  PASS [93ms]:  /auth/oauth/google/login wiring — HTTP 200 + .authorization_url → accounts.google.com
==> Stg smoke summary: 6/6 passed, total 736ms
RESULT: ALL SMOKE CHECKS PASSED
```

Checks 2 and 5 — the two that were failing — now pass. `bash -n` + `shellcheck` clean on both scripts.

## Runtime item (post-merge)

The 6/6 above is a direct script run against live stg. After this merges (and again at wave→main merge), re-run the **Verify Deployment** workflow for the official green through the CI path.

## Acceptance Criteria

- [x] verify_stg_smoke.sh checks 2 + 5 probe USER_SERVICE_BASE_URL directly
- [x] verify_prod_smoke.sh mirror updated identically
- [x] Verify Deployment (stg) passes end-to-end — proven via direct 6/6 live run; CI-workflow re-run is the post-merge runtime item above
- [x] Vestigial isnad-vhost user-service handles dispositioned — none exist post-carve-out (documented above)
