### PR TITLE
ci(deploy#426): wire post-migrate admin bootstrap into db-migrate.yml

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -14,6 +14,12 @@ name: DB Migrate (user-service alembic)
 # divergence `alembic upgrade head` alone would mask). Bump EXPECTED_MERGE_HEAD
 # (below) in lockstep whenever user-service adds a migration — deploy#407 was a
 # wedged stg deploy caused by `0041` landing (us#54/#520) without this bump.
+#
+# Post-migrate admin bootstrap (deploy#426): right after `alembic upgrade head`
+# the same SSH step reasserts the `admin` role grant on the bootstrap account via
+# user-service's idempotent scripts/bootstrap_admin.py (us#159). It is
+# best-effort and never fails the gate — see the step body and
+# docs/runbooks/user-service-alembic.md#admin-bootstrap.
 
 on:
   workflow_call:
@@ -213,6 +219,56 @@ jobs:
               /app/.venv/bin/alembic upgrade head
 
             echo "==> [${ENV_NAME}] alembic upgrade head succeeded"
+
+            # -------- post-migrate: reassert admin grant (deploy#426) --------
+            # Idempotently grant the `admin` role to the bootstrap account using
+            # user-service's unattended-safe bootstrap script (us#159 / PR #160).
+            # Runs against the just-migrated DB, reusing the SAME one-shot image,
+            # DATABASE_URL, and docker network the alembic step above used.
+            #
+            # Best-effort by design — it NEVER fails the migration gate:
+            #   * No-op exit 0 when the bootstrap account does not exist yet. The
+            #     account is OAuth-only, so on a brand-new env this correctly
+            #     no-ops until the owner logs in once via Google OAuth; the grant
+            #     then lands on the NEXT deploy. `set -e` tolerates this (exit 0).
+            #   * Idempotent across deploys — a second run reports `already_admin`
+            #     and exits 0 (no duplicate grant).
+            #   * A BootstrapError (exit 1, e.g. the `admin` role is missing)
+            #     is essentially impossible here because `alembic upgrade head`
+            #     just succeeded above and migration 0001 seeds that role. If it
+            #     somehow fires we LOG it loudly but do NOT abort: the `migrated`
+            #     output the promotion workflow gates on must reflect the alembic
+            #     result only, never the admin reassertion. Hence `set +e` around
+            #     the run and an explicit rc check (not a bare `set -e` abort).
+            #
+            # Config sourcing (not hardcoded in the pipeline):
+            #   * DATABASE_URL — the asyncpg URL assembled above from the VPS
+            #     .env USER_POSTGRES_* values (passed via --database-url so the
+            #     script need not import full app settings in the one-shot
+            #     container).
+            #   * BOOTSTRAP_ADMIN_EMAIL — read from the VPS .env (exported by the
+            #     `set -a; . ./.env` sourcing above). Absent → the script's own
+            #     default (the owner's bootstrap email). Like USER_POSTGRES_*,
+            #     it is intentionally sourced from the VPS env-file, not pushed
+            #     through the GH Actions transport.
+            echo "==> [${ENV_NAME}] post-migrate: reassert admin grant (bootstrap_admin.py)"
+            set +e
+            docker run --rm \
+              --network noorinalabs_user-backend \
+              -e BOOTSTRAP_ADMIN_EMAIL="${BOOTSTRAP_ADMIN_EMAIL:-}" \
+              "${IMAGE}" \
+              /app/.venv/bin/python scripts/bootstrap_admin.py \
+                --database-url "${DATABASE_URL}"
+            BOOTSTRAP_RC=$?
+            set -e
+            if [ "${BOOTSTRAP_RC}" -eq 0 ]; then
+              echo "==> [${ENV_NAME}] admin bootstrap completed (rc=0: granted / already_admin / no-op user-not-found)"
+            else
+              echo "WARNING: [${ENV_NAME}] admin bootstrap exited ${BOOTSTRAP_RC}." >&2
+              echo "         This does NOT fail the migration gate (alembic upgrade head already succeeded)." >&2
+              echo "         rc=1 means BootstrapError — most likely the 'admin' role is missing despite a" >&2
+              echo "         successful migrate. Investigate per docs/runbooks/user-service-alembic.md#admin-bootstrap." >&2
+            fi
 
       - name: Record migration result
         id: record

--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -243,9 +243,14 @@ jobs:
             #
             # Config sourcing (not hardcoded in the pipeline):
             #   * DATABASE_URL — the asyncpg URL assembled above from the VPS
-            #     .env USER_POSTGRES_* values (passed via --database-url so the
-            #     script need not import full app settings in the one-shot
-            #     container).
+            #     .env USER_POSTGRES_* values. Passed as an ENV var (NOT on argv)
+            #     so the password-bearing URL never lands in /proc/<pid>/cmdline
+            #     or the one-shot container's PID-1 argv (CWE-214 — Nino, security
+            #     review). The script's _resolve_database_url() falls back to the
+            #     app settings' effective_database_url, which reads DATABASE_URL
+            #     from env; every other Settings field has a default, so the
+            #     one-shot container needs no further config. Mirrors the adjacent
+            #     alembic invocations, which also pass DATABASE_URL via -e.
             #   * BOOTSTRAP_ADMIN_EMAIL — read from the VPS .env (exported by the
             #     `set -a; . ./.env` sourcing above). Absent → the script's own
             #     default (the owner's bootstrap email). Like USER_POSTGRES_*,
@@ -255,10 +260,10 @@ jobs:
             set +e
             docker run --rm \
               --network noorinalabs_user-backend \
+              -e DATABASE_URL="${DATABASE_URL}" \
               -e BOOTSTRAP_ADMIN_EMAIL="${BOOTSTRAP_ADMIN_EMAIL:-}" \
               "${IMAGE}" \
-              /app/.venv/bin/python scripts/bootstrap_admin.py \
-                --database-url "${DATABASE_URL}"
+              /app/.venv/bin/python scripts/bootstrap_admin.py
             BOOTSTRAP_RC=$?
             set -e
             if [ "${BOOTSTRAP_RC}" -eq 0 ]; then

--- a/compose/.env.example
+++ b/compose/.env.example
@@ -21,6 +21,14 @@ USER_POSTGRES_PASSWORD=changeme
 USER_POSTGRES_DB=user_service
 USER_REDIS_PASSWORD=changeme
 
+# Post-migrate admin bootstrap (deploy#426). The deploy pipeline's post-migrate
+# step (.github/workflows/db-migrate.yml) idempotently grants the `admin` role
+# to this account via user-service's scripts/bootstrap_admin.py (us#159).
+# Optional — leave unset to use the script's default (the owner's bootstrap
+# email). Account creation is OAuth-only, so the grant lands on the first deploy
+# AFTER the owner has logged in once via Google OAuth as this address.
+# BOOTSTRAP_ADMIN_EMAIL=parametrization@gmail.com
+
 # User service auth
 JWT_SECRET=changeme
 JWT_PRIVATE_KEY=

--- a/docs/runbooks/user-service-alembic.md
+++ b/docs/runbooks/user-service-alembic.md
@@ -144,6 +144,68 @@ If a migration needs to land urgently (e.g., a prod outage fix):
 3. Promote via the normal promotion workflow (`promote.yml`, deploy#155). Do NOT bypass the gate — even for hotfixes.
 4. If the gate flags an unexpected head and the migration is genuinely additive and safe, the correct action is still to update `EXPECTED_MERGE_HEAD` in `db-migrate.yml` — not to skip the assertion. This is a 1-line PR and reviewable in minutes.
 
+## Admin bootstrap
+
+The same `db-migrate.yml` SSH step runs a **post-migrate admin-grant reassertion**
+immediately after `alembic upgrade head` succeeds (deploy#426). It invokes
+user-service's `scripts/bootstrap_admin.py` (us#159 / PR
+[noorinalabs-user-service#160](https://github.com/noorinalabs/noorinalabs-user-service/pull/160))
+inside the same one-shot user-service image, against the just-migrated
+`user-postgres`, to grant the `admin` role to the bootstrap account.
+
+```
+alembic upgrade head  →  bootstrap_admin.py --database-url <user-postgres>
+```
+
+**Why it exists:** the `admin` ROLE is seeded by migration `0001`, but no user is
+granted it. Every user-service admin endpoint — and the isnad-graph admin panels
+behind it — needs an admin JWT, so without a seeded grant they 401/403. Wiring it
+into post-migrate makes the grant self-healing on every deploy instead of a
+forgettable manual step.
+
+**First-login dependency (important).** Account creation in user-service is
+**OAuth-only** — the bootstrap account row does not exist until the owner logs in
+once via Google OAuth as `BOOTSTRAP_ADMIN_EMAIL` (default
+`parametrization@gmail.com`). So:
+
+- On a **brand-new env**, this step correctly **no-ops** (the script logs
+  `user_not_found` and exits 0). It does **not** fail the deploy.
+- After the owner's **first OAuth login**, the grant lands on the **next** deploy.
+- Every subsequent deploy is idempotent — the script reports `already_admin` and
+  exits 0 (no duplicate grant).
+
+**It never fails the migration gate.** The step is deliberately best-effort: it is
+wrapped in `set +e` with an explicit rc check, so the `migrated` output the
+promotion workflow gates on reflects the **alembic** result only — never the admin
+reassertion. The only non-zero exit the script produces is `BootstrapError`
+(rc=1, the `admin` role missing => an unmigrated DB), which is essentially
+impossible here because `alembic upgrade head` just succeeded. If it ever fires it
+is **logged loudly** (a `WARNING:` line in the SSH step output) but does not abort
+the deploy.
+
+**Config sourcing.** `BOOTSTRAP_ADMIN_EMAIL` and the DB connection are sourced from
+the deploy env's existing user-service config, not hardcoded in the workflow:
+
+- DB — the asyncpg `DATABASE_URL` assembled from the VPS `.env` `USER_POSTGRES_*`
+  values (the same URL the alembic step uses), passed via `--database-url`.
+- Email — read from the VPS `.env` (`set -a; . ./.env` export). Documented as an
+  optional override in `compose/.env.example`; unset → the script's default. Like
+  `USER_POSTGRES_PASSWORD`, it is sourced from the VPS env-file, not pushed through
+  the GH Actions transport.
+
+**Manual run.** To grant out-of-band (e.g. right after the owner's first login,
+without waiting for the next deploy), run the user-service target directly on the
+VPS image, or from a user-service checkout:
+
+```bash
+make bootstrap-admin            # uv run python scripts/bootstrap_admin.py
+# or, one-shot against the deployed DB from the user-service image:
+docker run --rm --network noorinalabs_user-backend \
+  ghcr.io/noorinalabs/noorinalabs-user-service:<env>-latest \
+  /app/.venv/bin/python scripts/bootstrap_admin.py \
+    --database-url "postgresql+asyncpg://<user>:<pass>@user-postgres:5432/<db>"
+```
+
 ## Escalation
 
 | Failure | Primary | Secondary |
@@ -153,6 +215,7 @@ If a migration needs to land urgently (e.g., a prod outage fix):
 | `alembic upgrade head` fails on prod | Bereket.Tadesse (IM) | Nadia.Boukhari (user-service manager) |
 | SSH / VPS state problem | Lucas.Ferreira | Weronika.Zielinska (Platform Architect) |
 | Secret mismatch / env-file drift | Nino.Kavtaradze (Security) | Bereket.Tadesse |
+| admin bootstrap `WARNING` (rc=1) | Lucas.Ferreira | Anya.Kowalczyk (user-service) |
 
 ## Observability
 

--- a/docs/runbooks/user-service-alembic.md
+++ b/docs/runbooks/user-service-alembic.md
@@ -187,7 +187,10 @@ the deploy.
 the deploy env's existing user-service config, not hardcoded in the workflow:
 
 - DB — the asyncpg `DATABASE_URL` assembled from the VPS `.env` `USER_POSTGRES_*`
-  values (the same URL the alembic step uses), passed via `--database-url`.
+  values (the same URL the alembic step uses), passed as an `-e DATABASE_URL` env
+  var — **not** on argv — so the password-bearing URL never appears in the
+  container's PID-1 argv / `/proc/<pid>/cmdline` (CWE-214). The script reads it via
+  the app settings' `effective_database_url`.
 - Email — read from the VPS `.env` (`set -a; . ./.env` export). Documented as an
   optional override in `compose/.env.example`; unset → the script's default. Like
   `USER_POSTGRES_PASSWORD`, it is sourced from the VPS env-file, not pushed through
@@ -199,11 +202,13 @@ VPS image, or from a user-service checkout:
 
 ```bash
 make bootstrap-admin            # uv run python scripts/bootstrap_admin.py
-# or, one-shot against the deployed DB from the user-service image:
+# or, one-shot against the deployed DB from the user-service image. Pass the
+# password-bearing URL via -e (NOT --database-url on argv) so it never lands in
+# the container's PID-1 argv / /proc/<pid>/cmdline (CWE-214):
 docker run --rm --network noorinalabs_user-backend \
+  -e DATABASE_URL="postgresql+asyncpg://<user>:<pass>@user-postgres:5432/<db>" \
   ghcr.io/noorinalabs/noorinalabs-user-service:<env>-latest \
-  /app/.venv/bin/python scripts/bootstrap_admin.py \
-    --database-url "postgresql+asyncpg://<user>:<pass>@user-postgres:5432/<db>"
+  /app/.venv/bin/python scripts/bootstrap_admin.py
 ```
 
 ## Escalation


### PR DESCRIPTION
## What & why

Closes #426.

The user-service ships an idempotent admin-bootstrap (`scripts/bootstrap_admin.py` / `make bootstrap-admin`, us#159 / user-service PR #160) that grants the `admin` role to the bootstrap account, but nothing in the deploy pipeline invoked it — leaving the grant a forgettable manual step (isnad-graph admin panels 401/403 after a fresh deploy until someone remembers).

This wires the bootstrap into the **post-migrate** step: right after `alembic upgrade head` succeeds inside the reusable `db-migrate.yml` gate. That workflow is the single migration locus invoked by **both** `deploy-stg.yml` (`uses: ./.github/workflows/db-migrate.yml`) and `promote.yml` (prod pre-retag gate), so this one change covers stg **and** prod.

## How it satisfies each acceptance criterion

- **Runs after the alembic upgrade, against the deployed DB** — inserted immediately after the `alembic upgrade head succeeded` echo in the same SSH step, reusing the already-pulled one-shot user-service image, the asyncpg `DATABASE_URL` (assembled from the VPS `.env` `USER_POSTGRES_*`), and the `noorinalabs_user-backend` docker network.
- **Does not fail the deploy on the no-op path** — the OAuth-only bootstrap account doesn't exist on a brand-new env, so the script logs `user_not_found` and **exits 0**; `set -e` tolerates that. Verified against the script source: `main()` returns `0` for `user_not_found` unless `--require-user` is passed (we do not pass it).
- **Idempotent across repeated deploys** — second run reports `already_admin` and exits 0; no duplicate grant. Guaranteed by the script; the wiring invokes it once per migrate run.
- **Email + DB from deploy env config, not hardcoded** — `DATABASE_URL` passed via `--database-url` (same URL the alembic step builds); `BOOTSTRAP_ADMIN_EMAIL` read from the VPS `.env` via the existing `set -a; . ./.env` export (intentionally **not** pushed through the GH Actions transport, matching the `USER_POSTGRES_PASSWORD` pattern). Documented as an optional override in `compose/.env.example`.
- **Operator docs note the first-login dependency** — new `## Admin bootstrap` section in `docs/runbooks/user-service-alembic.md` (anchor `#admin-bootstrap`, referenced from the workflow) explains that on a brand-new env the step no-ops until the owner logs in once via Google OAuth, then grants on the **next** deploy; plus a manual-run recipe and an escalation row.

## Design note — never flips the `migrated` gate signal

The `db-migrate.yml` `run` step's `steps.run.outcome` drives the `migrated` output the promotion workflow gates on. The bootstrap is therefore wrapped in `set +e` + explicit rc capture so it can **never** abort the SSH script or flip `migrated=false`. The only non-zero exit the script produces is `BootstrapError` (rc=1, `admin` role missing => unmigrated DB) — essentially impossible here because `alembic upgrade head` just succeeded and migration `0001` seeds that role. If it ever fires, it is logged as a loud `WARNING:` but the deploy proceeds.

## Files changed

- `.github/workflows/db-migrate.yml` — post-migrate bootstrap step + header note.
- `compose/.env.example` — documents optional `BOOTSTRAP_ADMIN_EMAIL`.
- `docs/runbooks/user-service-alembic.md` — `## Admin bootstrap` section + escalation row.

## PR-verified vs deploy-time-only

**PR-verified (unit-mechanic):**
- `actionlint` clean on `db-migrate.yml` with `shellcheck` on PATH (matches the `lint-workflows.yml` CI gate).
- Full `pre-commit run --files` on all three changed files: `gitleaks`, `actionlint`, `env-example-check` all **Passed**.
- YAML parses; insertion point, image path (`/app/.venv/bin/python scripts/bootstrap_admin.py`, image WORKDIR `/app`), network, and `--database-url`/`-e BOOTSTRAP_ADMIN_EMAIL` sourcing all confirmed against the user-service Dockerfile + `bootstrap_admin.py` source.
- Script exit-code contract (no-op→0, already_admin→0, BootstrapError→1) read directly from `bootstrap_admin.py`.

**Deploy-time-only (post-merge Test Plan — NOT triggered by this PR; no stg/prod deploy run here):**

## Test Plan (deploy-time validation)

1. **Stg no-op path** — on the next user-service stg deploy *before* the owner has logged in, confirm the `Run alembic pre-deploy gate` step logs `==> [stg] post-migrate: reassert admin grant` then `admin bootstrap completed (rc=0: ... no-op user-not-found)` and the deploy proceeds (migrate job green).
2. **Stg grant path** — after the owner logs in once via Google OAuth as `parametrization@gmail.com`, trigger another stg deploy; confirm the step logs `granted` and the user-service `user_roles` table now has the admin grant.
3. **Stg idempotency** — trigger a third stg deploy; confirm the step logs `already_admin` (no duplicate row, rc=0).
4. **Prod** — confirm the same step runs in the `promote.yml` prod pre-retag `migrate-prod` job (owner-approved promotion) and reasserts the grant against prod `user-postgres`.
5. **Gate-isolation** — confirm a (simulated) bootstrap rc=1 emits the `WARNING:` lines but leaves `migrated=true` and does not block the deploy.

I did **not** trigger any stg/prod deploy — runtime validation is the post-merge owner/operator step above.
