### PR TITLE
fix(kafka): preflight detects stray KRaft log-dir dirs + runbook (#428)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -48,6 +48,7 @@ keypair
 keypairs
 Krishnamurthy
 Kwame
+logdir
 materialises
 minioadmin
 monkeypatch

--- a/.github/actions/write-deploy-env/action.yml
+++ b/.github/actions/write-deploy-env/action.yml
@@ -258,6 +258,46 @@ runs:
           fi
           echo "==> Kafka cluster-id consistent (or fresh volume) — proceeding."
 
+          # Pre-flight: Kafka KRaft stray non-topic directory detector (deploy#428).
+          # The cluster-id check above only compares ids — it passes clean while a
+          # stray dir is still present. apache/kafka's LogManager ALSO fatally
+          # rejects any DIRECTORY at the log-dir root that is not a topic-partition
+          # dir (a Bitnami-era `config/`, a nested `data/`, an ext4 `lost+found/`).
+          # prod's volume kept the old Bitnami layout (stg migrated onto a fresh
+          # volume in #385/#100), so its leftover `config/` crash-looped the broker
+          # with "Found directory .../config, 'config' is not in the form of
+          # topic-partition", aborting the whole stack on kafka-init. Scan the
+          # persisted volume's log-dir root with scripts/kafka_logdir_preflight.sh
+          # (piped into the apache/kafka image over the mounted volume — no bash in
+          # the image, so the scanner is POSIX sh) and fail loud with the runbook
+          # pointer BEFORE compose up. Only a genuine detection (the scanner's
+          # exit 2) aborts; any other non-zero (fresh volume, image not yet pulled,
+          # transient docker error) only WARNs and proceeds — mirroring the
+          # best-effort tolerance of the cluster-id reader above.
+          echo "==> Pre-flight: scanning Kafka log-dir for stray non-topic directories..."
+          stray_rc=0
+          stray_report="$(docker run --rm -i --entrypoint /bin/sh \
+            -v noorinalabs_kafka_data:/data apache/kafka:3.9.2 \
+            -s /data < scripts/kafka_logdir_preflight.sh 2>&1)" || stray_rc=$?
+          if [ "$stray_rc" -eq 2 ]; then
+            echo "ERROR: Kafka log-dir contains stray non-topic directories — apache/kafka's" >&2
+            echo "       LogManager will reject these on start and crash-loop the broker, aborting" >&2
+            echo "       the whole stack at kafka-init's depends_on. Bringing the stack up now would" >&2
+            echo "       repeat the deploy#428 prod outage." >&2
+            echo "$stray_report" | sed 's/^/         /' >&2
+            echo "       Re-bootstrap (wipe + reformat) the volume per" >&2
+            echo "       docs/runbooks/kafka-cluster-id-rebootstrap.md" >&2
+            echo "       § Variant: stray non-topic directories (stg first), then re-run this deploy." >&2
+            echo "       Aborting before compose up." >&2
+            exit 1
+          elif [ "$stray_rc" -ne 0 ]; then
+            echo "==> WARNING: stray-dir pre-flight could not run (rc=$stray_rc) — the volume is" >&2
+            echo "    likely fresh or the apache/kafka image is not pulled yet. Proceeding." >&2
+            [ -n "$stray_report" ] && echo "$stray_report" | sed 's/^/    /' >&2
+          else
+            echo "==> Kafka log-dir clean (no stray non-topic directories) — proceeding."
+          fi
+
           echo "==> Authenticating to GHCR..."
           trap 'docker logout ghcr.io >/dev/null 2>&1 || true' EXIT
           echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin

--- a/.github/workflows/compose-validate.yml
+++ b/.github/workflows/compose-validate.yml
@@ -291,3 +291,26 @@ jobs:
             -v "$PWD/infra/alertmanager:/etc/alertmanager:ro" \
             prom/alertmanager:v0.28.1 \
             check-config /etc/alertmanager/alertmanager.stg.yml
+
+  scripts-pytest:
+    # deploy#428 — unit tests for the standalone helpers under scripts/ that
+    # have no other runtime gate. Today the only such test is
+    # scripts/tests/test_kafka_logdir_preflight.py, which exercises the
+    # KRaft stray-non-topic-directory detector (scripts/kafka_logdir_preflight.sh)
+    # used by the write-deploy-env pre-flight. A real kafka_data volume is not
+    # available in CI, so the detector's directory-classification logic is
+    # tested against fixture dir layouts (clean vs stray-config/data). The .sh
+    # itself is already shellcheck + bash -n gated by the shellcheck job above;
+    # this job is the behavioral floor. Mirrored in .pre-commit-config.yaml
+    # (pytest-scripts pre-push hook) so the sync-drift gate stays green.
+    name: pytest (scripts)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install pytest
+        run: pip install pytest
+      - name: Run scripts unit tests
+        run: python3 -m pytest scripts/tests -q

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,6 +101,17 @@ repos:
         always_run: true
         stages: [pre-push]
 
+      # pytest over the scripts/ unit tests (mirrors compose-validate.yml's
+      # scripts-pytest job, deploy#428). Covers the KRaft stray-dir detector
+      # scripts/kafka_logdir_preflight.sh. Heavier, so pre-push.
+      - id: pytest-scripts
+        name: pytest-scripts (pre-push)
+        entry: python3 -m pytest scripts/tests -q
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
+
       # Env file completeness check (carried over from the prior config).
       # NOTE: entry is a YAML literal block scalar (`|-`) because the inline
       # `echo "WARNING: ..."` contains a colon-space that a plain scalar would

--- a/docs/runbooks/kafka-cluster-id-rebootstrap.md
+++ b/docs/runbooks/kafka-cluster-id-rebootstrap.md
@@ -1,9 +1,14 @@
-# Runbook: Kafka KRaft cluster-id re-bootstrap (deploy#393)
+# Runbook: Kafka KRaft log-dir re-bootstrap (deploy#393, deploy#428)
 
-**Scope:** the pipeline Kafka broker (`kafka` service in `compose/docker-compose.prod.yml`) failing its healthcheck on a stg or prod deploy because the persisted `kafka_data` volume was formatted with a cluster ID that no longer matches the `KAFKA_CLUSTER_ID` the broker is started with. This is the documented post-migration step from the Bitnami → `apache/kafka:3.9.2` migration (deploy#100 / PR #385) that re-bootstraps the log directory under the new image's storage format.
+**Scope:** the pipeline Kafka broker (`kafka` service in `compose/docker-compose.prod.yml`) failing its healthcheck on a stg or prod deploy because the persisted `kafka_data` volume's KRaft log directory is in a state `apache/kafka:3.9.2` refuses to start on. Two variants are covered, both leftovers from the Bitnami → `apache/kafka:3.9.2` migration (deploy#100 / PR #385), and both fixed by the SAME re-bootstrap (wipe + reformat the log dir under the new image's storage format):
+
+1. **Cluster-id mismatch** (deploy#393) — the volume was formatted with a cluster id that no longer matches the `KAFKA_CLUSTER_ID` the broker is started with → `InconsistentClusterIdException`. See § Why this happens.
+2. **Stray non-topic directories** (deploy#428) — the log-dir root carries a leftover Bitnami-era `config/` dir (and/or a nested `data/`) that apache-kafka's LogManager fatally rejects. See § Variant: stray non-topic directories.
+
+A volume can hit either or both; the recovery (§ Recovery) is identical.
 
 **NOT in scope:**
-- Routine deploys where the broker is already healthy — this runbook only applies to a cluster-id / storage-format mismatch.
+- Routine deploys where the broker is already healthy — this runbook only applies to a cluster-id mismatch or a stray-non-topic-dir rejection in the log dir.
 - App-tier (frontend / api / user-service) outages — Kafka is the ingestion-pipeline tier, not in the app request path. App health is independent (see `RUNBOOK.md`).
 - Topic layout / retention — owned by `infra/kafka/init-topics.sh`, see `docs/pipeline-kafka.md`.
 
@@ -40,6 +45,51 @@ docker run --rm -v noorinalabs_kafka_data:/data alpine \
 If the two `cluster.id` values differ, this runbook applies. If the volume has no `meta.properties`, the broker will format fresh on next boot — no action needed.
 
 > The volume name is `noorinalabs_kafka_data` — compose project `noorinalabs` (the `-p noorinalabs` flag in the deploy scripts) prefixes the `kafka_data` volume declared in `compose/docker-compose.prod.yml`. Confirm with `docker volume ls | grep kafka_data`.
+
+## Variant: stray non-topic directories (deploy#428)
+
+This is a SEPARATE failure mode from the cluster-id mismatch above, with the same root cause class (a Bitnami-era volume layout the apache image rejects) and the same fix.
+
+`apache/kafka`'s `LogManager` scans every entry at the log-dir root on startup and **fatally rejects any directory that is not a Kafka topic-partition dir** (`<topic>-<partition>`, optionally a `.<uniqueId>-delete` / `-future` suffix). A stray `config/` (empty, dated to the Bitnami era) and/or a nested `data/` left over on the volume make the broker abort with:
+
+```
+ERROR Encountered fatal fault: Error starting LogManager
+org.apache.kafka.common.KafkaException: Found directory /var/lib/kafka/data/config,
+'config' is not in the form of topic-partition or topic-partition.uniqueId-delete ...
+Kafka's log directories (and children) should only contain Kafka topic data.
+```
+
+Like the cluster-id case, the broker never reaches healthy and compose aborts the whole stack on `kafka-init`'s `depends_on: condition: service_healthy`, surfacing only as the opaque `dependency failed to start: container noorinalabs-kafka-1 is unhealthy`. This was the proximate cause of the deploy#428 prod outage (observed 2026-06-12 during the deploy#420 prod rollout): prod's volume retained the old Bitnami directory layout, while stg had been migrated onto a fresh volume in the #385/#100 cutover and was clean.
+
+**Note:** the cluster-id pre-flight does NOT catch this — the ids can match while a stray dir is still present. The stray-dir check is a distinct guard.
+
+### Detecting stray directories
+
+The deploy composite (`.github/actions/write-deploy-env`) runs a second pre-flight — `scripts/kafka_logdir_preflight.sh` piped into the `apache/kafka:3.9.2` image over the mounted volume — that scans the log-dir root and **fails loud with a pointer to this section** before `docker compose up`. If you are reading this because that step failed, the offenders are already named in the failure output — proceed to § Recovery.
+
+To confirm manually on the VPS:
+
+```bash
+cd /opt/noorinalabs-deploy
+
+# List the log-dir root; anything that is NOT a "<topic>-<partition>" dir
+# (or a legitimate file: meta.properties, *.checkpoint, *-offset-checkpoint,
+# bootstrap.checkpoint, .lock) is a stray that will crash the broker.
+docker run --rm --entrypoint /bin/sh \
+    -v noorinalabs_kafka_data:/data apache/kafka:3.9.2 \
+    -c 'ls -la /data'
+
+# Or run the same scanner the pre-flight uses (exit 2 ⇒ stray dirs found):
+docker run --rm -i --entrypoint /bin/sh \
+    -v noorinalabs_kafka_data:/data apache/kafka:3.9.2 \
+    -s /data < scripts/kafka_logdir_preflight.sh
+```
+
+A `config/`, `data/`, or `lost+found/` directory at the root means this variant applies. A clean root (only `__cluster_metadata-0/`, topic-partition dirs, and the files above) means it does not.
+
+### Remediation
+
+Identical to the cluster-id case: **wipe + reformat the log dir** per § Recovery below. Wiping `noorinalabs_kafka_data` removes the stray dirs along with the broker state; `apache/kafka` re-formats the empty log dir on next boot and `kafka-init` re-creates the topics. The replay-from-B2 recovery model (§ Why this happens, "Recovery model") applies unchanged — this is **OWNER / pipeline-owner gated** (volume wipe); surface before applying.
 
 ## Recovery (stg first, then prod)
 
@@ -99,10 +149,12 @@ Do stg first. A stg failure is cheap and proves the procedure before touching pr
 | Broker still unhealthy after re-bootstrap on stg | Lucas.Ferreira (SRE) | Aisha.Idrissi (SRE) |
 | Broker unhealthy on prod | Bereket.Tadesse (IM) | Lucas.Ferreira |
 | `meta.properties` cluster-id mismatch detector mis-fires | Lucas.Ferreira | Weronika.Zielinska (Platform Architect) |
+| Stray-non-topic-dir pre-flight mis-fires (flags a valid topic dir) | Nurul.Hakim (Observability) | Bereket.Tadesse (IM) |
 | Topics do not recreate after wipe | Lucas.Ferreira | Nurul.Hakim (Observability) |
 
 ## Related issues
 
-- **deploy#393** — staging deploy red on kafka healthcheck; this runbook authored alongside.
-- **deploy#100 / PR #385** — Bitnami → `apache/kafka:3.9.2` migration. Side-effects table item 1 deferred this re-bootstrap to a post-merge Test Plan step that was never executed — the proximate cause of #393.
+- **deploy#393** — staging deploy red on kafka healthcheck (cluster-id mismatch); this runbook authored alongside.
+- **deploy#428** — prod kafka crash-loop on Bitnami-era stray `config/`/`data/` dirs in `kafka_data`; added the stray-non-topic-dir pre-flight (`scripts/kafka_logdir_preflight.sh`) + the § Variant section above.
+- **deploy#100 / PR #385** — Bitnami → `apache/kafka:3.9.2` migration. Side-effects table item 1 deferred this re-bootstrap to a post-merge Test Plan step that was never executed — the proximate cause of both #393 and #428.
 - **docs/pipeline-kafka.md** — broker topology, topic inventory, cluster-id stability requirement, observability.

--- a/scripts/kafka_logdir_preflight.sh
+++ b/scripts/kafka_logdir_preflight.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+# kafka_logdir_preflight.sh — detect stray non-topic directories in a Kafka
+# KRaft log-dir root (deploy#428).
+#
+# apache/kafka's LogManager fatally rejects ANY directory at the log-dir root
+# that is not a Kafka topic-partition directory. A valid topic-partition dir is
+# named "<topic>-<partition>" (partition = non-negative integer), optionally
+# with a ".<uniqueId>-delete" or ".<uniqueId>-future" suffix for in-progress
+# deletes / future replicas. Everything else — a Bitnami-era "config/", a nested
+# "data/", an ext4 "lost+found/" — makes the broker log:
+#
+#   Found directory /var/lib/kafka/data/config, 'config' is not in the form of
+#   topic-partition or topic-partition.uniqueId-delete ...
+#   Kafka's log directories (and children) should only contain Kafka topic data.
+#
+# and crash-loop, which aborts the WHOLE compose stack on kafka-init's
+# `depends_on: condition: service_healthy` — surfacing only as the opaque
+# "container noorinalabs-kafka-1 is unhealthy". The deploy preflight in
+# `.github/actions/write-deploy-env` runs this scanner against the persisted
+# volume BEFORE `compose up` so the operator gets the diagnosis (and the
+# re-bootstrap runbook pointer) up front instead of reverse-engineering it.
+#
+# Only DIRECTORIES are subject to the rule. Files kafka legitimately keeps at
+# the log-dir root (meta.properties, bootstrap.checkpoint, *-offset-checkpoint,
+# *.checkpoint, .lock, ...) are ignored — this scanner never flags a file.
+#
+# POSIX sh on purpose: it runs inside the apache/kafka image (which ships
+# /bin/sh + busybox/coreutils grep, no bash) via
+#   docker run --rm -i --entrypoint /bin/sh -v <vol>:/data <img> -s /data < this
+# so it must not use bashisms. It is also unit-tested directly against fixture
+# directories (scripts/tests/test_kafka_logdir_preflight.py).
+#
+# Usage: kafka_logdir_preflight.sh <log-dir>
+# Exit codes:
+#   0  clean — no stray non-topic directories (also: log-dir absent/empty, i.e.
+#      a fresh volume the broker will format on boot)
+#   1  usage error (no log-dir argument)
+#   2  stray non-topic directories found (one per line on stdout)
+set -eu
+
+dir="${1:-}"
+if [ -z "$dir" ]; then
+	echo "usage: kafka_logdir_preflight.sh <log-dir>" >&2
+	exit 1
+fi
+
+# A non-existent log dir is not an error: a fresh volume has no log dir yet and
+# the broker formats it on first boot. Treat as clean.
+if [ ! -d "$dir" ]; then
+	exit 0
+fi
+
+stray=""
+for entry in "$dir"/* "$dir"/.*; do
+	# POSIX sh has no nullglob: an unmatched glob stays literal, so guard on
+	# actual existence before testing.
+	[ -e "$entry" ] || continue
+	# Only directories are subject to kafka's topic-partition naming rule.
+	[ -d "$entry" ] || continue
+	name="${entry##*/}"
+	# Skip the self/parent entries the ".*" glob always yields.
+	case "$name" in
+	. | ..) continue ;;
+	esac
+	# Valid topic-partition dir: ends in "-<digits>", optionally followed by a
+	# ".<uniqueId>-delete" or ".<uniqueId>-future" suffix. This mirrors kafka's
+	# LogManager parse rule — "config", "data", "lost+found" have no "-<digits>"
+	# tail and are therefore rejected by the broker (and by us).
+	if printf '%s\n' "$name" | grep -Eq '^.+-[0-9]+(\.[0-9A-Za-z_-]+-(delete|future))?$'; then
+		continue
+	fi
+	stray="$stray $name"
+done
+
+if [ -n "$stray" ]; then
+	echo "Stray non-topic directories in Kafka log-dir '$dir':"
+	for s in $stray; do
+		echo "  - $s"
+	done
+	echo "apache/kafka's LogManager will reject these and crash-loop the broker."
+	exit 2
+fi
+
+exit 0

--- a/scripts/tests/test_kafka_logdir_preflight.py
+++ b/scripts/tests/test_kafka_logdir_preflight.py
@@ -1,0 +1,108 @@
+"""Unit tests for scripts/kafka_logdir_preflight.sh (deploy#428).
+
+The preflight scanner runs inside the apache/kafka container against the
+persisted ``kafka_data`` volume during deploy. A real volume is not available
+in CI, so we exercise the pure directory-classification logic against fixture
+directory layouts built in a tmp dir — clean vs stray-config / stray-data —
+asserting the exit code and the reported offenders.
+
+Exit-code contract (see the script header):
+    0  clean (also: log-dir absent/empty — a fresh volume)
+    1  usage error (no log-dir argument)
+    2  stray non-topic directories found
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "kafka_logdir_preflight.sh"
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["sh", str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _mk_topic_dirs(root: Path, names: list[str]) -> None:
+    for name in names:
+        (root / name).mkdir(parents=True)
+
+
+def test_script_exists_and_executable() -> None:
+    assert SCRIPT.is_file(), f"detector script missing at {SCRIPT}"
+
+
+def test_clean_logdir_passes(tmp_path: Path) -> None:
+    """Valid topic-partition dirs + legitimate root files → exit 0."""
+    _mk_topic_dirs(
+        tmp_path,
+        ["__cluster_metadata-0", "pipeline.dedup.done-0", "pipeline.dlq-2"],
+    )
+    root_files = (
+        "meta.properties",
+        "bootstrap.checkpoint",
+        "recovery-point-offset-checkpoint",
+        ".lock",
+    )
+    for f in root_files:
+        (tmp_path / f).write_text("")
+    result = _run(str(tmp_path))
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+def test_stray_config_dir_is_detected(tmp_path: Path) -> None:
+    """The Bitnami-era ``config/`` leftover that triggered #428 → exit 2."""
+    _mk_topic_dirs(tmp_path, ["__cluster_metadata-0", "config"])
+    (tmp_path / "meta.properties").write_text("")
+    result = _run(str(tmp_path))
+    assert result.returncode == 2, result.stdout
+    assert "config" in result.stdout
+    # The valid topic-partition dir must NOT be reported as stray.
+    assert "__cluster_metadata-0" not in result.stdout
+
+
+def test_stray_data_and_lost_found_detected(tmp_path: Path) -> None:
+    """A nested ``data/`` mis-layout and an ext4 ``lost+found/`` are stray."""
+    _mk_topic_dirs(tmp_path, ["__cluster_metadata-0", "data", "lost+found"])
+    result = _run(str(tmp_path))
+    assert result.returncode == 2, result.stdout
+    assert "data" in result.stdout
+    assert "lost+found" in result.stdout
+
+
+def test_delete_and_future_suffix_dirs_are_valid(tmp_path: Path) -> None:
+    """In-progress delete/future replica dirs are valid topic-partition forms."""
+    _mk_topic_dirs(
+        tmp_path,
+        [
+            "topic-0",
+            "pipeline.raw.new-1.abc123ef-delete",
+            "pipeline.enrich.done-3.0000000000000000abcd-future",
+        ],
+    )
+    result = _run(str(tmp_path))
+    assert result.returncode == 0, result.stdout
+
+
+def test_empty_logdir_passes(tmp_path: Path) -> None:
+    """A fresh (empty) volume has nothing to reject → exit 0."""
+    result = _run(str(tmp_path))
+    assert result.returncode == 0, result.stdout
+
+
+def test_missing_logdir_passes(tmp_path: Path) -> None:
+    """A non-existent log dir (volume not yet formatted) is treated as clean."""
+    result = _run(str(tmp_path / "does-not-exist"))
+    assert result.returncode == 0, result.stdout
+
+
+def test_no_argument_is_usage_error() -> None:
+    result = _run()
+    assert result.returncode == 1
+    assert "usage" in result.stderr.lower()


### PR DESCRIPTION
Closes #428

## Root cause
prod kafka crash-looped during the deploy#420 prod rollout (deploy-prod run 27428917290, RestartCount 12, unhealthy). Its persisted `noorinalabs_kafka_data` volume kept a **Bitnami-era `config/` dir** (empty, dated Oct 2024) and a nested `data/` at the KRaft log-dir root. `apache/kafka:3.9.2`'s LogManager fatally rejects any non-topic-partition directory there:

```
Found directory /var/lib/kafka/data/config, 'config' is not in the form of
topic-partition or topic-partition.uniqueId-delete ...
```

The broker never reached healthy, so compose aborted the whole pipeline stack on `kafka-init`'s `depends_on: condition: service_healthy`. stg was clean (migrated onto a fresh volume in #385/#100); prod retained the old Bitnami layout. The existing `write-deploy-env` preflight only compares **cluster-id** — the ids can match while a stray dir is still present — so this variant slipped through to `compose up`.

## What this PR catches
A **second** preflight, distinct from the cluster-id check:

- **`scripts/kafka_logdir_preflight.sh`** — POSIX-sh scanner (runs inside the apache/kafka image over the mounted volume; no bash in that image) that flags any directory at the log-dir root that is not a `<topic>-<partition>` dir. Legitimate root files (`meta.properties`, `*.checkpoint`, `.lock`, …) and valid `.uniqueId-delete` / `-future` suffix dirs are NOT flagged. Exit 2 = stray found.
- **`.github/actions/write-deploy-env/action.yml`** — runs the scanner right after the cluster-id check; **hard-fails ONLY on a genuine detection** (exit 2) with a pointer to the runbook variant section, and **warns-and-proceeds** on any other rc (fresh volume / image not yet pulled / transient docker error) — mirroring the cluster-id reader's best-effort tolerance.
- **`docs/runbooks/kafka-cluster-id-rebootstrap.md`** — retitled to cover both variants; new **§ Variant: stray non-topic directories** documenting symptom, the manual `ls -la /data` / scanner confirmation, and that the remediation is the **same wipe + reformat** (§ Recovery). Escalation row + Related issues updated.

## Prod volume wipe is gated — documented-only here
The actual `noorinalabs_kafka_data` wipe/reformat is **OWNER + pipeline-owner gated** (Bereket / Nurul sign-off). This PR ships the **preflight detection code + runbook docs only** — it does NOT execute any prod operation. The wipe is low-cost by design (pipeline replays from B2; accepted in #385/#100 side-effects table) and is described for a human to run under sign-off.

## Test Plan
- `scripts/tests/test_kafka_logdir_preflight.py` (8 cases): clean log-dir passes; Bitnami `config/` detected (exit 2, valid `__cluster_metadata-0` not flagged); nested `data/` + `lost+found/` detected; `.uuid-delete`/`-future` suffix dirs accepted; empty/missing log-dir → clean; no-arg → usage error. **A real `kafka_data` volume is not available in CI**, so the detector's directory-classification logic is exercised against fixture dir layouts. Wired into CI via a new `scripts-pytest` job in `compose-validate.yml` and mirrored in `.pre-commit-config.yaml` (`pytest-scripts` pre-push) so the sync-drift gate stays green.
- Local gates green: shellcheck + `bash -n` (scanner), ruff + mypy (scripts), pytest (8 passed), `pre_commit_ci_sync.py` (OK), cspell + markdownlint (runbook), actionlint (compose-validate.yml), YAML parse.
- **Runtime acceptance** (prod kafka reaches healthy; preflight rejects a real stray-dir volume) is a gated post-merge runbook step — not PR-time, since it needs the real prod volume.

## Merge sequencing
**Does NOT touch `compose/docker-compose.prod.yml`** — no conflict with deploy#429's prod-compose path. Touches `.github/actions/write-deploy-env/action.yml` and `.github/workflows/compose-validate.yml`.

## Reviewers
@Aisha Idrissi (SRE, primary) · @Bereket Tadesse (IM + Kafka-pipeline owner, secondary)
