### PR TITLE
infra(P5W3): compose log-rotation anchor + Loki hot-reloadable retention (deploy#450, #451)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -74,6 +74,7 @@ promtool
 pubkeys
 Rashidi
 regen
+reloadable
 Renaud
 retag
 retagging

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -5,6 +5,19 @@
 # All application services use pre-built GHCR images (no build contexts).
 # Infrastructure services (neo4j, databases, observability) are configured here.
 
+# Shared log-rotation policy (deploy#450). The VPS docker daemon runs the
+# json-file log driver with NO /etc/docker/daemon.json limits, so any service
+# without an explicit `logging:` block writes an UNBOUNDED container log — a
+# disk-exhaustion risk on the space-constrained VPS. Every service below sets
+# `logging: *default-logging`, so a per-container log is capped at
+# max-size × max-file = 10m × 5 = ~50MB and coverage cannot drift as new
+# services are added (a service without the alias is an obvious review miss).
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "5"
+
 services:
   neo4j:
     build:
@@ -36,11 +49,7 @@ services:
         reservations:
           memory: 4G
           cpus: "2.0"
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "5"
+    logging: *default-logging
     networks:
       - backend
     restart: unless-stopped
@@ -69,11 +78,7 @@ services:
         reservations:
           memory: 1G
           cpus: "0.5"
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "5"
+    logging: *default-logging
     networks:
       - backend
     restart: unless-stopped
@@ -102,11 +107,7 @@ services:
         reservations:
           memory: 256M
           cpus: "0.25"
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
+    logging: *default-logging
     networks:
       - backend
     restart: unless-stopped
@@ -129,6 +130,16 @@ services:
     tmpfs:
       # Python stdlib (tempfile, multiprocessing) and uvicorn need a writable /tmp
       - /tmp:size=256M
+    volumes:
+      # Shared writable overrides file for Loki's hot-reloadable retention
+      # (deploy#451). The admin "log retention (days)" control (ig#1038) writes
+      # /etc/loki/runtime/overrides.yaml here (in-place truncate-write); Loki
+      # mounts the SAME `loki_runtime` volume read-side and picks the new value
+      # up on its next runtime_config reload (30s) + compaction cycle (10m), with
+      # no Loki restart. The read_only rootfs above does NOT apply to mounted
+      # volumes, so this write path works. Until ig#1038 ships this mount is
+      # inert (nothing writes it); Loki keeps serving the seeded 168h default.
+      - loki_runtime:/etc/loki/runtime
     environment:
       - NEO4J_URI=bolt://neo4j:7687
       # NEO4J_USER must be "neo4j" — Neo4j requires the admin account to use this name
@@ -171,11 +182,7 @@ services:
         reservations:
           memory: 512M
           cpus: "0.5"
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "5"
+    logging: *default-logging
     networks:
       - backend
       - frontend
@@ -232,11 +239,7 @@ services:
         reservations:
           memory: 128M
           cpus: "0.25"
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
+    logging: *default-logging
     networks:
       - frontend
     restart: unless-stopped
@@ -269,11 +272,7 @@ services:
         reservations:
           memory: 64M
           cpus: "0.1"
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
+    logging: *default-logging
     networks:
       - frontend
     restart: unless-stopped
@@ -323,11 +322,7 @@ services:
         reservations:
           memory: 64M
           cpus: "0.1"
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "5"
+    logging: *default-logging
     networks:
       - backend
       - frontend
@@ -397,11 +392,7 @@ services:
     # migration is fundamentally broken. `no` is the correct choice — the
     # non-zero exit cascades to user-service's depends_on block.
     restart: "no"
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
+    logging: *default-logging
 
   user-service:
     image: ghcr.io/noorinalabs/noorinalabs-user-service:${USER_SERVICE_IMAGE_TAG:-latest}
@@ -475,11 +466,7 @@ services:
         reservations:
           memory: 256M
           cpus: "0.25"
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "5"
+    logging: *default-logging
     networks:
       # egress is non-internal — gives user-service outbound reach for OAuth
       # provider calls (Google, GitHub, etc.). Caddy reaches user-service for
@@ -517,11 +504,7 @@ services:
         reservations:
           memory: 512M
           cpus: "0.25"
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "5"
+    logging: *default-logging
     networks:
       - user-backend
     restart: unless-stopped
@@ -547,11 +530,7 @@ services:
         limits:
           memory: 512M
           cpus: "0.5"
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
+    logging: *default-logging
     networks:
       - user-backend
     restart: unless-stopped
@@ -579,6 +558,7 @@ services:
         limits:
           memory: 128M
           cpus: "0.25"
+    logging: *default-logging
 
   # --- Observability ---
 
@@ -612,6 +592,7 @@ services:
         limits:
           memory: 1G
           cpus: "0.5"
+    logging: *default-logging
 
   alertmanager:
     image: prom/alertmanager:v0.28.1
@@ -660,11 +641,7 @@ services:
         reservations:
           memory: 64M
           cpus: "0.1"
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
+    logging: *default-logging
 
   grafana:
     image: grafana/grafana:11.6.0
@@ -705,12 +682,48 @@ services:
         limits:
           memory: 512M
           cpus: "0.5"
+    logging: *default-logging
+
+  # One-shot seed for Loki's hot-reloadable retention overrides (deploy#451).
+  # Copies the in-tree default overrides file into the writable `loki_runtime`
+  # volume IFF the volume has no overrides.yaml yet — so an admin-set retention
+  # (ig#1038) persists across redeploys and is NOT clobbered by the repo copy on
+  # every `compose up`. Mirrors the kafka-init / minio-setup one-shot idiom.
+  # The chmod makes the file/dir writable by the (non-root) api container uid that
+  # rewrites it — it lives only on the internal `backend` network and holds a
+  # retention duration, so the broad mode is acceptable for this internal config.
+  # busybox is ~4MB — negligible on the space-constrained VPS.
+  loki-runtime-init:
+    image: busybox:1.37
+    command:
+      - /bin/sh
+      - -c
+      - |
+        if [ ! -f /runtime/overrides.yaml ]; then
+          cp /seed/runtime-overrides.yaml /runtime/overrides.yaml;
+          echo "seeded Loki runtime overrides from in-tree default";
+        else
+          echo "Loki runtime overrides already present — leaving admin-set value intact";
+        fi;
+        chmod 666 /runtime/overrides.yaml;
+        chmod 777 /runtime
+    volumes:
+      - ../infra/loki/runtime-overrides.yaml:/seed/runtime-overrides.yaml:ro
+      - loki_runtime:/runtime
+    networks:
+      - backend
+    restart: "no"
+    logging: *default-logging
 
   loki:
     image: grafana/loki:2.9.10
     volumes:
       - ../infra/loki/loki-config.yml:/etc/loki/local-config.yaml:ro
       - loki_data:/loki
+      # Hot-reloadable per-tenant retention overrides (deploy#451). Loki reads
+      # /etc/loki/runtime/overrides.yaml here every runtime_config.period (30s);
+      # seeded by loki-runtime-init, rewritten by the api (ig#1038 admin control).
+      - loki_runtime:/etc/loki/runtime
     command:
       - "-config.file=/etc/loki/local-config.yaml"
     ports:
@@ -721,6 +734,11 @@ services:
       timeout: 5s
       retries: 5
       start_period: 15s
+    depends_on:
+      # Ensure the overrides file exists before Loki loads runtime_config, so the
+      # first start always sees a valid file (else Loki logs a load error).
+      loki-runtime-init:
+        condition: service_completed_successfully
     networks:
       - backend
     restart: unless-stopped
@@ -732,11 +750,7 @@ services:
         reservations:
           memory: 256M
           cpus: "0.25"
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
+    logging: *default-logging
 
   alloy:
     # Successor to promtail (deploy#132). River config in infra/alloy/config.alloy
@@ -786,11 +800,7 @@ services:
         reservations:
           memory: 64M
           cpus: "0.1"
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
+    logging: *default-logging
 
   node-exporter:
     image: prom/node-exporter:v1.9.1
@@ -832,6 +842,7 @@ services:
         limits:
           memory: 128M
           cpus: "0.25"
+    logging: *default-logging
 
   postgres-exporter:
     image: quay.io/prometheuscommunity/postgres-exporter:v0.16.0
@@ -855,6 +866,7 @@ services:
         limits:
           memory: 128M
           cpus: "0.25"
+    logging: *default-logging
 
   # blackbox-exporter — continuous external probing of prod public routes
   # (companion to scripts/verify_prod_smoke.sh post-deploy battery, see deploy#183).
@@ -887,11 +899,7 @@ services:
         reservations:
           memory: 32M
           cpus: "0.05"
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
+    logging: *default-logging
 
   # --- Pipeline messaging (Kafka KRaft, single-node) ---
   #
@@ -986,11 +994,7 @@ services:
         reservations:
           memory: 512M
           cpus: "0.5"
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "5"
+    logging: *default-logging
 
   kafka-init:
     # One-shot topic creation. Idempotent: uses --if-not-exists. Exits 0 on success.
@@ -1016,11 +1020,7 @@ services:
     networks:
       - backend
     restart: "no"
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
+    logging: *default-logging
 
   kafka-exporter:
     # Prometheus exporter for Kafka broker + consumer-group metrics (deploy#88).
@@ -1075,11 +1075,7 @@ services:
         reservations:
           memory: 32M
           cpus: "0.05"
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
+    logging: *default-logging
 
   kafka-ui:
     # Admin console for Kafka. Bound to loopback on the VPS — operators reach it
@@ -1115,11 +1111,7 @@ services:
         reservations:
           memory: 128M
           cpus: "0.1"
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
+    logging: *default-logging
 
   # ──────────────────────────────────────────────────────────────────────────
   # Ingest pipeline workers (deploy#440 — the deploy-side half of ingest-platform#83)
@@ -1205,11 +1197,7 @@ services:
         reservations:
           memory: 128M
           cpus: "0.1"
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
+    logging: *default-logging
     restart: unless-stopped
 
   enrich-worker:
@@ -1248,11 +1236,7 @@ services:
         reservations:
           memory: 128M
           cpus: "0.1"
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
+    logging: *default-logging
     restart: unless-stopped
 
   normalize-worker:
@@ -1291,11 +1275,7 @@ services:
         reservations:
           memory: 128M
           cpus: "0.1"
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
+    logging: *default-logging
     restart: unless-stopped
 
   # graph-load stage. Terminal worker: consumes pipeline.normalize.done and
@@ -1344,11 +1324,7 @@ services:
         reservations:
           memory: 256M
           cpus: "0.25"
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
+    logging: *default-logging
     restart: unless-stopped
 
 networks:
@@ -1378,6 +1354,9 @@ volumes:
   caddy_data:
   caddy_config:
   loki_data:
+  # Writable, persisted store for Loki's runtime retention overrides (deploy#451).
+  # Shared rw between loki-runtime-init (seed), loki (read), and api (admin write).
+  loki_runtime:
   kafka_data:
   user_pg_data:
   user_redis_data:

--- a/docs/runbooks/log-ingestion.md
+++ b/docs/runbooks/log-ingestion.md
@@ -2,8 +2,12 @@
 
 Alloy (container `noorinalabs-alloy-1`, image `grafana/alloy:v1.16.1`) ships
 container stdout/stderr from the Docker socket to Loki (`noorinalabs-loki-1`,
-image `grafana/loki:2.9.10`). Loki retains 7 days of logs and is the only
-ingestion path — there is no Logstash, no Fluent Bit, no alternative shipper.
+image `grafana/loki:2.9.10`). Loki retains 7 days of logs by default and is the
+only ingestion path — there is no Logstash, no Fluent Bit, no alternative
+shipper. The retention window is **hot-reloadable at runtime** (admin "keep last
+X days" control, ig#1038) — see
+[`observability.md` § Loki retention](observability.md#loki-retention-hot-reloadable)
+for the mechanism and how to change it.
 Migrated from promtail in deploy#132; pipeline semantics (Docker SD + JSON
 extraction + level/logger labels + drop-on-empty-level) are unchanged.
 

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -16,7 +16,7 @@ The list of running containers is canonical in
 |---|---|---|---|
 | Prometheus | metrics scrape | prod VPS, port 9090 (internal) | per-alert links in `infra/prometheus/alerts.yml` |
 | Grafana | metrics + log visualisation | prod VPS, `/grafana` behind Caddy | [§ Grafana access](#grafana-access) |
-| Loki + Alloy | log aggregation | prod VPS, container-side `docker-socket` scrape | [`log-ingestion.md`](log-ingestion.md) |
+| Loki + Alloy | log aggregation | prod VPS, container-side `docker-socket` scrape | [`log-ingestion.md`](log-ingestion.md) · [§ Loki retention](#loki-retention-hot-reloadable) |
 | Alertmanager | alert routing | prod VPS, port 9093 (internal) | [`alertmanager-slack-routing.md`](alertmanager-slack-routing.md) |
 | blackbox-exporter | synthetic probes (HTTP) | prod VPS, container `blackbox-exporter` | [`blackbox-probes.md`](blackbox-probes.md) |
 | Cloudflare Web Analytics (CWA) | real-user RUM | CF dashboard (per zone) | § below |
@@ -106,6 +106,92 @@ this change deploys, an operator confirms on the live host:
 If step 1 or 2 fails after deploy, check that `BASE_DOMAIN` is set in the
 VPS `compose/.env` and that the `isnad` Caddy vhost is serving (the
 Grafana route is nested under it, not a standalone subdomain).
+
+---
+
+## Loki retention (hot-reloadable)
+
+Loki's log retention is **hot-reloadable** — the "keep last X days" window can be
+changed at runtime **without redeploying or restarting** the Loki container
+(deploy#451). This backs the admin-panel "log retention (days)" control
+(isnad-graph ig#1038).
+
+### How it works
+
+Two layers, static default + dynamic override:
+
+| Layer | File | Behavior |
+|---|---|---|
+| Static default / fallback | `infra/loki/loki-config.yml` → `limits_config.retention_period` (`168h` / 7d) | Read at **startup only**. Applies to any tenant with no override entry. |
+| Dynamic override | `infra/loki/runtime-overrides.yaml` → `overrides.fake.retention_period` | Re-read every `runtime_config.period` (`30s`); **takes precedence**; hot-reloadable. |
+
+`auth_enabled: false`, so every log stream lands under the single built-in Loki
+tenant id **`fake`** — that is the key under `overrides:` to edit.
+
+The override file lives on the writable named volume **`loki_runtime`**, mounted
+into three containers (`compose/docker-compose.prod.yml`):
+
+- `loki-runtime-init` (one-shot) — seeds the volume with the in-tree default
+  `infra/loki/runtime-overrides.yaml` **iff** the volume is empty, then `chmod`s
+  it writable. Mirrors the `kafka-init` / `minio-setup` idiom. Loki
+  `depends_on` it with `service_completed_successfully` because **Loki fails to
+  start if the `runtime_config.file` is missing** (verified: the
+  `runtime-config` module errors and the whole process exits) — the seed
+  guarantees a valid file exists before Loki loads.
+- `loki` — reads `/etc/loki/runtime/overrides.yaml` (the volume), re-reading on
+  the 30s reload interval.
+- `api` — the ig#1038 admin endpoint writes the new `retention_period` into the
+  same file (in-place truncate-write — do **not** rename-replace, which changes
+  the inode and breaks the bind/volume view).
+
+Persistence: because the seed only runs when the volume is empty, an admin-set
+value survives redeploys and is not clobbered by the repo copy on every
+`compose up`.
+
+### Timing — two intervals stack
+
+A retention change is visible in two steps:
+
+1. **Config reload** (≤ `runtime_config.period`, 30s): Loki picks up the new
+   value. Observable on the `loki_runtime_config_hash` metric (it changes) and
+   `loki_runtime_config_last_reload_successful` (stays `1`).
+2. **Enforcement** (≤ `compactor.compaction_interval`, 10m): the compactor
+   applies the new window on its next cycle, marking now-expired chunks for
+   deletion (then `retention_delete_delay`, 2h, before the chunk is removed).
+
+So "shrink retention" frees disk within ~10m + 2h, not instantly; "grow
+retention" takes effect immediately for future compaction. Document this lag in
+the admin UI copy so the owner doesn't expect an instant disk drop.
+
+### Verify a retention change (live host)
+
+```bash
+# 1. Read the current effective override
+docker compose -f compose/docker-compose.prod.yml exec loki \
+  cat /etc/loki/runtime/overrides.yaml
+
+# 2. Capture the runtime-config hash BEFORE the change
+docker compose -f compose/docker-compose.prod.yml exec loki \
+  wget -qO- http://localhost:3100/metrics | grep loki_runtime_config_hash
+
+# 3. Change it (the ig#1038 admin control does this; manual edit shown for ops).
+#    Edit overrides.fake.retention_period IN PLACE, e.g. 168h -> 336h.
+
+# 4. After ~30s, confirm the hash CHANGED and the reload succeeded — and that
+#    the container did NOT restart (StartedAt / RestartCount unchanged).
+docker compose -f compose/docker-compose.prod.yml exec loki \
+  wget -qO- http://localhost:3100/metrics \
+  | grep -E 'loki_runtime_config_(hash|last_reload_successful)'
+docker inspect -f 'StartedAt={{.State.StartedAt}} RestartCount={{.RestartCount}}' \
+  "$(docker compose -f compose/docker-compose.prod.yml ps -q loki)"
+```
+
+This exact sequence was validated locally before merge (grafana/loki:2.9.10):
+the hash changed on a 168h→720h edit, `last_reload_successful=1`, and
+`RestartCount=0` / `StartedAt` unchanged — i.e. no restart. The compactor
+deletion step itself only runs against aged data on the live box, so confirming
+that now-expired chunks actually disappear is a **post-merge owner observation**
+(watch `loki_compactor_*` metrics / the Loki disk usage panel after a shrink).
 
 ---
 

--- a/infra/loki/loki-config.yml
+++ b/infra/loki/loki-config.yml
@@ -28,11 +28,29 @@ schema_config:
         period: 24h
 
 limits_config:
+  # Static default / fallback retention (deploy#451). This applies to any tenant
+  # that has NO entry in the runtime_config overrides file below. The admin
+  # "log retention (days)" control (isnad-graph ig#1038) does NOT touch this
+  # line — it writes the per-tenant override, which takes precedence and is
+  # hot-reloadable. Keep 168h as the safe baseline if the overrides file is
+  # ever absent or empty.
   retention_period: 168h  # 7 days
   ingestion_rate_mb: 10
   ingestion_burst_size_mb: 20
   max_streams_per_user: 10000
   max_entries_limit_per_query: 5000
+
+# Hot-reloadable per-tenant overrides (deploy#451). Loki re-reads this file every
+# `period` and the compactor applies any changed `retention_period` on its next
+# compaction cycle (see compactor.compaction_interval below, 10m) WITHOUT a Loki
+# restart. This backs the admin-panel "log retention (days)" control (ig#1038),
+# which rewrites the override value in place. The file is seeded with the static
+# default by the `loki-runtime-init` one-shot (compose) and lives on the writable
+# `loki_runtime` volume shared with the API. auth_enabled is false, so all log
+# streams land under the single built-in tenant id "fake".
+runtime_config:
+  file: /etc/loki/runtime/overrides.yaml
+  period: 30s
 
 compactor:
   working_directory: /loki/compactor

--- a/infra/loki/runtime-overrides.yaml
+++ b/infra/loki/runtime-overrides.yaml
@@ -1,0 +1,21 @@
+# Loki runtime overrides — hot-reloadable per-tenant limits (deploy#451).
+#
+# Loki re-reads this file every `runtime_config.period` (30s, see
+# infra/loki/loki-config.yml) and the compactor applies any changed
+# `retention_period` on its next compaction cycle (compaction_interval=10m) —
+# NO Loki restart required. This is the deploy-side half that backs the
+# admin-panel "log retention (days)" control (isnad-graph ig#1038): that
+# endpoint rewrites the `retention_period` value below IN PLACE (open+truncate
+# write — do not rename-replace, which would break the bind/volume inode).
+#
+# auth_enabled is false in loki-config.yml, so every log stream lands under the
+# single built-in tenant id "fake". Keep that key.
+#
+# If this file is absent or a tenant has no entry, Loki falls back to the static
+# limits_config.retention_period (168h / 7d) in loki-config.yml. This in-tree
+# copy is the SEED only: the `loki-runtime-init` one-shot copies it into the
+# writable `loki_runtime` volume on first stack-up if the volume is empty, so
+# admin edits persist across redeploys without being clobbered by the repo copy.
+overrides:
+  fake:
+    retention_period: 168h  # 7 days (default; admin control overwrites this)


### PR DESCRIPTION
## Summary

Closes two P5W3 Tier-3 ops issues backing the owner's limited-VPS-disk concern.

### deploy#450 — log rotation (unbounded-growth guard)
The VPS docker daemon runs `json-file` with no `/etc/docker/daemon.json` limits, so any service without a `logging:` block writes an **unbounded** log. Audited all services in `compose/docker-compose.prod.yml`:

- **Actual state: 28 services, 23 with logging, 5 unbounded** — `prometheus`, `grafana`, `node-exporter`, `postgres-exporter`, `user-postgres-exporter`. (The issue estimated 9/32; the "23 with logging" figure in it was exact, the total/missing was an over-count.)
- Introduced a shared `x-logging` anchor (`json-file`, `max-size 10m` × `max-file 5` = ~50MB/container) and applied `logging: *default-logging` to **every** service. This closes the 5 gaps and collapses the 23 copy-pasted blocks so coverage can't drift as services are added.

**Declined the optional `docker system prune` companion:** an unconditional `prune -f` removes the previous image tags that `rollback.yml` relies on (it retags against images already on the box), so auto-prune would undermine rollback safety. Left as a manual/guarded op instead.

### deploy#451 — Loki hot-reloadable retention (backs admin ig#1038)
Loki's static `limits_config.retention_period` is read only at startup. Enabled `runtime_config` so the per-tenant `retention_period` override is hot-reloadable:

- `infra/loki/loki-config.yml`: `runtime_config.file` + `period: 30s`; static `168h` kept as fallback default.
- `infra/loki/runtime-overrides.yaml`: seed override for tenant `fake` (auth disabled → single tenant).
- `loki_runtime` named volume seeded by a `loki-runtime-init` one-shot (mirrors `kafka-init`/`minio-setup`), mounted **rw** into `loki` (reads) and `api` (the ig#1038 admin endpoint writes it in place).
- `loki depends_on loki-runtime-init: service_completed_successfully` — **Loki hard-fails at startup if the runtime file is missing** (confirmed in testing), so the seed must land first.

## Verification (local)
- `docker compose -f compose/docker-compose.prod.yml --env-file .env config --quiet` → OK (CI parity).
- `loki -verify-config` (grafana/loki:2.9.10) → exit 0.
- **Live hot-reload trace:** started Loki with the runtime config, edited the override `168h → 720h` in place; after ~reload interval the `loki_runtime_config_hash` metric changed, `loki_runtime_config_last_reload_successful=1`, and `RestartCount=0` / `StartedAt` unchanged — i.e. retention changed **without a Loki restart**.
- Docs gates: cspell, markdownlint, lychee all clean.

## Runtime acceptance (post-merge, owner/operator)
- The compactor's actual chunk-deletion step only runs against aged data on the live box — confirming expired chunks disappear after a *shrink* is a post-merge observation (watch `loki_compactor_*` / the Loki disk panel). Documented in the runbook.
- Effective enforcement lag: reload ≤30s + next compaction cycle (10m) + `retention_delete_delay` (2h). Documented so the admin UI copy sets the right expectation.

## Docs
- `docs/runbooks/observability.md` — new "Loki retention (hot-reloadable)" section (mechanism, timing, live verify procedure).
- `docs/runbooks/log-ingestion.md` — note retention is now hot-reloadable + cross-link.

## Reviewers
@ Aisha Idrissi + @ Nino Kavtaradze (2-reviewer rule).

Closes #450
Closes #451
