### PR TITLE
ops(deploy#445): wire bootstrap_admin.py as idempotent post-deploy step (stg+prod)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -292,6 +292,92 @@ jobs:
             docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env ps --format '{{.Name}}\t{{.Status}}'
             echo "==> Prod deployment verified"
 
+      # Post-deploy: reassert the owner's `admin` grant (deploy#445, option 2).
+      #
+      # Runs AFTER the stack is up and user-service is healthy, on EVERY prod
+      # deploy, so the owner's admin role survives redeploys and DB resets. This
+      # complements the pre-deploy bootstrap in db-migrate.yml (deploy#426), which
+      # runs against a one-shot image BEFORE compose-up via promote.yml's prod
+      # gate; this step closes the gap by running against the LIVE container after
+      # every prod rollout (including manual / break-glass dispatches that don't
+      # traverse promote.yml's migrate gate).
+      #
+      # `docker exec` into the running noorinalabs-user-service-1 container so the
+      # script resolves DATABASE_URL from the container's own environment (compose
+      # already injects DATABASE_URL / DATABASE_* there). No password-bearing URL
+      # is passed on argv — the only argv value is the email, which the script
+      # docstring explicitly documents as an identifier, not a credential.
+      #
+      # Safety (why this can never fail the deploy):
+      #   * `--require-user` is intentionally NOT passed. Without it the script is
+      #     a no-op exit 0 when the bootstrap account does not exist yet — the
+      #     account is OAuth-only, so on a fresh env this correctly no-ops until
+      #     the owner logs in once; the grant then lands on the NEXT deploy.
+      #   * Idempotent — a second run reports `already_admin` and exits 0.
+      #   * Best-effort — wrapped in explicit rc handling (not `set -e`); a
+      #     non-zero rc is LOGGED loudly but never aborts the deploy. The deploy's
+      #     success signal must reflect the rollout + api health only.
+      #
+      # Email config (not hardcoded): pass --email only when the repo/env var
+      # BOOTSTRAP_ADMIN_EMAIL is set; otherwise rely on the script's own default
+      # (the owner's bootstrap email). Sourced via GH var, mirroring how
+      # db-migrate.yml keeps the email out of the workflow body.
+      - name: Reassert admin grant (bootstrap_admin.py)
+        uses: appleboy/ssh-action@v1
+        env:
+          BOOTSTRAP_ADMIN_EMAIL: ${{ vars.BOOTSTRAP_ADMIN_EMAIL }}
+        with:
+          host: ${{ vars.VPS_HOST }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          envs: BOOTSTRAP_ADMIN_EMAIL
+          script: |
+            set -uo pipefail
+            cd /opt/noorinalabs-deploy
+
+            CONTAINER="noorinalabs-user-service-1"
+
+            # Wait for user-service to report healthy before exec-ing into it.
+            # The container ships a compose healthcheck (GET /health); poll it so
+            # the bootstrap runs against a ready app, not a still-starting one.
+            echo "==> [prod] waiting for ${CONTAINER} to be healthy..."
+            us_health="not_found"
+            for i in $(seq 1 24); do
+              us_health=$(docker inspect --format='{{.State.Health.Status}}' "${CONTAINER}" 2>/dev/null || echo "not_found")
+              echo "Attempt $i/24: user-service=${us_health}"
+              if [ "${us_health}" = "healthy" ]; then
+                break
+              fi
+              sleep 5
+            done
+            if [ "${us_health}" != "healthy" ]; then
+              echo "WARNING: [prod] ${CONTAINER} not healthy after 120s (status=${us_health})." >&2
+              echo "         Skipping admin bootstrap this deploy; it will reassert on the next one." >&2
+              echo "         This does NOT fail the deploy (rollout + api health already verified)." >&2
+              exit 0
+            fi
+
+            # Build args: --email only when the GH var is set, else script default.
+            set --
+            if [ -n "${BOOTSTRAP_ADMIN_EMAIL:-}" ]; then
+              set -- --email "${BOOTSTRAP_ADMIN_EMAIL}"
+            fi
+
+            echo "==> [prod] post-deploy: reassert admin grant (bootstrap_admin.py)"
+            set +e
+            docker exec -e PYTHONPATH=/app -w /app "${CONTAINER}" \
+              /app/.venv/bin/python scripts/bootstrap_admin.py "$@"
+            BOOTSTRAP_RC=$?
+            set -e
+            if [ "${BOOTSTRAP_RC}" -eq 0 ]; then
+              echo "==> [prod] admin bootstrap completed (rc=0: granted / already_admin / no-op user-not-found)"
+            else
+              echo "WARNING: [prod] admin bootstrap exited ${BOOTSTRAP_RC}." >&2
+              echo "         This does NOT fail the deploy (rollout + api health already verified)." >&2
+              echo "         rc=1 means BootstrapError — most likely the 'admin' role is missing." >&2
+              echo "         Investigate per docs/runbooks/user-service-alembic.md#admin-bootstrap." >&2
+            fi
+
       - name: Report status
         if: always()
         run: |

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -261,6 +261,93 @@ jobs:
             docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env ps --format '{{.Name}}\t{{.Status}}'
             echo "==> Stg deployment verified"
 
+      # Post-deploy: reassert the owner's `admin` grant (deploy#445, option 2).
+      #
+      # Runs AFTER the stack is up and user-service is healthy, on EVERY stg
+      # deploy (not just user-service dispatches), so the owner's admin role
+      # survives redeploys and DB resets. This complements the pre-deploy
+      # bootstrap in db-migrate.yml (deploy#426): that gate only fires on the
+      # user-service dispatch path (deploy-stg.yml `migrate` job `if:`) and runs
+      # against a one-shot image BEFORE compose-up; this step closes the gap by
+      # running against the LIVE container after every deploy regardless of which
+      # service triggered it.
+      #
+      # `docker exec` into the running noorinalabs-user-service-1 container so the
+      # script resolves DATABASE_URL from the container's own environment (compose
+      # already injects DATABASE_URL / DATABASE_* there). No password-bearing URL
+      # is passed on argv — the only argv value is the email, which the script
+      # docstring explicitly documents as an identifier, not a credential.
+      #
+      # Safety (why this can never fail the deploy):
+      #   * `--require-user` is intentionally NOT passed. Without it the script is
+      #     a no-op exit 0 when the bootstrap account does not exist yet — the
+      #     account is OAuth-only, so on a fresh env this correctly no-ops until
+      #     the owner logs in once; the grant then lands on the NEXT deploy.
+      #   * Idempotent — a second run reports `already_admin` and exits 0.
+      #   * Best-effort — wrapped in explicit rc handling (not `set -e`); a
+      #     non-zero rc is LOGGED loudly but never aborts the deploy. The deploy's
+      #     success signal must reflect the rollout + api health only.
+      #
+      # Email config (not hardcoded): pass --email only when the repo/env var
+      # BOOTSTRAP_ADMIN_EMAIL is set; otherwise rely on the script's own default
+      # (the owner's bootstrap email). Sourced via GH var, mirroring how
+      # db-migrate.yml keeps the email out of the workflow body.
+      - name: Reassert admin grant (bootstrap_admin.py)
+        uses: appleboy/ssh-action@v1
+        env:
+          BOOTSTRAP_ADMIN_EMAIL: ${{ vars.BOOTSTRAP_ADMIN_EMAIL }}
+        with:
+          host: ${{ vars.VPS_HOST }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          envs: BOOTSTRAP_ADMIN_EMAIL
+          script: |
+            set -uo pipefail
+            cd /opt/noorinalabs-deploy
+
+            CONTAINER="noorinalabs-user-service-1"
+
+            # Wait for user-service to report healthy before exec-ing into it.
+            # The container ships a compose healthcheck (GET /health); poll it so
+            # the bootstrap runs against a ready app, not a still-starting one.
+            echo "==> [stg] waiting for ${CONTAINER} to be healthy..."
+            us_health="not_found"
+            for i in $(seq 1 24); do
+              us_health=$(docker inspect --format='{{.State.Health.Status}}' "${CONTAINER}" 2>/dev/null || echo "not_found")
+              echo "Attempt $i/24: user-service=${us_health}"
+              if [ "${us_health}" = "healthy" ]; then
+                break
+              fi
+              sleep 5
+            done
+            if [ "${us_health}" != "healthy" ]; then
+              echo "WARNING: [stg] ${CONTAINER} not healthy after 120s (status=${us_health})." >&2
+              echo "         Skipping admin bootstrap this deploy; it will reassert on the next one." >&2
+              echo "         This does NOT fail the deploy (rollout + api health already verified)." >&2
+              exit 0
+            fi
+
+            # Build args: --email only when the GH var is set, else script default.
+            set --
+            if [ -n "${BOOTSTRAP_ADMIN_EMAIL:-}" ]; then
+              set -- --email "${BOOTSTRAP_ADMIN_EMAIL}"
+            fi
+
+            echo "==> [stg] post-deploy: reassert admin grant (bootstrap_admin.py)"
+            set +e
+            docker exec -e PYTHONPATH=/app -w /app "${CONTAINER}" \
+              /app/.venv/bin/python scripts/bootstrap_admin.py "$@"
+            BOOTSTRAP_RC=$?
+            set -e
+            if [ "${BOOTSTRAP_RC}" -eq 0 ]; then
+              echo "==> [stg] admin bootstrap completed (rc=0: granted / already_admin / no-op user-not-found)"
+            else
+              echo "WARNING: [stg] admin bootstrap exited ${BOOTSTRAP_RC}." >&2
+              echo "         This does NOT fail the deploy (rollout + api health already verified)." >&2
+              echo "         rc=1 means BootstrapError — most likely the 'admin' role is missing." >&2
+              echo "         Investigate per docs/runbooks/user-service-alembic.md#admin-bootstrap." >&2
+            fi
+
       - name: Report status
         if: always()
         run: |

--- a/docs/runbooks/user-service-alembic.md
+++ b/docs/runbooks/user-service-alembic.md
@@ -230,6 +230,42 @@ docker run --rm --network noorinalabs_user-backend \
   /app/.venv/bin/python scripts/bootstrap_admin.py
 ```
 
+### Post-deploy reassertion in the deploy workflows (deploy#445)
+
+`db-migrate.yml`'s reassertion above (deploy#426) only fires where the alembic
+gate runs: on stg **only for the user-service dispatch path**
+(`deploy-stg.yml`'s `migrate` job `if:`), and on prod via `promote.yml`'s prod
+gate. That leaves gaps — an isnad-graph-only or landing-only stg deploy, a
+manual `workflow_dispatch`, or a prod break-glass rollout never re-grants admin.
+
+To make the grant durable across **every** deploy, `deploy-stg.yml` and
+`deploy-prod.yml` each run a `Reassert admin grant (bootstrap_admin.py)` step
+**after** the `Verify health check` step (deploy#445, option 2). Differences
+from the db-migrate path:
+
+- **Live container, not a one-shot image.** It `docker exec`s into the running
+  `noorinalabs-user-service-1` container, so the script resolves `DATABASE_URL`
+  from the container's own environment (compose already injects `DATABASE_*`
+  there). No password-bearing URL is passed on argv.
+- **Waits for health first.** It polls the container's compose healthcheck
+  (`GET /health`) for up to 120s; if user-service is not healthy it **skips and
+  warns** (does not fail the deploy — it reasserts on the next one).
+- **Same no-op-safe / idempotent / best-effort contract.** `--require-user` is
+  intentionally **not** passed (no-op exit 0 before first OAuth login), and the
+  exec is wrapped in `set +e` + rc check so a non-zero rc is logged but never
+  aborts the deploy.
+
+```
+verify health  →  wait user-service healthy  →  docker exec ... bootstrap_admin.py
+```
+
+**Config sourcing here:** the email is read from the GitHub Actions
+**repo/environment variable `BOOTSTRAP_ADMIN_EMAIL`** (passed via the ssh-action
+`envs:` allow-list); when unset the script's own default
+(`parametrization@gmail.com`) applies. The DB URL is **not** supplied by the
+workflow — it comes from the live container's env, so there is no secret on argv
+at all.
+
 ## Escalation
 
 | Failure | Primary | Secondary |


### PR DESCRIPTION
## What & why

Owner-directed operational change (outside any wave). Implements **deploy#445 option 2** — wire user-service's `scripts/bootstrap_admin.py` (us#159) as an **idempotent post-deploy step** so the owner's `admin` grant survives redeploys and DB resets.

A new `Reassert admin grant (bootstrap_admin.py)` step runs **after** the existing `Verify health check` step in **both** `deploy-stg.yml` and `deploy-prod.yml`. It `docker exec`s into the running `noorinalabs-user-service-1` container:

```
docker exec -e PYTHONPATH=/app -w /app noorinalabs-user-service-1 \
    /app/.venv/bin/python scripts/bootstrap_admin.py [--email "$BOOTSTRAP_ADMIN_EMAIL"]
```

## Why this isn't a duplicate of deploy#426

deploy#426 already runs `bootstrap_admin.py` as a **pre-deploy** step inside `db-migrate.yml` (one-shot image, before compose-up). But that gate only fires where alembic runs:
- **stg:** only on the **user-service dispatch** path (`deploy-stg.yml`'s `migrate` job `if:`) — an isnad-graph-only / landing-only / manual `workflow_dispatch` deploy never reasserts.
- **prod:** only via `promote.yml`'s migrate gate — a manual / break-glass `deploy-prod` dispatch never reasserts.

This PR closes that gap by reasserting against the **live container on every deploy**, regardless of trigger. The two paths are complementary, not redundant.

## No-op-safe design (the key choice)

**`--require-user` is intentionally NOT passed.** Per the script docstring, without it the script is a **no-op exit 0 when the bootstrap account doesn't exist yet** — essential because account creation is **OAuth-only**, so on a fresh env (before the owner has ever logged in) the step must not fail the deploy. It:
- **no-ops** (`user_not_found`, exit 0) before first OAuth login → grant lands on the next deploy;
- is **idempotent** (`already_admin`, exit 0) on every subsequent deploy;
- only ever **elevates an existing OAuth account** — it never creates accounts or sets credentials.

The step is additionally wrapped in `set +e` + explicit rc check and a pre-exec health-wait that **skips + warns** if user-service isn't healthy in 120s — so it is **best-effort and can never fail the deploy** (the deploy success signal reflects rollout + api health only).

## Security posture (privilege-granting step — flagging for review)

- **Gated to staging + prod only** (lives in the env-scoped `deploy-stg` / `deploy-prod` jobs; `environment: staging` / `production`).
- **No secret on argv.** `DATABASE_URL` is resolved from the **live container's own environment** (compose already injects `DATABASE_*`) — the workflow passes nothing DB-related. The only argv value is the email, which the script docstring explicitly documents as an *identifier, not a credential*.
- **Email not hardcoded.** Passed via the `BOOTSTRAP_ADMIN_EMAIL` GH repo/env var (ssh-action `envs:` allow-list) **only when set**; otherwise the script's own default (`parametrization@gmail.com`) applies.
- Idempotent / no-op-safe as above — a stray run cannot escalate an unintended account or duplicate a grant.

## Test plan

- `actionlint` (v1.7.12 equiv, **shellcheck on PATH**) over all workflows — **clean, exit 0**.
- `pre-commit run --files <changed>` — **all hooks pass** (actionlint, gitleaks).
- `python3 .claude/lib/pre_commit_ci_sync.py .` (sync-drift gate) — **OK, mirror intact**.
- No compose change → `compose-validate` unaffected.
- **Idempotency / no-op reasoning** validated against the `bootstrap_admin.py` docstring + CLI (us#159): without `--require-user`, `user_not_found` ⇒ exit 0; second run ⇒ `already_admin` ⇒ exit 0; only `BootstrapError` (missing `admin` role) ⇒ exit 1, which the step logs but swallows.
- Staging/prod step bodies are kept **identical** (only the `[stg]`/`[prod]` log labels and header comments differ).

Runbook updated: `docs/runbooks/user-service-alembic.md` § Admin bootstrap → "Post-deploy reassertion in the deploy workflows (deploy#445)".

Closes noorinalabs/noorinalabs-deploy#445

🤖 Generated with [Claude Code](https://claude.com/claude-code)
