### PR TITLE
ci(compose): gate tiered-rollout service lists ⊆ compose services (#434)

### DIFF
--- a/.github/workflows/compose-validate.yml
+++ b/.github/workflows/compose-validate.yml
@@ -330,6 +330,10 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install pytest
-        run: pip install pytest
+        # PyYAML: test_check_service_tier_subset.py imports the gate module,
+        # which parses the deploy workflows via `import yaml` (deploy#434). The
+        # setup-python tool-cache interpreter has no PyYAML preinstalled (unlike
+        # the system python the compose-config job's gate step runs on).
+        run: pip install pytest pyyaml
       - name: Run scripts unit tests
         run: python3 -m pytest scripts/tests -q

--- a/.github/workflows/compose-validate.yml
+++ b/.github/workflows/compose-validate.yml
@@ -58,6 +58,21 @@ jobs:
       - name: Validate compose config
         working-directory: compose
         run: docker compose -f docker-compose.prod.yml --env-file .env config --quiet
+      - name: Tiered-rollout service lists ⊆ compose services (deploy#434)
+        # gated_services + deferred_services (the deploy#429 tier inputs on
+        # write-deploy-env in deploy-prod.yml) must each name a REAL compose
+        # service. A rename/removal/typo silently drops a name from its tier —
+        # a stale gated name fails `compose up --wait` mid-rollout in prod; a
+        # stale deferred name stops excluding the pipeline from the non-gating
+        # tier. The authoritative set is `config --services` with NO --profile,
+        # the same view compose_tiered_up.sh + the deploy itself see (the four
+        # `profiles: ["pipeline"]` workers are legitimately absent). Reuses the
+        # .env materialized above so the placeholder block can't drift between
+        # two jobs.
+        working-directory: compose
+        run: |
+          docker compose -f docker-compose.prod.yml --env-file .env config --services \
+            | python3 ../scripts/check_service_tier_subset.py
 
   shellcheck:
     # deploy#74: backup/restore are critical DR scripts only exercised in

--- a/scripts/check_service_tier_subset.py
+++ b/scripts/check_service_tier_subset.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Drift guard for the prod tiered-rollout service lists (deploy#434).
+
+The prod deploy brings the stack up in tiers (deploy#429): ``write-deploy-env``
+takes two space-separated inputs — ``gated_services`` (tier 1, health-gated
+``up --wait``) and ``deferred_services`` (tier 3, the Kafka pipeline, brought up
+NON-gating). ``scripts/compose_tiered_up.sh`` partitions the stack against the
+runtime ``docker compose config --services`` output using exactly these names.
+
+Nothing today checks that every name in those two lists is a REAL compose
+service. A service renamed or removed in ``compose/docker-compose.prod.yml``
+(or a plain typo in the workflow input) would silently drop out of its tier:
+a stale ``deferred_services`` entry stops excluding anything from tier 2, and a
+stale ``gated_services`` entry makes ``compose up --wait`` fail mid-rollout in
+prod — exactly the edge-outage failure mode deploy#429 set out to prevent.
+
+This gate mirrors compose-validate.yml's passlist-drift check: it reads the
+authoritative service set from ``docker compose config --services`` (fed on
+stdin so the check stays hermetic + unit-testable) and asserts
+
+    gated_services ∪ deferred_services  ⊆  compose config --services
+
+for every deploy workflow that sets the inputs. The service list is taken with
+NO ``--profile`` — the same view ``compose_tiered_up.sh`` and the deploy itself
+see, so the four ``profiles: ["pipeline"]`` workers are legitimately absent and
+must never appear in a tier list.
+
+Exit 0 if every tiered name resolves to a real service; exit 1 with a per-name
+diagnostic otherwise.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import IO
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Deploy workflows that may set the tiered-rollout inputs. stg leaves them empty
+# (legacy single-`up`); prod sets both. Listed explicitly — same shape as
+# compose-validate.yml's passlist-drift, which names deploy-{stg,prod}.yml.
+DEPLOY_WORKFLOWS = (
+    ".github/workflows/deploy-stg.yml",
+    ".github/workflows/deploy-prod.yml",
+)
+
+# The composite whose `with:` carries the tier inputs.
+WRITE_DEPLOY_ENV = "write-deploy-env"
+TIER_INPUTS = ("gated_services", "deferred_services")
+
+
+def read_services(stream: IO[str]) -> set[str]:
+    """Parse newline-separated `docker compose config --services` output."""
+    return {line.strip() for line in stream if line.strip()}
+
+
+def tier_lists(workflow_path: Path) -> dict[str, set[str]]:
+    """Map each tier input → its service-name set for one deploy workflow.
+
+    Walks every step that `uses:` the write-deploy-env composite and unions the
+    space-separated `with.{gated,deferred}_services` values. A workflow that
+    never sets an input (stg) yields empty sets for it.
+    """
+    doc = yaml.safe_load(workflow_path.read_text())
+    tiers: dict[str, set[str]] = {name: set() for name in TIER_INPUTS}
+    for job in (doc.get("jobs") or {}).values():
+        for step in job.get("steps", []) or []:
+            if WRITE_DEPLOY_ENV not in str(step.get("uses", "")):
+                continue
+            with_block = step.get("with") or {}
+            for name in TIER_INPUTS:
+                raw = with_block.get(name)
+                if raw:
+                    tiers[name].update(str(raw).split())
+    return tiers
+
+
+def find_drift(services: set[str], tiers: dict[str, set[str]]) -> dict[str, set[str]]:
+    """Return {input_name: names not in `services`} for any non-empty drift."""
+    return {name: members - services for name, members in tiers.items() if members - services}
+
+
+def main() -> int:
+    services = read_services(sys.stdin)
+    if not services:
+        print(
+            "::error::no services on stdin — pipe "
+            "`docker compose config --services` into this gate."
+        )
+        return 1
+
+    failed = False
+    for rel in DEPLOY_WORKFLOWS:
+        path = REPO_ROOT / rel
+        if not path.is_file():
+            print(f"::error file={rel}::deploy workflow not found.")
+            failed = True
+            continue
+        tiers = tier_lists(path)
+        drift = find_drift(services, tiers)
+        if drift:
+            failed = True
+            for name, unknown in sorted(drift.items()):
+                print(
+                    f"::error file={rel}::{name} names services not in "
+                    f"`docker compose config --services`: {sorted(unknown)}"
+                )
+            print(
+                "  A tiered-rollout name must be a real compose service. A "
+                "renamed/removed/typo'd entry silently drops out of its tier "
+                "(deploy#429): a stale deferred name stops excluding anything "
+                "from the non-gating tier; a stale gated name fails "
+                "`compose up --wait` mid-rollout in prod."
+            )
+        else:
+            tallied = sum(len(m) for m in tiers.values())
+            print(f"OK {rel}: {tallied} tiered service name(s) all resolve.")
+
+    if failed:
+        return 1
+    print(f"Service-tier drift check: OK ({len(services)} compose services).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_service_tier_subset.py
+++ b/scripts/tests/test_check_service_tier_subset.py
@@ -1,0 +1,116 @@
+"""Unit tests for scripts/check_service_tier_subset.py (deploy#434).
+
+The gate asserts that every name in the prod tiered-rollout inputs
+(``gated_services`` + ``deferred_services``, set on the write-deploy-env
+composite in deploy-prod.yml) is a real compose service — i.e. a subset of
+``docker compose config --services``. A renamed/removed/typo'd entry silently
+drops out of its tier (deploy#429), so we test:
+
+  * the pure subset logic (``find_drift``) catches missing names and passes a
+    clean superset,
+  * the workflow parser (``tier_lists``) reads the real deploy-{stg,prod}.yml —
+    prod sets both inputs, stg leaves them empty,
+  * an end-to-end run against the REAL workflows passes when fed a service list
+    that includes every tiered name, and fails (exit 1) when one is dropped —
+    feeding the list on stdin so no Docker daemon is needed.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from io import StringIO
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import check_service_tier_subset as gate  # noqa: E402
+
+# Real prod tiered-rollout names (deploy-prod.yml). Kept here so a future rename
+# of either the compose service OR the workflow input trips a test, not just CI.
+PROD_GATED = {"caddy", "frontend", "landing", "api", "user-service"}
+PROD_DEFERRED = {"kafka", "kafka-init", "kafka-ui", "kafka-exporter"}
+
+# A `docker compose config --services` view (no --profile) that is a superset of
+# every tiered name — the four pipeline workers are correctly absent.
+FULL_SERVICES = (
+    PROD_GATED
+    | PROD_DEFERRED
+    | {
+        "neo4j",
+        "postgres",
+        "redis",
+        "user-postgres",
+        "user-redis",
+        "user-service-migrate",
+        "prometheus",
+        "grafana",
+    }
+)
+
+
+def test_read_services_strips_and_skips_blanks() -> None:
+    parsed = gate.read_services(StringIO("api\n caddy \n\n\nkafka\n"))
+    assert parsed == {"api", "caddy", "kafka"}
+
+
+def test_find_drift_clean_when_subset() -> None:
+    tiers = {"gated_services": PROD_GATED, "deferred_services": PROD_DEFERRED}
+    assert gate.find_drift(FULL_SERVICES, tiers) == {}
+
+
+def test_find_drift_reports_only_unknown_names() -> None:
+    tiers = {
+        "gated_services": {"api", "caddi"},  # typo: caddi vs caddy
+        "deferred_services": {"kafka", "kafka-broker"},  # renamed-away
+    }
+    drift = gate.find_drift(FULL_SERVICES, tiers)
+    assert drift == {
+        "gated_services": {"caddi"},
+        "deferred_services": {"kafka-broker"},
+    }
+
+
+def test_tier_lists_reads_real_prod_workflow() -> None:
+    tiers = gate.tier_lists(gate.REPO_ROOT / ".github/workflows/deploy-prod.yml")
+    assert tiers["gated_services"] == PROD_GATED
+    assert tiers["deferred_services"] == PROD_DEFERRED
+
+
+def test_tier_lists_stg_leaves_inputs_empty() -> None:
+    tiers = gate.tier_lists(gate.REPO_ROOT / ".github/workflows/deploy-stg.yml")
+    assert tiers["gated_services"] == set()
+    assert tiers["deferred_services"] == set()
+
+
+def _run(services: set[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(gate.REPO_ROOT / "scripts/check_service_tier_subset.py")],
+        input="\n".join(sorted(services)) + "\n",
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_main_passes_against_real_workflows_with_full_stack() -> None:
+    result = _run(FULL_SERVICES)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Service-tier drift check: OK" in result.stdout
+
+
+def test_main_fails_when_a_gated_service_is_missing() -> None:
+    result = _run(FULL_SERVICES - {"caddy"})
+    assert result.returncode == 1
+    assert "gated_services" in result.stdout
+    assert "caddy" in result.stdout
+
+
+def test_main_fails_on_empty_stdin() -> None:
+    result = subprocess.run(
+        [sys.executable, str(gate.REPO_ROOT / "scripts/check_service_tier_subset.py")],
+        input="",
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "no services on stdin" in result.stdout


### PR DESCRIPTION
## What

Adds a CI gate asserting **`gated_services ∪ deferred_services ⊆ docker compose config --services`** — closes #434 (Weronika's PR #433 review note 1).

The prod tiered rollout (deploy#429) drives bring-up from two `write-deploy-env` inputs set in `deploy-prod.yml`:
- `gated_services` (tier 1, health-gated `up --wait`)
- `deferred_services` (tier 3, the Kafka pipeline, non-gating)

`scripts/compose_tiered_up.sh` partitions the stack against the runtime `docker compose config --services` output using exactly these names, but nothing checked that every name is a **real** compose service. A rename/removal/typo silently drops a name from its tier:
- a stale **gated** name fails `compose up --wait` mid-rollout in prod — the edge-outage deploy#429 set out to prevent;
- a stale **deferred** name stops excluding the pipeline from the non-gating tier.

## How

- **`scripts/check_service_tier_subset.py`** — reads the authoritative service set from `docker compose config --services` on **stdin** (hermetic + unit-testable), parses the tier inputs from `deploy-{stg,prod}.yml` via PyYAML, and asserts the subset for every workflow that sets them. Modeled on `check_tf_apply_locking.py` (the existing yaml-parsing gate) and sits beside the `passlist-drift` check it mirrors.
- **No `--profile`** — same view `compose_tiered_up.sh` + the deploy itself see, so the four `profiles: ["pipeline"]` workers are legitimately absent and correctly may not appear in a tier list. (Verified: `config --services` without a profile excludes the workers; with `--profile pipeline` includes them.)
- Wired as a **step in `compose-validate.yml`'s `compose-config` job**, reusing its already-materialized `.env` so the placeholder block can't drift between two jobs.
- **`scripts/tests/test_check_service_tier_subset.py`** — covers the subset logic, the real-workflow parser (prod sets both, stg empty), and end-to-end pass/fail. Auto-covered by the existing `scripts-pytest` CI job + `pytest-scripts` pre-push hook.

## Verification (local)

- `docker compose config --services | check_service_tier_subset.py` → exit 0, all 9 prod tier names resolve against 25 services.
- Negative (drop `kafka` from the service list) → exit 1 with a precise `::error::` naming `kafka` under `deferred_services`.
- ruff format/lint, mypy, pytest (8 new tests pass), actionlint, gitleaks — all green.
- Sync-drift gate: `OK: pre-commit config mirrors all CI-enforced checks`.

Closes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)
