### PR TITLE
fix(reembed): set command_timeout for 34k-hadith CPU embed (#465)

### DIFF
--- a/.github/workflows/reembed-corpus.yml
+++ b/.github/workflows/reembed-corpus.yml
@@ -80,6 +80,12 @@ jobs:
   reembed:
     name: re-embed corpus (${{ inputs.env }})
     runs-on: ubuntu-latest
+    # A real run embeds the full 34,028-hadith corpus on the VPS CPU, then
+    # rebuilds the pgvector index and verifies recall — minutes-to-tens-of-minutes,
+    # well past the GH default per-step budget. Give the job a generous ceiling so
+    # the runner-side never caps the SSH step short of `command_timeout` below
+    # (deploy#465). The dry-run path returns in seconds and is unaffected.
+    timeout-minutes: 120
     # Maps to GH Environment protection (stg -> staging, prod -> production).
     # prod requires manual approval; per-env secrets/host resolve from the
     # matching Environment. Same pattern as db-migrate.yml / terraform.yml.
@@ -127,6 +133,13 @@ jobs:
         with:
           host: ${{ vars.VPS_HOST }}
           username: deploy
+          # appleboy/ssh-action defaults command_timeout to 10m — far short of a
+          # real CPU embed of the 34,028-hadith corpus + reindex + verify-recall,
+          # which the prior stg run (deploy#465) hit at the 10m mark while still
+          # mid-embed. 60m comfortably covers a full CPU embed with headroom;
+          # capped below the job-level timeout-minutes above. The dry-run path is
+          # seconds, so this only affects real runs.
+          command_timeout: 60m
           key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
           envs: ENV_NAME,MODEL,BATCH_SIZE,DRY_RUN,IMAGE,GITHUB_TOKEN,GITHUB_ACTOR
           script: |

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -271,7 +271,12 @@ services:
     deploy:
       resources:
         limits:
-          memory: 2G
+          # 4G (was 2G): a real embed loads the sentence-transformer model +
+          # torch and batches 34k hadiths; 2G left no torch headroom and OOM
+          # pressure is a plausible contributor to the slow/killed run (deploy#465).
+          # Profile-gated (`embed`) so this never runs on an ordinary deploy —
+          # zero blast radius on the live stack; the box (CPX41, 16G) has room.
+          memory: 4G
           cpus: "2.0"
         reservations:
           memory: 512M


### PR DESCRIPTION
## Summary

`reembed-corpus.yml` SSHes the stg/prod VPS via `appleboy/ssh-action@v1` and runs the embed → reindex → verify-recall sequence. The action's `command_timeout` **defaults to 10m**, and the step has **no job-level `timeout-minutes`** either. A real run embeds the full **34,028-hadith** corpus on the VPS CPU, rebuilds the pgvector index, and verifies recall — far longer than 10m. The last stg run was killed at the 10m mark while still mid-embed (the embed image `import src` bug from isnad-graph#1094 is already fixed; the dry-run is green and the real run now reaches the embedding before being timed out).

This is the last known blocker for the #1071 capstone.

## Root cause

No `command_timeout` on the `appleboy/ssh-action@v1` step → SSH command killed at the action's 10m default, mid-`isnad embed-hadiths`.

## Fix

- **`reembed-corpus.yml`** — `appleboy/ssh-action@v1` step gets `command_timeout: 60m` (comfortably covers a full CPU embed + reindex + verify-recall with headroom; the prior run did ~10m and wasn't close). Added an explicit job-level `timeout-minutes: 120` so the runner never caps the SSH step short of `command_timeout`. The dry-run path returns in seconds and is unaffected.
- **`compose/docker-compose.prod.yml`** — bumped the `isnad-graph-embed` service memory limit `2G → 4G` for sentence-transformer + torch headroom. Memory pressure is a plausible contributor to the slow embed. The service is `profiles: ["embed"]`-gated, so it **never runs on an ordinary `compose up`** (zero blast radius on the live stack); the box (CPX41, 16G) has ample room.

No other changes — the embed/reindex/recall logic, `.env`/cred handling, and `.prom` metric emission are untouched.

## Test Plan

- [x] `actionlint` clean (shellcheck on PATH so its shell-script integration runs) — workflow valid.
- [x] `compose-validate` CI gate reproduced locally: `docker compose -f docker-compose.prod.yml --env-file <ci-materialized .env> config --quiet` → exit 0; embed service renders at 4G and stays `embed`-profile-gated.
- [x] Sync-drift gate (`pre_commit_ci_sync.py .`) → "OK: pre-commit config mirrors all CI-enforced checks."
- [x] pre-commit (commit + pre-push stages) green; no `--no-verify`, no force.
- [ ] **Runtime proof (post-merge, owner/author-driven):** a real stg `reembed-corpus` run reaching `isnad verify-recall` exit 0 — i.e. the embed no longer times out at 10m and the recall gate passes.

Closes #465
