### PR TITLE
deploy(#420): /runtime-config.js anti-drift smoke guard (prod login JSON.parse)

### DIFF
--- a/scripts/verify_prod_smoke.sh
+++ b/scripts/verify_prod_smoke.sh
@@ -23,6 +23,12 @@
 #                                  Redis state-store all reachable).
 #                                  Hit on USER_SERVICE_BASE_URL directly
 #                                  for honest attribution — see #256.
+#   7. /runtime-config.js     → HTTP 200 + a JS content-type (NOT the
+#                                  text/html SPA fallback) + body wires
+#                                  window.RUNTIME_CONFIG to the expected
+#                                  user-service origin. Anti-drift guard
+#                                  for the prod-lagging-stg login bug —
+#                                  see deploy#420.
 #
 # Env (post-#245-carve-out topology): frontend + isnad-graph API live on
 # `isnad.noorinalabs.com`; the pure user-service API surface (health, JWKS,
@@ -203,6 +209,50 @@ ms_from_secs() {
     fi
   else
     record "/auth/oauth/google/login wiring" fail "$ms" "HTTP $code (expected 200)"
+  fi
+}
+
+# --- 7. runtime-config.js (anti-drift guard — deploy#420) -----------
+# The login page resolves the user-service origin at RUNTIME from
+# window.RUNTIME_CONFIG, injected by GET /runtime-config.js — served by
+# the frontend container, which `envsubst`s USER_SERVICE_ORIGIN over
+# runtime-config.js.template at start-up (compose/docker-compose.prod.yml
+# sets USER_SERVICE_ORIGIN=https://users.${BASE_DOMAIN}). If the frontend
+# image predates this feature (or the file is otherwise absent), Caddy's
+# SPA catch-all serves index.html instead — HTTP 200 but text/html — and
+# the login fetch parses HTML as JSON, throwing "JSON.parse: unexpected
+# character" (deploy#420: prod ran an older image than stg). This check
+# fails loudly the moment prod/stg drifts back to a frontend image
+# without runtime-config, BEFORE a user hits a broken login. The
+# content-type discriminator is load-bearing: the SPA fallback also
+# returns 200, so an HTTP-code-only check would pass on the bug.
+{
+  rc_url="${ISNAD_BASE_URL}/runtime-config.js"
+  # Capture code + time + content-type in one request. content_type is
+  # taken as the trailing field because it may itself contain a space
+  # (e.g. "text/html; charset=utf-8").
+  rc_out="$(curl -sS -o "$SMOKE_BODY" \
+                 -w '%{http_code} %{time_total} %{content_type}' \
+                 --max-time "$TIMEOUT" "$rc_url" 2>/dev/null || echo '000 0 none')"
+  code="$(echo "$rc_out" | awk '{print $1}')"
+  secs="$(echo "$rc_out" | awk '{print $2}')"
+  ctype="$(echo "$rc_out" | cut -d' ' -f3-)"
+  body="$(read_body)"
+  ms="$(ms_from_secs "$secs")"
+  # Expected user-service host for this env = host part of the base URL.
+  us_host="$(echo "$USER_SERVICE_BASE_URL" | sed -E 's|^https?://([^/]+).*|\1|')"
+  if [ "$code" != "200" ]; then
+    record "runtime-config.js" fail "$ms" "HTTP $code (expected 200 — file absent / not provisioned)"
+  elif echo "$ctype" | grep -qiE 'text/html'; then
+    record "runtime-config.js" fail "$ms" "content-type=$ctype — SPA index.html fallback (frontend image lacks runtime-config; see deploy#420)"
+  elif ! echo "$ctype" | grep -qiE 'javascript'; then
+    record "runtime-config.js" fail "$ms" "content-type=$ctype (expected a JS script)"
+  elif ! echo "$body" | grep -q 'RUNTIME_CONFIG'; then
+    record "runtime-config.js" fail "$ms" "HTTP 200 + JS but body has no window.RUNTIME_CONFIG"
+  elif ! echo "$body" | grep -qF "$us_host"; then
+    record "runtime-config.js" fail "$ms" "RUNTIME_CONFIG present but does not reference expected user-service host $us_host"
+  else
+    record "runtime-config.js" pass "$ms" "HTTP 200 + JS, RUNTIME_CONFIG → $us_host"
   fi
 }
 

--- a/scripts/verify_stg_smoke.sh
+++ b/scripts/verify_stg_smoke.sh
@@ -40,6 +40,12 @@
 #                                  Redis state-store all reachable).
 #                                  Hit on USER_SERVICE_BASE_URL directly
 #                                  for honest attribution — see #256.
+#   7. /runtime-config.js     → HTTP 200 + a JS content-type (NOT the
+#                                  text/html SPA fallback) + body wires
+#                                  window.RUNTIME_CONFIG to the expected
+#                                  user-service origin. Anti-drift guard
+#                                  for the prod-lagging-stg login bug —
+#                                  see deploy#420.
 #
 # Env (stg topology — BASE_DOMAIN=stg.noorinalabs.com, deploy-stg.yml:158):
 # the Caddyfile is env-templated by {$BASE_DOMAIN}, so stg's vhosts are
@@ -227,6 +233,51 @@ ms_from_secs() {
     fi
   else
     record "/auth/oauth/google/login wiring" fail "$ms" "HTTP $code (expected 200)"
+  fi
+}
+
+# --- 7. runtime-config.js (anti-drift guard — deploy#420) -----------
+# Mirror of verify_prod_smoke.sh check 7 (keep in sync — prod is canonical).
+# The login page resolves the user-service origin at RUNTIME from
+# window.RUNTIME_CONFIG, injected by GET /runtime-config.js — served by
+# the frontend container, which `envsubst`s USER_SERVICE_ORIGIN over
+# runtime-config.js.template at start-up (compose sets USER_SERVICE_ORIGIN
+# =https://users.${BASE_DOMAIN}). If the frontend image predates this
+# feature (or the file is otherwise absent), Caddy's SPA catch-all serves
+# index.html instead — HTTP 200 but text/html — and the login fetch parses
+# HTML as JSON, throwing "JSON.parse: unexpected character" (deploy#420:
+# prod ran an older image than stg). This check fails loudly the moment an
+# env drifts back to a frontend image without runtime-config, BEFORE a
+# user hits a broken login. The content-type discriminator is load-bearing:
+# the SPA fallback also returns 200, so an HTTP-code-only check would pass
+# on the bug.
+{
+  rc_url="${ISNAD_BASE_URL}/runtime-config.js"
+  # Capture code + time + content-type in one request. content_type is
+  # taken as the trailing field because it may itself contain a space
+  # (e.g. "text/html; charset=utf-8").
+  rc_out="$(curl -sS -o "$SMOKE_BODY" \
+                 -w '%{http_code} %{time_total} %{content_type}' \
+                 --max-time "$TIMEOUT" "$rc_url" 2>/dev/null || echo '000 0 none')"
+  code="$(echo "$rc_out" | awk '{print $1}')"
+  secs="$(echo "$rc_out" | awk '{print $2}')"
+  ctype="$(echo "$rc_out" | cut -d' ' -f3-)"
+  body="$(read_body)"
+  ms="$(ms_from_secs "$secs")"
+  # Expected user-service host for this env = host part of the base URL.
+  us_host="$(echo "$USER_SERVICE_BASE_URL" | sed -E 's|^https?://([^/]+).*|\1|')"
+  if [ "$code" != "200" ]; then
+    record "runtime-config.js" fail "$ms" "HTTP $code (expected 200 — file absent / not provisioned)"
+  elif echo "$ctype" | grep -qiE 'text/html'; then
+    record "runtime-config.js" fail "$ms" "content-type=$ctype — SPA index.html fallback (frontend image lacks runtime-config; see deploy#420)"
+  elif ! echo "$ctype" | grep -qiE 'javascript'; then
+    record "runtime-config.js" fail "$ms" "content-type=$ctype (expected a JS script)"
+  elif ! echo "$body" | grep -q 'RUNTIME_CONFIG'; then
+    record "runtime-config.js" fail "$ms" "HTTP 200 + JS but body has no window.RUNTIME_CONFIG"
+  elif ! echo "$body" | grep -qF "$us_host"; then
+    record "runtime-config.js" fail "$ms" "RUNTIME_CONFIG present but does not reference expected user-service host $us_host"
+  else
+    record "runtime-config.js" pass "$ms" "HTTP 200 + JS, RUNTIME_CONFIG → $us_host"
   fi
 }
 


### PR DESCRIPTION
## ⏸️ HOLD: owner-gated prod deploy — do NOT deploy until owner approves

This PR ships **only the durable anti-drift guard** (a smoke check). The actual prod fix is an **image promotion + prod rollout**, which is **owner-gated** — see "What still needs the owner-approved prod deploy" below. Nothing here triggers or dispatches a prod deploy.

Closes #420

## Root cause (confirmed by live trace, 2026-06-11)
Prod login throws `JSON.parse: unexpected character at line 1 column 1` because **prod runs an older isnad-graph frontend image than stg** — one that predates the runtime-config feature.

The login page resolves the user-service origin at runtime from `window.RUNTIME_CONFIG`, injected by `GET /runtime-config.js`. The frontend container `envsubst`s `USER_SERVICE_ORIGIN` over `runtime-config.js.template` at start-up and nginx serves the result. On the old prod image that file is absent, so Caddy's SPA catch-all serves `index.html` (HTTP **200**, `text/html`); the login fetch then parses HTML as JSON and throws.

**Live trace (this PR's verification):**
| Probe | Prod | Stg |
|---|---|---|
| `GET /runtime-config.js` | `200 text/html` (SPA fallback — file absent) | `200 application/javascript`, real `window.RUNTIME_CONFIG = { USER_SERVICE_ORIGIN: "https://users.stg.noorinalabs.com" }` |

## What is already correct in this repo (no change needed)
The infra side of the fix is **already in place** on `main`/`wave-3`:
- `compose/docker-compose.prod.yml` frontend service sets `USER_SERVICE_ORIGIN: "https://users.${BASE_DOMAIN}"` → resolves to `https://users.noorinalabs.com` for prod (the runtime-config provisioning).
- `caddy/Caddyfile` routes `/runtime-config.js` to the frontend container (catch-all `reverse_proxy frontend:80`); `connect-src` CSP already allows `users.{$BASE_DOMAIN}`.
- `deploy-prod.yml` already does **per-service tag routing** (`api_frontend_tag` distinct from `user_service_tag`/`landing_tag`); `prod-*` tags are produced only by `promote.yml`.

So there is **no compose/Caddy/tag-file change to make** — the gap is purely the **deployed image digest** on the prod box, which is a runtime action.

## What this PR changes (the durable anti-drift mechanism)
Adds **smoke check #7** to **both** batteries (`scripts/verify_prod_smoke.sh` — canonical — and `scripts/verify_stg_smoke.sh` — kept in sync):

`GET /runtime-config.js` must return **HTTP 200 + a JS content-type (NOT `text/html`) + a body wiring `window.RUNTIME_CONFIG` to the expected user-service origin** (`USER_SERVICE_BASE_URL` host).

The **content-type discriminator is load-bearing**: the SPA fallback also returns `200`, so an HTTP-code-only check would silently pass on the bug. `verify-prod` runs this on every successful prod deploy, so the moment prod drifts back to a non-runtime-config frontend image, the smoke battery **fails loudly before a user hits a broken login**.

## ✅ Verified at PR-time (live, this branch)
Ran both batteries against the live public URLs from the branch:
- **Stg: 7/7 PASS** — check #7: `HTTP 200 + JS, RUNTIME_CONFIG → users.stg.noorinalabs.com`. Proves the new check passes on a correctly-deployed env.
- **Prod: 6/7** — check #7 is the **sole** failure: `content-type=text/html — SPA index.html fallback (frontend image lacks runtime-config; see deploy#420)`. Proves the guard correctly catches the current prod drift, and isolates the failure precisely to runtime-config (the other 6 prod checks pass).
- `shellcheck` clean on both scripts.

## ⏸️ What still needs the owner-approved prod deploy (NOT done here)
These require the prod box to change and are **owner-gated** — do not run without owner approval:
1. **Promote** the current stg-parity isnad-graph build to a `prod-<short>` tag via `promote.yml` (retag from the stg digest; the manual-approval gate lives on its `environment: production` retag step).
2. **Roll out** that `prod-<short>` tag to the prod VPS via `deploy-prod.yml` (`api_frontend_tag=prod-<short>`), leaving `user_service_tag`/`landing_tag` at `prod-latest` per the per-service-tag-routing rule so only the frontend+api move.

**Post-deploy acceptance (re-run after the owner-approved rollout):**
- `GET https://isnad.noorinalabs.com/runtime-config.js` → `200` + JS content-type + `USER_SERVICE_ORIGIN: "https://users.noorinalabs.com"` (i.e. prod smoke check #7 flips to PASS).
- `https://isnad.noorinalabs.com/login` renders providers + email login with no `JSON.parse` error.

## Follow-ups (out of scope for this deploy-repo PR)
- **Defensive non-JSON guard** in the login fetches (`isnad-graph/frontend/src/pages/LoginPage.tsx`) so a misrouted response degrades gracefully instead of an opaque `JSON.parse` throw — lives in the isnad-graph repo; file as a tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
