### PR TITLE
ops(P4W5): automated DB-password rotation (#387, ADR 0007)

### DIFF
--- a/.github/workflows/rotate-db-passwords.yml
+++ b/.github/workflows/rotate-db-passwords.yml
@@ -1,0 +1,211 @@
+# Automated database / cache password rotation (deploy#387).
+#
+# The P3-automated rotation mechanism the owner chose in ADR 0007 (deploy#388):
+# stay on the GitHub-Environment-secrets baseline (Option A) — NO new secrets
+# manager — and rotate DB/cache passwords with a bespoke scheduled workflow that
+# mints a value, applies it to the running stack, health-gates with rollback,
+# and persists it to the GH Environment secret. Per-secret scope (S1).
+#
+# Division of labour:
+#   - Runner (this workflow): mint a URL-safe value, mask it, SSH the on-box
+#     unit-mechanic `scripts/rotate_db_password.sh`, and — ONLY after that exits
+#     0 — write the new value to the GH Environment secret. That ordering keeps
+#     the "GH Environment secret == live box" invariant: a failed rotation rolls
+#     the box back to the old credential AND leaves the GH secret unchanged.
+#   - Box (`scripts/rotate_db_password.sh`): the ALTER ROLE / recreate +
+#     health-gate + rollback. See that script's header for the engine mechanics.
+#
+# Prod is owner-gated. The scheduled trigger auto-targets STAGING only. Rotating
+# PRODUCTION is a manual `workflow_dispatch` with environment=production, whose
+# GitHub Environment protection rule requires owner approval before the job runs
+# — the same gate deploy-prod.yml / promote.yml rely on. The workflow never
+# auto-rotates prod on a cron.
+#
+# Prerequisite (runtime, documented in docs/runbooks/db-password-rotation.md):
+#   secrets.SECRETS_ADMIN_TOKEN — a token with `secrets: write` on this repo's
+#   Environments (the built-in GITHUB_TOKEN CANNOT write Environment secrets).
+#   The job preflights it (gh secret list) BEFORE touching the box so a missing
+#   token fails fast with no half-applied state.
+
+name: Rotate DB passwords
+
+on:
+  schedule:
+    # Quarterly, 04:00 UTC on the 1st of Jan/Apr/Jul/Oct — the P2 periodic
+    # cadence (ADR 0007 § Rotation-policy Knob 1) for DB/cache passwords.
+    # Scheduled runs target STAGING only (see the `environment` resolution).
+    - cron: "0 4 1 1,4,7,10 *"
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target GitHub Environment (production requires owner approval)."
+        type: choice
+        options: [staging, production]
+        default: staging
+      secret:
+        description: "Which secret to rotate (all = the four DB/cache passwords)."
+        type: choice
+        options:
+          - all
+          - POSTGRES_PASSWORD
+          - REDIS_PASSWORD
+          - USER_POSTGRES_PASSWORD
+          - USER_REDIS_PASSWORD
+        default: all
+      dry_run:
+        description: "Mint + log only; do NOT touch the box or the GH secret."
+        type: boolean
+        default: false
+
+# Serialize against deploy-stg.yml / deploy-prod.yml (same per-env group) so a
+# rotation can never overlap a deploy mid-`.env`-rewrite.
+concurrency:
+  group: deploy-${{ github.event.inputs.environment || 'staging' }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  prep:
+    name: Resolve rotation matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.m.outputs.matrix }}
+      environment: ${{ steps.m.outputs.environment }}
+    steps:
+      - name: Compute matrix + environment
+        id: m
+        env:
+          SECRET_INPUT: ${{ github.event.inputs.secret || 'all' }}
+          ENV_INPUT: ${{ github.event.inputs.environment || 'staging' }}
+        run: |
+          set -euo pipefail
+          if [ "$SECRET_INPUT" = "all" ]; then
+            matrix='{"secret":["POSTGRES_PASSWORD","REDIS_PASSWORD","USER_POSTGRES_PASSWORD","USER_REDIS_PASSWORD"]}'
+          else
+            matrix="{\"secret\":[\"$SECRET_INPUT\"]}"
+          fi
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "environment=$ENV_INPUT" >> "$GITHUB_OUTPUT"
+          echo "Rotating in '$ENV_INPUT': $matrix"
+
+  rotate:
+    name: Rotate ${{ matrix.secret }} (${{ needs.prep.outputs.environment }})
+    needs: prep
+    runs-on: ubuntu-latest
+    environment: ${{ needs.prep.outputs.environment }}
+    strategy:
+      # Serialize on the box — one compose recreate at a time.
+      max-parallel: 1
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prep.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v6
+
+      # Fail fast BEFORE any box change if the secrets-write token is absent or
+      # under-scoped — this is what guarantees the box is never rotated into a
+      # state we cannot then persist to the GH Environment secret.
+      - name: Preflight — secrets-write token can reach this Environment
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.SECRETS_ADMIN_TOKEN }}
+          ENV_NAME: ${{ needs.prep.outputs.environment }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::SECRETS_ADMIN_TOKEN is not set in the '$ENV_NAME' Environment." \
+                 "It needs a token with 'secrets: write' (the built-in GITHUB_TOKEN cannot" \
+                 "write Environment secrets). See docs/runbooks/db-password-rotation.md."
+            exit 1
+          fi
+          if ! gh secret list --env "$ENV_NAME" --repo "${{ github.repository }}" >/dev/null; then
+            echo "::error::SECRETS_ADMIN_TOKEN cannot list secrets in the '$ENV_NAME' Environment" \
+                 "— it is missing or under-scoped. Aborting before touching the box."
+            exit 1
+          fi
+          echo "Preflight OK: token can manage '$ENV_NAME' Environment secrets."
+
+      - name: Mint a new URL-safe password
+        id: mint
+        run: |
+          set -euo pipefail
+          # token_urlsafe(32) -> ~43 chars from [A-Za-z0-9_-], the alphabet the
+          # on-box script enforces (guards PG_DSN/REDIS_URL interpolation).
+          new="$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')"
+          echo "::add-mask::$new"
+          echo "NEW_PASSWORD=$new" >> "$GITHUB_ENV"
+          echo "Minted a new value for ${{ matrix.secret }} (masked)."
+
+      - name: Dry-run notice
+        if: ${{ github.event.inputs.dry_run == 'true' }}
+        run: |
+          echo "DRY RUN — would rotate ${{ matrix.secret }} in" \
+               "'${{ needs.prep.outputs.environment }}'. Box and GH secret untouched."
+
+      # Apply on the box: refresh its checkout (to pick up this script), then run
+      # the health-gated rotation. NEW_PASSWORD travels via appleboy `envs:` as
+      # an environment variable — never on the remote argv (CWE-214).
+      - name: Rotate on the VPS (health-gated, rollback on failure)
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: appleboy/ssh-action@v1
+        env:
+          ROTATE_SECRET: ${{ matrix.secret }}
+          NEW_PASSWORD: ${{ env.NEW_PASSWORD }}
+        with:
+          host: ${{ vars.VPS_HOST }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          envs: ROTATE_SECRET,NEW_PASSWORD
+          script: |
+            set -euo pipefail
+            cd /opt/noorinalabs-deploy
+            echo "==> Refreshing deploy config (for the rotation script)..."
+            git fetch origin main
+            git reset --hard origin/main
+            echo "==> Running rotation for $ROTATE_SECRET..."
+            bash scripts/rotate_db_password.sh
+
+      # Only reached when the box rotation exited 0 (no `if: always()`), so the
+      # GH Environment secret is updated iff the live box now holds the new value.
+      - name: Persist the new value to the GH Environment secret
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.SECRETS_ADMIN_TOKEN }}
+          ENV_NAME: ${{ needs.prep.outputs.environment }}
+          SECRET_NAME: ${{ matrix.secret }}
+        run: |
+          set -euo pipefail
+          # Value on STDIN (--body -) so it is never on the gh argv / runner
+          # /proc/cmdline.
+          if printf '%s' "$NEW_PASSWORD" | gh secret set "$SECRET_NAME" \
+               --env "$ENV_NAME" --repo "${{ github.repository }}" --body -; then
+            echo "Persisted new $SECRET_NAME to the '$ENV_NAME' Environment."
+          else
+            echo "::error::Box rotated to the NEW credential but persisting it to the" \
+                 "'$ENV_NAME' Environment secret FAILED. The live box and the GH secret are" \
+                 "now out of sync — the next deploy would rewrite .env to the OLD value and" \
+                 "break $SECRET_NAME. Re-run 'gh secret set $SECRET_NAME --env $ENV_NAME'" \
+                 "with the new value, OR roll the box back per" \
+                 "docs/runbooks/db-password-rotation.md § Recovery. Do NOT deploy until reconciled."
+            exit 1
+          fi
+
+      - name: Record rotation event (audit)
+        if: always()
+        env:
+          ENV_NAME: ${{ needs.prep.outputs.environment }}
+        run: |
+          {
+            echo "## Rotation: ${{ matrix.secret }} — ${{ job.status }}"
+            echo ""
+            echo "- **Environment:** ${ENV_NAME}"
+            echo "- **Secret:** ${{ matrix.secret }}"
+            echo "- **Dry run:** ${{ github.event.inputs.dry_run || 'false' }}"
+            echo "- **Trigger:** ${{ github.event_name }}"
+            echo "- **Actor:** ${{ github.actor }}"
+            echo "- **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo ""
+            echo "Audit trail per ADR 0007: this workflow run is the rotation record" \
+                 "(distributed audit trail — GH Actions run + the org secret-change audit log)."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/runbooks/db-password-rotation.md
+++ b/docs/runbooks/db-password-rotation.md
@@ -1,0 +1,134 @@
+# Runbook — automated database / cache password rotation
+
+Source: [deploy#387](https://github.com/noorinalabs/noorinalabs-deploy/issues/387)
+(automated DB-password rotation, deferred from
+[deploy#11](https://github.com/noorinalabs/noorinalabs-deploy/issues/11)).
+Decision: [ADR 0007](../adr/0007-central-secrets-manager.md) (central
+secrets-manager + rotation policy, Accepted 2026-06-12).
+Policy: [`secret-rotation-policy.md`](secret-rotation-policy.md)
+(the cadence/scope this runbook mechanizes).
+
+## What this rotates
+
+The four app-runtime DB/cache password secrets, **per-secret** (ADR 0007 scope
+S1), for the env whose stack the target VPS runs:
+
+| Secret | Engine | How it is applied |
+|---|---|---|
+| `POSTGRES_PASSWORD` | isnad-graph Postgres | live `ALTER ROLE` + recreate `api`, `postgres-exporter` |
+| `USER_POSTGRES_PASSWORD` | user-service Postgres | live `ALTER ROLE` + recreate `user-service`, `user-postgres-exporter` |
+| `REDIS_PASSWORD` | isnad-graph Redis | recreate `redis` (re-applies `requirepass`) + `api` |
+| `USER_REDIS_PASSWORD` | user-service Redis | recreate `user-redis` + `user-service` |
+
+> **Why Postgres and Redis differ.** Postgres stores the role password in its
+> data volume — `POSTGRES_PASSWORD` only seeds an *empty* volume, so a recreate
+> does NOT change it; rotation runs a live `ALTER ROLE`. Redis takes
+> `requirepass` from its `command:` arg, so recreating the container with the
+> new `.env` value re-applies it by construction. See the header of
+> [`scripts/rotate_db_password.sh`](../../scripts/rotate_db_password.sh) for the
+> full mechanics.
+
+## Architecture
+
+```
+schedule (quarterly, stg only)  ─┐
+workflow_dispatch (stg or prod) ─┴─> rotate-db-passwords.yml (runner)
+        1. preflight SECRETS_ADMIN_TOKEN can write the Environment secret
+        2. mint URL-safe value (token_urlsafe), mask it
+        3. SSH ─> scripts/rotate_db_password.sh (on the VPS)
+                    ALTER ROLE / recreate  ->  health-gate  ->  rollback-on-fail
+        4. on box-success ONLY: gh secret set  (GH Environment secret = box)
+```
+
+The **ordering is the safety property**: the GH Environment secret is updated
+*only after* the box rotation exits 0. A failed health gate rolls the box back
+to the old credential and the workflow leaves the GH secret unchanged — so
+"**GH Environment secret == live box**" always holds, and the next deploy never
+rewrites `.env` to a value the running DB does not accept.
+
+## Cadence
+
+- **Scheduled:** quarterly (1st of Jan/Apr/Jul/Oct, 04:00 UTC) — **staging only**.
+- **On-demand / production:** `workflow_dispatch` (below). Also rotate
+  immediately on any [`secret-rotation-policy.md` § On-demand trigger](secret-rotation-policy.md#on-demand-triggers-apply-to-every-class)
+  (offboarding, value-in-logs, provider compromise, drift alarm).
+
+## Prerequisite — `SECRETS_ADMIN_TOKEN`
+
+The workflow writes Environment secrets, which the built-in `GITHUB_TOKEN`
+**cannot** do. Provision a token with `secrets: write` on this repo and store it
+as `SECRETS_ADMIN_TOKEN` in **both** the `staging` and `production` GitHub
+Environments:
+
+- A **fine-grained PAT** scoped to `noorinalabs/noorinalabs-deploy` with
+  **Secrets: Read and write** (covers Environment secrets), or
+- a GitHub App installation token with the same permission.
+
+The job **preflights** this token (`gh secret list --env <env>`) before touching
+the box, so a missing or under-scoped token fails fast with **no** half-applied
+state. Rotate `SECRETS_ADMIN_TOKEN` itself on its provider cadence (it is a
+`provider`-class secret; record in #11).
+
+## How to run an on-demand / production rotation
+
+1. Actions → **Rotate DB passwords** → **Run workflow**.
+2. Inputs:
+   - **environment:** `staging` or `production`.
+   - **secret:** `all` (the four) or one specific secret.
+   - **dry_run:** `true` to mint + log only (verifies wiring without touching
+     anything) — recommended for a first run in a new Environment.
+3. **Production gate:** with `environment=production` the job waits on the
+   `production` Environment **approval rule** — an authorized owner must approve
+   the run (the same gate `deploy-prod.yml` / `promote.yml` use). The workflow
+   **never** auto-rotates production on the cron.
+4. Watch the run: the box step is health-gated; on failure it rolls back and the
+   GH secret is left untouched. On success the GH Environment secret is updated
+   and the run summary records the rotation (the audit trail per ADR 0007).
+
+## Verification (runtime — post-merge / per-run)
+
+These can only be confirmed against a live stack, not at PR time:
+
+- [ ] **Staging dry run** (`dry_run=true`) succeeds — proves token preflight,
+      mint, and matrix wiring without side effects.
+- [ ] **Staging real run** (`all`) succeeds: each secret's recreated services
+      reach `healthy`; a pre-rotation app session re-connects with the new
+      credential; the four `staging` Environment secrets show new values.
+- [ ] **Forced-rollback drill (staging):** temporarily point the rotation at a
+      stack where the app cannot come healthy (or fault-inject) and confirm the
+      script restores `.env`, `ALTER ROLE`s Postgres back, recreates against the
+      old credential, and the GH secret is **unchanged**.
+- [ ] **Production run** (owner-approved): same checks against prod URLs via the
+      [`verify_prod_smoke.sh`](../../scripts/verify_prod_smoke.sh) battery.
+- [ ] Rotation timestamps recorded in
+      [deploy#11](https://github.com/noorinalabs/noorinalabs-deploy/issues/11).
+
+## Recovery — box rotated but GH secret not persisted
+
+The one residual gap (a transient `gh` API failure *after* the box rotated but
+*before* the secret was written) leaves the live box on the **new** value while
+the GH secret still holds the **old** one. The persist step fails loudly with
+this instruction. Pick one:
+
+- **Re-persist (preferred):** set the GH Environment secret to the new value the
+  run minted (it is masked in logs; if unrecoverable, do a fresh rotation
+  instead), then verify with a no-op deploy.
+- **Roll the box back:** SSH to the VPS and run the rotation script's rollback
+  path against the OLD value (re-run a rotation targeting the old credential is
+  not supported; instead `gh secret set` the OLD value and run
+  `deploy-<env>.yml`, which rewrites `.env` from the GH secret and recreates the
+  stack — for Postgres also `ALTER ROLE … WITH PASSWORD '<old>'` on the box
+  first, since the volume holds the new password).
+
+**Do not deploy** the affected env until the box and the GH secret are
+reconciled — a deploy would rewrite `.env` from the GH secret and break the
+service whose live DB no longer accepts it.
+
+## Out of scope
+
+- The central-management posture and tool choice — settled in
+  [ADR 0007](../adr/0007-central-secrets-manager.md) (Option A + SOPS-for-config).
+- Non-DB secret classes (JWT, GHCR, pipeline, state-bucket, SSH) — see their own
+  rows in [`secret-rotation-policy.md`](secret-rotation-policy.md) and runbooks.
+- A consolidated audit pane — ADR 0007 accepts the distributed audit trail (GH
+  Actions run + org secret-change audit log) at current scale.

--- a/docs/runbooks/db-password-rotation.md
+++ b/docs/runbooks/db-password-rotation.md
@@ -124,6 +124,22 @@ this instruction. Pick one:
 reconciled — a deploy would rewrite `.env` from the GH secret and break the
 service whose live DB no longer accepts it.
 
+> **Note — forward-recreate failure is NOT auto-rolled-back.** The script's
+> automatic rollback covers the **health-gate** failure (recreate succeeded but
+> a container never went healthy). If the *forward* `docker compose up
+> --force-recreate` itself errors (e.g. the daemon rejects the recreate),
+> `set -e` aborts the script **before** the health gate, so the auto-rollback
+> does not run: Postgres may already be `ALTER ROLE`d to the new value and
+> `.env` rewritten, while the GH secret is still the old value (the persist step
+> never runs). Treat this exactly like the out-of-sync case above — reconcile
+> via the **Roll the box back** path before deploying.
+
+> **Note — the first run must be after the wave merges to `main`.** The on-box
+> step does `git fetch origin main && git reset --hard origin/main` to pick up
+> `scripts/rotate_db_password.sh`, so a real rotation only works once this PR is
+> on `origin/main`. Before then it would run the pre-existing (or absent) script
+> on the box. Plan the first staging dry run / real run for **post-wave-merge**.
+
 ## Out of scope
 
 - The central-management posture and tool choice — settled in

--- a/docs/runbooks/secret-rotation-policy.md
+++ b/docs/runbooks/secret-rotation-policy.md
@@ -87,13 +87,22 @@ with the P3 automated mechanism**:
   is only verifiable at runtime.
 - The on-demand `.env`-swap path (the #126 pattern) remains the manual fallback.
 
-## Central management — open decision (owner / ADR)
+## Central management — ~~open decision (owner / ADR)~~ DECIDED
+
+> **Superseded by [ADR 0007](../adr/0007-central-secrets-manager.md) (Accepted
+> 2026-06-12).** The owner chose the **A + B hybrid**: GitHub Environment
+> secrets (per-env) as the baseline store **plus SOPS + age for git-resident
+> config files**. No new managed service; Vault (D) was judged over-scaled and
+> SaaS (C) retained only as the documented fallback. The "deliberately does not
+> pick one / the choice is the owner's" framing below is **historical** — the
+> decision is recorded in ADR 0007; treat the table + recommendation as the
+> options analysis that fed it.
 
 #11 lists four options for *where* secrets live. This is a **security
 architecture decision with real tradeoffs**, and per team convention an
 options-with-tradeoffs choice of this weight is an **owner / ADR call**, not an
-implementer default. This PR deliberately does **not** pick one. The framing,
-for the decision:
+implementer default. This PR deliberately did **not** pick one (ADR 0007 since
+did). The framing, for the decision:
 
 | Option | Pros | Cons / cost |
 |---|---|---|

--- a/docs/runbooks/secret-rotation-policy.md
+++ b/docs/runbooks/secret-rotation-policy.md
@@ -35,7 +35,7 @@ per-secret runbooks the inventory points at; this file does not duplicate them.
 | B2 master key | on-demand | offboarding / suspected compromise | ADR 0004 Decision D (workstation-only) |
 | SSH deploy/root keys | on-demand | offboarding / suspected compromise | [`ssh-key-rotation.md`](ssh-key-rotation.md) |
 | State-resident app secrets (jwt/ghcr/pipeline) | on-demand | the #172 SSE-window defense-in-depth pass | state-resident-secret-rotation runbook ([#193](https://github.com/noorinalabs/noorinalabs-deploy/issues/193)) |
-| DB / cache passwords | on-demand → **target: automated** | compromise; otherwise see § Automated rotation | per-deploy `.env` swap |
+| DB / cache passwords | **automated** (quarterly + on-demand) | scheduled cadence; compromise; offboarding | [`db-password-rotation.md`](db-password-rotation.md) (`rotate-db-passwords.yml`) |
 | OAuth / PAT / webhook | provider | provider rotation / expiry | provider console |
 
 ## On-demand triggers (apply to every class)
@@ -63,19 +63,29 @@ Until a central manager provides one natively (see § Central management):
 This is a **distributed** audit trail, not a single pane — its consolidation is
 part of the central-management decision below.
 
-## Automated rotation — target, not yet built
+## Automated rotation — built (deploy#387)
+
+> **Superseded by [ADR 0007](../adr/0007-central-secrets-manager.md) (Accepted
+> 2026-06-12) + deploy#387.** The "target, not yet built" framing below is
+> historical; automated DB-password rotation now exists.
 
 #11's acceptance asks that **at least database passwords have automated
-rotation**. That automation is **runtime-gated** (needs a live state backend,
-real credentials, and a scheduled runner against the production stack) and is
-**not** delivered by this PR. The shape it should take:
+rotation**. ADR 0007 chose to build this as a **bespoke scheduled GH Actions
+workflow on the GitHub-Environment-secrets baseline** (Option A — no new secrets
+manager), rotating **per-secret** (S1) on a **P2 cadence (quarterly + on-demand)
+with the P3 automated mechanism**:
 
-- A scheduled GH Actions workflow (or central-manager dynamic secret) that mints
-  a new DB password, updates the GH Environment secret, applies it to the running
-  Postgres/Redis, and redeploys — gated on a green health check, with rollback.
-- Until that exists, DB passwords rotate via the on-demand `.env`-swap path
-  (the #126 pattern). **Filing the automation as its own implementation issue is
-  the next step**; it depends on the central-management choice below.
+- **Workflow:** [`.github/workflows/rotate-db-passwords.yml`](../../.github/workflows/rotate-db-passwords.yml)
+  mints a URL-safe value, applies it to the running Postgres/Redis via
+  [`scripts/rotate_db_password.sh`](../../scripts/rotate_db_password.sh)
+  (health-gated, with automatic rollback), and — only on success — writes it to
+  the GH Environment secret. Scheduled runs target **staging**; **production is
+  owner-gated** (manual `workflow_dispatch` behind the `production` Environment
+  approval rule).
+- **Operator runbook:** [`db-password-rotation.md`](db-password-rotation.md) —
+  on-demand trigger, the `SECRETS_ADMIN_TOKEN` prerequisite, recovery, and what
+  is only verifiable at runtime.
+- The on-demand `.env`-swap path (the #126 pattern) remains the manual fallback.
 
 ## Central management — open decision (owner / ADR)
 

--- a/scripts/rotate_db_password.sh
+++ b/scripts/rotate_db_password.sh
@@ -178,10 +178,12 @@ rewrite_env() {
   local value="$1" tmp esc
   esc="${value//\'/\'\\\'\'}"
   tmp="$(mktemp "${TMPDIR:-/tmp}/env.write.XXXXXX")"
-  # awk replaces only the matching key line; the new value is passed via -v
-  # (awk variable), never on a child process argv.
-  awk -v key="$ROTATE_SECRET" -v val="$esc" '
-    index($0, key "=") == 1 { printf "%s=\047%s\047\n", key, val; next }
+  # awk replaces only the matching key line. The new value is passed through the
+  # ENVIRONMENT (read via ENVIRON["val"]), never as `-v val=` — `-v` would put
+  # the secret on awk's argv (visible in /proc/<pid>/cmdline). Only the secret
+  # NAME (non-sensitive) stays on -v. (CWE-214 — Nino, PR #438 review.)
+  val="$esc" awk -v key="$ROTATE_SECRET" '
+    index($0, key "=") == 1 { printf "%s=\047%s\047\n", key, ENVIRON["val"]; next }
     { print }
   ' "$ENV_FILE" > "$tmp"
   mv "$tmp" "$ENV_FILE"

--- a/scripts/rotate_db_password.sh
+++ b/scripts/rotate_db_password.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# rotate_db_password.sh — rotate ONE database/cache password on the running
+# deploy VPS, health-gated, with automatic rollback (deploy#387).
+#
+# Implements the bespoke scheduled-workflow rotation mechanism the owner chose
+# in ADR 0007 (deploy#388): stay on the GitHub-Environment-secrets baseline
+# (Option A), no new secrets manager, P2/P3 DB-password rotation built on top.
+# This script is the on-box UNIT MECHANIC; the runner-side orchestration (mint
+# the value, persist it to the GH Environment secret) lives in
+# `.github/workflows/rotate-db-passwords.yml`, which invokes this over SSH.
+#
+# Scope (ADR 0007 § Decision — per-secret / S1): exactly one of the four
+# DB/cache password secrets, for the env whose stack this box runs:
+#   POSTGRES_PASSWORD       REDIS_PASSWORD
+#   USER_POSTGRES_PASSWORD  USER_REDIS_PASSWORD
+#
+# Why the two engines differ (the load-bearing detail):
+#   - Postgres stores the role password IN its data volume (pg_authid).
+#     `POSTGRES_PASSWORD` only seeds an *empty* volume on first init, so a
+#     container recreate does NOT change the password. Rotation therefore runs
+#     a live `ALTER ROLE … WITH PASSWORD` against the running server, then
+#     recreates the *client* services so they reconnect with the new value.
+#     The postgres healthcheck uses `pg_isready` (no auth), so it does not
+#     break across the change.
+#   - Redis takes `requirepass` from its `command:` arg (no persisted password
+#     and — here — no config file, so `CONFIG REWRITE` has nowhere to write).
+#     Recreating the redis container with the new `.env` value re-applies the
+#     password by construction; no live command is needed. Its healthcheck
+#     interpolates `REDISCLI_AUTH=${REDIS_PASSWORD}` at container-create time,
+#     so the redis container MUST be recreated (not just its clients) or its
+#     healthcheck would keep using the old value and flap.
+#
+# Security (CWE-214 — no secret on argv / in /proc/cmdline):
+#   - The old password is read from the box's own `.env` (never passed over the
+#     wire); the new password arrives via the environment (appleboy `envs:`),
+#     never as a command-line argument.
+#   - psql auth uses `-e PGPASSWORD` NAME-ONLY passthrough (docker reads the
+#     value from this script's environment, it is not on docker's argv); the
+#     `ALTER ROLE` SQL (which contains the new value) is fed on STDIN, not `-c`.
+#   - The new value is validated to the URL-safe alphabet `[A-Za-z0-9_-]` so it
+#     can never corrupt the compose `PG_DSN`/`REDIS_URL` interpolation
+#     (the us#65 / ig#956 url-unsafe-password class of bug) and needs no SQL
+#     quote-escaping.
+#
+# Rollback invariant (#387 acceptance): a failed rotation leaves the stack on
+# the OLD credential — `.env` is restored, postgres is `ALTER ROLE`d back, redis
+# clients are recreated against the restored `.env`, and the script exits non-
+# zero WITHOUT the caller persisting the new GH secret. The caller only updates
+# the GH Environment secret AFTER this script exits 0, keeping
+# "GH secret == live box" intact.
+#
+# Inputs (environment variables — never positional args):
+#   ROTATE_SECRET   required  one of the four secret names above
+#   NEW_PASSWORD    required  the freshly-minted value (URL-safe alphabet)
+#   ENV_FILE        optional  path to the compose .env (default: .env)
+#   COMPOSE_CMD     optional  compose invocation (default: the prod stack);
+#                             overridable for tests
+#   DOCKER          optional  docker binary (default: docker); overridable
+#   HEALTH_RETRIES  optional  health-poll attempts per container (default: 24)
+#   HEALTH_INTERVAL optional  seconds between polls (default: 5)
+#
+# Exit: 0 = rotated + healthy; 1 = rolled back to old credential (or input
+# error before any change). Designed to run from /opt/noorinalabs-deploy.
+
+set -euo pipefail
+
+ENV_FILE="${ENV_FILE:-.env}"
+DOCKER="${DOCKER:-docker}"
+COMPOSE_CMD="${COMPOSE_CMD:-$DOCKER compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file $ENV_FILE}"
+HEALTH_RETRIES="${HEALTH_RETRIES:-24}"
+HEALTH_INTERVAL="${HEALTH_INTERVAL:-5}"
+
+log()  { printf '%s %s\n' "$(date -u +%H:%M:%SZ)" "$*"; }
+fail() { printf '::error::%s\n' "$*" >&2; }
+
+# --- Input validation -------------------------------------------------------
+: "${ROTATE_SECRET:?ROTATE_SECRET must be set (one of POSTGRES_PASSWORD, REDIS_PASSWORD, USER_POSTGRES_PASSWORD, USER_REDIS_PASSWORD)}"
+: "${NEW_PASSWORD:?NEW_PASSWORD must be set}"
+
+if ! printf '%s' "$NEW_PASSWORD" | grep -qE '^[A-Za-z0-9_-]{24,}$'; then
+  fail "NEW_PASSWORD must be >=24 chars from the URL-safe alphabet [A-Za-z0-9_-] (got ${#NEW_PASSWORD} chars). This guards the compose PG_DSN/REDIS_URL interpolation (us#65/ig#956) and avoids SQL quoting."
+  exit 1
+fi
+
+if [ ! -f "$ENV_FILE" ]; then
+  fail "ENV_FILE '$ENV_FILE' not found — run from /opt/noorinalabs-deploy after a deploy has written .env."
+  exit 1
+fi
+
+# Per-secret routing: engine, DB container, the .env vars needed to auth, which
+# compose services to recreate so they pick up the new credential, and which
+# containers to health-gate on. Kept in one place so adding a secret is a single
+# case arm. Container names follow the `noorinalabs-<service>-1` compose default.
+ENGINE=""
+DB_CONTAINER=""
+USER_VAR=""
+DB_VAR=""
+RECREATE_SERVICES=""
+HEALTH_CONTAINERS=""
+case "$ROTATE_SECRET" in
+  POSTGRES_PASSWORD)
+    ENGINE="postgres"; DB_CONTAINER="noorinalabs-postgres-1"
+    USER_VAR="POSTGRES_USER"; DB_VAR="POSTGRES_DB"
+    RECREATE_SERVICES="api postgres-exporter"
+    HEALTH_CONTAINERS="noorinalabs-postgres-1 noorinalabs-api-1" ;;
+  USER_POSTGRES_PASSWORD)
+    ENGINE="postgres"; DB_CONTAINER="noorinalabs-user-postgres-1"
+    USER_VAR="USER_POSTGRES_USER"; DB_VAR="USER_POSTGRES_DB"
+    RECREATE_SERVICES="user-service user-postgres-exporter"
+    HEALTH_CONTAINERS="noorinalabs-user-postgres-1 noorinalabs-user-service-1" ;;
+  REDIS_PASSWORD)
+    ENGINE="redis"; DB_CONTAINER="noorinalabs-redis-1"
+    RECREATE_SERVICES="redis api"
+    HEALTH_CONTAINERS="noorinalabs-redis-1 noorinalabs-api-1" ;;
+  USER_REDIS_PASSWORD)
+    ENGINE="redis"; DB_CONTAINER="noorinalabs-user-redis-1"
+    RECREATE_SERVICES="user-redis user-service"
+    HEALTH_CONTAINERS="noorinalabs-user-redis-1 noorinalabs-user-service-1" ;;
+  *)
+    fail "ROTATE_SECRET '$ROTATE_SECRET' is not a rotatable DB/cache password. Allowed: POSTGRES_PASSWORD, REDIS_PASSWORD, USER_POSTGRES_PASSWORD, USER_REDIS_PASSWORD."
+    exit 1 ;;
+esac
+
+if ! grep -qE "^${ROTATE_SECRET}=" "$ENV_FILE"; then
+  fail "$ROTATE_SECRET not present in $ENV_FILE — nothing to rotate (is the stack deployed?)."
+  exit 1
+fi
+
+# --- Read the OLD value + auth context from the box's own .env --------------
+# Sourcing the .env is exactly how docker compose consumes it; the file is the
+# 0600 deploy artifact written by the write-deploy-env composite in the
+# `NAME='...'` single-quote-escaped form, so the values round-trip safely. We
+# read in a subshell-scoped way and only keep what we need.
+set -a
+# shellcheck disable=SC1090  # ENV_FILE is the runtime deploy artifact, not a static path
+. "$ENV_FILE"
+set +a
+
+OLD_PASSWORD="${!ROTATE_SECRET-}"
+if [ -z "${OLD_PASSWORD:-}" ]; then
+  fail "$ROTATE_SECRET is empty in $ENV_FILE — cannot authenticate to rotate."
+  exit 1
+fi
+if [ "$OLD_PASSWORD" = "$NEW_PASSWORD" ]; then
+  fail "NEW_PASSWORD equals the current value — refusing a no-op rotation."
+  exit 1
+fi
+
+DB_USER=""
+DB_NAME=""
+if [ "$ENGINE" = "postgres" ]; then
+  DB_USER="${!USER_VAR-}"
+  DB_NAME="${!DB_VAR-}"
+  if [ -z "$DB_USER" ] || [ -z "$DB_NAME" ]; then
+    fail "postgres rotation needs $USER_VAR and $DB_VAR in $ENV_FILE (got user='$DB_USER' db='$DB_NAME')."
+    exit 1
+  fi
+  # Identifier sanity — the role name is interpolated into ALTER ROLE.
+  if ! printf '%s' "$DB_USER" | grep -qE '^[A-Za-z_][A-Za-z0-9_]*$'; then
+    fail "$USER_VAR='$DB_USER' is not a plain SQL identifier — refusing to build ALTER ROLE."
+    exit 1
+  fi
+fi
+
+log "==> Rotating $ROTATE_SECRET (engine=$ENGINE, container=$DB_CONTAINER) on $ENV_FILE"
+log "    recreate services: $RECREATE_SERVICES"
+log "    health gate:       $HEALTH_CONTAINERS"
+
+# --- .env backup for rollback ----------------------------------------------
+BAK="$(mktemp "${TMPDIR:-/tmp}/env.rotate.XXXXXX")"
+cp -p "$ENV_FILE" "$BAK"
+trap 'rm -f "$BAK" 2>/dev/null || true' EXIT
+
+# Rewrite the single ROTATE_SECRET line in .env to `value`, preserving every
+# other line and the `NAME='...'` single-quote-escaped form the deploy
+# composite uses (so the next normal deploy stays consistent).
+rewrite_env() {
+  local value="$1" tmp esc
+  esc="${value//\'/\'\\\'\'}"
+  tmp="$(mktemp "${TMPDIR:-/tmp}/env.write.XXXXXX")"
+  # awk replaces only the matching key line; the new value is passed via -v
+  # (awk variable), never on a child process argv.
+  awk -v key="$ROTATE_SECRET" -v val="$esc" '
+    index($0, key "=") == 1 { printf "%s=\047%s\047\n", key, val; next }
+    { print }
+  ' "$ENV_FILE" > "$tmp"
+  mv "$tmp" "$ENV_FILE"
+  chmod 600 "$ENV_FILE"
+}
+
+# Apply a password to the LIVE engine. For postgres this is the real rotation
+# (ALTER ROLE); for redis the recreate does it, so this is a no-op.
+#   $1 = password to authenticate WITH   $2 = password to SET
+apply_live() {
+  local auth="$1" target="$2"
+  if [ "$ENGINE" = "postgres" ]; then
+    # SQL (incl. the target value) on STDIN; PGPASSWORD via NAME-ONLY -e
+    # passthrough — neither reaches docker/psql argv.
+    printf 'ALTER ROLE "%s" WITH PASSWORD '\''%s'\'';\n' "$DB_USER" "$target" \
+      | PGPASSWORD="$auth" "$DOCKER" exec -i -e PGPASSWORD "$DB_CONTAINER" \
+          psql -v ON_ERROR_STOP=1 -U "$DB_USER" -d "$DB_NAME" >/dev/null
+  fi
+}
+
+recreate() {
+  # shellcheck disable=SC2086  # RECREATE_SERVICES is a deliberate word-split list
+  $COMPOSE_CMD up -d --force-recreate $RECREATE_SERVICES
+}
+
+wait_healthy() {
+  local c i st rstate ok
+  for c in $HEALTH_CONTAINERS; do
+    ok=0
+    for ((i = 1; i <= HEALTH_RETRIES; i++)); do
+      st="$("$DOCKER" inspect --format '{{.State.Health.Status}}' "$c" 2>/dev/null || echo missing)"
+      if [ "$st" = "healthy" ]; then ok=1; break; fi
+      # Containers without a HEALTHCHECK report "<no value>"/empty — accept them
+      # if simply running (e.g. the exporters).
+      if [ "$st" = "<no value>" ] || [ -z "$st" ]; then
+        rstate="$("$DOCKER" inspect --format '{{.State.Status}}' "$c" 2>/dev/null || echo missing)"
+        if [ "$rstate" = "running" ]; then ok=1; break; fi
+      fi
+      sleep "$HEALTH_INTERVAL"
+    done
+    if [ "$ok" -ne 1 ]; then
+      log "    health gate FAILED for $c (last status: ${st:-empty})"
+      return 1
+    fi
+    log "    healthy: $c"
+  done
+  return 0
+}
+
+rollback() {
+  fail "Rotation of $ROTATE_SECRET failed health gate — rolling back to the OLD credential."
+  cp -p "$BAK" "$ENV_FILE"
+  chmod 600 "$ENV_FILE"
+  if [ "$ENGINE" = "postgres" ]; then
+    # The live DB is currently on NEW; set it back to OLD, authenticating with NEW.
+    apply_live "$NEW_PASSWORD" "$OLD_PASSWORD" || fail "    WARNING: ALTER ROLE rollback failed — DB may still hold the new password; investigate before next deploy."
+  fi
+  # Recreate clients (+ redis) against the restored .env so they hold OLD again.
+  recreate || fail "    WARNING: rollback recreate failed — run deploy-${ENV_FILE} to reconcile."
+  log "==> Rollback complete: stack restored to the previous credential."
+}
+
+# --- Rotate -----------------------------------------------------------------
+log "==> Applying new credential to the live engine..."
+apply_live "$OLD_PASSWORD" "$NEW_PASSWORD"
+
+log "==> Rewriting $ENV_FILE..."
+rewrite_env "$NEW_PASSWORD"
+
+log "==> Recreating dependent services..."
+recreate
+
+log "==> Health-gating ($HEALTH_RETRIES x ${HEALTH_INTERVAL}s)..."
+if wait_healthy; then
+  log "==> Rotation of $ROTATE_SECRET succeeded — stack healthy on the new credential."
+  exit 0
+else
+  rollback
+  exit 1
+fi

--- a/scripts/tests/test_rotate_db_password.py
+++ b/scripts/tests/test_rotate_db_password.py
@@ -19,6 +19,7 @@ process argv (CWE-214 — it must travel via stdin / env only).
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -82,15 +83,20 @@ def _write_mock_compose(tmp_path: Path, up_log: Path) -> Path:
 
 
 def _run(
-    env_file: Path, mock_docker: Path, mock_compose: Path, secret: str
+    env_file: Path,
+    mock_docker: Path,
+    mock_compose: Path,
+    secret: str,
+    extra_path: str = "",
 ) -> subprocess.CompletedProcess[str]:
+    path = f"{extra_path}:/usr/bin:/bin" if extra_path else "/usr/bin:/bin"
     return subprocess.run(
         ["bash", str(SCRIPT)],
         capture_output=True,
         text=True,
         check=False,
         env={
-            "PATH": "/usr/bin:/bin",
+            "PATH": path,
             "ROTATE_SECRET": secret,
             "NEW_PASSWORD": NEW,
             "ENV_FILE": str(env_file),
@@ -100,6 +106,19 @@ def _run(
             "HEALTH_INTERVAL": "0",
         },
     )
+
+
+def _write_argv_recording_awk(tmp_path: Path, argv_log: Path) -> Path:
+    """A PATH-shadowing `awk` that records its OWN argv then delegates to the
+    real awk (so the .env rewrite still happens). Lets the argv-leak test prove
+    the rewrite passes the secret via ENVIRON, never on `-v val=` / argv."""
+    real_awk = shutil.which("awk", path="/usr/bin:/bin") or "/usr/bin/awk"
+    bindir = tmp_path / "shim-bin"
+    bindir.mkdir()
+    awk = bindir / "awk"
+    awk.write_text(f'#!/bin/sh\necho "$@" >> "{argv_log}"\nexec {real_awk} "$@"\n')
+    awk.chmod(0o755)
+    return bindir
 
 
 def _lines(path: Path) -> list[str]:
@@ -185,17 +204,26 @@ def test_failed_health_gate_rolls_back(tmp_path: Path) -> None:
 
 def test_password_never_on_argv(tmp_path: Path) -> None:
     """CWE-214: neither the old nor the new password may appear in any recorded
-    child-process argv (they travel via stdin / env only)."""
+    child-process argv. Covers the docker/compose mocks AND — via a PATH-shadow
+    `awk` shim — the real `.env`-rewrite awk invocation (which must read the
+    value from ENVIRON, not `-v val=`). Without the shim this would silently
+    miss the awk path (Nino, PR #438 review)."""
     env = _write_env(tmp_path, "POSTGRES_PASSWORD", with_user_db=True)
     exec_log, up_log = tmp_path / "exec.log", tmp_path / "up.log"
+    awk_argv = tmp_path / "awk_argv.log"
+    bindir = _write_argv_recording_awk(tmp_path, awk_argv)
     res = _run(
         env,
         _write_mock_docker(tmp_path, exec_log),
         _write_mock_compose(tmp_path, up_log),
         "POSTGRES_PASSWORD",
+        extra_path=str(bindir),
     )
     assert res.returncode == 0, res.stderr
-    for recorded in _lines(exec_log) + _lines(up_log):
+    # The shim must actually have run (otherwise the awk assertion is vacuous).
+    awk_calls = _lines(awk_argv)
+    assert awk_calls, "awk shim was never invoked — rewrite path not exercised"
+    for recorded in _lines(exec_log) + _lines(up_log) + awk_calls:
         assert OLD not in recorded, f"OLD password leaked to argv: {recorded}"
         assert NEW not in recorded, f"NEW password leaked to argv: {recorded}"
 

--- a/scripts/tests/test_rotate_db_password.py
+++ b/scripts/tests/test_rotate_db_password.py
@@ -1,0 +1,254 @@
+"""Unit tests for scripts/rotate_db_password.sh (deploy#387).
+
+The script rotates ONE DB/cache password on the running deploy stack, health-
+gated with rollback (the bespoke mechanism ADR 0007 / deploy#388 chose on top of
+the GitHub-Environment-secrets baseline). A real Docker daemon / prod stack is
+not available in CI, so we inject:
+
+  * a mock ``docker`` (DOCKER=) that answers ``inspect`` with a controllable
+    health string and records every ``exec`` invocation (draining its stdin),
+  * a mock ``docker compose`` (COMPOSE_CMD=) that records every ``up`` argv,
+  * a fixture ``.env`` in the single-quote-escaped form the deploy composite
+    writes.
+
+That lets us assert the engine-specific apply mechanics (postgres ALTER ROLE vs
+redis recreate-only), the ``.env`` rewrite, the rollback invariant on a failed
+health gate, and the security property that NO password ever reaches a child
+process argv (CWE-214 — it must travel via stdin / env only).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "rotate_db_password.sh"
+
+OLD = "oldpass_0123456789abcdefGHIJ"
+NEW = "NEWpass_0123456789abcdefABCDEF"
+
+# Other .env lines that MUST survive a rotation untouched (rollback safety —
+# the deploy composite and rollback.yml both depend on the full .env shape).
+PRESERVED = [
+    "IMAGE_TAG='stg-abc1234'",
+    "BASE_DOMAIN='stg.noorinalabs.com'",
+    "NEO4J_PASSWORD='someneo4jpass_aaaaaaaaaaaa'",
+]
+
+
+def _write_env(tmp_path: Path, secret: str, *, with_user_db: bool) -> Path:
+    lines = [f"{secret}='{OLD}'"]
+    if with_user_db:
+        # Match the secret's companion user/db vars the postgres branch reads.
+        if secret == "POSTGRES_PASSWORD":
+            lines += ["POSTGRES_USER='ig'", "POSTGRES_DB='isnad'"]
+        elif secret == "USER_POSTGRES_PASSWORD":
+            lines += ["USER_POSTGRES_USER='usersvc'", "USER_POSTGRES_DB='users'"]
+    lines += PRESERVED
+    env = tmp_path / ".env"
+    env.write_text("\n".join(lines) + "\n")
+    env.chmod(0o600)
+    return env
+
+
+def _write_mock_docker(tmp_path: Path, exec_log: Path, health: str = "healthy") -> Path:
+    mock = tmp_path / "mock_docker.sh"
+    mock.write_text(
+        "#!/bin/sh\n"
+        'if [ "$1" = "inspect" ]; then\n'
+        f'  printf "%s\\n" "{health}"\n'
+        "  exit 0\n"
+        "fi\n"
+        'if [ "$1" = "exec" ]; then\n'
+        # Drain (and discard) stdin so the producing printf does not SIGPIPE,
+        # then record only the ARGV — never the stdin (which carries the SQL +
+        # new password). This is what lets the argv-leak assertion be meaningful.
+        "  cat >/dev/null 2>&1 || true\n"
+        f'  echo "exec $*" >> "{exec_log}"\n'
+        "  exit 0\n"
+        "fi\n"
+        f'echo "other $*" >> "{exec_log}"\n'
+        "exit 0\n"
+    )
+    mock.chmod(0o755)
+    return mock
+
+
+def _write_mock_compose(tmp_path: Path, up_log: Path) -> Path:
+    mock = tmp_path / "mock_compose.sh"
+    mock.write_text(f'#!/bin/sh\necho "$*" >> "{up_log}"\nexit 0\n')
+    mock.chmod(0o755)
+    return mock
+
+
+def _run(
+    env_file: Path, mock_docker: Path, mock_compose: Path, secret: str
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={
+            "PATH": "/usr/bin:/bin",
+            "ROTATE_SECRET": secret,
+            "NEW_PASSWORD": NEW,
+            "ENV_FILE": str(env_file),
+            "DOCKER": str(mock_docker),
+            "COMPOSE_CMD": f"sh {mock_compose}",
+            "HEALTH_RETRIES": "1",
+            "HEALTH_INTERVAL": "0",
+        },
+    )
+
+
+def _lines(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    return [ln for ln in path.read_text().splitlines() if ln.strip()]
+
+
+def test_script_exists() -> None:
+    assert SCRIPT.is_file(), f"rotation script missing at {SCRIPT}"
+
+
+def test_postgres_happy_path_alters_and_rewrites(tmp_path: Path) -> None:
+    env = _write_env(tmp_path, "POSTGRES_PASSWORD", with_user_db=True)
+    exec_log, up_log = tmp_path / "exec.log", tmp_path / "up.log"
+    res = _run(
+        env,
+        _write_mock_docker(tmp_path, exec_log),
+        _write_mock_compose(tmp_path, up_log),
+        "POSTGRES_PASSWORD",
+    )
+    assert res.returncode == 0, res.stderr
+
+    # .env rewritten to the new value; all other lines preserved verbatim.
+    body = env.read_text()
+    assert f"POSTGRES_PASSWORD='{NEW}'" in body
+    assert OLD not in body
+    for line in PRESERVED:
+        assert line in body, f"preserved line lost: {line}"
+
+    # A live ALTER ROLE was issued against the postgres container (exec, psql).
+    execs = _lines(exec_log)
+    assert any("psql" in e and "noorinalabs-postgres-1" in e for e in execs), execs
+
+    # The client services were recreated (NOT the db itself for postgres).
+    up = _lines(up_log)
+    assert len(up) == 1 and "--force-recreate" in up[0]
+    assert " api" in f" {up[0]}" and "postgres-exporter" in up[0]
+
+
+def test_redis_happy_path_recreates_without_exec(tmp_path: Path) -> None:
+    env = _write_env(tmp_path, "REDIS_PASSWORD", with_user_db=False)
+    exec_log, up_log = tmp_path / "exec.log", tmp_path / "up.log"
+    res = _run(
+        env,
+        _write_mock_docker(tmp_path, exec_log),
+        _write_mock_compose(tmp_path, up_log),
+        "REDIS_PASSWORD",
+    )
+    assert res.returncode == 0, res.stderr
+
+    assert f"REDIS_PASSWORD='{NEW}'" in env.read_text()
+    # Redis rotation is recreate-only: NO live `exec` (no ALTER/CONFIG SET).
+    assert not any(e.startswith("exec") for e in _lines(exec_log)), _lines(exec_log)
+    # The redis container itself MUST be recreated (re-applies requirepass), plus its client.
+    up = _lines(up_log)
+    assert len(up) == 1
+    assert " redis" in f" {up[0]}" and " api" in f" {up[0]}"
+
+
+def test_failed_health_gate_rolls_back(tmp_path: Path) -> None:
+    env = _write_env(tmp_path, "POSTGRES_PASSWORD", with_user_db=True)
+    exec_log, up_log = tmp_path / "exec.log", tmp_path / "up.log"
+    # Health never reaches "healthy" -> gate fails -> rollback.
+    res = _run(
+        env,
+        _write_mock_docker(tmp_path, exec_log, health="starting"),
+        _write_mock_compose(tmp_path, up_log),
+        "POSTGRES_PASSWORD",
+    )
+    assert res.returncode != 0
+
+    # .env restored to the OLD credential (rollback invariant).
+    body = env.read_text()
+    assert f"POSTGRES_PASSWORD='{OLD}'" in body
+    assert NEW not in body
+
+    # Two ALTER ROLEs: forward (old->new) then rollback (new->old).
+    assert sum(1 for e in _lines(exec_log) if "psql" in e) == 2
+    # Recreate ran forward AND in rollback.
+    assert len(_lines(up_log)) == 2
+
+
+def test_password_never_on_argv(tmp_path: Path) -> None:
+    """CWE-214: neither the old nor the new password may appear in any recorded
+    child-process argv (they travel via stdin / env only)."""
+    env = _write_env(tmp_path, "POSTGRES_PASSWORD", with_user_db=True)
+    exec_log, up_log = tmp_path / "exec.log", tmp_path / "up.log"
+    res = _run(
+        env,
+        _write_mock_docker(tmp_path, exec_log),
+        _write_mock_compose(tmp_path, up_log),
+        "POSTGRES_PASSWORD",
+    )
+    assert res.returncode == 0, res.stderr
+    for recorded in _lines(exec_log) + _lines(up_log):
+        assert OLD not in recorded, f"OLD password leaked to argv: {recorded}"
+        assert NEW not in recorded, f"NEW password leaked to argv: {recorded}"
+
+
+def test_rejects_url_unsafe_new_password(tmp_path: Path) -> None:
+    env = _write_env(tmp_path, "POSTGRES_PASSWORD", with_user_db=True)
+    exec_log, up_log = tmp_path / "exec.log", tmp_path / "up.log"
+    res = subprocess.run(
+        ["bash", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={
+            "PATH": "/usr/bin:/bin",
+            "ROTATE_SECRET": "POSTGRES_PASSWORD",
+            "NEW_PASSWORD": "has/slash+and=specials@chars",  # url-unsafe
+            "ENV_FILE": str(env),
+            "DOCKER": str(_write_mock_docker(tmp_path, exec_log)),
+            "COMPOSE_CMD": f"sh {_write_mock_compose(tmp_path, up_log)}",
+        },
+    )
+    assert res.returncode != 0
+    assert not exec_log.exists() and not up_log.exists(), (
+        "no engine action before validation passes"
+    )
+    assert env.read_text().count(f"POSTGRES_PASSWORD='{OLD}'") == 1
+
+
+def test_rejects_unknown_secret(tmp_path: Path) -> None:
+    env = _write_env(tmp_path, "POSTGRES_PASSWORD", with_user_db=True)
+    exec_log, up_log = tmp_path / "exec.log", tmp_path / "up.log"
+    res = _run(
+        env,
+        _write_mock_docker(tmp_path, exec_log),
+        _write_mock_compose(tmp_path, up_log),
+        "JWT_PRIVATE_KEY",
+    )
+    assert res.returncode != 0
+    assert "not a rotatable" in (res.stdout + res.stderr)
+
+
+def test_rejects_noop_rotation(tmp_path: Path) -> None:
+    """NEW == current value must be refused before touching anything."""
+    env = tmp_path / ".env"
+    env.write_text(f"POSTGRES_PASSWORD='{NEW}'\nPOSTGRES_USER='ig'\nPOSTGRES_DB='isnad'\n")
+    env.chmod(0o600)
+    exec_log, up_log = tmp_path / "exec.log", tmp_path / "up.log"
+    res = _run(
+        env,
+        _write_mock_docker(tmp_path, exec_log),
+        _write_mock_compose(tmp_path, up_log),
+        "POSTGRES_PASSWORD",
+    )
+    assert res.returncode != 0
+    assert "no-op" in (res.stdout + res.stderr)
+    assert not up_log.exists()


### PR DESCRIPTION
## What & why

Implements **deploy#387** — automated database/cache password rotation, the one runtime-gated acceptance item deferred from #11. Built per the now-Accepted **ADR 0007** (#388): stay on the **GitHub-Environment-secrets baseline (Option A)** — *no new secrets manager* — and rotate **per-secret (S1)**, **health-gated with rollback**, on a **P2 cadence with the P3 automated mechanism**.

## Changes

- **`scripts/rotate_db_password.sh`** — the on-box unit mechanic for rotating ONE secret.
  - **Postgres** rotates via a live `ALTER ROLE` (the password lives in the data volume; `POSTGRES_PASSWORD` only seeds an empty volume, so a recreate would NOT change it) + recreate of the client services. **Redis** rotates by recreating the container (its `requirepass` comes from the `command:` arg, re-applied from `.env` on recreate) + clients.
  - **`.env` rewrite** preserves the `write-deploy-env` single-quote-escaped form **and every other line** — so `rollback.yml` (which rewrites only the image tag against the current compose) is unaffected.
  - **Security (CWE-214 — no secret on argv):** old value read from the box's own `.env`; new value via env (appleboy `envs:`); the `ALTER ROLE` SQL on **stdin**; psql auth via `-e PGPASSWORD` **name-only** passthrough. New value constrained to the URL-safe alphabet `[A-Za-z0-9_-]` so it cannot corrupt the compose `PG_DSN`/`REDIS_URL` interpolation (the us#65 / ig#956 class).
  - **Health-gated** on the recreated containers; on failure it **rolls back** to the old credential (`.env` restored, Postgres `ALTER ROLE`d back, clients recreated) and exits non-zero.
- **`.github/workflows/rotate-db-passwords.yml`** — scheduled (quarterly, **staging only**) + `workflow_dispatch`. **Production is owner-gated** via the `production` Environment approval rule (never auto-rotated on cron). Shares the `deploy-<env>` concurrency group so rotation never races a deploy. Persists the new value to the GH Environment secret **only after** the box rotation exits 0 — keeping the **"GH Environment secret == live box"** invariant. Preflights `SECRETS_ADMIN_TOKEN` before touching the box (the built-in `GITHUB_TOKEN` cannot write Environment secrets).
- **`docs/runbooks/db-password-rotation.md`** — operator runbook (trigger, `SECRETS_ADMIN_TOKEN` prereq, recovery, runtime-only verification).
- **`docs/runbooks/secret-rotation-policy.md`** — cadence row `target` → `automated`; the "not yet built" section superseded per ADR 0007 acceptance.
- **`scripts/tests/test_rotate_db_password.py`** — 8 tests (engine mechanics, `.env` rewrite + preservation, rollback invariant, a CWE-214 argv-leak assertion, input validation).

## Verified locally (PR-time)

- `shellcheck` + `bash -n` on the script — clean.
- `actionlint` (shellcheck on PATH) on the workflow — clean.
- `ruff check` / `ruff format --check` (0.11.6) + `mypy` on the test — clean.
- `pytest scripts/tests` — **21 passed** (8 new).
- `cspell` + `markdownlint-cli2` on the docs — clean.
- Pre-commit ⇄ CI sync-drift gate — OK.

## Test Plan — runtime-only (post-merge; live stack required)

Per the runtime-gate-scoping discipline, these are NOT PR-time acceptance — the unit mechanic + workflow correctness is delivered above; the following can only be confirmed against a live stack and are **owner-gated for prod**:

- [ ] **Staging dry run** (`dry_run=true`) — proves token preflight, mint, matrix wiring with no side effects.
- [ ] **Staging real run** (`all`) — recreated services reach `healthy`; an app session reconnects on the new credential; the four `staging` Environment secrets show new values.
- [ ] **Forced-rollback drill (staging)** — confirm `.env` restored, Postgres `ALTER ROLE`d back, clients recreated on the old credential, GH secret **unchanged**.
- [ ] **Production run** (owner-approved) — same, validated via `verify_prod_smoke.sh`.
- [ ] Provision `SECRETS_ADMIN_TOKEN` in the `staging` + `production` Environments (token with `secrets: write`).
- [ ] Record rotation timestamps in #11.

No rotation was executed against any environment (prod rotation is an owner-gated operational action).

## Reviewers

- **Nino Kavtaradze** — primary (security).
- **Weronika Zielinska** — second (ADR 0007 author / platform architect).

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)
