### PR TITLE
fix(promote): trigger-prod-deploy explicit guard (#427)

### DIFF
--- a/.github/workflows/cold-rebuild-dryrun.yml
+++ b/.github/workflows/cold-rebuild-dryrun.yml
@@ -110,7 +110,7 @@ permissions:
 
 jobs:
   workflow-cold-checks:
-    name: Static workflow-shape guards (bugs #1, #2, #3, #5)
+    name: Static workflow-shape guards (bugs #1, #2, #3, #5, #427)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -944,6 +944,17 @@ jobs:
   trigger-prod-deploy:
     name: Trigger prod VPS rollout
     needs: [plan, retag]
+    # Explicit guard (deploy#427). Without an `if:`, this job inherits the
+    # implicit `if: success()`, which GitHub evaluates over the TRANSITIVE
+    # needs closure — not just direct needs. `retag` deliberately survives a
+    # skipped `migrate-prod` (its own `always() && …` above), but the implicit
+    # success() here re-sees that skipped `migrate-prod` ancestor through
+    # `retag` and returns false, so the rollout silently skipped on every
+    # api/frontend-only promotion (migrate-prod gated on user-service). Key
+    # only on the DIRECT needs instead — `retag` already encodes the
+    # gate-stg-verify + migrate-prod acceptability, so retag==success is
+    # sufficient. Same pattern `retag` uses to ignore a skipped ancestor.
+    if: ${{ always() && needs.plan.result == 'success' && needs.retag.result == 'success' }}
     runs-on: ubuntu-latest
     # NOT env-gated — the approval already happened at retag.
     # Firing deploy-prod.yml here is the rollout-execution step.

--- a/.github/workflows/scripts/cold_rebuild_static_checks.py
+++ b/.github/workflows/scripts/cold_rebuild_static_checks.py
@@ -289,6 +289,97 @@ def check_promote_no_floating_source() -> list[Failure]:
     return failures
 
 
+def check_promote_trigger_deploy_direct_needs_guard() -> list[Failure]:
+    """Bug #427: promote.yml's `trigger-prod-deploy` (auto-rollout) job must
+    carry an EXPLICIT `if:` that keys on its DIRECT needs' results — not the
+    implicit `if: success()`.
+
+    The bug shape: a `trigger-prod-deploy` with no job-level `if:` inherits
+    `if: success()`, which GitHub evaluates over the TRANSITIVE needs closure.
+    `retag` deliberately survives a skipped `migrate-prod` (user-service not in
+    the promotion set) via its own `always() && …` guard, but the implicit
+    success() on `trigger-prod-deploy` re-sees that skipped `migrate-prod`
+    ancestor through `retag` and returns false → the VPS rollout silently
+    skips on every api/frontend-only promotion (observed 2026-06-12, promote
+    run 27423040222). The fix shape: an `always() &&
+    needs.<direct>.result == 'success'` guard that ignores the skipped
+    ancestor, mirroring the pattern `retag` already uses.
+    """
+    failures: list[Failure] = []
+    pm = (WORKFLOWS / "promote.yml").read_text(encoding="utf-8")
+
+    job_match = re.search(r"^  trigger-prod-deploy:\s*$", pm, re.MULTILINE)
+    if not job_match:
+        failures.append(
+            Failure(
+                "promote-trigger-deploy-job-present",
+                "trigger-deploy-guard",
+                "promote.yml has no `trigger-prod-deploy:` job — workflow shape "
+                "changed. The deploy#427 auto-rollout guard check can no longer "
+                "locate its target; confirm the rollout dispatch still exists "
+                "and update this check.",
+            )
+        )
+        return failures
+
+    # Slice from `trigger-prod-deploy:` to the next top-level job or EOF.
+    job_start = job_match.start()
+    next_job = re.search(r"^  [a-z][a-z0-9_-]*:\s*$", pm[job_start + 1 :], re.MULTILINE)
+    job_end = job_start + 1 + next_job.start() if next_job else len(pm)
+    job_block = pm[job_start:job_end]
+
+    # Job-level `if:` sits at 4-space indent; step-level `if:` is at 8. Match
+    # only the job-level guard so a step's `if: always()` (e.g. a Summary step)
+    # can't satisfy this check.
+    job_if = re.search(r"^    if:.*$", job_block, re.MULTILINE)
+    if not job_if:
+        failures.append(
+            Failure(
+                "promote-trigger-deploy-has-explicit-if",
+                "trigger-deploy-guard",
+                "promote.yml `trigger-prod-deploy` has NO job-level `if:`. It "
+                "therefore inherits the implicit `if: success()`, which is "
+                "evaluated over the TRANSITIVE needs closure and returns false "
+                "whenever an ancestor (e.g. `migrate-prod`) is skipped — the "
+                "deploy#427 silent-rollout-skip bug. Add an explicit guard: "
+                "`if: ${{ always() && needs.plan.result == 'success' && "
+                "needs.retag.result == 'success' }}`.",
+            )
+        )
+        return failures
+
+    if_line = job_if.group(0)
+    # The guard must (a) use always() so a skipped ancestor doesn't short the
+    # job, and (b) key on the DIRECT needs' results explicitly.
+    if "always()" not in if_line:
+        failures.append(
+            Failure(
+                "promote-trigger-deploy-if-uses-always",
+                "trigger-deploy-guard",
+                "promote.yml `trigger-prod-deploy` job-level `if:` does not call "
+                "`always()`. Without it, a skipped `migrate-prod` ancestor "
+                "(reached transitively via `retag`) makes the implicit-success "
+                "short-circuit re-appear (deploy#427). The guard must be "
+                "`always() && needs.<direct>.result == 'success'`.",
+            )
+        )
+    if not re.search(r"needs\.retag\.result\s*==\s*'success'", if_line):
+        failures.append(
+            Failure(
+                "promote-trigger-deploy-if-keys-on-retag",
+                "trigger-deploy-guard",
+                "promote.yml `trigger-prod-deploy` job-level `if:` does not key "
+                "on `needs.retag.result == 'success'`. The auto-rollout must "
+                "fire on its DIRECT need succeeding (`retag` already encodes the "
+                "gate-stg-verify + migrate-prod acceptability), NOT on the "
+                "transitive closure that the implicit success() walks "
+                "(deploy#427).",
+            )
+        )
+
+    return failures
+
+
 def check_db_migrate_driver_aligned() -> list[Failure]:
     """Bug #5 (#235, fixed #236): db-migrate.yml's DATABASE_URL driver
     scheme must match a driver actually shipped in the user-service
@@ -516,6 +607,10 @@ def main() -> int:
         ("Terraform: no ephemeral keypair (bug #1, #216)", check_terraform_no_ephemeral_keypair),
         ("Promote: retag uses GH_PACKAGES_TOKEN (bug #2)", check_promote_token_scope),
         ("Promote: no floating-tag source (bug #3, #234)", check_promote_no_floating_source),
+        (
+            "Promote: trigger-prod-deploy direct-needs guard (bug #427)",
+            check_promote_trigger_deploy_direct_needs_guard,
+        ),
         ("DB-migrate: driver matches pyproject (bug #5, #235)", check_db_migrate_driver_aligned),
         ("Stg-verify artifact v2 contract (#199)", check_stg_verify_artifact_v2_contract),
     ]


### PR DESCRIPTION
Closes #427

## Problem
`promote.yml`'s `trigger-prod-deploy` job (the auto-rollout that dispatches `deploy-prod.yml` after a successful retag) **silently skipped for every api/frontend-only promotion**, so the approved `prod-<short>` image was tagged but never rolled out to the prod VPS. No error, no second gate — the promotion just stopped after retag, and an operator had to dispatch `deploy-prod.yml` manually. Observed 2026-06-12, promote run `27423040222` (images=`api,frontend`): `plan` ✓, `gate-stg-verify` ✓, `Retag api/frontend` ✓, but `Trigger prod VPS rollout` → **skipped**.

## Root cause — transitive `success()` over a skipped ancestor
`trigger-prod-deploy` had **no job-level `if:`**, so it inherited the implicit `if: success()`. GitHub evaluates `success()` over the **transitive** `needs` closure, not just direct needs:

```
trigger-prod-deploy  needs: [plan, retag]          # no if: → implicit success()
retag                needs: [plan, gate-stg-verify, migrate-prod]
                     if: always() && gate-stg-verify==success && migrate-prod in (success,skipped)
migrate-prod         if: (user-service in image set)  →  SKIPPED for api/frontend-only promotions
```

`retag` deliberately survives a skipped `migrate-prod` via its own `always() && …` guard. But `trigger-prod-deploy`'s implicit `success()` re-saw the **skipped `migrate-prod` ancestor** (reached transitively through `retag`) and returned false → the job skipped, even though its **direct** needs `[plan, retag]` both succeeded. Net: the auto-rollout fired only when `migrate-prod` ran (user-service in the promotion) — every isnad-graph-only ship silently skipped.

## Fix
Give `trigger-prod-deploy` the same explicit guard `retag` already uses, keyed only on its **direct** needs:

```yaml
trigger-prod-deploy:
  needs: [plan, retag]
  if: ${{ always() && needs.plan.result == 'success' && needs.retag.result == 'success' }}
```

`retag` already encodes the gate-stg-verify + migrate-prod acceptability, so `retag.result == 'success'` is sufficient. A failed **or** skipped `retag` still blocks the rollout — no unapproved/wrong image ships (acceptance criterion #3).

## Regression guard (CI-lint)
Added `check_promote_trigger_deploy_direct_needs_guard` to `.github/workflows/scripts/cold_rebuild_static_checks.py`, the existing "bug shape MUST NOT reappear, fix shape MUST stay" static-shape suite. It runs on **every `promote.yml` change** via `cold-rebuild-dryrun.yml`'s path filter (promote.yml is already listed). The check asserts the `trigger-prod-deploy` job has an explicit job-level `if:` that (a) calls `always()` and (b) keys on `needs.retag.result == 'success'`; it fails on the bug shape (no `if:`). Job display name updated to `(bugs #1, #2, #3, #5, #427)`.

## Test Plan
**Verified locally (this PR):**
- New guard runs green against the fixed workflow; reconstructed the bug shape (stripped the job-level `if:`) and confirmed the guard **fails** with the deploy#427 diagnosis — both directions asserted via a unit harness.
- `uvx ruff@0.11.6 format --check` + `ruff check` clean; `mypy` clean; `actionlint` (with shellcheck on PATH) exit 0 on `promote.yml` + `cold-rebuild-dryrun.yml`; both YAMLs parse.

**Post-merge (runtime — cannot be exercised at PR time; owner gates all prod deploys):**
- [ ] An api/frontend-only promotion (`images=api,frontend`, `migrate-prod` skipped) runs `trigger-prod-deploy` and dispatches `deploy-prod.yml` after a successful retag.
- [ ] A user-service-inclusive promotion (migrate-prod runs) still rolls out.
- [ ] A failed/skipped `retag` does NOT fire `trigger-prod-deploy`.

This PR is a **workflow-logic fix only** — no prod deploy was triggered or approved.

## Reviewers
@-attn **Weronika Zielinska** (platform architect, primary) and **Bereket Tadesse** (infra manager, secondary) — please verify the guard expression keys on direct needs and the static-check covers the bug shape.

Related: deploy#423 (the v2-gate KeyError, fixed #425) — both are latent defects in the same never-fully-exercised v2 promote path.
