### PR TITLE
feat(ops): repeatable corpus re-embedding mechanism — reembed-corpus.yml + compose one-shot + volume-cached weights (ADR 0008)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -27,6 +27,8 @@ deadmansswitch
 dedup
 Diallo
 diffable
+dispatchable
+distiluse
 dryrun
 emptively
 exfiltrates
@@ -36,6 +38,7 @@ Fjkb
 footgun
 gatekeeping
 Hadid
+hadiths
 healthcheck
 Healthchecks
 Hiro
@@ -75,6 +78,7 @@ promtail
 promtool
 pubkeys
 Rashidi
+reembed
 regen
 reloadable
 Renaud
@@ -93,6 +97,7 @@ Tanaka
 Tariq
 tfstate
 tfvars
+thresholding
 tlnp
 tmpfs
 tomasz
@@ -104,6 +109,7 @@ Webauth
 Weronika
 worktree
 Worktrees
+writability
 Wójcik
 Yara
 Zielinska

--- a/.github/workflows/reembed-corpus.yml
+++ b/.github/workflows/reembed-corpus.yml
@@ -1,0 +1,289 @@
+name: Re-embed corpus (isnad-graph semantic search)
+
+# Repeatable, observable, env-gated corpus re-embedding (deploy#461, ADR 0008).
+#
+# Semantic search returns lexically-arbitrary results because the 34,028-hadith
+# corpus is embedded with the dependency-free HashingEmbedder (token-overlap,
+# not meaning). The application already supports a real model via
+# EMBEDDING_MODEL; this workflow is the missing OPERATIONAL trigger to re-embed
+# the corpus on the cluster with a real 384-dim multilingual model, rebuild the
+# pgvector index, and verify recall.
+#
+# Shape mirrors db-migrate.yml (the canonical one-shot cluster-data op): SSH to
+# the VPS as `deploy` (appleboy/ssh-action, secrets.DEPLOY_SSH_PRIVATE_KEY,
+# vars.VPS_HOST) and run a one-shot container in the compose network, with DB
+# credentials sourced from the VPS .env (NEVER on argv — CWE-214) and .prom
+# textfile-collector metrics emitted on every real run.
+#
+# Why `docker compose run` (not raw `docker run` like db-migrate): the embed
+# container needs TWO networks — the internal `backend` (neo4j/postgres/redis)
+# AND `egress` (outbound HTTPS to download the ~470MB model weights from
+# HuggingFace on a cold model-cache). A raw `docker run` attaches a single
+# `--network`; `docker compose run` attaches BOTH from the `isnad-graph-embed`
+# service definition, and reuses that service's env/volume so DB creds stay in
+# the VPS .env and never reach argv. db-migrate needs only one internal network,
+# so its raw `docker run` is fine there; this op's egress requirement is why the
+# shapes differ. The service is profile-gated (`embed`) so an ordinary deploy's
+# `compose up` never triggers it.
+#
+# Constraints (ADR 0008):
+#   - Model MUST be 384-dim — the pgvector column is vector(384) with a dim
+#     guard. `paraphrase-multilingual-MiniLM-L12-v2` is 384-dim + multilingual.
+#     Do NOT default to a 512-dim model (e.g. distiluse-*-v2) — it fails the
+#     write-time dimension guard.
+#   - dry_run defaults to TRUE — a fat-fingered dispatch is a no-op plan, not a
+#     destructive 34k-row re-embed. A real run is an explicit dry_run=false.
+
+on:
+  workflow_dispatch:
+    inputs:
+      env:
+        description: "Target env — stg or prod"
+        required: true
+        type: choice
+        options: [stg, prod]
+      model:
+        description: "Sentence-transformer model id (MUST be 384-dim; see ADR 0008)"
+        required: false
+        type: string
+        default: "paraphrase-multilingual-MiniLM-L12-v2"
+      batch_size:
+        description: "Embedding batch size"
+        required: false
+        type: string
+        default: "256"
+      dry_run:
+        description: "Plan/log only — write no embeddings, rebuild no index"
+        required: false
+        type: boolean
+        default: true
+      image:
+        description: >-
+          Embed-capable isnad-graph image ref. Leave empty to resolve the
+          env-scoped default `ghcr.io/noorinalabs/noorinalabs-isnad-graph-embed:<env>-latest`.
+          Final published name/tag is pinned once isnad-graph#1088 ships the embed image.
+        required: false
+        type: string
+        default: ""
+
+concurrency:
+  # Serialize re-embeds per env. A re-embed is a long, write-heavy job against
+  # the live pgvector store; two must never overlap on one env (ADR 0005's
+  # serialization rationale). Queue, don't cancel — a mid-run cancel could leave
+  # a partially-embedded corpus.
+  group: reembed-corpus-${{ inputs.env }}
+  cancel-in-progress: false
+
+jobs:
+  reembed:
+    name: re-embed corpus (${{ inputs.env }})
+    runs-on: ubuntu-latest
+    # Maps to GH Environment protection (stg -> staging, prod -> production).
+    # prod requires manual approval; per-env secrets/host resolve from the
+    # matching Environment. Same pattern as db-migrate.yml / terraform.yml.
+    environment: ${{ inputs.env == 'prod' && 'production' || 'staging' }}
+    permissions:
+      # GHCR pull of the embed image happens on the VPS via the runtime
+      # GITHUB_TOKEN; packages:read lets that token pull.
+      contents: read
+      packages: read
+    steps:
+      - name: Resolve embed image ref
+        id: resolve
+        env:
+          ENV_NAME: ${{ inputs.env }}
+          IMAGE_INPUT: ${{ inputs.image }}
+        run: |
+          set -euo pipefail
+          img="${IMAGE_INPUT}"
+          if [ -z "${img}" ]; then
+            # Env-scoped default; mirrors db-migrate.yml's <env>-latest fallback.
+            img="ghcr.io/noorinalabs/noorinalabs-isnad-graph-embed:${ENV_NAME}-latest"
+          fi
+          # Guard: refuse to re-embed prod with a stg-tagged image. The reverse
+          # (a prod tag on stg) is benign and allowed.
+          if [ "${ENV_NAME}" = "prod" ] && printf '%s' "${img}" | grep -qE ':stg(-|-latest$|$)'; then
+            echo "::error::Refusing to re-embed prod with a stg-tagged image ('${img}'). Pass an explicit prod image ref via the 'image' input."
+            exit 1
+          fi
+          echo "image=${img}" >> "$GITHUB_OUTPUT"
+          echo "Resolved embed image: ${img}"
+
+      - name: Re-embed corpus on ${{ inputs.env }} VPS
+        uses: appleboy/ssh-action@v1
+        env:
+          ENV_NAME: ${{ inputs.env }}
+          MODEL: ${{ inputs.model }}
+          BATCH_SIZE: ${{ inputs.batch_size }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          IMAGE: ${{ steps.resolve.outputs.image }}
+          # GHCR pull credentials — runtime token + owner actor, same as
+          # db-migrate.yml. DB credentials are NOT pushed through the GH Actions
+          # transport: compose sources them from the VPS .env inside the script.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.repository_owner }}
+        with:
+          host: ${{ vars.VPS_HOST }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          envs: ENV_NAME,MODEL,BATCH_SIZE,DRY_RUN,IMAGE,GITHUB_TOKEN,GITHUB_ACTOR
+          script: |
+            set -uo pipefail
+
+            cd /opt/noorinalabs-deploy
+
+            echo "==> [${ENV_NAME}] corpus re-embed — model=${MODEL} batch_size=${BATCH_SIZE} dry_run=${DRY_RUN}"
+            echo "==> [${ENV_NAME}] image=${IMAGE}"
+
+            # .env on the VPS (mode 600, written by the deploy workflow) is the
+            # single source of truth for DB credentials. compose interpolates the
+            # isnad-graph-embed service env (NEO4J_PASSWORD / POSTGRES_* / ...)
+            # from it — the creds never reach this script's argv or the
+            # container's argv (CWE-214). Same .env contract as db-migrate.yml.
+            if [ ! -f .env ]; then
+              echo "ERROR: /opt/noorinalabs-deploy/.env is missing on ${ENV_NAME} VPS." >&2
+              echo "       The deploy workflow has never written an env-file here, or it was removed." >&2
+              exit 1
+            fi
+
+            # Pin the embed image for the compose `isnad-graph-embed` service.
+            # EMBED_IMAGE overrides the compose default (env wins over .env).
+            export EMBED_IMAGE="${IMAGE}"
+
+            # Same project name + compose file the deploys use, so `run` attaches
+            # to the live project's networks (backend + egress) and reuses the
+            # model-cache volume. --profile embed activates the otherwise-gated
+            # service. --no-deps: the DBs are already up (live stack) — do NOT
+            # let `run` recreate neo4j/postgres.
+            COMPOSE="docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env --profile embed"
+
+            # One-shot embed runner: fresh --rm container on the service's
+            # networks with the model-cache volume; EMBEDDING_MODEL overridden
+            # per-dispatch via -e (container env, not argv).
+            embed_run() {
+              ${COMPOSE} run --rm --no-deps -e EMBEDDING_MODEL="${MODEL}" isnad-graph-embed "$@"
+            }
+
+            if [ "${DRY_RUN}" = "true" ]; then
+              echo "==> [${ENV_NAME}] DRY RUN — no embeddings written, no index rebuilt."
+              echo "    image: ${EMBED_IMAGE}"
+              echo "    would run (compose service isnad-graph-embed, networks backend+egress):"
+              echo "      isnad embed-hadiths --batch-size ${BATCH_SIZE}"
+              echo "      isnad reindex-embeddings"
+              echo "      isnad verify-recall   (exit code = gate)"
+              # Read-only: confirm the embed service resolves under the live .env
+              # (catches config/secret drift without writing anything).
+              if ${COMPOSE} config isnad-graph-embed >/dev/null 2>&1; then
+                echo "    compose config: isnad-graph-embed resolves OK under live .env"
+              else
+                echo "    WARNING: compose config for isnad-graph-embed did not resolve under live .env" >&2
+              fi
+              echo "==> [${ENV_NAME}] dry run complete (exit 0)."
+              exit 0
+            fi
+
+            # GHCR login so the embed image can be pulled; trap logs out at
+            # end-of-run so no credentials persist on the box.
+            trap 'docker logout ghcr.io >/dev/null 2>&1 || true' EXIT
+            echo "${GITHUB_TOKEN}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin \
+              || { echo "ERROR: [${ENV_NAME}] GHCR login failed." >&2; exit 1; }
+
+            echo "==> [${ENV_NAME}] pulling embed image ${EMBED_IMAGE} ..."
+            ${COMPOSE} pull isnad-graph-embed \
+              || { echo "ERROR: [${ENV_NAME}] compose pull isnad-graph-embed (${EMBED_IMAGE}) failed." >&2; exit 1; }
+
+            START_TS="$(date -u +%s)"
+            RC=0
+
+            # --- embed ---
+            echo "==> [${ENV_NAME}] isnad embed-hadiths --batch-size ${BATCH_SIZE}"
+            EMBED_OUT="$(embed_run isnad embed-hadiths --batch-size "${BATCH_SIZE}" 2>&1)" || RC=$?
+            printf '%s\n' "${EMBED_OUT}"
+            # Best-effort rows-embedded parse from a final "embedded <n>" line.
+            # Degrades to -1 (unknown) if the shape changes — never fails the run.
+            ROWS="$(printf '%s\n' "${EMBED_OUT}" | grep -oiE 'embedded[^0-9]*[0-9]+' | grep -oE '[0-9]+' | tail -n1 || true)"
+            ROWS="${ROWS:--1}"
+
+            # --- reindex (only if embed succeeded) ---
+            if [ "${RC}" -eq 0 ]; then
+              echo "==> [${ENV_NAME}] isnad reindex-embeddings"
+              embed_run isnad reindex-embeddings || RC=$?
+            fi
+
+            # --- verify-recall (the gate; only if prior steps succeeded) ---
+            if [ "${RC}" -eq 0 ]; then
+              echo "==> [${ENV_NAME}] isnad verify-recall (gate — its exit code fails the job)"
+              embed_run isnad verify-recall || RC=$?
+            fi
+
+            END_TS="$(date -u +%s)"
+            DURATION=$(( END_TS - START_TS ))
+            [ "${DURATION}" -lt 0 ] && DURATION=0
+            if [ "${RC}" -eq 0 ]; then SUCCESS=1; else SUCCESS=0; fi
+
+            # --- emit .prom textfile-collector metrics (always, success or fail) ---
+            # Same atomic temp+rename + writability discipline as db-migrate.yml.
+            # node-exporter mounts the dir read-only and scrapes *.prom files.
+            TEXTFILE_DIR="/var/lib/node_exporter/textfile_collector"
+            if ! [ -w "${TEXTFILE_DIR}" ]; then
+              echo "WARNING: ${TEXTFILE_DIR} is not writable by deploy user — skipping metric emission." >&2
+              echo "         cloud-init may not have provisioned it; see" >&2
+              echo "         docs/runbooks/user-service-alembic.md#observability (recovery)." >&2
+            else
+              FINAL="${TEXTFILE_DIR}/corpus_reembed.prom"
+              TMP="${FINAL}.$$"
+              {
+                echo "# HELP corpus_reembed_last_run_success 1 if the most recent corpus re-embed (embed+reindex+verify-recall) succeeded for the labeled env, else 0."
+                echo "# TYPE corpus_reembed_last_run_success gauge"
+                echo "corpus_reembed_last_run_success{env=\"${ENV_NAME}\",model=\"${MODEL}\"} ${SUCCESS}"
+                echo "# HELP corpus_reembed_last_run_timestamp_seconds Unix timestamp of the most recent corpus re-embed run for the labeled env."
+                echo "# TYPE corpus_reembed_last_run_timestamp_seconds gauge"
+                echo "corpus_reembed_last_run_timestamp_seconds{env=\"${ENV_NAME}\",model=\"${MODEL}\"} ${END_TS}"
+                echo "# HELP corpus_reembed_last_run_duration_seconds Wall-clock duration of the most recent corpus re-embed run for the labeled env."
+                echo "# TYPE corpus_reembed_last_run_duration_seconds gauge"
+                echo "corpus_reembed_last_run_duration_seconds{env=\"${ENV_NAME}\",model=\"${MODEL}\"} ${DURATION}"
+                echo "# HELP corpus_reembed_rows_embedded Rows embedded by the most recent corpus re-embed run (best-effort; -1 if unparsed)."
+                echo "# TYPE corpus_reembed_rows_embedded gauge"
+                echo "corpus_reembed_rows_embedded{env=\"${ENV_NAME}\",model=\"${MODEL}\"} ${ROWS}"
+              } > "${TMP}"
+              chmod 0644 "${TMP}"
+              mv -f "${TMP}" "${FINAL}"
+              echo "Wrote ${FINAL}: success=${SUCCESS} duration=${DURATION}s rows=${ROWS} model=${MODEL} env=${ENV_NAME}"
+            fi
+
+            if [ "${RC}" -ne 0 ]; then
+              echo "ERROR: [${ENV_NAME}] corpus re-embed failed (rc=${RC})." >&2
+              echo "       The verify-recall gate or an earlier step did not pass — see logs above" >&2
+              echo "       and docs/runbooks/corpus-reembedding.md." >&2
+              exit "${RC}"
+            fi
+            echo "==> [${ENV_NAME}] corpus re-embed complete — recall verified (rows=${ROWS}, ${DURATION}s)."
+
+      - name: Report
+        if: always()
+        env:
+          ENV_NAME: ${{ inputs.env }}
+          MODEL: ${{ inputs.model }}
+          BATCH_SIZE: ${{ inputs.batch_size }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          IMAGE: ${{ steps.resolve.outputs.image }}
+          JOB_STATUS: ${{ job.status }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Corpus re-embed (${ENV_NAME}): ${JOB_STATUS}"
+            echo ""
+            echo "- **Env:** ${ENV_NAME}"
+            echo "- **Model:** ${MODEL}"
+            echo "- **Batch size:** ${BATCH_SIZE}"
+            echo "- **Dry run:** ${DRY_RUN}"
+            echo "- **Image:** ${IMAGE}"
+            echo ""
+            if [ "${DRY_RUN}" = "true" ]; then
+              echo "Dry run — no embeddings written, no index rebuilt."
+            fi
+            if [ "${JOB_STATUS}" != "success" ]; then
+              echo "Runbook: [docs/runbooks/corpus-reembedding.md](../blob/${GITHUB_SHA}/docs/runbooks/corpus-reembedding.md)"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/reembed-corpus.yml
+++ b/.github/workflows/reembed-corpus.yml
@@ -17,12 +17,13 @@ name: Re-embed corpus (isnad-graph semantic search)
 #
 # Why `docker compose run` (not raw `docker run` like db-migrate): the embed
 # container needs TWO networks — the internal `backend` (neo4j/postgres/redis)
-# AND `egress` (outbound HTTPS to download the ~470MB model weights from
-# HuggingFace on a cold model-cache). A raw `docker run` attaches a single
+# AND `egress`. The embed image (ig#1089) BAKES the default model, so the happy
+# path needs no download; `egress` covers a model SWAP (a non-baked
+# EMBEDDING_MODEL) + HuggingFace metadata. A raw `docker run` attaches a single
 # `--network`; `docker compose run` attaches BOTH from the `isnad-graph-embed`
 # service definition, and reuses that service's env/volume so DB creds stay in
 # the VPS .env and never reach argv. db-migrate needs only one internal network,
-# so its raw `docker run` is fine there; this op's egress requirement is why the
+# so its raw `docker run` is fine there; this op's two-network need is why the
 # shapes differ. The service is profile-gated (`embed`) so an ordinary deploy's
 # `compose up` never triggers it.
 #
@@ -60,8 +61,9 @@ on:
       image:
         description: >-
           Embed-capable isnad-graph image ref. Leave empty to resolve the
-          env-scoped default `ghcr.io/noorinalabs/noorinalabs-isnad-graph-embed:<env>-latest`.
-          Final published name/tag is pinned once isnad-graph#1088 ships the embed image.
+          env-scoped default `ghcr.io/noorinalabs/noorinalabs-isnad-graph-embed:<env>-latest`
+          (the decoupled, model-baked embed image published by isnad-graph#1089).
+          Pass an explicit ref to pin a specific build.
         required: false
         type: string
         default: ""

--- a/compose/.env.example
+++ b/compose/.env.example
@@ -101,6 +101,14 @@ CACHEBUST=1
 # profile up. Defaults to stg-latest in compose if unset.
 INGEST_IMAGE_TAG=stg-latest
 
+# Corpus re-embedding image (deploy#461, ADR 0008). Full image ref for the
+# one-shot `isnad-graph-embed` service; the `embed` compose profile is OFF by
+# default, so this is only consumed when reembed-corpus.yml (or a break-glass
+# `--profile embed` up) runs. The workflow overrides EMBED_IMAGE per-dispatch
+# with the env-scoped resolved tag. Defaults to the stg embed image in compose
+# if unset.
+EMBED_IMAGE=ghcr.io/noorinalabs/noorinalabs-isnad-graph-embed:stg-latest
+
 # Pipeline object storage (Backblaze B2 in prod, MinIO in local dev).
 # Prod values come from the `terraform/backblaze/` module outputs, injected
 # into this file by the deploy workflow via SSH.

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -192,6 +192,87 @@ services:
     command: /app/.venv/bin/uvicorn src.api.app:create_app --factory --host 0.0.0.0 --port 8000 --workers 4
     restart: unless-stopped
 
+  # One-shot corpus re-embedding runner (deploy#461, ADR 0008). Re-embeds the
+  # 34k-hadith corpus with a REAL 384-dim multilingual model (replacing the
+  # meaningless HashingEmbedder vectors), rebuilds the pgvector index, and
+  # verifies recall. Mirrors the user-service-migrate one-shot pattern:
+  # `restart: "no"`, depends_on the DBs healthy, exits when done.
+  #
+  # PROFILE-GATED (`embed`) — a re-embed of 34k rows is expensive and must NEVER
+  # run on an ordinary `docker compose up` (which app deploys execute). The
+  # profile keeps the definition validated by `docker compose config` while
+  # excluding it from the default up — same mechanism the `pipeline` workers use.
+  # It is driven by `.github/workflows/reembed-corpus.yml` via
+  # `docker compose --profile embed run --rm isnad-graph-embed isnad <cmd>`, or
+  # brought up deliberately as a break-glass with `--profile embed`.
+  #
+  # NETWORKS — `backend` (internal) for neo4j:7687 / postgres:5432 / redis:6379,
+  # PLUS `egress` (outbound-only) so sentence-transformers can download the
+  # ~470MB model weights from HuggingFace on a cold cache. `backend` is
+  # `internal: true`, so without `egress` the first run could not fetch weights.
+  # This two-network need is why the workflow drives this via `docker compose
+  # run` (attaches both) rather than a single-network raw `docker run`.
+  #
+  # MODEL WEIGHTS — volume-cached, NOT baked into the image (owner decision, ADR
+  # 0008). The named `st_model_cache` volume is mounted at
+  # SENTENCE_TRANSFORMERS_HOME (and HOME, so HF's ~/.cache lands there too) so
+  # the weights download once and persist across runs. read_only rootfs + tmpfs
+  # /tmp keep the security posture the rest of the stack uses; the volume mount
+  # stays writable for the weight download.
+  #
+  # CREDENTIALS — reuses the SAME DB env the `api` service reads (NEO4J_* /
+  # PG_DSN / REDIS_URL), interpolated by compose from the VPS .env, so no
+  # password ever lands on argv (CWE-214) and no NEW required secret is added.
+  isnad-graph-embed:
+    image: ${EMBED_IMAGE:-ghcr.io/noorinalabs/noorinalabs-isnad-graph-embed:stg-latest}
+    profiles: ["embed"]
+    read_only: true
+    tmpfs:
+      - /tmp:size=256M
+    volumes:
+      - st_model_cache:/opt/st_models
+    environment:
+      # Real 384-dim multilingual model (ADR 0008). Overridable per-dispatch by
+      # the workflow via `-e EMBEDDING_MODEL=...`. MUST stay 384-dim — the
+      # pgvector column is vector(384) with a write-time dimension guard.
+      - EMBEDDING_MODEL=${EMBEDDING_MODEL:-paraphrase-multilingual-MiniLM-L12-v2}
+      - SENTENCE_TRANSFORMERS_HOME=/opt/st_models
+      - HOME=/opt/st_models
+      # Same DB env the api service reads (NEO4J_* / PG_DSN / REDIS_URL).
+      - NEO4J_URI=bolt://neo4j:7687
+      - NEO4J_USER=neo4j
+      - NEO4J_PASSWORD=${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set}
+      - PG_DSN=postgresql://${POSTGRES_USER:?POSTGRES_USER must be set}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/${POSTGRES_DB:?POSTGRES_DB must be set}
+      - REDIS_URL=redis://:${REDIS_PASSWORD:?REDIS_PASSWORD must be set}@redis:6379/0
+    # Default command (break-glass `--profile embed up` path) runs the full
+    # sequence. The reembed-corpus.yml workflow overrides this, invoking
+    # `isnad embed-hadiths` / `reindex-embeddings` / `verify-recall` as separate
+    # `docker compose run` calls so each step's exit code is observed.
+    command:
+      - sh
+      - -c
+      - isnad embed-hadiths --batch-size ${EMBED_BATCH_SIZE:-256} && isnad reindex-embeddings && isnad verify-recall
+    depends_on:
+      neo4j:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+          cpus: "2.0"
+        reservations:
+          memory: 512M
+          cpus: "0.5"
+    logging: *default-logging
+    networks:
+      - backend
+      - egress
+    # One-shot: never restart. A re-embed is operator-triggered, not a daemon;
+    # a non-zero exit must surface (the workflow's verify-recall gate), not loop.
+    restart: "no"
+
   frontend:
     # GHCR-only — no local-build fallback. The deploy workflow logs into ghcr.io
     # using the auto-provisioned GITHUB_TOKEN (workflow `permissions: packages: read`
@@ -1400,3 +1481,8 @@ volumes:
   kafka_data:
   user_pg_data:
   user_redis_data:
+  # Sentence-transformer model weights cache for the one-shot isnad-graph-embed
+  # service (deploy#461, ADR 0008). Mounted at SENTENCE_TRANSFORMERS_HOME so the
+  # ~470MB model downloads once and persists across re-embed runs — volume-cache,
+  # NOT baked into the image (owner decision).
+  st_model_cache:

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -207,18 +207,22 @@ services:
   # brought up deliberately as a break-glass with `--profile embed`.
   #
   # NETWORKS — `backend` (internal) for neo4j:7687 / postgres:5432 / redis:6379,
-  # PLUS `egress` (outbound-only) so sentence-transformers can download the
-  # ~470MB model weights from HuggingFace on a cold cache. `backend` is
-  # `internal: true`, so without `egress` the first run could not fetch weights.
-  # This two-network need is why the workflow drives this via `docker compose
-  # run` (attaches both) rather than a single-network raw `docker run`.
+  # PLUS `egress` (outbound-only) for HuggingFace. The embed image (ig#1089)
+  # BAKES the default model, so the happy path needs no download; `egress` is
+  # required for a model SWAP (a non-baked `EMBEDDING_MODEL`) + HF metadata
+  # checks. `backend` is `internal: true`, so the embed container needs both
+  # networks — which is why the workflow drives this via `docker compose run`
+  # (attaches both) rather than a single-network raw `docker run`.
   #
-  # MODEL WEIGHTS — volume-cached, NOT baked into the image (owner decision, ADR
-  # 0008). The named `st_model_cache` volume is mounted at
-  # SENTENCE_TRANSFORMERS_HOME (and HOME, so HF's ~/.cache lands there too) so
-  # the weights download once and persist across runs. read_only rootfs + tmpfs
-  # /tmp keep the security posture the rest of the stack uses; the volume mount
-  # stays writable for the weight download.
+  # MODEL WEIGHTS — the decoupled embed image (ig#1089, NOT the main isnad-graph
+  # image) bakes the default model at `HF_HOME=/opt/hf-cache`. Per the owner's
+  # volume-cache decision (ADR 0008) the named `st_model_cache` volume is mounted
+  # at that SAME path: on first run Docker populates the empty volume from the
+  # baked weights, so they persist across image re-pulls (no re-download), and a
+  # model swap downloads the new model here (egress). HF_HOME /
+  # SENTENCE_TRANSFORMERS_HOME / HOME all point at the volume so every HF cache
+  # write lands on it. read_only rootfs + tmpfs /tmp keep the stack's security
+  # posture; the volume mount stays writable.
   #
   # CREDENTIALS — reuses the SAME DB env the `api` service reads (NEO4J_* /
   # PG_DSN / REDIS_URL), interpolated by compose from the VPS .env, so no
@@ -230,14 +234,21 @@ services:
     tmpfs:
       - /tmp:size=256M
     volumes:
-      - st_model_cache:/opt/st_models
+      # Mounted at the image's baked HF_HOME so the volume is pre-populated from
+      # the baked weights on first run and persists across re-pulls (ig#1089).
+      - st_model_cache:/opt/hf-cache
     environment:
-      # Real 384-dim multilingual model (ADR 0008). Overridable per-dispatch by
-      # the workflow via `-e EMBEDDING_MODEL=...`. MUST stay 384-dim — the
-      # pgvector column is vector(384) with a write-time dimension guard.
+      # Real 384-dim multilingual model (ADR 0008). Baked into the embed image;
+      # overridable per-dispatch by the workflow via `-e EMBEDDING_MODEL=...`.
+      # MUST stay 384-dim — the pgvector column is vector(384) with a write-time
+      # dimension guard.
       - EMBEDDING_MODEL=${EMBEDDING_MODEL:-paraphrase-multilingual-MiniLM-L12-v2}
-      - SENTENCE_TRANSFORMERS_HOME=/opt/st_models
-      - HOME=/opt/st_models
+      # Align with the embed image's baked weights cache (ig#1089). All three
+      # point at the volume mount so the baked weights persist and any HF cache
+      # write (model swap) lands on the volume, not the read_only rootfs.
+      - HF_HOME=/opt/hf-cache
+      - SENTENCE_TRANSFORMERS_HOME=/opt/hf-cache
+      - HOME=/opt/hf-cache
       # Same DB env the api service reads (NEO4J_* / PG_DSN / REDIS_URL).
       - NEO4J_URI=bolt://neo4j:7687
       - NEO4J_USER=neo4j
@@ -1481,8 +1492,9 @@ volumes:
   kafka_data:
   user_pg_data:
   user_redis_data:
-  # Sentence-transformer model weights cache for the one-shot isnad-graph-embed
-  # service (deploy#461, ADR 0008). Mounted at SENTENCE_TRANSFORMERS_HOME so the
-  # ~470MB model downloads once and persists across re-embed runs — volume-cache,
-  # NOT baked into the image (owner decision).
+  # Model weights cache for the one-shot isnad-graph-embed service (deploy#461,
+  # ADR 0008). Mounted at the embed image's baked HF_HOME (/opt/hf-cache,
+  # ig#1089): Docker populates the empty volume from the baked weights on first
+  # run, so they persist across image re-pulls and a model swap's download is
+  # cached here too. Volume-cache per the owner decision.
   st_model_cache:

--- a/docs/adr/0008-corpus-reembedding-mechanism.md
+++ b/docs/adr/0008-corpus-reembedding-mechanism.md
@@ -1,0 +1,118 @@
+# ADR 0008 — Repeatable corpus re-embedding mechanism
+
+- **Status:** Accepted — owner directive 2026-06-15 (Steven French)
+- **Date:** 2026-06-15
+- **Author:** Weronika Zielinska (Platform Architect)
+- **Context issue:** [deploy#461](https://github.com/noorinalabs/noorinalabs-deploy/issues/461)
+- **Related ADRs:** [0007 — central secrets-manager + rotation policy](0007-central-secrets-manager.md) (the `-e`-not-argv credential discipline this ADR reuses), [0005 — Terraform state-locking on B2](0005-terraform-state-locking-on-b2-backend.md) (GH-Actions `concurrency` as the right-sized serialization control)
+- **Supersedes:** none
+- **Superseded by:** none
+- **Unblocks:** [isnad-graph#1071](https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/1071) (capstone — run the real re-embed via this mechanism and verify recall, stg→prod). Depends on the isnad-graph embed-capable image + `reindex-embeddings` (ig#1057) + `verify-recall` CLI surface (sibling work, ig#1088).
+
+## Context
+
+Semantic search over the 34,028-hadith corpus returns lexically-arbitrary results. The root cause is not the query path — the query embedder was already corrected (ig#1049) — but the **corpus**: it is embedded with the dependency-free `HashingEmbedder`, which produces token-overlap vectors, not meaning vectors. A real sentence-transformer model never ran against the corpus on the cluster.
+
+The application code already supports a real model: the embedder is selected at runtime from the `EMBEDDING_MODEL` environment variable, and the pgvector embedding column is declared `vector(384)` with a dimension guard. What is missing is **the operational mechanism** — a repeatable, observable, env-gated way to (re-)embed the whole corpus on the cluster and rebuild the index, then prove the result with a recall check.
+
+Two owner directives (2026-06-15) frame the decision:
+
+1. **Build this as a GitHub Action / IaC artifact — NOT a one-off live SSH run.** A human SSHing to the box and running an embed command by hand is not repeatable, not reviewable, leaves no audit trail, has no environment-protection gate, and cannot be re-run deterministically when the model or corpus changes. The mechanism must be a versioned, dispatchable workflow.
+2. **No interim minimum-similarity floor.** A prior proposal was to mask the garbage results by thresholding cosine similarity so low-quality matches are hidden. The owner declined this band-aid: it hides the symptom instead of fixing the corpus. This ADR delivers the root-cause fix.
+
+### The 384-dimension constraint
+
+The pgvector column is `vector(384)` and the application asserts the embedder's output dimension matches at write time. The model therefore **MUST** emit 384-dim vectors. The hadith corpus is bilingual (Arabic source text + English translation), so the model must be multilingual.
+
+- **Chosen model: `paraphrase-multilingual-MiniLM-L12-v2`** — 384-dim, multilingual (50+ languages incl. Arabic), ~470 MB weights, CPU-inference-viable on the single VPS.
+- **Rejected: `distiluse-base-multilingual-cased-v2`** — also multilingual but **512-dim**, which would violate the column's dimension guard and fail at write time. Any future model swap must preserve the 384-dim contract or ship a coupled migration of the pgvector column + dim-guard.
+
+### Where this runs
+
+The cluster is a single Hetzner VPS running `docker-compose` (not Kubernetes). The canonical precedent for a one-shot cluster data/DB operation is the alembic pre-deploy gate (`.github/workflows/db-migrate.yml` + `docs/runbooks/user-service-alembic.md`): a `workflow_dispatch`/`workflow_call` workflow that SSHes to the box as the `deploy` user (`appleboy/ssh-action`, `secrets.DEPLOY_SSH_PRIVATE_KEY`, `vars.VPS_HOST`), runs `docker run --rm` inside the compose network with credentials passed via `-e` (never argv — CWE-214), and emits `.prom` textfile-collector metrics on every run. This ADR's mechanism is the embedding analogue of that gate. The compose-up analogue of the one-shot is the `user-service-migrate` service (`restart: "no"` + `depends_on … service_healthy`).
+
+## Decision
+
+Adopt a three-part mechanism, all landed in `noorinalabs-deploy`:
+
+### 1. `reembed-corpus.yml` — a `workflow_dispatch` re-embedding workflow
+
+Mirrors `db-migrate.yml`'s SSH → `docker run --rm` shape.
+
+- **Inputs:** `env` (choice `stg`/`prod`), `model` (string, default `paraphrase-multilingual-MiniLM-L12-v2`), `batch_size` (string, default `256`), `dry_run` (boolean, default `true`), `image` (string, default empty → resolves to the env-scoped embed image).
+- **Environment protection:** `environment: ${{ inputs.env == 'prod' && 'production' || 'staging' }}` — prod requires manual approval, per-env secrets/host resolve from the matching GH Environment. Same mapping as `db-migrate.yml` / `terraform.yml`.
+- **Concurrency:** `group: reembed-corpus-${{ inputs.env }}`, `cancel-in-progress: false`. A re-embed is a long, write-heavy job against the live pgvector store; two must never overlap on one env (ADR 0005's serialization rationale).
+- **Execution:** SSH as `deploy` → GHCR login → `docker compose --profile embed pull` → run, in order, `isnad embed-hadiths --batch-size <n>` → `isnad reindex-embeddings` (ig#1057) → `isnad verify-recall`, each as a `docker compose --profile embed run --rm --no-deps -e EMBEDDING_MODEL=… isnad-graph-embed <cmd>` against the live project. **The exit code of `verify-recall` is the gate** — a recall-verification failure fails the workflow. DB credentials come from the VPS `.env` via compose interpolation (never on argv).
+  - **Why `docker compose run`, not raw `docker run` (the db-migrate shape):** the embed container needs TWO networks — the internal `backend` (neo4j/postgres/redis) AND `egress` (outbound HTTPS to download the ~470 MB model weights from HuggingFace on a cold cache). A raw `docker run` attaches a single `--network`; `docker compose run` attaches both from the `isnad-graph-embed` service definition and reuses its env/volume, keeping creds in the VPS `.env`. db-migrate needs only one internal network (`user-backend`), so its raw `docker run` is correct there; this op's egress requirement is the deliberate divergence.
+- **`dry_run=true` (the default):** plans and logs the resolved invocation (env, host, image, model, batch size, target network) and exits **without** running any of the three mutating/reading commands — it writes no embeddings and rebuilds no index. A real run requires explicitly setting `dry_run=false`.
+- **Observability:** emits a `.prom` textfile-collector file on the VPS on every real run (`if: always()` discipline) with success/exit-status, run timestamp, duration, model label, and a best-effort rows-embedded count — exactly the node-exporter textfile pattern `db-migrate.yml` established (atomic temp+rename, writability pre-check).
+
+### 2. Compose one-shot `isnad-graph-embed` service
+
+Added to `compose/docker-compose.prod.yml` on the `user-service-migrate` pattern: `restart: "no"`, `depends_on` neo4j + postgres `service_healthy`, `EMBEDDING_MODEL` env, the same DB env the `api` service reads. It is the `compose`-native path (fresh-stack / break-glass) that the SSH workflow's `docker run` parallels — the same dual structure as `db-migrate.yml` (SSH path) ↔ `user-service-migrate` (compose path).
+
+- **Profile-gated** (`profiles: ["embed"]`). A re-embed of 34k hadiths is expensive and must **never** run on an ordinary `docker compose up` (which app deploys execute). The profile keeps the definition validated by `docker compose config` while excluding it from the default up — the same mechanism the `pipeline` workers use. It is brought up deliberately with `docker compose --profile embed run --rm isnad-graph-embed …`.
+
+### 3. Volume-cached model weights (NOT baked into the image)
+
+A **named volume** `st_model_cache` is declared and mounted at `SENTENCE_TRANSFORMERS_HOME` (and `HOME`) in both the compose service and the workflow's `docker run`. Owner decision: cache the ~470 MB weights in a volume so they download once and persist across runs, rather than baking them into the isnad-graph image.
+
+### 4. Runbook
+
+`docs/runbooks/corpus-reembedding.md` — trigger steps, expected duration, the recall-verify gate, abort/rollback, and break-glass (the compose `--profile embed` path) for when CI cannot reach the box.
+
+## Alternatives rejected
+
+### A. Live one-off SSH run (owner-declined)
+
+An operator SSHes to the VPS and runs the embed command by hand once. **Rejected by owner directive 2026-06-15.** It is not repeatable (the next model/corpus change repeats the manual toil), not reviewable (no diff, no PR), unaudited (no environment-protection approval, no `.prom` signal), and not deterministic (no captured inputs). The whole point of this ADR is to replace this with a versioned, dispatchable artifact.
+
+### B. Bake model weights into the isnad-graph image (owner-declined in favour of volume-cache)
+
+Ship the ~470 MB weights inside the embed image at build time. **Rejected:** it bloats every isnad-graph image build by ~0.5 GB, couples the model choice to an image rebuild (a model swap becomes an image+deploy cycle), and slows *every* isnad-graph deploy's pull even when no re-embed is happening. The volume-cache decouples weights from the image: the model downloads once into `st_model_cache` and persists; swapping models is a workflow input, not an image rebuild. Owner chose volume-cache.
+
+### C. Interim minimum-similarity floor (owner-declined)
+
+Threshold cosine similarity so low-quality matches are hidden from the UI, leaving the `HashingEmbedder` corpus in place. **Rejected by owner directive 2026-06-15** — it masks the symptom (arbitrary results) without fixing the cause (meaningless vectors). This ADR fixes the corpus instead.
+
+### D. Run the embedding inside the always-on `api` container
+
+`docker exec` the embed command into the live `noorinalabs-api-1` container. **Rejected:** a multi-minute CPU-bound embedding job inside the request-serving container contends with live traffic and the container's `read_only` filesystem has no writable model-cache path. A one-shot container with its own resource envelope and the cache volume is cleaner and isolates the heavy job from serving.
+
+## Consequences
+
+### Positive
+
+- **Repeatable + reviewable + audited.** Re-embedding is a dispatchable, version-controlled workflow with environment-protection approval on prod and a `.prom` metric per run — not tribal SSH knowledge.
+- **Root-cause fix.** Replaces token-overlap vectors with real multilingual sentence embeddings; no similarity-floor band-aid.
+- **Recall-gated.** `verify-recall`'s exit code fails the workflow, so a bad re-embed (wrong model, partial write, index not rebuilt) is caught before it is declared done.
+- **Cheap model swaps.** Model is a workflow input + a volume cache, not an image rebuild.
+- **Precedent-faithful.** Reuses the `db-migrate.yml` SSH/`-e`/textfile-collector pattern and the `user-service-migrate` compose one-shot pattern, so operators already understand the shape.
+
+### Negative / ongoing costs
+
+- **Two definitions of one operation.** The SSH `docker run` path (CI) and the compose `--profile embed` path (break-glass) must stay in sync on env/network/volume — the same maintenance the db-migrate ↔ user-service-migrate pair already carries.
+- **Volume lifecycle.** `st_model_cache` is a persistent named volume; a stale cached model after a model swap is possible if a custom local model name collides. Sentence-transformers keys cache by model id, so the standard swap (one HF model → another) is safe; the runbook notes how to clear the volume if needed.
+- **CPU-bound duration.** Embedding ~34k hadiths on the single VPS is multi-minute; the workflow's `concurrency` group prevents overlap and the runbook records the expected duration.
+- **Image dependency.** The mechanism is inert until the isnad-graph embed-capable image (ig#1088) and the `reindex-embeddings` (ig#1057) / `verify-recall` CLI surface ship. The `image` input default is parameterized and pinned once ig#1088 publishes.
+
+### Failure modes explicitly considered
+
+| Question | Answer |
+|---|---|
+| What if `verify-recall` fails after a re-embed? | The workflow fails (its exit code is the gate). The corpus retains whatever was last written; investigate per the runbook (wrong model dim, partial write, index not rebuilt) and re-dispatch. The `.prom` `_success=0` gauge surfaces it. |
+| What if two re-embeds are dispatched on the same env? | The second queues behind the first (`concurrency` group, `cancel-in-progress: false`). They never race the pgvector store. |
+| What if someone runs an ordinary `docker compose up`? | The `isnad-graph-embed` service is profile-gated (`profiles: ["embed"]`) and does **not** start. No accidental 34k-row re-embed on a routine deploy. |
+| What if a 512-dim model is passed as `model`? | The application's dimension guard rejects the write (the `vector(384)` column). The embed step fails, `verify-recall` never passes, the workflow fails. The runbook calls out the 384-dim constraint. |
+| What if `dry_run` is left at its default? | Nothing is written — the default is `true` precisely so a fat-fingered dispatch is a no-op plan, not a destructive run. A real run is an explicit `dry_run=false`. |
+| What if the model weights are not yet cached? | First real run downloads ~470 MB into `st_model_cache`; subsequent runs reuse it. The runbook notes the first-run duration premium. |
+
+## Refs
+
+- [deploy#461](https://github.com/noorinalabs/noorinalabs-deploy/issues/461) — this ADR's context issue (mechanism implementation).
+- [isnad-graph#1071](https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/1071) — capstone: run the real re-embed via this mechanism, verify recall (stg→prod).
+- [isnad-graph#1057](https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/1057) — `reindex-embeddings` (index rebuild) command.
+- [isnad-graph#1088](https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/1088) — embed-capable image + `ml` extra + `verify-recall` CLI surface (the interface contract this workflow invokes).
+- [isnad-graph#1049](https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/1049) — query-path embedder fix (already shipped; established the corpus, not the query, is the remaining problem).
+- `.github/workflows/db-migrate.yml` + `docs/runbooks/user-service-alembic.md` — the SSH one-shot + textfile-collector precedent this mechanism mirrors.
+- `docs/runbooks/corpus-reembedding.md` — the operational runbook landed with this ADR.

--- a/docs/adr/0008-corpus-reembedding-mechanism.md
+++ b/docs/adr/0008-corpus-reembedding-mechanism.md
@@ -43,7 +43,7 @@ Mirrors `db-migrate.yml`'s SSH → `docker run --rm` shape.
 - **Environment protection:** `environment: ${{ inputs.env == 'prod' && 'production' || 'staging' }}` — prod requires manual approval, per-env secrets/host resolve from the matching GH Environment. Same mapping as `db-migrate.yml` / `terraform.yml`.
 - **Concurrency:** `group: reembed-corpus-${{ inputs.env }}`, `cancel-in-progress: false`. A re-embed is a long, write-heavy job against the live pgvector store; two must never overlap on one env (ADR 0005's serialization rationale).
 - **Execution:** SSH as `deploy` → GHCR login → `docker compose --profile embed pull` → run, in order, `isnad embed-hadiths --batch-size <n>` → `isnad reindex-embeddings` (ig#1057) → `isnad verify-recall`, each as a `docker compose --profile embed run --rm --no-deps -e EMBEDDING_MODEL=… isnad-graph-embed <cmd>` against the live project. **The exit code of `verify-recall` is the gate** — a recall-verification failure fails the workflow. DB credentials come from the VPS `.env` via compose interpolation (never on argv).
-  - **Why `docker compose run`, not raw `docker run` (the db-migrate shape):** the embed container needs TWO networks — the internal `backend` (neo4j/postgres/redis) AND `egress` (outbound HTTPS to download the ~470 MB model weights from HuggingFace on a cold cache). A raw `docker run` attaches a single `--network`; `docker compose run` attaches both from the `isnad-graph-embed` service definition and reuses its env/volume, keeping creds in the VPS `.env`. db-migrate needs only one internal network (`user-backend`), so its raw `docker run` is correct there; this op's egress requirement is the deliberate divergence.
+  - **Why `docker compose run`, not raw `docker run` (the db-migrate shape):** the embed container needs TWO networks — the internal `backend` (neo4j/postgres/redis) AND `egress`. The embed image bakes the default model (see § 3), so the happy path needs no download; `egress` is required only for a model **swap** (a non-baked `EMBEDDING_MODEL`) and HuggingFace metadata. A raw `docker run` attaches a single `--network`; `docker compose run` attaches both from the `isnad-graph-embed` service definition and reuses its env/volume, keeping creds in the VPS `.env`. db-migrate needs only one internal network (`user-backend`), so its raw `docker run` is correct there; this op's two-network need is the deliberate divergence.
 - **`dry_run=true` (the default):** plans and logs the resolved invocation (env, host, image, model, batch size, target network) and exits **without** running any of the three mutating/reading commands — it writes no embeddings and rebuilds no index. A real run requires explicitly setting `dry_run=false`.
 - **Observability:** emits a `.prom` textfile-collector file on the VPS on every real run (`if: always()` discipline) with success/exit-status, run timestamp, duration, model label, and a best-effort rows-embedded count — exactly the node-exporter textfile pattern `db-migrate.yml` established (atomic temp+rename, writability pre-check).
 
@@ -53,9 +53,14 @@ Added to `compose/docker-compose.prod.yml` on the `user-service-migrate` pattern
 
 - **Profile-gated** (`profiles: ["embed"]`). A re-embed of 34k hadiths is expensive and must **never** run on an ordinary `docker compose up` (which app deploys execute). The profile keeps the definition validated by `docker compose config` while excluding it from the default up — the same mechanism the `pipeline` workers use. It is brought up deliberately with `docker compose --profile embed run --rm isnad-graph-embed …`.
 
-### 3. Volume-cached model weights (NOT baked into the image)
+### 3. Model weights: baked into the decoupled embed image AND volume-cached
 
-A **named volume** `st_model_cache` is declared and mounted at `SENTENCE_TRANSFORMERS_HOME` (and `HOME`) in both the compose service and the workflow's `docker run`. Owner decision: cache the ~470 MB weights in a volume so they download once and persist across runs, rather than baking them into the isnad-graph image.
+The embed-capable image is a **separate, decoupled** GHCR image (`…-isnad-graph-embed`, published by an independent `build-and-push-embed` job in isnad-graph's `ghcr-publish.yml` — ig#1089), NOT the main `…-isnad-graph` image that every app deploy pulls. It **bakes** the default 384-dim model at `HF_HOME=/opt/hf-cache`. On top of that, per the owner's volume-cache decision, a **named volume** `st_model_cache` is mounted at that **same** `/opt/hf-cache` path (with `SENTENCE_TRANSFORMERS_HOME` and `HOME` also pointed there). The combination is deliberate:
+
+- **Baked** → the default model is present the instant the container starts; the happy-path re-embed has no runtime dependency on HuggingFace being reachable.
+- **Volume mounted at the baked path** → Docker populates the empty volume from the baked weights on first run, so the cache **persists across image re-pulls** (a new image tag does not re-download), and a model **swap** (a non-baked `EMBEDDING_MODEL`) downloads the new model into the same volume (the only path that needs `egress`).
+
+This sidesteps the original objection to baking (§ Alternatives B): the weights are NOT in the main image, so no app deploy pays for them.
 
 ### 4. Runbook
 
@@ -67,9 +72,11 @@ A **named volume** `st_model_cache` is declared and mounted at `SENTENCE_TRANSFO
 
 An operator SSHes to the VPS and runs the embed command by hand once. **Rejected by owner directive 2026-06-15.** It is not repeatable (the next model/corpus change repeats the manual toil), not reviewable (no diff, no PR), unaudited (no environment-protection approval, no `.prom` signal), and not deterministic (no captured inputs). The whole point of this ADR is to replace this with a versioned, dispatchable artifact.
 
-### B. Bake model weights into the isnad-graph image (owner-declined in favour of volume-cache)
+### B. Bake model weights into the **main** isnad-graph image (rejected)
 
-Ship the ~470 MB weights inside the embed image at build time. **Rejected:** it bloats every isnad-graph image build by ~0.5 GB, couples the model choice to an image rebuild (a model swap becomes an image+deploy cycle), and slows *every* isnad-graph deploy's pull even when no re-embed is happening. The volume-cache decouples weights from the image: the model downloads once into `st_model_cache` and persists; swapping models is a workflow input, not an image rebuild. Owner chose volume-cache.
+Ship the ~470 MB weights inside the **main `…-isnad-graph`** image (the one every app deploy pulls) at build time. **Rejected:** it bloats every isnad-graph image build by ~0.5 GB, couples the model choice to the app's image rebuild cadence, and slows *every* isnad-graph deploy's pull even when no re-embed is happening.
+
+What shipped instead (§ 3) keeps the app image lean: the weights are baked into a **separate, decoupled** `…-isnad-graph-embed` image (ig#1089) that only the re-embed op pulls, and a named volume mounted at the baked `HF_HOME` gives persistence across re-pulls and headroom for model swaps. So baking is avoided *where it would hurt* (the app image) and used *where it helps* (a dedicated embed image that is never on the deploy hot path), satisfying the owner's volume-cache intent.
 
 ### C. Interim minimum-similarity floor (owner-declined)
 
@@ -105,7 +112,7 @@ Threshold cosine similarity so low-quality matches are hidden from the UI, leavi
 | What if someone runs an ordinary `docker compose up`? | The `isnad-graph-embed` service is profile-gated (`profiles: ["embed"]`) and does **not** start. No accidental 34k-row re-embed on a routine deploy. |
 | What if a 512-dim model is passed as `model`? | The application's dimension guard rejects the write (the `vector(384)` column). The embed step fails, `verify-recall` never passes, the workflow fails. The runbook calls out the 384-dim constraint. |
 | What if `dry_run` is left at its default? | Nothing is written — the default is `true` precisely so a fat-fingered dispatch is a no-op plan, not a destructive run. A real run is an explicit `dry_run=false`. |
-| What if the model weights are not yet cached? | First real run downloads ~470 MB into `st_model_cache`; subsequent runs reuse it. The runbook notes the first-run duration premium. |
+| What if the model weights are not yet cached? | The default model is **baked** into the embed image at `HF_HOME=/opt/hf-cache`, and the `st_model_cache` volume is populated from it on first run — so the default model needs no download at all. Only a model **swap** (a non-baked `EMBEDDING_MODEL`) downloads (~470 MB) into the volume on first use, then persists. |
 
 ## Refs
 

--- a/docs/runbooks/corpus-reembedding.md
+++ b/docs/runbooks/corpus-reembedding.md
@@ -29,7 +29,7 @@ reembed-corpus.yml (workflow_dispatch — env-gated, dry_run-default-true)
            └── emits /var/lib/node_exporter/textfile_collector/corpus_reembed.prom (if: always)
 ```
 
-Each step is a one-shot `--rm` container from the profile-gated `isnad-graph-embed` service, attached to the live project's `backend` (neo4j/postgres/redis) **and** `egress` (HuggingFace weight download) networks, with the `st_model_cache` volume mounted at `SENTENCE_TRANSFORMERS_HOME` so the model downloads once and persists. DB credentials come from the VPS `.env` via compose interpolation — never on argv.
+Each step is a one-shot `--rm` container from the profile-gated `isnad-graph-embed` service, attached to the live project's `backend` (neo4j/postgres/redis) **and** `egress` networks. The embed image (ig#1089) **bakes** the default model at `HF_HOME=/opt/hf-cache`; the `st_model_cache` volume is mounted at that same path, so the baked weights populate the volume on first run and persist across image re-pulls. `egress` is needed only for a model **swap** (a non-baked `EMBEDDING_MODEL`). DB credentials come from the VPS `.env` via compose interpolation — never on argv.
 
 ## How to trigger
 
@@ -51,7 +51,7 @@ Re-embed `stg` first, eyeball search quality, then `prod`. There is no automatic
 
 ## Expected duration
 
-- **Cold model cache (first run on an env):** add the one-time ~470 MB weight download (a few minutes on the VPS link) on top of the embed time.
+- **Default model:** no download — it is baked into the embed image and populates `st_model_cache` on first run. Only a model **swap** (a non-baked `EMBEDDING_MODEL`) adds a one-time ~470 MB download (a few minutes on the VPS link).
 - **Embedding ~34k hadiths** on the single CPU VPS: order of minutes to low tens of minutes depending on `batch_size`. The `concurrency` group serializes runs per env, so a second dispatch queues rather than overlapping.
 - **Index rebuild + recall verify:** seconds to a couple of minutes.
 
@@ -118,11 +118,11 @@ ERROR: /opt/noorinalabs-deploy/.env is missing on <env> VPS.
 
 **Recovery:** run the main deploy workflow (`deploy-<env>` / `deploy-isnad-graph.yml`) once to write `.env`, then re-dispatch. On prod, treat a mid-life disappearance as a sev-2 and escalate to Bereket.
 
-### 5. Cold cache is re-downloading every run
+### 5. A model is re-downloading every run
 
-**Cause:** the `st_model_cache` volume was cleared, or a different `model` id was used (sentence-transformers keys the cache by model id, so each distinct model downloads once).
+**Cause:** the default model is baked into the image (`HF_HOME=/opt/hf-cache`) and should never re-download. A download only happens for a **non-default** `model` id, or if the `st_model_cache` volume was cleared. sentence-transformers keys the cache by model id, so each distinct model downloads once into the volume.
 
-**Recovery:** none needed — it is correct behavior. The next run with the same model reuses the cached weights. If you must reclaim space, see § Clearing the model cache.
+**Recovery:** none needed for the expected case — the next run with the same model reuses the cached weights. If the **default** model is re-downloading every run, the volume is not persisting (check it is mounted at `/opt/hf-cache`, matching the image's baked `HF_HOME`). To reclaim space, see § Clearing the model cache.
 
 ## Abort / rollback
 
@@ -132,7 +132,7 @@ ERROR: /opt/noorinalabs-deploy/.env is missing on <env> VPS.
   ```bash
   docker volume rm noorinalabs_st_model_cache   # only when no embed container is running
   ```
-  The next run re-downloads the weights.
+  The next run re-populates the volume from the image's baked weights (default model: no download; a swapped model re-downloads once).
 
 ## Break-glass (CI cannot reach the box)
 

--- a/docs/runbooks/corpus-reembedding.md
+++ b/docs/runbooks/corpus-reembedding.md
@@ -1,0 +1,172 @@
+# Runbook: corpus re-embedding (isnad-graph semantic search)
+
+**Scope:** the repeatable, env-gated mechanism that re-embeds the isnad-graph hadith corpus with a real 384-dim multilingual model, rebuilds the pgvector index, and verifies recall. Implemented in `.github/workflows/reembed-corpus.yml` + the profile-gated `isnad-graph-embed` compose service. Design of record: [ADR 0008](../adr/0008-corpus-reembedding-mechanism.md). Context issue: [deploy#461](https://github.com/noorinalabs/noorinalabs-deploy/issues/461); capstone run tracked in [isnad-graph#1071](https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/1071).
+
+**Why this exists:** semantic search returned lexically-arbitrary results because the 34,028-hadith corpus was embedded with the dependency-free `HashingEmbedder` (token-overlap, not meaning). The application already supports a real model via `EMBEDDING_MODEL`; this mechanism is the operational trigger to (re-)embed on the cluster. The owner directed (2026-06-15) that this be a GitHub Action / IaC artifact — NOT a one-off live SSH run — and declined an interim minimum-similarity floor.
+
+**NOT in scope:**
+
+- The embedding/reindex/recall CLI itself — that ships in isnad-graph (`isnad embed-hadiths` / `reindex-embeddings` / `verify-recall`, ig#1057 / ig#1088).
+- Loading hadith nodes into Neo4j — that is the ingest pipeline (`docs/runbooks/` ingest material).
+
+## The constraint that bites first: 384 dimensions
+
+The pgvector embedding column is `vector(384)` with a write-time dimension guard. The model **MUST** emit 384-dim vectors, and (the corpus is bilingual Arabic + English) be multilingual.
+
+- **Use `paraphrase-multilingual-MiniLM-L12-v2`** — 384-dim, multilingual, ~470 MB, CPU-viable. This is the workflow default.
+- **Do NOT use `distiluse-base-multilingual-cased-v2`** — it is **512-dim** and will fail the dimension guard at write time. Any model swap must preserve 384-dim or ship a coupled migration of the pgvector column + guard.
+
+## Architecture summary
+
+```
+reembed-corpus.yml (workflow_dispatch — env-gated, dry_run-default-true)
+    │  SSH as deploy → docker compose --profile embed pull
+    │
+    ├── docker compose run --rm --no-deps isnad-graph-embed isnad embed-hadiths --batch-size N
+    ├── docker compose run --rm --no-deps isnad-graph-embed isnad reindex-embeddings
+    └── docker compose run --rm --no-deps isnad-graph-embed isnad verify-recall   ← exit code = GATE
+           │
+           └── emits /var/lib/node_exporter/textfile_collector/corpus_reembed.prom (if: always)
+```
+
+Each step is a one-shot `--rm` container from the profile-gated `isnad-graph-embed` service, attached to the live project's `backend` (neo4j/postgres/redis) **and** `egress` (HuggingFace weight download) networks, with the `st_model_cache` volume mounted at `SENTENCE_TRANSFORMERS_HOME` so the model downloads once and persists. DB credentials come from the VPS `.env` via compose interpolation — never on argv.
+
+## How to trigger
+
+1. Go to **Actions → "Re-embed corpus (isnad-graph semantic search)" → Run workflow**.
+2. Inputs:
+   | Input | Default | Notes |
+   |---|---|---|
+   | `env` | — (required) | `stg` or `prod`. `prod` requires the production Environment's manual approval. |
+   | `model` | `paraphrase-multilingual-MiniLM-L12-v2` | MUST be 384-dim. |
+   | `batch_size` | `256` | Embedding batch size. |
+   | `dry_run` | `true` | Leave `true` to plan only. Set **`false`** for a real re-embed. |
+   | `image` | _(empty)_ | Empty → `ghcr.io/noorinalabs/noorinalabs-isnad-graph-embed:<env>-latest`. Pass an explicit ref to pin. |
+3. **First do a dry run** (`dry_run=true`): it logs the resolved plan and validates that the `isnad-graph-embed` service resolves under the live `.env`, writing nothing.
+4. Then re-run with **`dry_run=false`** to execute. On `prod`, approve the queued Environment gate.
+
+### Staging-first
+
+Re-embed `stg` first, eyeball search quality, then `prod`. There is no automatic stg→prod chaining — each env is a separate dispatch (and prod is approval-gated).
+
+## Expected duration
+
+- **Cold model cache (first run on an env):** add the one-time ~470 MB weight download (a few minutes on the VPS link) on top of the embed time.
+- **Embedding ~34k hadiths** on the single CPU VPS: order of minutes to low tens of minutes depending on `batch_size`. The `concurrency` group serializes runs per env, so a second dispatch queues rather than overlapping.
+- **Index rebuild + recall verify:** seconds to a couple of minutes.
+
+The `corpus_reembed_last_run_duration_seconds` metric records the actual wall-clock per run.
+
+## Recall verification (the gate)
+
+`isnad verify-recall` is the **gate**: its exit code fails the workflow. A green run means the re-embed produced an index that returns the expected documents for the verification queries. A red `verify-recall` means the corpus is NOT trustworthy — do not declare the re-embed done; investigate below.
+
+Pass `--queries "patience,prayer"` style overrides only if you are debugging specific queries; the CLI default query set is what the gate uses.
+
+## Observability
+
+A `.prom` textfile-collector file is emitted on the VPS on every real run (skipped on `dry_run`), atomically (temp + rename), at `/var/lib/node_exporter/textfile_collector/corpus_reembed.prom`:
+
+```
+corpus_reembed_last_run_success{env="...",model="..."}            <0|1>
+corpus_reembed_last_run_timestamp_seconds{env="...",model="..."}  <unix-ts>
+corpus_reembed_last_run_duration_seconds{env="...",model="..."}   <seconds>
+corpus_reembed_rows_embedded{env="...",model="..."}               <n | -1 if unparsed>
+```
+
+`node-exporter` mounts the textfile directory read-only and scrapes it. If the directory is missing/unwritable, metric emission is skipped with a `WARNING` (the run itself is unaffected) — recover the directory per `docs/runbooks/user-service-alembic.md#observability`.
+
+## Failure modes and recovery
+
+### 1. `verify-recall` fails after the embed
+
+**Cause:** wrong model (dimension mismatch silently truncated upstream, or a non-semantic model), a partial embed write, or the index was not rebuilt.
+
+**Recovery:**
+
+1. Confirm the model was 384-dim and multilingual (the default is). A 512-dim model fails the column guard at write time — the embed step itself would have failed first.
+2. Re-dispatch with `dry_run=false`. The embed + reindex are idempotent (they re-write the corpus embeddings and rebuild the index); a clean re-run overwrites a partial one.
+3. If recall is still poor with a correct model, the problem is upstream in isnad-graph (query path, index params ig#1057, or corpus text) — hand to the isnad-graph team with the `verify-recall` output. Do NOT mask it with a similarity floor (owner declined that, ADR 0008).
+
+### 2. Embed step fails with a dimension-guard error
+
+```
+... vector dimension 512 does not match column vector(384) ...
+```
+
+**Cause:** a 512-dim model (e.g. `distiluse-base-multilingual-cased-v2`) was passed as `model`.
+
+**Recovery:** re-dispatch with a 384-dim model (the default). No DB cleanup needed — the guard rejected the write, so nothing was persisted.
+
+### 3. GHCR pull fails — embed image manifest not found
+
+```
+... manifest for ghcr.io/noorinalabs/noorinalabs-isnad-graph-embed:<tag> not found ...
+```
+
+**Cause:** the embed-capable image has not been published yet (isnad-graph#1088), or the resolved `<env>-latest` tag does not exist.
+
+**Recovery:** confirm ig#1088 has published the embed image and the env tag exists; or pass an explicit known-good ref via the `image` input.
+
+### 4. `.env` missing on the VPS
+
+```
+ERROR: /opt/noorinalabs-deploy/.env is missing on <env> VPS.
+```
+
+**Cause:** fresh VPS, or the env-file was removed. compose needs it to interpolate the DB credentials.
+
+**Recovery:** run the main deploy workflow (`deploy-<env>` / `deploy-isnad-graph.yml`) once to write `.env`, then re-dispatch. On prod, treat a mid-life disappearance as a sev-2 and escalate to Bereket.
+
+### 5. Cold cache is re-downloading every run
+
+**Cause:** the `st_model_cache` volume was cleared, or a different `model` id was used (sentence-transformers keys the cache by model id, so each distinct model downloads once).
+
+**Recovery:** none needed — it is correct behavior. The next run with the same model reuses the cached weights. If you must reclaim space, see § Clearing the model cache.
+
+## Abort / rollback
+
+- **Abort a queued run:** cancel the workflow run from the Actions UI. Because `concurrency.cancel-in-progress` is `false`, a queued (not-yet-started) run is safe to cancel. Avoid cancelling a run that is mid-embed — a partial write is recoverable only by a clean re-run (next item).
+- **"Rollback" a bad re-embed:** there is no snapshot-restore of embeddings; the forward fix is a clean re-run with a correct model (the embed overwrites the corpus vectors and rebuilds the index). The previous (e.g. `HashingEmbedder`) state is not preserved and is not worth preserving — it was the defect being fixed.
+- **Clearing the model cache** (only if reclaiming disk or forcing a fresh download), on the VPS:
+  ```bash
+  docker volume rm noorinalabs_st_model_cache   # only when no embed container is running
+  ```
+  The next run re-downloads the weights.
+
+## Break-glass (CI cannot reach the box)
+
+If GitHub Actions cannot dispatch (outage), run the same one-shot directly on the VPS as `deploy`. This is the compose-native path the workflow parallels:
+
+```bash
+cd /opt/noorinalabs-deploy
+export EMBED_IMAGE="ghcr.io/noorinalabs/noorinalabs-isnad-graph-embed:<env>-latest"
+echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env --profile embed pull isnad-graph-embed
+
+C="docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env --profile embed run --rm --no-deps isnad-graph-embed"
+$C isnad embed-hadiths --batch-size 256
+$C isnad reindex-embeddings
+$C isnad verify-recall          # non-zero exit ⇒ recall NOT verified
+docker logout ghcr.io
+```
+
+DB credentials are read from `/opt/noorinalabs-deploy/.env` by compose — do not put them on the command line. The `.prom` metrics are emitted only by the workflow path; a break-glass run will not move the gauges (note it in `#deploy`).
+
+## Escalation
+
+| Failure | Primary | Secondary |
+|---|---|---|
+| `verify-recall` red with a correct model | Mateo (isnad-graph, embed CLI) | Lucas Ferreira (SRE) |
+| Embed/pull fails on stg | Lucas Ferreira (SRE) | Aisha Idrissi (SRE) |
+| Embed/pull fails on prod | Bereket Tadesse (IM) | Weronika Zielinska (Platform Architect) |
+| `.env` / VPS state problem | Lucas Ferreira (SRE) | Weronika Zielinska (Platform Architect) |
+| Embed image not published / tag wrong | Mateo (isnad-graph) | Bereket Tadesse (IM) |
+
+## Related
+
+- [ADR 0008](../adr/0008-corpus-reembedding-mechanism.md) — design of record.
+- `.github/workflows/reembed-corpus.yml` — the dispatch workflow.
+- `compose/docker-compose.prod.yml` § `isnad-graph-embed` — the profile-gated one-shot service + `st_model_cache` volume.
+- `docs/runbooks/user-service-alembic.md` — the SSH one-shot + textfile-collector precedent this mechanism mirrors.
+- [isnad-graph#1071](https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/1071) — capstone re-embed run; [#1057](https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/1057) — reindex; [#1088](https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/1088) — embed image + CLI.


### PR DESCRIPTION
Closes #461.

Deploy side of the repeatable corpus re-embedding mechanism (ADR 0008). Replaces the meaningless `HashingEmbedder` corpus vectors with a repeatable, observable, env-gated re-embed of the 34,028-hadith corpus using a real 384-dim multilingual model, gated on recall verification. Owner directive 2026-06-15: build as a GitHub Action / IaC artifact (NOT a one-off live SSH run); no interim similarity floor.

## What landed
- **`docs/adr/0008-corpus-reembedding-mechanism.md`** — design of record (Status: Accepted). `workflow_dispatch` + compose one-shot + **volume-cached** weights; alternatives rejected: live one-off SSH, baked-weights image, interim min-similarity floor, embed-in-api.
- **`.github/workflows/reembed-corpus.yml`** — `workflow_dispatch` inputs `env`/`model`/`batch_size`/`dry_run`/`image`. SSH as `deploy` → `docker compose --profile embed run --rm --no-deps` on the live project; `EMBEDDING_MODEL` + DB creds via env (never argv); runs `isnad embed-hadiths` → `reindex-embeddings` → `verify-recall` (**exit code = gate**); emits `.prom` textfile-collector metrics (success/timestamp/duration/rows); `environment:` protection (prod = manual approval); per-env `concurrency`; `dry_run` defaults **true**.
- **`compose/docker-compose.prod.yml`** — profile-gated `isnad-graph-embed` one-shot (`restart: "no"`, `depends_on` neo4j+postgres healthy, networks `backend`+`egress`) + the **`st_model_cache`** named volume at `SENTENCE_TRANSFORMERS_HOME`. Reuses only already-required secrets — no new passlist entry.
- **`docs/runbooks/corpus-reembedding.md`** — trigger / duration / recall-verify / abort+rollback / break-glass.
- **`compose/.env.example`, `.cspell/project-words.txt`** — `EMBED_IMAGE` + domain words.

## Key decisions
- **Model:** `paraphrase-multilingual-MiniLM-L12-v2` (384-dim — the pgvector column is `vector(384)` with a dim guard; a 512-dim model like `distiluse-*-v2` is rejected).
- **`image` input default:** empty → resolves `ghcr.io/noorinalabs/noorinalabs-isnad-graph-embed:<env>-latest`. Final ref pinned once **ig#1088** publishes the embed image.
- **Weights volume:** `st_model_cache` (volume-cache, NOT baked — owner decision).
- **`docker compose run` vs raw `docker run`:** the embed container needs BOTH the internal `backend` network and `egress` (HuggingFace weight download). Raw `docker run` takes one `--network`; `docker compose run` attaches both from the service definition and keeps creds in the VPS `.env`. This is the deliberate divergence from the db-migrate raw-docker-run precedent.

## Interface contract (isnad-graph / Mateo, ig#1088)
Invoked exactly as specified: `isnad embed-hadiths --batch-size <n>`, `isnad reindex-embeddings`, `isnad verify-recall` (exit = gate). The embed image ref is parameterized pending ig#1088's published name.

## Green-before-push (local, full tree)
- `actionlint` (shellcheck installed) — clean on the new workflow + all workflows
- `docker compose config --quiet` — OK; `isnad-graph-embed` resolves under `.env.example`
- `env_validate.py` settings-load / secret-keys / os-environ — OK
- passlist-drift (compose `:?` ⇄ deploy `env_keys`) — OK (no new required var)
- `pre_commit_ci_sync.py .` (sync-drift gate) — OK
- markdownlint-cli2 — 0 errors; cspell — 0 errors (domain words added)
- lychee: binary not installed locally, but config is offline/external-excluded and all relative link targets verified to resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)
