### PR TITLE
fix(deploy#412): derive alembic head from image — kill EXPECTED_MERGE_HEAD drift

### DIFF
--- a/.github/workflows/db-migrate-ci-gate.yml
+++ b/.github/workflows/db-migrate-ci-gate.yml
@@ -136,16 +136,29 @@ jobs:
       - name: Verify schema landed (sanity check)
         run: |
           set -euo pipefail
-          # alembic_version row must exist and match the workflow's EXPECTED_MERGE_HEAD.
-          # Read EXPECTED_MERGE_HEAD from db-migrate.yml so this stays in sync
-          # without a second source of truth.
-          EXPECTED_HEAD="$(grep -E '^[[:space:]]*EXPECTED_MERGE_HEAD:' .github/workflows/db-migrate.yml \
-                          | head -n1 | sed -E 's/.*"([^"]+)".*/\1/')"
+          # DERIVE the expected head from the SAME image we just migrated from
+          # (deploy#412, mirrors db-migrate.yml's derive-not-pin gate). The image
+          # is the single source of truth — no hardcoded revision to drift.
+          EXPECTED_HEAD="$(docker run --rm "${IMAGE}" /app/.venv/bin/alembic heads 2>&1 \
+                          | grep -E '\(head\)' | head -n1 | awk '{print $1}')"
           if [ -z "${EXPECTED_HEAD}" ]; then
-            echo "ERROR: could not parse EXPECTED_MERGE_HEAD from db-migrate.yml" >&2
+            echo "ERROR: could not derive a single head from the image's \`alembic heads\`." >&2
             exit 1
           fi
-          echo "==> Expected head from db-migrate.yml: ${EXPECTED_HEAD}"
+          echo "==> Derived single head from image: ${EXPECTED_HEAD}"
+
+          # OPTIONAL opt-in pin cross-check, mirroring the SSH gate's tripwire.
+          # db-migrate.yml's EXPECTED_MERGE_HEAD defaults to "" (derive mode); if
+          # a maintainer pinned it, assert the image's head matches and name both
+          # possible causes on mismatch (stale-pin drift vs real image mismatch).
+          PINNED_HEAD="$(grep -E '^[[:space:]]*EXPECTED_MERGE_HEAD:' .github/workflows/db-migrate.yml \
+                          | head -n1 | sed -E 's/.*EXPECTED_MERGE_HEAD:[[:space:]]*"?([^"]*)"?.*/\1/')"
+          if [ -n "${PINNED_HEAD}" ] && [ "${PINNED_HEAD}" != "${EXPECTED_HEAD}" ]; then
+            echo "ERROR: optional EXPECTED_MERGE_HEAD pin '${PINNED_HEAD}' in db-migrate.yml does" >&2
+            echo "       not match the image's single head '${EXPECTED_HEAD}'. Either clear/bump the" >&2
+            echo "       optional pin (stale-pin drift) or investigate the image tag (real mismatch)." >&2
+            exit 1
+          fi
 
           # psql via the postgres image itself (no host psql install needed).
           ACTUAL="$(docker run --rm --network host \
@@ -155,7 +168,8 @@ jobs:
             -c "SELECT version_num FROM alembic_version;")"
           echo "==> alembic_version.version_num = ${ACTUAL}"
           if [ "${ACTUAL}" != "${EXPECTED_HEAD}" ]; then
-            echo "ERROR: alembic_version mismatch — got '${ACTUAL}', expected '${EXPECTED_HEAD}'." >&2
+            echo "ERROR: alembic_version mismatch — DB at '${ACTUAL}', image head '${EXPECTED_HEAD}'." >&2
+            echo "       \`alembic upgrade head\` did not land the image's head — investigate." >&2
             exit 1
           fi
 

--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -5,15 +5,25 @@ name: DB Migrate (user-service alembic)
 # against the target env's user-postgres. Fails fast on migration failure;
 # a stg failure must block the prod promotion in the caller's job graph.
 #
-# Belt-and-suspenders (deploy#85, per Anya.Kowalczyk 2026-04-23): before
-# `alembic upgrade head`, assert that `alembic heads` reports exactly ONE
-# line containing the expected head — currently `0041`
-# (`0041_add_subscriptions_user_id_index`, down_revision `0040`; the `0040`
-# merge-migration was introduced by user-service#80). This catches a future
-# migration landing without bumping `down_revision` properly (a silent
-# divergence `alembic upgrade head` alone would mask). Bump EXPECTED_MERGE_HEAD
-# (below) in lockstep whenever user-service adds a migration — deploy#407 was a
-# wedged stg deploy caused by `0041` landing (us#54/#520) without this bump.
+# Single-head assertion — DERIVE, don't pin (deploy#412, supersedes the
+# literal-pin design of deploy#85/#407). Before `alembic upgrade head`, assert
+# that `alembic heads` (run inside the very image we are about to deploy)
+# reports exactly ONE head, then DERIVE that head's revision from the image
+# itself rather than comparing it to a hardcoded revision. The image is the
+# single source of truth for "what head should the DB be at", so a normal new
+# migration in user-service can no longer wedge the deploy. This kills the
+# recurring EXPECTED_MERGE_HEAD drift (deploy#407: `0041` landed in us#54/#520
+# without a lockstep bump and hard-stopped every stg deploy until someone
+# noticed). The single-head assertion is what actually catches the dangerous
+# case — a migration added without a proper `down_revision`, which produces TWO
+# heads and which `alembic upgrade head` would mishandle.
+#
+# EXPECTED_MERGE_HEAD (below) is now an OPTIONAL opt-in tripwire, default "".
+# Leave it empty for the drift-proof derive behavior. Set it to a revision id
+# only to pin a specific high-stakes promotion; a mismatch then is reported as
+# EITHER stale-pin drift (bump/clear the pin) OR a real unexpected-image
+# mismatch (investigate tag resolution) — see the assertion block below and
+# docs/runbooks/user-service-alembic.md §2.
 #
 # Post-migrate admin bootstrap (deploy#426): right after `alembic upgrade head`
 # the same SSH step reasserts the `admin` role grant on the bootstrap account via
@@ -73,10 +83,11 @@ jobs:
     outputs:
       migrated: ${{ steps.record.outputs.migrated }}
     env:
-      # Expected merge-migration revision. Bump this line in the same PR that
-      # lands a future alembic merge migration in user-service. A mismatch
-      # here means "the migration DAG moved under us" and is a hard stop.
-      EXPECTED_MERGE_HEAD: "0041"
+      # OPTIONAL opt-in head pin. Default "" → derive the expected head from the
+      # image (drift-proof; the normal mode). Set to a revision id ONLY to pin a
+      # specific promotion; the gate then additionally asserts the image's single
+      # head equals it. See the header comment and the assertion block below.
+      EXPECTED_MERGE_HEAD: ""
     steps:
       - uses: actions/checkout@v6
 
@@ -186,29 +197,41 @@ jobs:
             echo "$HEADS_OUT"
 
             # Count non-empty lines. alembic prints one revision per line in
-            # the form "<revid> (head)". Any count != 1 is a hard stop.
+            # the form "<revid> (head)". Any count != 1 is a REAL DAG divergence
+            # (not pin drift) and a hard stop.
             HEADS_COUNT="$(printf '%s\n' "$HEADS_OUT" | grep -cE '\(head\)')"
             if [ "$HEADS_COUNT" -ne 1 ]; then
               echo "ERROR: [${ENV_NAME}] alembic heads reported ${HEADS_COUNT} heads, expected exactly 1."
-              echo "       Multiple heads means a migration was added without bumping down_revision,"
-              echo "       or the merge migration was reverted. \`alembic upgrade head\` would fail"
-              echo "       or silently pick a branch. Fix upstream in user-service before retrying."
+              echo "       This is a REAL migration-DAG divergence, not pin drift: a migration"
+              echo "       landed without a proper down_revision, or the merge migration was"
+              echo "       reverted. \`alembic upgrade head\` would fail or silently pick a branch."
+              echo "       Fix upstream in user-service before retrying — runbook §1."
               exit 1
             fi
 
-            # Confirm the single head matches the expected merge-migration id.
-            # If a future merge migration lands in user-service, the PR that
-            # lands it must also bump EXPECTED_MERGE_HEAD in this workflow.
-            if ! printf '%s' "$HEADS_OUT" | grep -qE "^${EXPECTED_MERGE_HEAD}[[:space:]]+\(head\)"; then
-              echo "ERROR: [${ENV_NAME}] alembic heads reports a single head, but it is NOT the"
-              echo "       expected merge-migration revision '${EXPECTED_MERGE_HEAD}'."
-              echo "       A new merge migration was probably added in user-service without"
-              echo "       bumping EXPECTED_MERGE_HEAD in .github/workflows/db-migrate.yml."
-              echo "       Update the workflow in the same PR as the migration, then retry."
+            # DERIVE the single head from the image itself (deploy#412). The image
+            # we are about to deploy is the source of truth; we no longer compare
+            # against a hardcoded revision, so a normal new migration cannot wedge
+            # the deploy. Line shape: "<revid> (head)" — take the first field.
+            DERIVED_HEAD="$(printf '%s\n' "$HEADS_OUT" | grep -E '\(head\)' | head -n1 | awk '{print $1}')"
+            echo "==> [${ENV_NAME}] derived single head from image: ${DERIVED_HEAD}"
+
+            # OPTIONAL opt-in tripwire. Only fires if a maintainer set a non-empty
+            # EXPECTED_MERGE_HEAD. The message names BOTH possible causes so the
+            # operator can tell stale-pin drift from a real unexpected-image bug.
+            if [ -n "${EXPECTED_MERGE_HEAD}" ] && [ "${DERIVED_HEAD}" != "${EXPECTED_MERGE_HEAD}" ]; then
+              echo "ERROR: [${ENV_NAME}] optional EXPECTED_MERGE_HEAD pin is '${EXPECTED_MERGE_HEAD}',"
+              echo "       but the image's single head is '${DERIVED_HEAD}'. Exactly one is true:"
+              echo "         (a) STALE-PIN DRIFT — a legitimate new migration shipped and the optional"
+              echo "             pin was not updated. Fix: clear or bump EXPECTED_MERGE_HEAD in"
+              echo "             .github/workflows/db-migrate.yml (default \"\" = derive, no pin)."
+              echo "         (b) REAL MISMATCH — an unexpected/older image is being deployed."
+              echo "             Investigate image-tag resolution before proceeding."
+              echo "       Runbook §2."
               exit 1
             fi
 
-            echo "==> [${ENV_NAME}] heads-count assertion passed: 1 head, matches ${EXPECTED_MERGE_HEAD}"
+            echo "==> [${ENV_NAME}] single-head assertion passed (head=${DERIVED_HEAD}${EXPECTED_MERGE_HEAD:+, matches pin})"
 
             # -------- alembic upgrade head (singular) --------
             echo "==> [${ENV_NAME}] alembic upgrade head"
@@ -387,7 +410,7 @@ jobs:
             echo ""
             echo "- **Env:** ${{ inputs.env }}"
             echo "- **Image tag:** ${{ steps.tag.outputs.tag }}"
-            echo "- **Expected head:** ${{ env.EXPECTED_MERGE_HEAD }}"
+            echo "- **Head mode:** ${{ env.EXPECTED_MERGE_HEAD == '' && 'derived-from-image' || format('pinned={0}', env.EXPECTED_MERGE_HEAD) }}"
             echo "- **Migrated output:** ${{ steps.record.outputs.migrated }}"
             echo ""
             if [ "${{ job.status }}" != "success" ]; then

--- a/docs/runbooks/user-service-alembic.md
+++ b/docs/runbooks/user-service-alembic.md
@@ -15,8 +15,9 @@ promotion workflow (promote.yml — deploy#155, merged)
     ├── pre-deploy gate (this workflow): db-migrate.yml
     │       │
     │       ├── step 1: alembic heads  (belt-and-suspenders)
-    │       │     ├── must print exactly 1 line with "(head)"
-    │       │     └── that line must contain EXPECTED_MERGE_HEAD (currently 0040)
+    │       │     ├── must print exactly 1 line with "(head)"  ← the real safety
+    │       │     ├── DERIVE that head's revision from the image (deploy#412)
+    │       │     └── optional: if EXPECTED_MERGE_HEAD pin is set, assert match
     │       │
     │       └── step 2: alembic upgrade head  (singular)
     │             └── runs inside ghcr.io/noorinalabs/noorinalabs-user-service:<tag>
@@ -59,24 +60,42 @@ ERROR: [stg] alembic heads reported 2 heads, expected exactly 1.
 
 **Do not bypass the gate.** The gate is protecting prod.
 
-### 2. Heads-count assertion fails — head != EXPECTED_MERGE_HEAD
+### 2. Optional pin tripwire fails — derived head != EXPECTED_MERGE_HEAD
+
+> **deploy#412 changed this.** The gate now **derives** the expected head from
+> the image it is about to deploy; it no longer requires a hardcoded revision.
+> `EXPECTED_MERGE_HEAD` defaults to `""` (derive mode) and a normal new migration
+> can no longer wedge a deploy. This failure mode only fires if a maintainer has
+> deliberately set a non-empty `EXPECTED_MERGE_HEAD` pin.
 
 ```
-ERROR: [stg] alembic heads reports a single head, but it is NOT the
-       expected merge-migration revision '0040'.
+ERROR: [stg] optional EXPECTED_MERGE_HEAD pin is '0041', but the image's
+       single head is '0042'. Exactly one is true:
+         (a) STALE-PIN DRIFT ...
+         (b) REAL MISMATCH ...
 ```
 
-**Cause:** a new migration landed in user-service (probably another merge migration down the line) and `EXPECTED_MERGE_HEAD` in `db-migrate.yml` was not bumped in the same PR.
+**Cause — discriminate the two the error names:**
+
+- **(a) Stale-pin drift** — a legitimate new migration shipped and the optional
+  pin was not updated. This is the *expected* benign case if anyone re-pinned.
+- **(b) Real mismatch** — an unexpected or older image is being deployed (a
+  tag-resolution bug); the head moving *backwards* or to an unrelated id.
 
 **Recovery:**
 
-1. Confirm the migration chain in user-service:
+1. Confirm the image's actual head:
    ```bash
    docker run --rm ghcr.io/noorinalabs/noorinalabs-user-service:<tag> \
      /app/.venv/bin/alembic heads
    ```
-2. If the new head is legitimate, open a same-wave PR in `noorinalabs-deploy` that updates `EXPECTED_MERGE_HEAD` in `.github/workflows/db-migrate.yml` to the new revision id. Merge that PR, then retry the promotion.
-3. If the new head is NOT legitimate (someone committed it by mistake), revert in user-service and restart the promotion.
+2. **(a)** If the new head is the legitimately-deployed one, the durable fix is to
+   **clear** `EXPECTED_MERGE_HEAD` back to `""` in `.github/workflows/db-migrate.yml`
+   (return to drift-proof derive mode) — or bump it to the new revision if you are
+   intentionally keeping a pin for this promotion. Merge, then retry.
+3. **(b)** If the head is NOT what should be deploying (wrong/older image), do not
+   bump the pin — investigate image-tag resolution (`<env>-latest` routing, GHCR
+   digest) per the deploy/promote workflow. The pin caught a real problem.
 
 ### 3. `alembic upgrade head` fails
 
@@ -142,7 +161,7 @@ If a migration needs to land urgently (e.g., a prod outage fix):
 1. Land the alembic migration in `noorinalabs-user-service` → merge to the wave branch.
 2. Wait for the image publish workflow to produce a new `<env>-latest` tag.
 3. Promote via the normal promotion workflow (`promote.yml`, deploy#155). Do NOT bypass the gate — even for hotfixes.
-4. If the gate flags an unexpected head and the migration is genuinely additive and safe, the correct action is still to update `EXPECTED_MERGE_HEAD` in `db-migrate.yml` — not to skip the assertion. This is a 1-line PR and reviewable in minutes.
+4. As of deploy#412 a genuinely additive, safe new migration **no longer trips the gate** — the head is derived from the image, so the hotfix flows through with no deploy-repo PR. The gate still hard-stops on multiple heads (§1) — never skip that assertion. (Only if someone pinned the optional `EXPECTED_MERGE_HEAD` does a head change require a 1-line PR to clear/bump it — see §2.)
 
 ## Admin bootstrap
 


### PR DESCRIPTION
Closes #412

## Problem

`db-migrate.yml`'s pre-deploy gate (and its CI-side dry-run companion `db-migrate-ci-gate.yml`) hard-asserted that the user-service image's single alembic head equalled a **hardcoded** `EXPECTED_MERGE_HEAD`. Nothing forced that literal to move when user-service added a migration, so a *normal* new migration changed the image head and:

- **wedged every staging deploy** (the SSH gate hard-stops before `alembic upgrade head`), and
- **redded every compose-touching deploy PR** (the CI gate asserts `alembic_version == pinned literal`)

…until a human noticed and bumped the literal. It drifted at least once for real (`0040 → 0041`, PR #411 / deploy#407).

## Fix — Option A (derive, don't pin)

The image we are about to deploy is the single source of truth for "what head should the DB be at." The gate now **derives** the head from the image's own `alembic heads` instead of comparing it to a hardcoded revision. A normal new migration can no longer wedge a deploy.

The genuinely-protective check — **exactly one head** (catches a real DAG divergence that `alembic upgrade head` would mishandle) — is **kept**, with its message reworded to say "REAL divergence, not pin drift."

`EXPECTED_MERGE_HEAD` is **demoted to an optional opt-in tripwire**, default `""`:
- **empty (default):** pure derive mode — drift-proof.
- **non-empty (opt-in):** additionally assert the image's single head equals the pin. On mismatch the message names **both** possible causes — (a) stale-pin drift → clear/bump the pin; (b) real unexpected/older-image mismatch → investigate tag resolution. This is the "distinguish real migration mismatch from stale-pin drift" requirement, and preserves Option B's human-reviewed-pin property without making it a mandatory cross-repo sync point.

This is structurally simpler than a lockstep CI gate (no cross-repo coordination) — implementer's recommendation per the issue; **reviewer + owner to confirm Option A over Option B.**

### Files
- `.github/workflows/db-migrate.yml` — derive head; optional-pin tripwire; header comment documents the mechanism (AC #2); job-summary now shows `derived-from-image` vs `pinned=<rev>`.
- `.github/workflows/db-migrate-ci-gate.yml` — derive expected head from the image (no longer requires parsing the literal; the old `sed 's/.*"([^"]+)".*/\1/'` would have *broken* on an empty `""`); optional-pin cross-check mirrors the SSH gate.
- `docs/runbooks/user-service-alembic.md` — §2 reframed as the optional-pin failure (with stale-pin-vs-real-mismatch triage); arch diagram + hotfix cadence updated.

## Acceptance criteria
- [x] A user-service migration merge can no longer silently wedge staging deploys — default derive mode has no literal to drift.
- [x] Mechanism documented in `db-migrate.yml`'s header comment.
- [x] deploy#407's fix (PR #411) remains compatible — the deploy flow still works; the pin is simply no longer required to be bumped.

## Test Plan
Unit-exercised the exact derive/assert shell snippets against synthetic `alembic heads` outputs:

| Case | Input | Result |
|---|---|---|
| single head, derive mode | `0041 (head)`, pin `""` | PASS (head=0041) |
| **new migration**, derive mode | `0042 (head)`, pin `""` | PASS (head=0042) — no wedge |
| two heads | `0041 (head)\n0042 (head)` | FAIL — real DAG divergence |
| pin set, matches | `0041 (head)`, pin `0041` | PASS (pinned) |
| pin set, drifted | `0042 (head)`, pin `0041` | FAIL — both causes named |
| pin parse, empty | `EXPECTED_MERGE_HEAD: ""` | `""` (derive) |
| pin parse, set | `EXPECTED_MERGE_HEAD: "0041"` | `0041` |

`actionlint` clean on both workflows (shellcheck on PATH → shell integration active).

**Runtime-only (post-merge, not PR-time):** the full SSH-into-VPS path and a live image pull can only be exercised by an actual promotion. The CI dry-run gate (`db-migrate-ci-gate.yml`) covers the hermetic mechanic on `pull_request` touching these files and will run on this PR.

## Reviewers
- **Aisha Idrissi** (SRE) — primary
- **Lucas Ferreira** (SRE) — second (raised this in PR #409 + memory note)

Both approvals required per charter.
