### PR TITLE
fix(reembed): raise command_timeout 60m -> 90m for prod margin (#468)

### DIFF
--- a/.github/workflows/reembed-corpus.yml
+++ b/.github/workflows/reembed-corpus.yml
@@ -136,10 +136,11 @@ jobs:
           # appleboy/ssh-action defaults command_timeout to 10m — far short of a
           # real CPU embed of the 34,028-hadith corpus + reindex + verify-recall,
           # which the prior stg run (deploy#465) hit at the 10m mark while still
-          # mid-embed. 60m comfortably covers a full CPU embed with headroom;
+          # mid-embed. The first successful stg run took ~47.5m (2853s); 90m gives
+          # comfortable margin over that for the slower/larger prod run (deploy#468),
           # capped below the job-level timeout-minutes above. The dry-run path is
           # seconds, so this only affects real runs.
-          command_timeout: 60m
+          command_timeout: 90m
           key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
           envs: ENV_NAME,MODEL,BATCH_SIZE,DRY_RUN,IMAGE,GITHUB_TOKEN,GITHUB_ACTOR
           script: |


### PR DESCRIPTION
## Summary

Follow-up to #466. The first owner-approved stg corpus re-embed (via the deploy#465 mechanism) ran **~47.5m (2853s)** against the `command_timeout: 60m` — a thin margin (Aisha flagged exactly this on the #466 review). Before the owner-approved **prod** run, raise the `appleboy/ssh-action` `command_timeout` **60m → 90m** for comfortable headroom over the slower/larger prod corpus.

- Job-level `timeout-minutes` is already `120`, so it stays `>= command_timeout`.
- Comment refreshed to record the measured 47.5m stg runtime as the basis for the margin.
- Workflow-only; one value + comment. Embed/reindex/recall logic, creds, metrics, and the compose memory limit are untouched.

## Test Plan

- [x] `actionlint` clean (shellcheck on PATH) — workflow valid; `command_timeout: 90m`, `timeout-minutes: 120` (>=).
- [x] pre-commit commit + pre-push stages green; no `--no-verify`, no force. compose-validate untouched (no compose change).
- [ ] **Runtime proof (post-merge, owner-driven):** the prod `reembed-corpus` run reaching `verify-recall` exit 0 within the 90m budget.

Closes #468
