### PR TITLE
deploy(#423): normalize digests on both sides of v2 stg-verify gate

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -621,6 +621,18 @@ jobs:
               fi
               checked=$((checked + 1))
               verify_digest=$(printf '%s' "$verify_digests" | python3 -c "import json,sys,os;print(json.loads(sys.stdin.read()).get(os.environ['K'], ''))" K="$key" 2>/dev/null || echo "")
+              # Normalize BOTH sides before any equality/emptiness check
+              # (deploy#423). The plan job resolves digests via
+              # `$(docker buildx imagetools inspect …)` threaded through
+              # env → JSONL → step-output; a stray trailing CR (`\r`) there
+              # rendered invisibly in logs but broke the byte-equality below
+              # against the JSON-clean verify digests, failing this gate on
+              # digests that were in fact hex-identical — blocking every v2
+              # promotion. A digest is `sha256:` + 64 hex with no legitimate
+              # whitespace, so stripping all whitespace is safe and makes the
+              # comparison robust regardless of which side carries the byte.
+              plan_digest="$(printf '%s' "$plan_digest" | tr -d '[:space:]')"
+              verify_digest="$(printf '%s' "$verify_digest" | tr -d '[:space:]')"
               if [ -z "$plan_digest" ]; then
                 # Plan failed to resolve a digest for this service (e.g.,
                 # explicit-short path + registry outage). Treat as


### PR DESCRIPTION
## What & why
The Schema-v2 stg-verify divergence gate (`gate-stg-verify` in `promote.yml`, deploy#199) **failed with "plan/verify digest divergence" on digests that were byte-equal**, blocking **every** v2 promotion to prod — the retag and the `environment: production` owner-approval gate were never reached. Found while promoting the runtime-config frontend build to fix the prod-login `JSON.parse` bug (deploy#420); three promote runs failed identically (27396413898, 27396571275) despite the gate's own log showing plan and verify digests identical (api `5490173d…`, frontend `63e56414…`).

Full diagnosis in **#423**.

## Root cause
The `plan` job resolves each digest via `$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' …)`, threaded through env → JSONL → step-output. A stray trailing carriage return (`\r`) on that path renders invisibly in logs but breaks the shell `[ "$plan_digest" != "$verify_digest" ]` against the JSON-clean verify digests (verify-deploy writes `service_digests` via `json.dump`). Net: a MISMATCH on every service whose hex actually matched. Reproducing the gate's exact comparison locally with the real values yields `OK` for both services — it only fails inside the runner, the classic invisible-character signature.

## Fix (minimal, both-sides, robust)
Strip all whitespace from **both** `plan_digest` and `verify_digest` immediately after extraction, before any emptiness/equality check — so the comparison is robust regardless of which side carries the stray byte. A digest is `sha256:` + 64 hex with no legitimate whitespace, so stripping is safe. 12 lines, comment-documented, scoped to the gate compare; the plan-resolve, retag, and trigger-prod-deploy paths are untouched.

## Verified (local simulation against the patched logic)
- **CR-contaminated plan digest + clean verify, hex-equal → gate PASSES** (the bug).
- **Genuinely different hex → gate still FAILS** (real-divergence guard intact — no regression).
- `actionlint` clean (shellcheck integration active).

No natural unit-test seam exists for the inline-YAML gate bash without extracting the whole job to a script (out of scope for this minimal hotfix); the two simulations above cover both the fixed path and the preserved FAIL path.

## Rollout context
This unblocks the owner-gated promote for deploy#420. Once merged to `deployments/phase-4/wave-3`, re-running `promote.yml --ref deployments/phase-4/wave-3` (source_sha empty/`b52f46f`, images `api,frontend`) should pass the gate and **pause at the `environment: production` owner-approval gate** — no prod change until the owner approves. (The `production` environment has no deployment-branch restriction, so running promote from the wave branch is valid.)

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)
