### PR TITLE
infra(VPS): add ingest worker services (dedup/enrich/normalize/graph-load) to staging compose stack (#440)

### DIFF
--- a/compose/.env.example
+++ b/compose/.env.example
@@ -80,6 +80,11 @@ KAFKA_UI_READONLY=true
 IMAGE_TAG=latest
 USER_SERVICE_IMAGE_TAG=latest
 CACHEBUST=1
+# Ingest pipeline workers (deploy#440). Independent per-service tag (deploy#418
+# routing) — the `pipeline` compose profile is OFF by default, so this is only
+# consumed once ingest-platform#83 publishes the worker image and brings the
+# profile up. Defaults to stg-latest in compose if unset.
+INGEST_IMAGE_TAG=stg-latest
 
 # Pipeline object storage (Backblaze B2 in prod, MinIO in local dev).
 # Prod values come from the `terraform/backblaze/` module outputs, injected

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -1121,6 +1121,236 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  # ──────────────────────────────────────────────────────────────────────────
+  # Ingest pipeline workers (deploy#440 — the deploy-side half of ingest-platform#83)
+  #
+  # The streaming pipeline (B2 → Kafka → workers → Neo4j) has never run on
+  # staging: Kafka topics sit at offset 0 and NO worker containers exist
+  # (main#601 criterion #1). These four services are the compose definitions;
+  # ingest-platform#83 publishes the images, wires the deploy fan-in, and runs
+  # the pipeline E2E on the box.
+  #
+  # Stage topology — single source of truth is the ingest-platform
+  # `workers/lib/topics.py` (and now `infra/kafka/init-topics.sh`, reconciled
+  # in this PR):
+  #     pipeline.raw.landed → dedup → pipeline.dedup.done → enrich →
+  #     pipeline.enrich.done → normalize → pipeline.normalize.done → ingest
+  #     → Neo4j      (any stage's failures → pipeline.dlq)
+  #
+  # PROFILE-GATED — all four carry `profiles: ["pipeline"]`, so a plain
+  # `docker compose up -d` (what deploy-stg.yml / deploy-prod.yml run) does NOT
+  # start them. This lets the definitions land now — BEFORE ingest-platform#83
+  # publishes the worker image to GHCR — without breaking app deploys (an
+  # unpublished image would otherwise hard-fail the `compose up` pull). The
+  # deploy-stg pre-flight GHCR manifest check (PULL_SERVICES) likewise does not
+  # include these. `docker compose config` still validates them. ip#83 brings
+  # them up with `docker compose --profile pipeline up -d` once the image exists.
+  #
+  # IMAGE CONTRACT for ip#83: a single multi-worker image published to
+  # `ghcr.io/noorinalabs/noorinalabs-isnad-ingest-platform` containing all of
+  # `workers.{dedup,enrich,normalize,ingest}`; the per-service `command:` below
+  # selects the stage. `INGEST_IMAGE_TAG` is independent of the isnad-graph
+  # `IMAGE_TAG` and user-service `USER_SERVICE_IMAGE_TAG` (per-service tag
+  # routing, deploy#418) and defaults to `stg-latest` — its own last-good
+  # pointer. (If ip#83 prefers four per-worker images, each `image:` line below
+  # is a one-token change; the single-image form is the lighter contract.)
+  #
+  # CREDENTIALS — no new secret keys. The workers read S3-style env
+  # (PIPELINE_BUCKET / S3_ENDPOINT_URL / AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY)
+  # via boto3; the deploy stack already owns these as the PIPELINE_B2_* family
+  # (write-deploy-env + deploy-stg `env_keys`), mapped in the environment block
+  # below. Checkpoints persist to Postgres (INGEST_CHECKPOINT_BACKEND=pg, PG_DSN
+  # built from the existing POSTGRES_* vars, same form as the api service).
+  #
+  # NETWORKS — `backend` (internal) for kafka:9092 / neo4j:7687 / postgres:5432,
+  # plus `egress` (outbound-only) for B2 over HTTPS, mirroring the
+  # user-service / alertmanager split. `backend` is `internal: true`, so without
+  # `egress` the workers could not reach Backblaze.
+  # ──────────────────────────────────────────────────────────────────────────
+
+  dedup-worker:
+    image: ghcr.io/noorinalabs/noorinalabs-isnad-ingest-platform:${INGEST_IMAGE_TAG:-stg-latest}
+    profiles: ["pipeline"]
+    # Selects the pipeline stage from the multi-worker image (overrides CMD).
+    command: ["python", "-m", "workers.dedup.main"]
+    read_only: true
+    tmpfs:
+      - /tmp:size=128M
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
+      INGEST_CHECKPOINT_BACKEND: "pg"
+      PG_DSN: "postgresql://${POSTGRES_USER:?POSTGRES_USER must be set}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/${POSTGRES_DB:?POSTGRES_DB must be set}"
+      PIPELINE_BUCKET: "${PIPELINE_B2_BUCKET:-noorinalabs-pipeline}"
+      S3_ENDPOINT_URL: "${PIPELINE_B2_ENDPOINT:-https://s3.us-east-005.backblazeb2.com}"
+      AWS_ACCESS_KEY_ID: "${PIPELINE_B2_KEY_ID}"
+      AWS_SECRET_ACCESS_KEY: "${PIPELINE_B2_KEY}"
+      AWS_DEFAULT_REGION: "${PIPELINE_B2_REGION:-us-east-005}"
+      LOG_LEVEL: "INFO"
+      LOG_FORMAT: "json"
+    depends_on:
+      kafka:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+    networks:
+      - backend
+      - egress
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "0.5"
+        reservations:
+          memory: 128M
+          cpus: "0.1"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    restart: unless-stopped
+
+  enrich-worker:
+    image: ghcr.io/noorinalabs/noorinalabs-isnad-ingest-platform:${INGEST_IMAGE_TAG:-stg-latest}
+    profiles: ["pipeline"]
+    command: ["python", "-m", "workers.enrich.main"]
+    read_only: true
+    tmpfs:
+      - /tmp:size=128M
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
+      INGEST_CHECKPOINT_BACKEND: "pg"
+      PG_DSN: "postgresql://${POSTGRES_USER:?POSTGRES_USER must be set}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/${POSTGRES_DB:?POSTGRES_DB must be set}"
+      PIPELINE_BUCKET: "${PIPELINE_B2_BUCKET:-noorinalabs-pipeline}"
+      S3_ENDPOINT_URL: "${PIPELINE_B2_ENDPOINT:-https://s3.us-east-005.backblazeb2.com}"
+      AWS_ACCESS_KEY_ID: "${PIPELINE_B2_KEY_ID}"
+      AWS_SECRET_ACCESS_KEY: "${PIPELINE_B2_KEY}"
+      AWS_DEFAULT_REGION: "${PIPELINE_B2_REGION:-us-east-005}"
+      LOG_LEVEL: "INFO"
+      LOG_FORMAT: "json"
+    depends_on:
+      kafka:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+    networks:
+      - backend
+      - egress
+    deploy:
+      resources:
+        limits:
+          memory: 768M
+          cpus: "0.5"
+        reservations:
+          memory: 128M
+          cpus: "0.1"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    restart: unless-stopped
+
+  normalize-worker:
+    image: ghcr.io/noorinalabs/noorinalabs-isnad-ingest-platform:${INGEST_IMAGE_TAG:-stg-latest}
+    profiles: ["pipeline"]
+    command: ["python", "-m", "workers.normalize.main"]
+    read_only: true
+    tmpfs:
+      - /tmp:size=128M
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
+      INGEST_CHECKPOINT_BACKEND: "pg"
+      PG_DSN: "postgresql://${POSTGRES_USER:?POSTGRES_USER must be set}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/${POSTGRES_DB:?POSTGRES_DB must be set}"
+      PIPELINE_BUCKET: "${PIPELINE_B2_BUCKET:-noorinalabs-pipeline}"
+      S3_ENDPOINT_URL: "${PIPELINE_B2_ENDPOINT:-https://s3.us-east-005.backblazeb2.com}"
+      AWS_ACCESS_KEY_ID: "${PIPELINE_B2_KEY_ID}"
+      AWS_SECRET_ACCESS_KEY: "${PIPELINE_B2_KEY}"
+      AWS_DEFAULT_REGION: "${PIPELINE_B2_REGION:-us-east-005}"
+      LOG_LEVEL: "INFO"
+      LOG_FORMAT: "json"
+    depends_on:
+      kafka:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+    networks:
+      - backend
+      - egress
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "0.5"
+        reservations:
+          memory: 128M
+          cpus: "0.1"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    restart: unless-stopped
+
+  # graph-load stage. Terminal worker: consumes pipeline.normalize.done and
+  # MERGEs nodes/edges into Neo4j (hence the extra NEO4J_* env + neo4j
+  # dependency). Module is `workers.ingest.main` (the ip repo's name for the
+  # graph-load stage).
+  graph-load-worker:
+    image: ghcr.io/noorinalabs/noorinalabs-isnad-ingest-platform:${INGEST_IMAGE_TAG:-stg-latest}
+    profiles: ["pipeline"]
+    command: ["python", "-m", "workers.ingest.main"]
+    read_only: true
+    tmpfs:
+      - /tmp:size=128M
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
+      INGEST_CHECKPOINT_BACKEND: "pg"
+      PG_DSN: "postgresql://${POSTGRES_USER:?POSTGRES_USER must be set}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/${POSTGRES_DB:?POSTGRES_DB must be set}"
+      PIPELINE_BUCKET: "${PIPELINE_B2_BUCKET:-noorinalabs-pipeline}"
+      S3_ENDPOINT_URL: "${PIPELINE_B2_ENDPOINT:-https://s3.us-east-005.backblazeb2.com}"
+      AWS_ACCESS_KEY_ID: "${PIPELINE_B2_KEY_ID}"
+      AWS_SECRET_ACCESS_KEY: "${PIPELINE_B2_KEY}"
+      AWS_DEFAULT_REGION: "${PIPELINE_B2_REGION:-us-east-005}"
+      # NEO4J_USER must be "neo4j" — Neo4j requires the admin account name.
+      NEO4J_URI: "bolt://neo4j:7687"
+      NEO4J_USER: "neo4j"
+      NEO4J_PASSWORD: "${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set}"
+      LOG_LEVEL: "INFO"
+      LOG_FORMAT: "json"
+    depends_on:
+      kafka:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+      neo4j:
+        condition: service_healthy
+    networks:
+      - backend
+      - egress
+    deploy:
+      resources:
+        limits:
+          memory: 768M
+          cpus: "1.0"
+        reservations:
+          memory: 256M
+          cpus: "0.25"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    restart: unless-stopped
+
 networks:
   backend:
     driver: bridge

--- a/docs/pipeline-kafka.md
+++ b/docs/pipeline-kafka.md
@@ -8,13 +8,15 @@ Consumers live in `noorinalabs-isnad-ingest-platform` (see `#107`). This repo on
 
 | Topic | Retention | Purpose |
 |---|---|---|
-| `pipeline.raw.new` | 7d | A new file has landed in B2 `raw/{source}/{date}/`. Fan-in for dedup worker. |
+| `pipeline.raw.landed` | 7d | A new file has landed in B2 `raw/{source}/{date}/`. Fan-in for dedup worker. |
 | `pipeline.dedup.done` | 3d | Dedup finished → `dedup/{source}/{batch-id}/`. Consumed by enrich. |
 | `pipeline.enrich.done` | 3d | Enrichment finished → `enriched/{source}/{batch-id}/`. Consumed by normalize. |
-| `pipeline.norm.done` | 3d | Normalization finished → `normalized/{batch-id}/`. Consumed by graph-load. |
+| `pipeline.normalize.done` | 3d | Normalization finished → `normalized/{batch-id}/`. Consumed by graph-load. |
 | `pipeline.dlq` | 30d | Dead-letter queue. Any worker failure lands here with the original message plus `error_code` / `error_stage` headers. Manual triage. |
 
-Longer retention on `raw.new` gives operators a replay window after a downstream stage is fixed. DLQ retention is long enough to diagnose intermittent issues without filling disk.
+Topic names are the canonical set from the ingest-platform `workers/lib/topics.py` (naming locked in ip#192). They were reconciled here in deploy#440 — the prior `pipeline.raw.new` / `pipeline.norm.done` names predated that rename, and the deployed workers (which consume `pipeline.raw.landed` / `pipeline.normalize.done`) would never have found their topics with auto-create disabled.
+
+Longer retention on `raw.landed` gives operators a replay window after a downstream stage is fixed. DLQ retention is long enough to diagnose intermittent issues without filling disk.
 
 Defaults for every topic: 3 partitions, replication factor 1, `cleanup.policy=delete`. Retention is enforced by the init script — Kafka UI runs in read-only mode (`KAFKA_UI_READONLY=true`) so operators cannot drift retention out of source control.
 

--- a/docs/runbooks/kafka-cluster-id-rebootstrap.md
+++ b/docs/runbooks/kafka-cluster-id-rebootstrap.md
@@ -131,7 +131,7 @@ Do stg first. A stg failure is cheap and proves the procedure before touching pr
        --env-file .env exec kafka \
        /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --list
    ```
-   Expect the 5 pipeline topics: `pipeline.raw.new`, `pipeline.dedup.done`, `pipeline.enrich.done`, `pipeline.norm.done`, `pipeline.dlq`.
+   Expect the 5 pipeline topics: `pipeline.raw.landed`, `pipeline.dedup.done`, `pipeline.enrich.done`, `pipeline.normalize.done`, `pipeline.dlq`.
 
 6. **Confirm observability re-populates:** `kafka-exporter` scrapes the broker over the wire protocol; the Grafana `kafka-pipeline` dashboard broker/topic gauges should come back within a scrape interval. Consumer-group panels stay empty until ingest-platform workers run — that is expected (see `docs/pipeline-kafka.md` § Observability).
 

--- a/infra/kafka/init-topics.sh
+++ b/infra/kafka/init-topics.sh
@@ -2,12 +2,19 @@
 # Initialize pipeline topics on first boot. Idempotent — safe to re-run.
 # Invoked by the kafka-init one-shot service in docker-compose.prod.yml.
 #
+# Topic names are the canonical set from the ingest-platform workers — single
+# source of truth is `workers/lib/topics.py` (naming locked in ip#192:
+# `pipeline.<stage>.<past-tense-event>`). The earlier `pipeline.raw.new` /
+# `pipeline.norm.done` names here predated that rename, so the deployed workers
+# (which consume `pipeline.raw.landed` / `pipeline.normalize.done`) would never
+# have found their topics with auto-create disabled. Reconciled in deploy#440.
+#
 # Topic retention (ms) comes from the pipeline design (issue #106):
-#   pipeline.raw.new       7d   — upstream of dedup; replay window for missed events
-#   pipeline.dedup.done    3d
-#   pipeline.enrich.done   3d
-#   pipeline.norm.done     3d
-#   pipeline.dlq          30d   — failures across all workers; manual triage window
+#   pipeline.raw.landed     7d   — upstream of dedup; replay window for missed events
+#   pipeline.dedup.done     3d
+#   pipeline.enrich.done    3d
+#   pipeline.normalize.done 3d
+#   pipeline.dlq           30d   — failures across all workers; manual triage window
 #
 # Consumer-group naming convention: pipeline.<stage>.<worker-variant>
 #   e.g. pipeline.dedup.v1, pipeline.enrich.v1
@@ -75,11 +82,11 @@ wait_for_broker() {
 main() {
     wait_for_broker
 
-    create_topic "pipeline.raw.new"       7
-    create_topic "pipeline.dedup.done"    3
-    create_topic "pipeline.enrich.done"   3
-    create_topic "pipeline.norm.done"     3
-    create_topic "pipeline.dlq"          30
+    create_topic "pipeline.raw.landed"     7
+    create_topic "pipeline.dedup.done"     3
+    create_topic "pipeline.enrich.done"    3
+    create_topic "pipeline.normalize.done" 3
+    create_topic "pipeline.dlq"           30
 
     echo "kafka-init: topic inventory:"
     kafka-topics.sh --bootstrap-server "${BOOTSTRAP}" --list | sort


### PR DESCRIPTION
Closes #440. Cross-repo deploy-side half of **ingest-platform#83** (which publishes the worker image, wires the deploy fan-in, and runs the pipeline E2E on the box).

## What & why

The streaming pipeline (B2 → Kafka → workers → Neo4j) has **never run on staging**: Kafka topics sit at offset 0 and no worker containers exist (main#601 criterion #1). This PR adds the four worker service definitions to `compose/docker-compose.prod.yml` so the pipeline becomes *deployable* on the VPS.

| Service | Module | Consumes → Produces |
|---|---|---|
| `dedup-worker` | `workers.dedup.main` | `pipeline.raw.landed` → `pipeline.dedup.done` |
| `enrich-worker` | `workers.enrich.main` | `pipeline.dedup.done` → `pipeline.enrich.done` |
| `normalize-worker` | `workers.normalize.main` | `pipeline.enrich.done` → `pipeline.normalize.done` |
| `graph-load-worker` | `workers.ingest.main` | `pipeline.normalize.done` → Neo4j (terminal) |

Any stage's failures → `pipeline.dlq`.

## Key design decisions

- **Profile-gated** (`profiles: ["pipeline"]`). A plain `docker compose up -d` — what `deploy-stg.yml` / `deploy-prod.yml` run — does **not** start these, and the deploy-stg pre-flight GHCR manifest check (`PULL_SERVICES`) does not include them. This lets the definitions land **now**, before ip#83 publishes the worker image to GHCR, **without breaking app deploys** (an unpublished image would otherwise hard-fail the `compose up` pull). `docker compose config` still validates them.
- **Per-service tag routing** (deploy#418): `INGEST_IMAGE_TAG` is independent of `IMAGE_TAG` (isnad-graph) and `USER_SERVICE_IMAGE_TAG`; defaults to `stg-latest`.
- **No new secret keys.** Workers read S3-style env (`PIPELINE_BUCKET` / `S3_ENDPOINT_URL` / `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) mapped from the existing `PIPELINE_B2_*` family (already in `env_keys` + `write-deploy-env`). Checkpoints persist to Postgres (`INGEST_CHECKPOINT_BACKEND=pg`, `PG_DSN` built from existing `POSTGRES_*` — same form as the `api` service).
- **Networks:** `backend` (internal — kafka/neo4j/postgres) + `egress` (outbound-only — B2 over HTTPS). `backend` is `internal: true`, so `egress` is required for Backblaze reachability. `read_only: true` + tmpfs `/tmp`, matching the app-service hardening.
- **Topic-name reconciliation** (bundled fix): `infra/kafka/init-topics.sh` created `pipeline.raw.new` / `pipeline.norm.done`, but the deployed workers consume `pipeline.raw.landed` / `pipeline.normalize.done` (the canonical names from ip's `workers/lib/topics.py`, locked in ip#192). With `KAFKA_AUTO_CREATE_TOPICS_ENABLE=false`, the workers would never have found their topics. Init script + `docs/pipeline-kafka.md` + the rebootstrap runbook are reconciled to the canonical set.

## What ip#83 consumes from this PR

1. The four profiled worker services — started with `docker compose --profile pipeline up -d`.
2. **Image contract:** publish a single multi-worker image to `ghcr.io/noorinalabs/noorinalabs-isnad-ingest-platform` containing all of `workers.{dedup,enrich,normalize,ingest}` with `stg-*` tags. (If ip prefers four per-worker images, each `image:` line is a one-token change.)
3. Optionally plumb `INGEST_IMAGE_TAG` through `write-deploy-env` + a `deploy-noorinalabs-ingest-platform` dispatch fan-in when per-SHA worker pins are wanted (deferred here — out of scope; default `stg-latest` resolves today).
4. The corrected topic inventory (`pipeline.raw.landed` … `pipeline.normalize.done`).

## Rollback safety

No existing env form removed or renamed (per the rollback.yml constraint — it rewrites only the image tag against the current compose). All new vars are additive; `INGEST_IMAGE_TAG` has a default.

## Validation (local)

- `bash -n` + `shellcheck` clean on `init-topics.sh`.
- `docker compose -f docker-compose.prod.yml --env-file .env config --quiet` green with CI placeholders (replicates the compose-validate gate).
- Profile gating verified: **0** worker services under the default profile, **4** under `--profile pipeline`; resolved env/networks/depends_on confirmed for `graph-load-worker`.
- `markdownlint-cli2` + `cspell` (real `.cspell.json`) clean on the two changed docs.

## Must-verify at runtime on staging (ip#83 — not testable in this PR)

- Worker containers reach Kafka (`kafka:9092`), Neo4j (`bolt://neo4j:7687`), Postgres, and B2 over `egress`.
- `read_only: true` is sufficient (drop it for a specific worker only if boto3/kafka-python needs an additional writable path beyond `/tmp`).
- Topics advance past offset 0 and the staging graph is populated via the deployed path.
- Loader bug (APPEARS_IN null-`hadith_number` MERGE abort, ip#84) is a known prereq for a clean E2E run on scraped data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
