### PR TITLE
fix(monitoring): repoint user-service blackbox probes to users.* vhost (deploy#449)

### DIFF
--- a/docs/api-surface-partition.md
+++ b/docs/api-surface-partition.md
@@ -36,17 +36,8 @@ fixed before the next PR in the offending service merges.
 
 | Path | Owner | Notes |
 |---|---|---|
-| `/auth/callback/*` | frontend | OAuth post-login UI render (`AuthCallbackPage`); MUST be matched **before** `/auth/*` — see Caddyfile comment block at line 32. |
-| `/auth/*` | user-service | OAuth provider redirects (`/auth/oauth/{provider}/login`, `/auth/oauth/{provider}/callback`), login, logout, refresh. |
-| `/.well-known/jwks.json` | user-service | JWT verifier discovery (IETF well-known). |
-| `/api/v1/users`, `/api/v1/users/*` | user-service | User CRUD. |
-| `/api/v1/sessions`, `/api/v1/sessions/*` | user-service | Session lifecycle. |
-| `/api/v1/subscriptions`, `/api/v1/subscriptions/*` | user-service | Billing / subscription. |
-| `/api/v1/verification`, `/api/v1/verification/*` | user-service | Email / phone verification. |
-| `/api/v1/roles`, `/api/v1/roles/*` | user-service | RBAC role assignment. |
-| `/api/v1/2fa`, `/api/v1/2fa/*` | user-service | 2FA enroll / verify (TOTP). |
-| `/api/v1/user-service/health` | user-service | Rewritten to `/health` on user-service — explicit so the isnad-vhost can probe user-service liveness without colliding with the isnad-graph-api `/health`. |
-| `/api/*` (everything else) | isnad-graph-api | Catch-all for the isnad-graph domain. |
+| `/auth/callback/*` | frontend | OAuth post-login UI render (`AuthCallbackPage`); the **only** `/auth/*` path that stays on this vhost post-#245. Matched before the `/api/*` catch-all — see Caddyfile comment block. |
+| `/api/*` | isnad-graph-api | The entire `/api/*` space on this vhost. All user-service routes (`/auth/*`, JWKS, `/api/v1/{users,sessions,subscriptions,verification,roles,2fa}`, and the `/api/v1/user-service/health` rewrite) were **removed** from `isnad.*` in #245 phase 2 (commit `e321e9a7`) and now live solely on `users.{$BASE_DOMAIN}` — see "Vhost split" below. A request for any of those paths on `isnad.*` now hits this catch-all (→ isnad-graph-api 404) or the SPA fallthrough, by design; monitoring probes for them target `users.*` (deploy#449). |
 | `/health` | isnad-graph-api | Liveness probe for isnad-graph-api on this vhost. |
 | `/status` | isnad-graph-api | Status endpoint for isnad-graph-api. |
 | `/metrics` | (none — 403) | Prometheus scrapes `api:8000/metrics` directly via the Docker backend network. |
@@ -97,29 +88,36 @@ in the Caddyfile at line 232.
    isnad-graph-api `/api/*` catch-all. See Caddyfile comment at line 32 for
    the documented precedent.
 
-## Vhost split (post-#241)
+## Vhost split (complete — post-#245)
 
-Post-#241, user-service routes are **dual-bound** on `users.{$BASE_DOMAIN}`
-AND `isnad.{$BASE_DOMAIN}`. This is the pragmatic two-phase migration
-completion documented in the Caddyfile comment at line 18:
+The user-service vhost split is **done**. The migration ran in two phases,
+documented in the Caddyfile comment block on the `isnad.{$BASE_DOMAIN}` site:
 
-- **Phase 1 (current):** dual-binding both vhosts because the frontend
-  hard-codes relative URLs (`/auth/oauth/{provider}/login`, `/api/v1/users`,
-  …) — see `frontend/src/hooks/useAuth.ts` and
-  `frontend/src/pages/LoginPage.tsx`. Removing the user-service routes from
-  `isnad.*` entirely would break login.
-- **Phase 2 (#245):** update the frontend to issue absolute URLs targeting
-  `users.{$BASE_DOMAIN}`, then drop the user-service `handle` blocks from
-  `isnad.*`.
+- **Phase 1 (#241, 2026-05-02):** dual-bound user-service routes on
+  `users.{$BASE_DOMAIN}` AND `isnad.{$BASE_DOMAIN}` because the frontend then
+  hard-coded relative URLs (`/auth/oauth/{provider}/login`, `/api/v1/users`,
+  …). Removing the routes from `isnad.*` at that point would have broken login.
+- **Phase 2 (#245, commit `e321e9a7`):** the frontend cut over to absolute URLs
+  resolved from `window.RUNTIME_CONFIG.USER_SERVICE_ORIGIN =
+  https://users.{$BASE_DOMAIN}` (isnad-graph#932/#934), so the dual-bind was no
+  longer load-bearing and the user-service `handle` blocks were dropped from
+  `isnad.*`. That vhost is now a **pure frontend + isnad-graph-API surface**;
+  the only `/auth/*` path it keeps is the `/auth/callback/*` frontend carve-out
+  (AuthCallbackPage). All user-service routes — `/auth/*`, JWKS, the
+  `/api/v1/*` user prefixes, and the `/api/v1/user-service/health` rewrite —
+  live **solely** on `users.{$BASE_DOMAIN}`.
 
-Until #245 lands, **the partition table above applies to BOTH vhosts** for
-the user-service-owned prefixes — i.e., a new user-service prefix must be
-added to **both** the `isnad.{$BASE_DOMAIN}` block (transitional) and the
-`users.{$BASE_DOMAIN}` block (permanent).
+**Consequence for monitoring (deploy#449):** the post-deploy smoke battery
+(`scripts/verify_{stg,prod}_smoke.sh`) moved its user-service checks to
+`USER_SERVICE_BASE_URL` (the `users.*` vhost) in #414. The Prometheus blackbox
+probes (`infra/prometheus/prometheus.{stg,prod}.yml`) were left probing
+`isnad.*` and so 404'd / fell through to the SPA for those paths; deploy#449
+re-pointed them to `users.*` to re-align with the smoke battery and the
+runtime truth. The regression guard `scripts/tests/test_blackbox_partition.py`
+asserts that no user-service-owned probe targets the `isnad.*` host.
 
-After #245 lands, the user-service rows in the `isnad.{$BASE_DOMAIN}`
-partition table can be removed; the `/auth/callback/*` → frontend carve-out
-and the isnad-graph-api rows remain.
+**Rule going forward:** a new user-service prefix is added to the
+`users.{$BASE_DOMAIN}` block **only** — never to `isnad.*`.
 
 ## References
 

--- a/infra/prometheus/prometheus.prod.yml
+++ b/infra/prometheus/prometheus.prod.yml
@@ -93,24 +93,32 @@ scrape_configs:
     # destroyed in the 2026-05-02 emergency reconciliation (#226) and
     # all 5 routes below were resolving to NXDOMAIN, leaving blackbox
     # blind on this surface. Companion to deploy#252 / PR#254 which
-    # fixed the same root cause on the post-deploy smoke side. Per
-    # caddy/Caddyfile the user-service routes (`/auth/*`, JWKS, the
-    # `/api/v1/user-service/health` rewrite) are dual-bound on
-    # `isnad.{$BASE_DOMAIN}` AND `users.{$BASE_DOMAIN}`; we keep the
-    # blackbox surface aligned with the smoke battery (single host
-    # `isnad.noorinalabs.com`) so the two probes share an apex. The
-    # eventual de-duplication onto `users.*` is tracked in the
-    # transitional comment block in caddy/Caddyfile.
+    # fixed the same root cause on the post-deploy smoke side.
+    #
+    # Host partition (de-duplicated onto users.* in deploy#449): the
+    # "eventual de-duplication onto users.*" that this block previously
+    # deferred to the caddy/Caddyfile transitional note has now happened.
+    # #245 phase 2 (commit e321e9a7) dropped ALL user-service routes
+    # (`/auth/*`, JWKS, the `/api/v1/user-service/health` rewrite) from the
+    # isnad.* vhost — it is now a pure frontend + isnad-graph-API surface —
+    # so the user-service-owned probes target the canonical
+    # `users.noorinalabs.com` vhost. The post-deploy smoke battery already
+    # made this move in #414 (scripts/verify_prod_smoke.sh → USER_SERVICE_
+    # BASE_URL); this keeps the blackbox surface aligned with it. Leaving the
+    # probes on isnad.* hit the isnad-graph-api `/api/*` catch-all (→ 404) or
+    # the SPA fallthrough → red probes for routes that were never broken.
     static_configs:
       - targets: ["https://isnad.noorinalabs.com/health"]
         labels: { route: "isnad-health", module: "http_2xx_json" }
-      - targets: ["https://isnad.noorinalabs.com/api/v1/user-service/health"]
+      # user-service liveness via its own vhost; smoke battery uses the same
+      # USER_SERVICE_BASE_URL/health (the isnad-vhost rewrite was retired #414).
+      - targets: ["https://users.noorinalabs.com/health"]
         labels: { route: "user-service-health", module: "http_2xx" }
       - targets: ["https://noorinalabs.com/"]
         labels: { route: "landing-root", module: "http_2xx" }
       - targets: ["https://isnad.noorinalabs.com/api/v1/narrators?limit=1"]
         labels: { route: "narrator-401", module: "http_401_json" }
-      - targets: ["https://isnad.noorinalabs.com/.well-known/jwks.json"]
+      - targets: ["https://users.noorinalabs.com/.well-known/jwks.json"]
         labels: { route: "jwks", module: "http_2xx_json" }
       # Path corrected 2026-05-03 (deploy#255 ChangesRequested) lockstep
       # with deploy#256 / PR#258 (Aisha): user-service exposes
@@ -122,7 +130,8 @@ scrape_configs:
       # historical name to avoid churning `alerts.yml`'s
       # BlackboxUnexpectedStatus matcher; the implicit "expect HTTP
       # 200" branch in that alert is correct for this route post-fix.
-      - targets: ["https://isnad.noorinalabs.com/auth/oauth/google/login"]
+      # Host repointed to users.* in deploy#449 (see partition note above).
+      - targets: ["https://users.noorinalabs.com/auth/oauth/google/login"]
         labels: { route: "auth-login-redirect", module: "http_2xx_json" }
     relabel_configs:
       - source_labels: [__address__]

--- a/infra/prometheus/prometheus.stg.yml
+++ b/infra/prometheus/prometheus.stg.yml
@@ -75,18 +75,31 @@ scrape_configs:
     metrics_path: /probe
     scrape_interval: 60s
     scrape_timeout: 10s
+    # Host partition (post-#245/#414, fixed in deploy#449): the isnad.* vhost
+    # is a pure frontend + isnad-graph-API surface — the user-service routes
+    # (`/auth/*`, JWKS, the `/api/v1/user-service/health` rewrite) were dropped
+    # from it when the frontend cut over to absolute users.* URLs (#245 phase 2,
+    # commit e321e9a7). The user-service-owned probes below therefore target
+    # the canonical `users.stg.noorinalabs.com` vhost, NOT isnad.*. This
+    # re-aligns the blackbox surface with the post-deploy smoke battery, which
+    # already moved these checks to USER_SERVICE_BASE_URL in #414
+    # (scripts/verify_stg_smoke.sh). Probing them on isnad.* hit the
+    # isnad-graph-api `/api/*` catch-all (→ 404) / SPA fallthrough → red probes
+    # for routes that were never broken — the drift this comment closes.
     static_configs:
       - targets: ["https://isnad.stg.noorinalabs.com/health"]
         labels: { route: "isnad-health", module: "http_2xx_json" }
-      - targets: ["https://isnad.stg.noorinalabs.com/api/v1/user-service/health"]
+      # user-service liveness via its own vhost; smoke battery uses the same
+      # USER_SERVICE_BASE_URL/health (the isnad-vhost rewrite was retired #414).
+      - targets: ["https://users.stg.noorinalabs.com/health"]
         labels: { route: "user-service-health", module: "http_2xx" }
       - targets: ["https://stg.noorinalabs.com/"]
         labels: { route: "landing-root", module: "http_2xx" }
       - targets: ["https://isnad.stg.noorinalabs.com/api/v1/narrators?limit=1"]
         labels: { route: "narrator-401", module: "http_401_json" }
-      - targets: ["https://isnad.stg.noorinalabs.com/.well-known/jwks.json"]
+      - targets: ["https://users.stg.noorinalabs.com/.well-known/jwks.json"]
         labels: { route: "jwks", module: "http_2xx_json" }
-      - targets: ["https://isnad.stg.noorinalabs.com/auth/oauth/google/login"]
+      - targets: ["https://users.stg.noorinalabs.com/auth/oauth/google/login"]
         labels: { route: "auth-login-redirect", module: "http_2xx_json" }
     relabel_configs:
       - source_labels: [__address__]

--- a/scripts/tests/test_blackbox_partition.py
+++ b/scripts/tests/test_blackbox_partition.py
@@ -1,0 +1,86 @@
+"""Regression guard for the blackbox-probe host partition (deploy#449).
+
+After the #245 vhost split, the ``isnad.{$BASE_DOMAIN}`` Caddy vhost is a pure
+frontend + isnad-graph-API surface — all user-service routes (``/auth/*``,
+JWKS, the ``/api/v1/user-service/health`` rewrite) live solely on
+``users.{$BASE_DOMAIN}``. The post-deploy smoke battery already probes those on
+``USER_SERVICE_BASE_URL`` (#414), but the Prometheus blackbox config was left
+probing ``isnad.*`` — so ``user-service-health`` 404'd against the
+isnad-graph-api ``/api/*`` catch-all, and ``jwks`` / ``auth-login-redirect``
+fell through to the SPA. deploy#449 re-pointed them to ``users.*``.
+
+This test parses the committed ``prometheus.{stg,prod}.yml`` blackbox jobs and
+asserts the partition holds, so the drift cannot silently come back:
+
+  * every user-service-owned probe targets the ``users.*`` host, never ``isnad.*``
+  * the isnad-graph-owned probes stay on the ``isnad.*`` host
+
+It is intentionally dependency-free (regex over the file text) because the
+``pytest (scripts)`` CI job installs only ``pytest`` — no PyYAML.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from urllib.parse import urlsplit
+
+PROM_DIR = Path(__file__).resolve().parent.parent.parent / "infra" / "prometheus"
+CONFIGS = ["prometheus.stg.yml", "prometheus.prod.yml"]
+
+# Probes owned by user-service — must live on the users.* vhost post-#245.
+USER_SERVICE_ROUTES = {"user-service-health", "jwks", "auth-login-redirect"}
+# Probes owned by isnad-graph (frontend + api) — must stay on the isnad.* vhost.
+ISNAD_ROUTES = {"isnad-health", "narrator-401"}
+
+# Matches a blackbox `- targets: ["<url>"]` entry whose very next line is its
+# `labels: { route: "<name>" ... }`. Requiring the `labels:` line immediately
+# after the target scopes the match to blackbox probe entries and excludes
+# plain scrape targets (alertmanager, api:8000, exporters) that have no route
+# label — so a target never gets paired with a far-away route.
+_PROBE_RE = re.compile(
+    r'targets:\s*\[\s*"(?P<url>[^"]+)"\s*\]\s*\n\s*'
+    r'labels:\s*\{\s*route:\s*"(?P<route>[^"]+)"',
+)
+
+
+def _probes(config: str) -> dict[str, str]:
+    """Return {route_label: host} for every blackbox target in *config*."""
+    text = (PROM_DIR / config).read_text(encoding="utf-8")
+    probes: dict[str, str] = {}
+    for m in _PROBE_RE.finditer(text):
+        probes[m.group("route")] = urlsplit(m.group("url")).hostname or ""
+    return probes
+
+
+def test_configs_exist() -> None:
+    for config in CONFIGS:
+        assert (PROM_DIR / config).is_file(), f"missing {config}"
+
+
+def test_user_service_probes_target_users_vhost() -> None:
+    for config in CONFIGS:
+        probes = _probes(config)
+        for route in USER_SERVICE_ROUTES:
+            assert route in probes, f"{config}: probe '{route}' missing"
+            host = probes[route]
+            assert host.startswith("users."), (
+                f"{config}: user-service probe '{route}' targets host "
+                f"'{host}' — must be the users.* vhost post-#245 (deploy#449)"
+            )
+            assert not host.startswith("isnad."), (
+                f"{config}: user-service probe '{route}' is back on isnad.* "
+                f"('{host}') — the #245/#449 partition regressed"
+            )
+
+
+def test_isnad_probes_stay_on_isnad_vhost() -> None:
+    for config in CONFIGS:
+        probes = _probes(config)
+        for route in ISNAD_ROUTES:
+            assert route in probes, f"{config}: probe '{route}' missing"
+            host = probes[route]
+            assert host.startswith("isnad."), (
+                f"{config}: isnad-graph probe '{route}' targets host "
+                f"'{host}' — expected the isnad.* vhost"
+            )


### PR DESCRIPTION
## What

Fixes the `/api/v1/user-service/health` 404 (and the related JWKS / google-login probe failures) on stg/prod. **Closes #449.**

## Root cause — monitoring drift, not a Caddy bug

The issue framed this as a missing `isnad.*` carve-out, but the Caddyfile is already correct. #245 phase 2 (commit `e321e9a7`) deliberately made `isnad.*` a **pure frontend + isnad-graph-API surface** and moved every user-service route (`/auth/*`, JWKS, the `/api/v1/user-service/health` rewrite) to the dedicated `users.*` vhost. The frontend resolves `USER_SERVICE_ORIGIN = https://users.{base}` from `RUNTIME_CONFIG`, so login/JWKS/health all work on `users.*`.

The drift is entirely in the **monitoring layer**: the post-deploy smoke battery already moved these checks to `USER_SERVICE_BASE_URL` (`users.*`) in #414, but the Prometheus **blackbox probes** were left pointing at `isnad.*`. There they hit the isnad-graph-api `/api/*` catch-all (→ 404) or fell through to the SPA → three red probes for routes that were never actually broken. The prod prometheus comment even admitted the eventual goal was "de-duplication onto users.*"; this completes it.

## Decision: Option B (issue-sanctioned), no Caddyfile change

I chose **Option B** over Option A (re-adding routes to `isnad.*`) because A would partially reverse the accepted #245 architecture and re-open a recon surface on `isnad.*` to satisfy a synthetic probe — you point the probe at where the route actually lives, not the reverse. The smoke battery already made exactly this call in #414; this re-aligns blackbox with it and with the runtime truth.

## Changes

- `infra/prometheus/prometheus.stg.yml` / `prometheus.prod.yml` — repoint `user-service-health`, `jwks`, `auth-login-redirect` probes from `isnad.*` → `users.*`. **Route labels unchanged**, so `alerts.yml` `BlackboxUnexpectedStatus`/`BlackboxProbeFailing` matchers need no edit. Refreshed the stale prod comment block.
- `docs/api-surface-partition.md` — aligned the `isnad.*` partition table with the post-#245 Caddyfile (per rule #4 "Caddyfile wins"); marked the vhost split complete.
- `scripts/tests/test_blackbox_partition.py` — **regression guard** (the pre-flight/manifest check requested in the issue): asserts no user-service-owned probe targets the `isnad.*` host and that isnad-graph probes stay on `isnad.*`. Dependency-free (regex), gated by the `pytest (scripts)` CI job.

## Validation

- `promtool check config` — both `prometheus.stg.yml` and `prometheus.prod.yml` valid (alerts.yml: 19 rules).
- `pytest scripts/tests` — 24 passed (incl. the 3 new partition tests).
- `ruff@0.11.6` format+lint and `mypy` clean on the new test; `markdownlint-cli2` + `cspell` clean on the doc.

## Post-deploy verification (runtime gate — owner/SRE)

Blackbox probes only fire from inside the cluster, so this can't be exercised from the sandbox. After this rides a stg deploy, confirm:
- `curl -s -o /dev/null -w '%{http_code}' https://users.stg.noorinalabs.com/health` → `200`
- `…/.well-known/jwks.json` → `200` + `.keys[]`; `…/auth/oauth/google/login` → `200` + `.authorization_url`
- In Prometheus: `probe_success{route=~"user-service-health|jwks|auth-login-redirect"} == 1` (env=stg) and the `BlackboxProbeFailing` / `BlackboxUnexpectedStatus` alerts clear.

## Reviewers
@nino-kavtaradze @aisha-idrissi

🤖 Generated with [Claude Code](https://claude.com/claude-code)
