### PR TITLE
docs(branch-protection): read-back echo says omitted, not empty (#413)

### DIFF
--- a/.github/branch-protection/apply-ruleset.sh
+++ b/.github/branch-protection/apply-ruleset.sh
@@ -87,5 +87,5 @@ gh api "repos/$REPO/rulesets" \
 echo
 echo "Confirm the rules (pull_request req_approvals=0, deletion, non_fast_forward)"
 echo "and the bypass actor in the ruleset detail (gh api repos/$REPO/rulesets/<id>)"
-echo "before declaring #322 met for this repo. required_status_checks is empty by"
-echo "design (deploy CI is path-filtered) — see SPEC.md."
+echo "before declaring #322 met for this repo. required_status_checks is omitted by"
+echo "design (deploy CI is path-filtered; the API 422s on an empty array) — see SPEC.md."


### PR DESCRIPTION
## Summary

One-line prose fix to the trailing read-back echo in `.github/branch-protection/apply-ruleset.sh`.

Since #406 (deploy#395, P4W1) dropped the `required_status_checks` rule from the committed ruleset entirely — rather than including it with an empty array — the read-back echo's claim that the field is *"empty by design"* is factually wrong. The rule is now **omitted** by design: path-filtered deploy CI means a `strict` ruleset naming any context would deadlock PRs that don't touch that path, and the rulesets API 422s on an empty `required_status_checks` array ("Expected at least 1 elements, got 0"). The script's own design-notes comment block and `SPEC.md` already use the omit wording; only this trailing echo was missed.

**Behavior is unaffected** — this is a wording-only change to the human-readable read-back guidance the owner sees after applying the ruleset.

### Before → after

```
-echo "before declaring #322 met for this repo. required_status_checks is empty by"
-echo "design (deploy CI is path-filtered) — see SPEC.md."
+echo "before declaring #322 met for this repo. required_status_checks is omitted by"
+echo "design (deploy CI is path-filtered; the API 422s on an empty array) — see SPEC.md."
```

## Test Plan

- Prose-only change; no executable behavior changes (no payload, API call, or control-flow touched).
- `shellcheck .github/branch-protection/apply-ruleset.sh` — clean.
- Pre-commit hooks pass on commit.
- Acceptance criterion (deploy#413): the read-back echo now describes the omit-by-design state accurately.

Closes #413
