### PR TITLE
deploy(#423): pass verify-digest key as env prefix (real v2-gate fix; supersedes #424 RCA)

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -620,7 +620,13 @@ jobs:
                 continue
               fi
               checked=$((checked + 1))
-              verify_digest=$(printf '%s' "$verify_digests" | python3 -c "import json,sys,os;print(json.loads(sys.stdin.read()).get(os.environ['K'], ''))" K="$key" 2>/dev/null || echo "")
+              # NB: `K` MUST be an environment PREFIX here. Written as a
+              # trailing `… python3 -c "…" K="$key"` it is python's argv[1],
+              # not an env var, so `os.environ['K']` raised KeyError → swallowed
+              # by `2>/dev/null || echo ""` → verify_digest empty for EVERY
+              # service → every service hit the "verify-digest missing" branch
+              # → the gate could NEVER pass a v2 artifact (deploy#423).
+              verify_digest=$(printf '%s' "$verify_digests" | K="$key" python3 -c "import json,sys,os;print(json.loads(sys.stdin.read()).get(os.environ['K'], ''))" 2>/dev/null || echo "")
               # Normalize BOTH sides before any equality/emptiness check
               # (deploy#423). The plan job resolves digests via
               # `$(docker buildx imagetools inspect …)` threaded through


### PR DESCRIPTION
## What & why — the ACTUAL fix for #423 (supersedes #424's root cause)
#424 was merged on a wrong root-cause diagnosis (a hypothesised trailing `\r`). A post-merge promote from the fixed wave-3 (`promote.yml` run `27422381208`, headSha `4c5174e`, WITH #424) **still failed the gate** identically. Re-investigating produced the real, proven cause.

## Root cause (proven)
The `verify_digest` extraction in `gate-stg-verify` passed the service key as a **trailing argument** to `python3`, not as an environment variable:

```bash
verify_digest=$(printf '%s' "$verify_digests" \
  | python3 -c "import json,sys,os;print(json.loads(sys.stdin.read()).get(os.environ['K'], ''))" K="$key" \
  2>/dev/null || echo "")
```

`K="$key"` after the `-c` script is python's `sys.argv[1]`, **not** an env assignment. So `os.environ['K']` raises `KeyError: 'K'`, swallowed by `2>/dev/null || echo ""` → `verify_digest` is **empty for every service** → every service hits the `[ -z "$verify_digest" ]` "verify-digest missing in artifact" branch → `mismatch++` → "N of N divergence." **The v2 per-service gate could never pass a v2-schema artifact.** (Prior successful promotions used the v1 freshness path, not this code.)

## Fix
Move `K="$key"` to an environment **prefix**: `K="$key" python3 -c "…"`. #424's whitespace-strips are retained as harmless defense-in-depth.

## Verified (local, exact gate forms)
```
trailing-arg form  python3 -c "…os.environ['K']…" K="api"  → verify_digest=[]   (stderr: KeyError: 'K')
env-prefix form    K="api" python3 -c "…os.environ['K']…"  → verify_digest=[sha256:5490173d…]
```
Full gate loop simulated against the **real** stg-verify artifact (run 27396375779/27396205015 — same api/frontend digests):
- plan == verify (api `5490173d…`, frontend `63e56414…`) → **PASS** (was FAIL before this change).
- genuinely-different hex → **still FAILS** (no-regression; real-divergence guard intact).
- `actionlint` clean.

## Reviewers — please verify the actual mechanism this time
Reproduce both forms locally (the two one-liners above) to confirm trailing-arg → empty vs prefix → resolves, and confirm the no-regression FAIL path. This is the mechanism #424's review missed because the local repro inadvertently used the prefix form.

## Rollout
Lands on `deployments/phase-4/wave-3`. On merge I re-run `promote.yml --ref deployments/phase-4/wave-3` (source_sha empty, images `api,frontend`) → fixed gate should finally pass → retag `prod-b52f46f` → **pause at the `environment: production` owner-approval gate**. No prod change until the owner approves.

Re #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)
