### PR TITLE
fix(deploy-prod): tier compose up --wait to app+edge; pipeline non-gating (#429)

### DIFF
--- a/.github/actions/write-deploy-env/action.yml
+++ b/.github/actions/write-deploy-env/action.yml
@@ -63,6 +63,30 @@ inputs:
     description: "Whitespace-separated compose service names to pull."
     required: false
     default: "api frontend landing user-service"
+  gated_services:
+    description: >-
+      Whitespace-separated compose service names for the health-GATED app+edge
+      tier of a tiered rollout (deploy#429). When non-empty the remote script
+      uses scripts/compose_tiered_up.sh: tier 1 = these services brought up with
+      `up -d --wait` (a still-unhealthy one fails the deploy); their deps are
+      pulled in transitively. tier 2 = every other non-deferred service
+      (observability) brought up NON-gating; tier 3 = `deferred_services` (the
+      pipeline tier) brought up NON-gating so an unhealthy Kafka broker can never
+      abort the app rollout and leave caddy/frontend in `Created`. When empty
+      (stg / default) the legacy single full-stack `up -d --force-recreate
+      --remove-orphans` is used unchanged. Prod passes
+      "caddy frontend landing api user-service".
+    required: false
+    default: ""
+  deferred_services:
+    description: >-
+      Whitespace-separated compose service names for the NON-gating pipeline
+      tier of a tiered rollout (deploy#429) — only consulted when
+      `gated_services` is set. These are brought up LAST and in isolation so
+      their (broker) health never gates the deploy. Prod passes
+      "kafka kafka-init kafka-ui kafka-exporter".
+    required: false
+    default: ""
   extra_env:
     description: >-
       Newline-separated NAME=value pairs of additional non-secret env
@@ -107,6 +131,8 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github_token }}
         GITHUB_ACTOR: ${{ inputs.github_actor }}
         PULL_SERVICES: ${{ inputs.pull_services }}
+        GATED_SERVICES: ${{ inputs.gated_services }}
+        DEFERRED_SERVICES: ${{ inputs.deferred_services }}
         SLACK_WEBHOOK_URL: ${{ inputs.slack_webhook_url }}
       with:
         host: ${{ inputs.ssh_host }}
@@ -118,7 +144,7 @@ runs:
         # the caller is responsible for including everything its
         # env_keys references. The composite's own pass-throughs below
         # are appended via the composite action's `env:` block above.
-        envs: IMAGE_TAG,EXTRA_IMAGE_TAGS,EXTRA_ENV,BASE_DOMAIN,ENV_KEYS,GITHUB_TOKEN,GITHUB_ACTOR,PULL_SERVICES,SLACK_WEBHOOK_URL,${{ inputs.env_keys }}
+        envs: IMAGE_TAG,EXTRA_IMAGE_TAGS,EXTRA_ENV,BASE_DOMAIN,ENV_KEYS,GITHUB_TOKEN,GITHUB_ACTOR,PULL_SERVICES,GATED_SERVICES,DEFERRED_SERVICES,SLACK_WEBHOOK_URL,${{ inputs.env_keys }}
         script: |
           set -euo pipefail
           cd /opt/noorinalabs-deploy
@@ -267,7 +293,20 @@ runs:
           docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env pull $PULL_SERVICES
 
           echo "==> Starting services..."
-          docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env up -d --force-recreate --remove-orphans
+          if [ -n "${GATED_SERVICES:-}" ]; then
+            # Tiered bring-up (deploy#429): only the app+edge tier is health-
+            # gated; observability + the pipeline (Kafka) tier are NON-gating, so
+            # an unhealthy non-app service can never abort the rollout and leave
+            # caddy/frontend in `Created` (total edge outage). Prod sets
+            # gated_services + deferred_services; stg leaves them empty and keeps
+            # the legacy single-`up` path below. See scripts/compose_tiered_up.sh.
+            COMPOSE_CMD="docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env" \
+              GATED_SERVICES="$GATED_SERVICES" \
+              DEFERRED_SERVICES="${DEFERRED_SERVICES:-}" \
+              sh scripts/compose_tiered_up.sh
+          else
+            docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env up -d --force-recreate --remove-orphans
+          fi
 
           echo "==> Waiting for services to stabilize..."
           sleep 15

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -247,6 +247,17 @@ jobs:
             ALERTMANAGER_CONFIG_FILE=alertmanager.prod.yml
             SLACK_WEBHOOK_FILE=slack_webhook_url.secret
           base_domain: noorinalabs.com
+          # Tiered prod rollout (deploy#429). Only the app+edge tier is health-
+          # gated (`up -d --wait`); the Kafka pipeline tier comes up NON-gating so
+          # a crash-looping broker can never abort the rollout and leave
+          # caddy/frontend in `Created` → total edge outage. gated_services lists
+          # the app+edge leaf services (their deps — neo4j/postgres/redis/
+          # user-postgres/user-redis/user-service-migrate — are pulled in
+          # transitively by the --wait closure). deferred_services is the Kafka
+          # subgraph (broker + its only dependents). See write-deploy-env +
+          # scripts/compose_tiered_up.sh. stg omits both → legacy single-`up`.
+          gated_services: caddy frontend landing api user-service
+          deferred_services: kafka kafka-init kafka-ui kafka-exporter
           env_keys: NEO4J_PASSWORD,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,REDIS_PASSWORD,AUTH_GOOGLE_CLIENT_ID,AUTH_GOOGLE_CLIENT_SECRET,AUTH_GITHUB_CLIENT_ID,AUTH_GITHUB_CLIENT_SECRET,GRAFANA_ADMIN_PASSWORD,JWT_PRIVATE_KEY,JWT_PUBLIC_KEY,KAFKA_CLUSTER_ID,KAFKA_UI_PASSWORD,KAFKA_UI_USER,PIPELINE_B2_BUCKET,PIPELINE_B2_ENDPOINT,PIPELINE_B2_KEY,PIPELINE_B2_KEY_ID,PIPELINE_B2_REGION,BACKUP_B2_KEY_ID,BACKUP_B2_APP_KEY,BACKUP_B2_BUCKET,USER_POSTGRES_DB,USER_POSTGRES_PASSWORD,USER_POSTGRES_USER,USER_REDIS_PASSWORD
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_actor: ${{ github.repository_owner }}

--- a/scripts/compose_tiered_up.sh
+++ b/scripts/compose_tiered_up.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+# compose_tiered_up.sh — tiered `docker compose up` for the prod rollout
+# (deploy#429).
+#
+# THE BUG THIS FIXES
+# ------------------
+# The prod deploy previously ran a single
+#   docker compose ... up -d --force-recreate --remove-orphans
+# over the WHOLE stack. `compose up` brings services up in dependency order and
+# (with healthcheck-gated `depends_on`) FAILS THE WHOLE COMMAND if any service
+# is unhealthy. The Kafka broker (pipeline tier) has dependents — kafka-init /
+# kafka-ui / kafka-exporter (`depends_on: condition: service_healthy`) — so when
+# the broker crash-loops, that single `up` aborts with
+#   "dependency failed to start: container noorinalabs-kafka-1 is unhealthy"
+# and the services LATER in the start graph (caddy + frontend) are left in
+# `Created`, never started. caddy never binds :80/:443 → every public endpoint
+# returns 521 (Cloudflare origin-unreachable) → total edge outage — even though
+# api/neo4j/postgres/redis came up healthy. The app tier does NOT depend on
+# Kafka, so a broker hiccup must NEVER take the reverse proxy down.
+#
+# THE FIX — THREE TIERS
+# ---------------------
+#   tier 1  app+edge  ($GATED_SERVICES)   health-GATED  (`up -d --wait`)
+#           A genuine app/edge failure (api/frontend/landing/user-service/caddy
+#           unhealthy) fails the deploy HERE. These are the only services whose
+#           health may gate the rollout.
+#   tier 2  remainder (observability + already-up app deps)  NON-gating
+#           Everything that is neither gated nor deferred. Brought up best-effort
+#           so an observability hiccup also cannot down the edge.
+#   tier 3  pipeline  ($DEFERRED_SERVICES)  NON-gating
+#           Kafka + its dependents, brought up LAST and in isolation so a broker
+#           crash-loop is reported (::warning::) but never fails the app deploy.
+#
+# The app deps (neo4j/postgres/redis/user-postgres/user-redis/
+# user-service-migrate) are pulled in transitively by the tier-1 `--wait`
+# closure; tier 2 re-touches them as a no-op (compose only recreates on a
+# config/image change).
+#
+# INVOCATION
+# ----------
+# Called by `.github/actions/write-deploy-env` on the prod VPS (the repo is
+# `git reset --hard origin/main` there, so this script is present):
+#   COMPOSE_CMD="docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env" \
+#     GATED_SERVICES="caddy frontend landing api user-service" \
+#     DEFERRED_SERVICES="kafka kafka-init kafka-ui kafka-exporter" \
+#     sh scripts/compose_tiered_up.sh
+#
+# stg keeps the legacy single-`up` path (the composite only calls this script
+# when GATED_SERVICES is set), so this change is prod-only.
+#
+# POSIX sh on purpose (mirrors scripts/kafka_logdir_preflight.sh): no bashisms,
+# so it is unit-tested directly with a mocked COMPOSE_CMD — see
+# scripts/tests/test_compose_tiered_up.py.
+set -eu
+
+# Base `docker compose ...` invocation. Overridable so the unit test can inject
+# a mock that records its args and simulates `config --services` + failures.
+COMPOSE_CMD="${COMPOSE_CMD:-docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env}"
+GATED_SERVICES="${GATED_SERVICES:-}"
+DEFERRED_SERVICES="${DEFERRED_SERVICES:-}"
+
+if [ -z "$GATED_SERVICES" ]; then
+  echo "ERROR: GATED_SERVICES is empty — refusing to roll prod with no health-gated tier." >&2
+  echo "       (The composite only invokes this script for the prod tiered path.)" >&2
+  exit 1
+fi
+
+# Run the base compose command with the given args. COMPOSE_CMD is deliberately
+# word-split into the program + its flags.
+compose() {
+  # shellcheck disable=SC2086
+  $COMPOSE_CMD "$@"
+}
+
+is_deferred() {
+  _needle="$1"
+  for _d in $DEFERRED_SERVICES; do
+    if [ "$_needle" = "$_d" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# ── tier 1: app+edge — health-gated ──────────────────────────────────────────
+# `--wait` makes a still-unhealthy app/edge service (incl. caddy, whose own
+# health nothing else depends on) fail the deploy. The deferred pipeline tier is
+# NOT in this set, so the broker's health can never gate or abort it.
+echo "==> [tier 1/3] App+edge bring-up (health-gated --wait): $GATED_SERVICES"
+# shellcheck disable=SC2086
+compose up -d --force-recreate --wait $GATED_SERVICES
+
+# ── tier 2: remainder (observability + app deps) — NON-gating ─────────────────
+# Everything that is not deferred. Excludes the pipeline tier so a broker hiccup
+# cannot abort observability bring-up. Non-gating: a failure here is reported but
+# does not fail the app deploy.
+_rest=""
+for _svc in $(compose config --services); do
+  if is_deferred "$_svc"; then
+    continue
+  fi
+  _rest="$_rest $_svc"
+done
+echo "==> [tier 2/3] Observability/remainder bring-up (non-gating):$_rest"
+# shellcheck disable=SC2086
+compose up -d --remove-orphans $_rest \
+  || echo "::warning::tier 2 (observability/remainder) bring-up returned non-zero — NOT failing the app deploy (deploy#429)."
+
+# ── tier 3: pipeline — NON-gating ─────────────────────────────────────────────
+# Kafka + dependents, brought up LAST and in isolation. A broker crash-loop here
+# is reported but must NEVER down the reverse proxy / fail the app deploy.
+if [ -n "$DEFERRED_SERVICES" ]; then
+  echo "==> [tier 3/3] Pipeline bring-up (non-gating): $DEFERRED_SERVICES"
+  # shellcheck disable=SC2086
+  compose up -d $DEFERRED_SERVICES \
+    || echo "::warning::tier 3 (pipeline) bring-up returned non-zero — NOT failing the app deploy (deploy#429). A broker hiccup must never down the edge."
+fi
+
+echo "==> Tiered bring-up complete."

--- a/scripts/tests/test_compose_tiered_up.py
+++ b/scripts/tests/test_compose_tiered_up.py
@@ -1,0 +1,172 @@
+"""Unit tests for scripts/compose_tiered_up.sh (deploy#429).
+
+The script runs the prod rollout as three tiers so an unhealthy non-app service
+(a crash-looping Kafka broker) can never abort the app+edge bring-up and leave
+caddy/frontend in ``Created`` (total edge outage):
+
+    tier 1  app+edge  ($GATED_SERVICES)   health-GATED   -> failure fails deploy
+    tier 2  remainder (observability)     NON-gating
+    tier 3  pipeline  ($DEFERRED_SERVICES) NON-gating
+
+A real Docker daemon / prod stack is not available in CI, so we inject a mock
+``COMPOSE_CMD`` that (a) answers ``config --services`` with a fixture service
+list and (b) records every ``up`` invocation, optionally failing the one whose
+argv contains a chosen token. That lets us assert the exact service partition
+across the three tiers and the gating contract (tier 1 fatal, tiers 2/3 not).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "compose_tiered_up.sh"
+
+# Fixture stack — a representative subset of compose/docker-compose.prod.yml:
+# app+edge + their deps, two observability services, and the Kafka subgraph.
+ALL_SERVICES = [
+    "neo4j",
+    "postgres",
+    "redis",
+    "api",
+    "frontend",
+    "landing",
+    "user-postgres",
+    "user-redis",
+    "user-service-migrate",
+    "user-service",
+    "caddy",
+    "prometheus",
+    "grafana",
+    "kafka",
+    "kafka-init",
+    "kafka-ui",
+    "kafka-exporter",
+]
+GATED = "caddy frontend landing api user-service"
+DEFERRED = "kafka kafka-init kafka-ui kafka-exporter"
+
+
+def _write_mock(tmp_path: Path, up_log: Path, fail_token: str = "") -> Path:
+    """Write a mock `docker compose` that records `up` argv and can fail one."""
+    services = "\n".join(ALL_SERVICES)
+    mock = tmp_path / "mock_compose.sh"
+    mock.write_text(
+        "#!/bin/sh\n"
+        'if [ "$1" = "config" ]; then\n'
+        f'  printf "%s\\n" "{services}"\n'
+        "  exit 0\n"
+        "fi\n"
+        # Record the full argv of any non-config (i.e. `up`) invocation.
+        f'echo "$*" >> "{up_log}"\n'
+        f'fail_token="{fail_token}"\n'
+        'if [ -n "$fail_token" ]; then\n'
+        '  case " $* " in\n'
+        '    *" $fail_token "*) exit 1 ;;\n'
+        "  esac\n"
+        "fi\n"
+        "exit 0\n"
+    )
+    mock.chmod(0o755)
+    return mock
+
+
+def _run(mock: Path, up_log: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["sh", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={
+            "PATH": "/usr/bin:/bin",
+            "COMPOSE_CMD": f"sh {mock}",
+            "GATED_SERVICES": GATED,
+            "DEFERRED_SERVICES": DEFERRED,
+        },
+    )
+
+
+def _up_lines(up_log: Path) -> list[str]:
+    return [ln for ln in up_log.read_text().splitlines() if ln.strip()]
+
+
+def test_script_exists() -> None:
+    assert SCRIPT.is_file(), f"tiered-up script missing at {SCRIPT}"
+
+
+def test_three_tiers_partition_services(tmp_path: Path) -> None:
+    """Happy path: exactly three `up` calls with the right service sets."""
+    up_log = tmp_path / "up.log"
+    mock = _write_mock(tmp_path, up_log)
+    res = _run(mock, up_log)
+    assert res.returncode == 0, res.stderr
+
+    lines = _up_lines(up_log)
+    assert len(lines) == 3, f"expected 3 up invocations, got: {lines}"
+
+    tier1, tier2, tier3 = lines
+
+    # tier 1 — app+edge, health-gated with --wait + --force-recreate.
+    assert "--wait" in tier1
+    assert "--force-recreate" in tier1
+    for svc in GATED.split():
+        assert f" {svc}" in f" {tier1}", f"{svc} missing from tier 1: {tier1}"
+    for svc in DEFERRED.split():
+        assert f" {svc} " not in f" {tier1} ", f"{svc} must NOT be in tier 1"
+
+    # tier 2 — remainder: every non-deferred service, and NO deferred one.
+    assert "--remove-orphans" in tier2
+    assert "--wait" not in tier2, "tier 2 must be non-gating (no --wait)"
+    for svc in ALL_SERVICES:
+        present = f" {svc} " in f" {tier2} "
+        if svc in DEFERRED.split():
+            assert not present, f"deferred {svc} leaked into tier 2: {tier2}"
+        else:
+            assert present, f"non-deferred {svc} missing from tier 2: {tier2}"
+
+    # tier 3 — pipeline only, non-gating (no --wait).
+    assert "--wait" not in tier3, "tier 3 must be non-gating (no --wait)"
+    for svc in DEFERRED.split():
+        assert f" {svc}" in f" {tier3}", f"{svc} missing from tier 3: {tier3}"
+    assert "caddy" not in tier3 and "api" not in tier3
+
+
+def test_pipeline_failure_is_non_fatal(tmp_path: Path) -> None:
+    """A failing tier-3 (pipeline) `up` must NOT fail the deploy."""
+    up_log = tmp_path / "up.log"
+    # `kafka-init` only ever appears in the tier-3 argv, so this fails tier 3.
+    mock = _write_mock(tmp_path, up_log, fail_token="kafka-init")
+    res = _run(mock, up_log)
+    assert res.returncode == 0, f"pipeline failure must be non-gating: {res.stderr}"
+    assert len(_up_lines(up_log)) == 3, "all three tiers should still be attempted"
+    assert "::warning::tier 3" in res.stdout
+
+
+def test_app_tier_failure_is_fatal(tmp_path: Path) -> None:
+    """A failing tier-1 (app+edge) `up` must fail the deploy before later tiers."""
+    up_log = tmp_path / "up.log"
+    # `caddy` appears only in the tier-1 argv → tier 1 fails under `set -e`.
+    mock = _write_mock(tmp_path, up_log, fail_token="caddy")
+    res = _run(mock, up_log)
+    assert res.returncode != 0, "app/edge failure must fail the deploy"
+    assert len(_up_lines(up_log)) == 1, "must abort after tier 1; no tier 2/3 run"
+
+
+def test_empty_gated_services_refused(tmp_path: Path) -> None:
+    """No GATED_SERVICES → refuse (the composite never calls it that way)."""
+    up_log = tmp_path / "up.log"
+    mock = _write_mock(tmp_path, up_log)
+    res = subprocess.run(
+        ["sh", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={
+            "PATH": "/usr/bin:/bin",
+            "COMPOSE_CMD": f"sh {mock}",
+            "GATED_SERVICES": "",
+            "DEFERRED_SERVICES": DEFERRED,
+        },
+    )
+    assert res.returncode != 0
+    assert not up_log.exists(), "no `up` should run when GATED_SERVICES is empty"


### PR DESCRIPTION
## Summary
Fixes the prod edge outage in #429: a crash-looping Kafka broker aborted the whole `docker compose up` and left **caddy + frontend in `Created`** → every public endpoint 521 (total edge outage), even though the app tier (api/neo4j/postgres/redis) was healthy and does **not** depend on Kafka.

### Root cause
The prod deploy ran a single `docker compose up -d --force-recreate --remove-orphans` over the **whole stack**. With healthcheck-gated `depends_on`, that one `up` **fails the entire command** when any service is unhealthy. Kafka's dependents (`kafka-init`/`kafka-ui`/`kafka-exporter`, `condition: service_healthy`) made the broker's health gate the rollout; caddy + frontend are later in the start graph, so the abort left them un-started. App availability was hostage to an unrelated pipeline broker.

### Fix — tiered rollout (`scripts/compose_tiered_up.sh`)
| tier | services | gating |
|------|----------|--------|
| 1 — app+edge | `caddy frontend landing api user-service` (+ transitive deps neo4j/postgres/redis/user-postgres/user-redis/user-service-migrate) | **health-GATED** `up -d --wait` — a genuine app/edge failure still fails the deploy |
| 2 — remainder | observability + already-up deps | non-gating |
| 3 — pipeline | `kafka kafka-init kafka-ui kafka-exporter` | **non-gating**, brought up last/in isolation — a broker hiccup is `::warning::`'d, never fatal |

Wired **prod-only** via two new `write-deploy-env` composite inputs (`gated_services` / `deferred_services`). **stg passes neither and keeps the legacy single-`up` path unchanged.** `compose/docker-compose.prod.yml` is **untouched** — no env-var-sync / tag-invariant impact.

### Acceptance (#429)
- [x] An unhealthy Kafka (or any non-app service) does NOT abort the app rollout, does NOT leave caddy/frontend un-started, does NOT skip the app health-check — pipeline is tier 3, non-gating; the existing `Verify health check` step now **runs** (the deploy step no longer fails first).
- [x] A genuine app-tier failure still fails the deploy — tier 1 `--wait` over api/frontend/landing/user-service/caddy fails the run if any is unhealthy (caddy now gated too, where it previously was not).

### Tests
- `scripts/tests/test_compose_tiered_up.py` (5 tests, green locally) — asserts the three-tier **service partition** and the **gating contract**: tier-1 failure is fatal, tier-2/tier-3 failures are non-fatal. Mocks `docker compose` (no daemon needed).
- Local: `shellcheck -s sh` clean, `ruff format/check` clean, `mypy scripts` clean, `actionlint` clean, YAML parses.

### Test Plan (post-merge, prod-only — needs the real VPS + secrets, not PR-time)
1. **stg regression first** — deploy-stg still uses the legacy single-`up` (no inputs passed); confirm a normal stg rollout is unchanged.
2. **Prod happy path** — a prod deploy brings caddy+frontend healthy via tier 1; tiers 2/3 come up; `Verify health check` passes.
3. **`--wait` + one-shot** — confirm tier-1 `--wait` correctly treats `user-service-migrate` (`service_completed_successfully`) as satisfied on the prod compose version (it is a transitive dep of `user-service`, not a top-level `--wait` target).
4. **Fault injection** — with a deliberately-unhealthy Kafka, confirm the app+edge tier still comes up healthy and the deploy succeeds (the bug's repro now passes).

### Reviewers
@Lucas Ferreira (SRE, primary) · @Weronika Zielinska (platform architect, secondary)

### Serial-merge note
Touches `.github/actions/write-deploy-env/action.yml` — **so does deploy#428** (Nurul, kafka stray-dir pre-flight). The two edits are in **non-overlapping hunks**: #428 inserts in the Kafka pre-flight block (~L258, before GHCR auth); this PR adds two `inputs:` (~L66), two `env:`/`envs:` entries (~L134/L147), and the bring-up branch (~L295). **Neither touches `compose/docker-compose.prod.yml`.** Clean 3-way merge expected; whichever lands second needs no manual resolution.

Closes #429
