### PR TITLE
tech-debt(deploy): sweep stale Kafka topic 'pipeline.raw.new' in preflight test fixture

### DIFF
--- a/scripts/tests/test_kafka_logdir_preflight.py
+++ b/scripts/tests/test_kafka_logdir_preflight.py
@@ -82,7 +82,7 @@ def test_delete_and_future_suffix_dirs_are_valid(tmp_path: Path) -> None:
         tmp_path,
         [
             "topic-0",
-            "pipeline.raw.new-1.abc123ef-delete",
+            "pipeline.raw.landed-1.abc123ef-delete",
             "pipeline.enrich.done-3.0000000000000000abcd-future",
         ],
     )


### PR DESCRIPTION
## Summary
Sweeps the stale Kafka topic name `pipeline.raw.new` in the logdir-preflight test fixture to the canonical `pipeline.raw.landed`.

`scripts/tests/test_kafka_logdir_preflight.py:85` used the pre-rename topic `pipeline.raw.new` as a logdir fixture. The preflight test is topic-name-agnostic (it validates partition-dir form, not topic identity), so nothing was broken — but the fixture diverged from the canonical topic inventory. `infra/kafka/init-topics.sh` is the source of truth and creates `pipeline.raw.landed` (the `pipeline.raw.new` name is explicitly called out there as the earlier, incorrect name). This aligns the fixture with the ip#192 topic inventory reconciled in #441.

## Change
- `scripts/tests/test_kafka_logdir_preflight.py`: `pipeline.raw.new-1.abc123ef-delete` → `pipeline.raw.landed-1.abc123ef-delete`

## Testing
- `ENVIRONMENT=test pytest scripts/tests/test_kafka_logdir_preflight.py` → 8 passed
- pre-commit hooks (ruff-format, ruff-lint, gitleaks) → passed

## Reviewers
- Lucas Ferreira
- Nurul Hakim

Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)
