### PR TITLE
fix(observability): admin-gated Grafana via Caddy forward_auth SSO bridge (deploy#458)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -100,6 +100,7 @@ Tremblay
 vhosts
 visualisation
 Volkov
+Webauth
 Weronika
 worktree
 Worktrees

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -81,9 +81,58 @@ isnad.{$BASE_DOMAIN} {
 
     # ── Other services ───────────────────────────────────────────────
 
-    # Grafana
+    # Grafana — admin-gated via forward_auth SSO bridge (deploy#458).
+    # An app admin already authenticated to the product reaches Grafana
+    # (dashboards / Explore-Logs / Alerting) with NO second login; a non-admin
+    # or unauthenticated caller is rejected by user-service before a single
+    # Grafana byte is served. This closes the dead-end reported in ig#1073:
+    # the obs quick-links previously landed on Grafana's own login wall because
+    # the app session never carried through.
+    #
+    # CROSS-REPO COMPLETION GATE — this is the DEPLOY slice of a 3-repo feature.
+    # It is INERT-until-coordinated and MUST NOT be promoted to stg/prod ahead
+    # of its companions, because forward_auth is a HARD cutover (once present,
+    # Grafana's own login form is no longer reachable through Caddy — see the
+    # break-glass note in docs/runbooks/grafana-forward-auth-sso.md):
+    #   1. user-service — GET /auth/forward-auth: validates the app session the
+    #      browser carries to isnad.* and the admin role; replies 2xx with
+    #      `X-Webauth-User` (+ `X-Webauth-Role: Admin`) for admins, 401/403
+    #      otherwise. (NOT the existing /auth/token/validate — that one reads an
+    #      Authorization: Bearer header, which a top-level browser NAVIGATION to
+    #      /grafana/ does not send. The app access token lives only in the SPA's
+    #      localStorage, so a session credential the browser auto-sends to
+    #      isnad.* is the companion's job to mint — owner sign-off pending.)
+    #   2. frontend (ig#1073) — re-enable the obs links + carry that session
+    #      credential on the link click.
     handle /grafana/* {
-        reverse_proxy grafana:3000
+        # `route` pins directive order: strip → verify → proxy. Without it
+        # Caddy would re-sort the directives and the up-front strip could run
+        # after forward_auth's copy_headers.
+        route {
+            # ── Anti-spoof, layer 1 (inline security guard) ───────────────
+            # Strip ANY client-supplied auth-proxy identity headers BEFORE the
+            # sub-request, so a forged X-Webauth-* can never be trusted by the
+            # verify endpoint nor survive to Grafana if the endpoint happens
+            # not to overwrite it. The ONLY X-Webauth-* that may reach Grafana
+            # is the one forward_auth copies from the user-service 2xx below.
+            request_header -X-Webauth-User
+            request_header -X-Webauth-Role
+
+            # ── forward_auth RBAC bridge ──────────────────────────────────
+            # Caddy reaches user-service over the shared `backend` network
+            # (same path the users.* vhost uses). The whole original request —
+            # crucially its Cookie header — is forwarded to /auth/forward-auth.
+            # On 2xx the asserted identity headers are copied onto the upstream
+            # request and we continue to Grafana; on 401/403 Caddy relays that
+            # response to the client (→ app login / 403) and Grafana is never
+            # reached.
+            forward_auth user-service:8000 {
+                uri /auth/forward-auth
+                copy_headers X-Webauth-User X-Webauth-Role
+            }
+
+            reverse_proxy grafana:3000
+        }
     }
 
     # Frontend (default)

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -672,6 +672,36 @@ services:
       # breaking reachability + login (deploy#45).
       GF_SERVER_ROOT_URL: https://isnad.${BASE_DOMAIN:?BASE_DOMAIN required}/grafana
       GF_SERVER_SERVE_FROM_SUB_PATH: "true"
+      # ── Admin-gated SSO via Caddy forward_auth (deploy#458) ─────────────
+      # Trust the X-WEBAUTH-USER identity header that Caddy injects AFTER its
+      # forward_auth check against user-service (caddy/Caddyfile `handle
+      # /grafana/*`). Grafana auto-creates/updates the matching user on first
+      # hit and maps the X-Webauth-Role header to a Grafana org role. Only app
+      # admins clear forward_auth, so every request that reaches Grafana
+      # already carries a trusted identity — there is no second login.
+      GF_AUTH_PROXY_ENABLED: "true"
+      GF_AUTH_PROXY_HEADER_NAME: "X-WEBAUTH-USER"
+      GF_AUTH_PROXY_HEADER_PROPERTY: "username"
+      GF_AUTH_PROXY_AUTO_SIGN_UP: "true"
+      GF_AUTH_PROXY_SYNC_TTL: "60"
+      # Map the proxied email + role headers onto the Grafana user. The login
+      # id (header property above) is the email in X-WEBAUTH-USER; Role drives
+      # the org role (Admin for app admins).
+      GF_AUTH_PROXY_HEADERS: "Email:X-WEBAUTH-USER Role:X-Webauth-Role"
+      # Do NOT hand the browser a Grafana login-token cookie — keep the app
+      # session the single source of truth so a de-admined user loses Grafana
+      # access on their next request rather than riding a stale Grafana cookie.
+      GF_AUTH_PROXY_ENABLE_LOGIN_TOKEN: "false"
+      # Header-trust scoping (anti-spoof, layer 3 — companion to the Caddy
+      # up-front strip). Grafana accepts the auth-proxy header ONLY from these
+      # source IPs. Grafana is published NOWHERE on the host (expose: 3000, no
+      # `ports:`) and sits ONLY on the internal `backend` network, so the sole
+      # caller able to reach grafana:3000 is Caddy; the RFC1918 docker ranges
+      # below bound trust to in-cluster sources as defense-in-depth on top of
+      # (1) that network isolation and (2) Caddy stripping any client-supplied
+      # X-Webauth-* up front. Tighten to Caddy's /32 once the backend subnet /
+      # Caddy IP is pinned (cluster-verify — see runbook).
+      GF_AUTH_PROXY_WHITELIST: "172.16.0.0/12,192.168.0.0/16,10.0.0.0/8"
     expose:
       - "3000"
     healthcheck:

--- a/docs/runbooks/grafana-forward-auth-sso.md
+++ b/docs/runbooks/grafana-forward-auth-sso.md
@@ -1,0 +1,120 @@
+# Runbook — Grafana admin-gated SSO (forward_auth RBAC bridge)
+
+Closes the gap reported in **deploy#458** / ig#1073: the admin-dashboard
+Observability quick-links (Grafana / Logs / Alerts, added in ig#1066) used to
+dead-end on Grafana's own login wall because the app session did not carry
+through. This runbook documents the SSO bridge that lets an app admin reach
+Grafana with no second login, how it is hardened against header spoofing, the
+operator break-glass path, and exactly what can only be verified live on the
+cluster.
+
+## How it works
+
+```
+browser (app admin on isnad.<domain>)
+  │  GET /grafana/...   (carries the app session credential — see "Credential
+  │                      carry" below)
+  ▼
+Caddy  handle /grafana/*  (caddy/Caddyfile, isnad.<domain> vhost)
+  │  1. strip any client-supplied X-Webauth-User / X-Webauth-Role  (anti-spoof L1)
+  │  2. forward_auth → user-service:8000  GET /auth/forward-auth
+  │        ├─ 2xx + X-Webauth-User[, X-Webauth-Role]  → admin: continue
+  │        └─ 401/403                                  → relayed to client, STOP
+  │  3. copy_headers X-Webauth-User X-Webauth-Role onto the upstream request
+  ▼
+Grafana  grafana:3000   (GF_AUTH_PROXY_ENABLED, trusts X-WEBAUTH-USER)
+         auto-creates/updates the user, maps Role → org role
+```
+
+Three independent controls stop a forged identity header (acceptance item
+"external X-WEBAUTH-USER cannot impersonate"):
+
+1. **Network isolation** — Grafana has `expose: 3000` and NO host `ports:`, and
+   sits only on the `internal: true` `backend` network. The only process that
+   can reach `grafana:3000` is Caddy. An external client cannot.
+2. **Caddy up-front strip** — `request_header -X-Webauth-User` / `-X-Webauth-Role`
+   run before the verify sub-request, so a client that forges the header has it
+   removed; the only `X-Webauth-*` that survives is the one `copy_headers` lifts
+   from the user-service 2xx response.
+3. **Grafana whitelist** — `GF_AUTH_PROXY_WHITELIST` bounds the set of source
+   IPs Grafana will trust the header from to the in-cluster RFC1918 ranges
+   (defense-in-depth against a *compromised in-cluster* peer, on top of 1 & 2).
+
+## Credential carry — the cross-repo contract
+
+A top-level browser **navigation** to `/grafana/` does not send an
+`Authorization: Bearer` header, and the app access token lives only in the SPA's
+`localStorage` — so the existing `GET /auth/token/validate` (Bearer-based) is the
+wrong endpoint for forward_auth. The bridge therefore needs a session credential
+the browser auto-sends to `isnad.<domain>` and a cookie-aware verify endpoint:
+
+- **user-service — `GET /auth/forward-auth`** (companion change): read the app
+  session credential the browser carries to `isnad.<domain>`, return
+  **2xx + `X-Webauth-User: <email>`** (and `X-Webauth-Role: Admin`) for an admin
+  principal, **401/403** otherwise. The mechanism by which a credential reaches
+  `isnad.<domain>` (e.g. a short-lived parent-domain `Domain=<domain>` session
+  cookie, httpOnly+Secure+SameSite=Lax, minted from the app bearer) is a
+  **security decision that needs owner sign-off** (parent-domain scoping widens
+  the cookie surface to every subdomain) — see deploy#458.
+- **frontend (ig#1073)** — re-enable the obs links and carry that credential on
+  the link click.
+
+Until both companions ship, the Caddy/Grafana config here is **inert and must
+not be promoted** (see next section).
+
+## Promotion gate (release coordination)
+
+`forward_auth` is a **hard cutover**: once it is live, Grafana's own login form
+is no longer reachable *through Caddy*. If this deploy slice is promoted to
+stg/prod before `user-service GET /auth/forward-auth` exists, every `/grafana`
+request gets a `502`/`401` from the missing endpoint and Grafana becomes
+unreachable via the browser. Therefore:
+
+> **Do NOT promote the `/grafana` forward_auth + Grafana auth-proxy change to
+> stg or prod until the user-service `/auth/forward-auth` endpoint is deployed.**
+> The product surface is already safe in the meantime — ig#1073 hides the obs
+> links until SSO ships.
+
+## Break-glass — Grafana admin login (form)
+
+Operators who need the raw Grafana login form (the `GRAFANA_ADMIN_USER` /
+`GRAFANA_ADMIN_PASSWORD` path) bypass Caddy and hit Grafana directly over an SSH
+tunnel — this sidesteps forward_auth entirely:
+
+```bash
+ssh -L 3000:127.0.0.1:3000 deploy@<prod-vps>   # then open http://localhost:3000
+```
+
+Grafana is bound to the container only; the tunnel reaches it through the host
+docker bridge. The auth-proxy header is absent on this path, so Grafana presents
+its normal login form.
+
+## What can only be verified live on the cluster (operational gate, not PR-time)
+
+These require the full stack + the user-service companion running on staging and
+cannot be asserted by `docker compose config` / unit checks:
+
+- [ ] App admin (logged into the product) clicks an obs link → reaches Grafana
+      with **no second login** (acceptance #1).
+- [ ] Unauthenticated / non-admin request to `/grafana/*` is **rejected**
+      (401/403 or app-login redirect), verified on staging (acceptance #2).
+- [ ] A request that forges `X-WEBAUTH-USER` (direct or via Caddy) does **not**
+      impersonate — confirm the Caddy strip + Grafana whitelist hold
+      (acceptance #3). Probe both `curl -H 'X-Webauth-User: ...' https://isnad.stg…/grafana/`
+      and (from a non-Caddy backend peer) `curl -H 'X-Webauth-User: ...' http://grafana:3000/…`.
+- [ ] (Hardening follow-up) tighten `GF_AUTH_PROXY_WHITELIST` from the RFC1918
+      ranges to Caddy's `/32` once the backend subnet or Caddy IP is pinned.
+
+## Why Loki is not exposed as `/loki/*`
+
+The issue mentions "`/loki/*` if exposed". Loki is **internal only** (no public
+Caddy route; queried by Grafana over the `backend` network as a datasource).
+Adding a public `/loki/*` route would expose the raw Loki API to the edge — a
+security downgrade. Admin log access is delivered through Grafana **Explore**,
+which is itself now SSO-gated by this bridge. So no `/loki/*` route is added.
+
+## Files
+
+- `caddy/Caddyfile` — `handle /grafana/*` forward_auth block (isnad.<domain> vhost)
+- `compose/docker-compose.prod.yml` — `grafana` service `GF_AUTH_PROXY_*` env
+- Companion (other repos): user-service `GET /auth/forward-auth`, frontend ig#1073

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -67,8 +67,14 @@ The password is **not** in the repo. On the VPS it lives in
 `compose/.env`, written from the GitHub Actions encrypted secret
 `GRAFANA_ADMIN_PASSWORD` by the deploy workflow. To retrieve it for the
 project owner, read `compose/.env` on the VPS (`grep GRAFANA_ADMIN
-compose/.env`) or rotate it via the GitHub secret + redeploy. There is
-no OAuth integration for Grafana today — admin basic-auth only.
+compose/.env`) or rotate it via the GitHub secret + redeploy.
+
+**App-admin SSO (deploy#458):** app admins reach Grafana with no second login
+via a Caddy `forward_auth` RBAC bridge (`GF_AUTH_PROXY_*` env + the `handle
+/grafana/*` block) — see [`grafana-forward-auth-sso.md`](grafana-forward-auth-sso.md)
+for the design, the anti-spoof controls, the cross-repo completion gate, and the
+SSH-tunnel break-glass to the admin login form. The basic-auth path above is the
+break-glass; there is no Grafana OAuth integration.
 
 ### Dashboards
 


### PR DESCRIPTION
## What & why

The admin-dashboard Observability quick-links (ig#1066: Grafana / Logs / Alerts) dead-end on Grafana's own login wall — the app session never carries through. This is the **deploy slice** of the forward_auth RBAC SSO bridge proposed in #458 / meta noorinalabs-main#681 so an app admin reaches Grafana (dashboards / Explore-Logs / Alerting) with **no second login**, and non-admins are rejected before any Grafana byte is served.

## Changes

- **`caddy/Caddyfile`** — `handle /grafana/*` now wraps a `route` (order-pinned) that:
  1. strips any client-supplied `X-Webauth-User` / `X-Webauth-Role` (anti-spoof layer 1),
  2. `forward_auth user-service:8000 { uri /auth/forward-auth }` — validates the app session + admin role,
  3. `copy_headers` the asserted identity onto the upstream request, then `reverse_proxy grafana:3000`.
- **`compose/docker-compose.prod.yml`** — `grafana` service `GF_AUTH_PROXY_*`: trust `X-WEBAUTH-USER`, map `Email`/`Role` headers, `AUTO_SIGN_UP`, no login-token cookie, and `GF_AUTH_PROXY_WHITELIST` bounded to in-cluster RFC1918 ranges.
- **`docs/runbooks/grafana-forward-auth-sso.md`** (new) + observability.md cross-ref — design, anti-spoof model, cross-repo gate, break-glass, cluster-only checks.

## Security — three independent anti-spoof controls (acceptance #3)
1. **Network isolation** — grafana is `expose: 3000` only, on the `internal: true` `backend` network; the only process that can reach it is Caddy.
2. **Caddy up-front strip** — forged `X-Webauth-*` is removed before the verify sub-request; the only one that survives is `copy_headers`-lifted from the user-service 2xx.
3. **Grafana whitelist** — `GF_AUTH_PROXY_WHITELIST` bounds trust to in-cluster sources (defense-in-depth; tighten to Caddy `/32` once the backend subnet/IP is pinned).

**Loki stays internal** — no public `/loki/*` route is added (that would expose the raw Loki API); admin log access is via Grafana Explore, itself SSO-gated here.

## ⚠️ Cross-repo completion gate (release-coordination)
`forward_auth` is a **hard cutover** — once live, Grafana's own login form is no longer reachable through Caddy. This slice **must not be promoted to stg/prod** before its companions land, or `/grafana` 502s:

1. **user-service — `GET /auth/forward-auth`** (NOT yet filed): reads the app session credential the browser carries to `isnad.*`, returns `2xx + X-Webauth-User` (+ `X-Webauth-Role: Admin`) for admins, `401/403` otherwise. The existing `/auth/token/validate` is Bearer-header-based and is the wrong endpoint — a top-level navigation to `/grafana/` sends no `Authorization` header, and the app token lives only in the SPA's `localStorage`. **The credential-carry mechanism (e.g. a short-lived parent-domain session cookie) is the security decision #458 flags for owner sign-off.**
2. **frontend (ig#1073)** — re-enable the obs links + carry that credential on the click.

Product surface is already safe meanwhile — ig#1073 hides the links until SSO ships.

## Test Plan

**PR-time (done, local):**
- [x] `docker compose -f docker-compose.prod.yml --env-file .env config --quiet` — OK (CI-parity `.env`).
- [x] `caddy validate` (via `caddy:2-alpine`) — **Valid configuration**.
- [x] No `.github/workflows/**` changes → actionlint N/A. No new `${VAR:?}` required vars → passlist-drift unaffected.
- [x] `caddy fmt` diff is whole-file tabs-vs-spaces (pre-existing 4-space convention; no caddy-fmt CI gate) — block matches surrounding style; not reformatting the whole file.

**Operational gate — cluster-only (NOT PR acceptance; needs the user-service companion live on staging):**
- [ ] App admin clicks an obs link → reaches Grafana with no second login (#458 acceptance 1).
- [ ] Unauthenticated/non-admin `/grafana/*` → rejected 401/403 (acceptance 2).
- [ ] Forged `X-WEBAUTH-USER` (edge + non-Caddy backend peer) cannot impersonate (acceptance 3).
- [ ] Tighten `GF_AUTH_PROXY_WHITELIST` to Caddy `/32` once backend subnet/IP pinned.

Closes #458

cc reviewers: @Nino-Kavtaradze @Weronika-Zielinska (security + platform-architect focus: header-trust scoping, hard-cutover/promotion gate, Loki-stays-internal call)
