### PR TITLE
feat(observability): alert on corpus_reembed_last_run_* (failed + stale) (#467)

### DIFF
--- a/docs/runbooks/corpus-reembedding.md
+++ b/docs/runbooks/corpus-reembedding.md
@@ -76,6 +76,23 @@ corpus_reembed_rows_embedded{env="...",model="..."}               <n | -1 if unp
 
 `node-exporter` mounts the textfile directory read-only and scrapes it. If the directory is missing/unwritable, metric emission is skipped with a `WARNING` (the run itself is unaffected) — recover the directory per `docs/runbooks/user-service-alembic.md#observability`.
 
+A small Grafana dashboard renders these gauges per env: **Corpus re-embed** (`infra/grafana/dashboards/corpus-reembed.json`, uid `corpus-reembed`) — last-run status, time-since-last-run (with a 30-day amber/red threshold matching `CorpusReembedStale`), rows embedded, and run duration.
+
+### Alerts
+
+Two Prometheus alerts (`infra/prometheus/alerts.yml`, group `corpus_reembed`, deploy#467) fire on the gauges above and route through Alertmanager → Slack at **warning** severity (see [alertmanager-slack-routing.md](alertmanager-slack-routing.md)). Neither is a prod outage: semantic search stays up, it may just return degraded/lexical results.
+
+| Alert | Fires when | What it catches |
+|---|---|---|
+| `CorpusReembedFailed` | `corpus_reembed_last_run_success == 0` per `env`,`model` (`for: 0m`) | The last real run's embed, reindex, or `verify-recall` gate returned non-zero. The corpus is untrustworthy until a clean re-run. |
+| `CorpusReembedStale` | `time() - corpus_reembed_last_run_timestamp_seconds > 30d` (`for: 1h`) | Either a real run was killed at the `command_timeout` (90m) / job (120m) ceiling **before** the `if: always` `.prom` write — so the timestamp never advanced (the failed Actions run is the immediate signal; this is the metric-layer backstop) — or the corpus has drifted embedding-stale (data grew, never re-embedded). |
+
+**Staleness threshold rationale.** `reembed-corpus.yml` is `workflow_dispatch`-only — there is **no cron cadence**, so 30 days is not cadence-derived; it is an embedding-freshness SLO. It is long enough that a deliberately-stable corpus does not nag, and short enough to bound undetected drift or a silently-killed run. It is tunable — raise it if re-embeds become rare-by-design post-launch. The timestamp series is absent until the first real run, so the alert never fires on a corpus that has simply never been embedded.
+
+**On `CorpusReembedFailed`:** diagnose per § Failure modes and recovery, then re-dispatch with `dry_run=false` — embed + reindex are idempotent, so a clean re-run overwrites a partial one and replaces the `_success=0` gauge.
+
+**On `CorpusReembedStale`:** check the most recent `reembed-corpus.yml` run in the Actions UI first. A red run that died at the timeout ceiling explains the stale gauge (forward fix: re-dispatch); a clean run history means the corpus is simply due for a refresh.
+
 ## Failure modes and recovery
 
 ### 1. `verify-recall` fails after the embed

--- a/infra/grafana/dashboards/corpus-reembed.json
+++ b/infra/grafana/dashboards/corpus-reembed.json
@@ -1,0 +1,144 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "uid": "corpus-reembed",
+  "title": "Corpus re-embed",
+  "tags": ["observability", "isnad-graph", "reembed"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "5m",
+  "time": { "from": "now-90d", "to": "now" },
+  "links": [],
+  "panels": [
+    {
+      "title": "Last re-embed status",
+      "type": "stat",
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "corpus_reembed_last_run_success",
+          "legendFormat": "{{env}} / {{model}}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "FAILED", "color": "red" }, "1": { "text": "OK", "color": "green" } } }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "value_and_name",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      }
+    },
+    {
+      "title": "Time since last re-embed",
+      "type": "stat",
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 0 },
+      "targets": [
+        {
+          "expr": "time() - corpus_reembed_last_run_timestamp_seconds",
+          "legendFormat": "{{env}}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 2160000 },
+              { "color": "red", "value": 2592000 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "value_and_name",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      }
+    },
+    {
+      "title": "Rows embedded (last run)",
+      "type": "stat",
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 0 },
+      "targets": [
+        {
+          "expr": "corpus_reembed_rows_embedded",
+          "legendFormat": "{{env}} / {{model}}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "mappings": [
+            { "type": "value", "options": { "-1": { "text": "unparsed", "color": "text" } } }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "textMode": "value_and_name",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      }
+    },
+    {
+      "title": "Re-embed run duration",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 6 },
+      "targets": [
+        {
+          "expr": "corpus_reembed_last_run_duration_seconds",
+          "legendFormat": "{{env}} / {{model}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "fillOpacity": 15,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    }
+  ]
+}

--- a/infra/prometheus/alerts.yml
+++ b/infra/prometheus/alerts.yml
@@ -184,6 +184,98 @@ groups:
             production` runs before assuming the gate itself is at fault.
           runbook: "docs/runbooks/user-service-alembic.md#observability"
 
+  # Corpus re-embed observability (deploy#467). reembed-corpus.yml emits
+  # textfile-collector gauges on every REAL run (skipped on dry_run):
+  #   corpus_reembed_last_run_success{env,model}            <0|1>
+  #   corpus_reembed_last_run_timestamp_seconds{env,model}  <unix-ts>
+  #   corpus_reembed_last_run_duration_seconds{env,model}   <seconds>
+  #   corpus_reembed_rows_embedded{env,model}               <n | -1 unparsed>
+  # at /var/lib/node_exporter/textfile_collector/corpus_reembed.prom (atomic
+  # temp+rename, mode 0644 — same discipline as db-migrate.yml). The file is
+  # fully rewritten each run, so there is exactly one (env,model) series per env
+  # (the last run's model) — no stale per-model series accumulate.
+  #
+  # Two failure modes were silent before this group:
+  #
+  #   - App-level failure: embed / reindex / verify-recall returned non-zero,
+  #     the workflow correctly wrote _success=0, but nothing paged.
+  #     -> CorpusReembedFailed.
+  #
+  #   - Hard timeout-kill: appleboy/ssh-action's command_timeout (90m) or the
+  #     job timeout-minutes (120m) ceiling (deploy#465) aborts the SSH command
+  #     BEFORE the `if: always` .prom write, so NO fresh metric is emitted at
+  #     all — _success is NOT updated to 0; the prior run's gauges simply go
+  #     stale. A bare _success==0 rule cannot see this; only a staleness rule on
+  #     the timestamp catches it. -> CorpusReembedStale.
+  #
+  # Both route through Alertmanager `default` -> Slack (warning severity; see
+  # docs/runbooks/alertmanager-slack-routing.md). Neither is a prod OUTAGE —
+  # semantic search stays up, it may just return degraded/lexical results — so
+  # warning (default receiver), not critical.
+  - name: corpus_reembed
+    rules:
+      - alert: CorpusReembedFailed
+        # Bare equality on _success, for: 0m — same reasoning as
+        # UserServiceAlembicGateFailure above: every failed run is
+        # operator-actionable, and a stuck _success=0 must not be silenced by a
+        # freshness window (the corpus stays untrustworthy until a clean re-run
+        # replaces the gauge). embed + reindex are idempotent, so the forward
+        # fix is a re-dispatch with dry_run=false (see runbook).
+        expr: |
+          corpus_reembed_last_run_success == 0
+        for: 0m
+        labels:
+          severity: warning
+          service: isnad-graph
+        annotations:
+          summary: "Corpus re-embed FAILED in {{ $labels.env }} (model {{ $labels.model }})"
+          description: >-
+            The most recent corpus re-embed in {{ $labels.env }} reported
+            _success=0 — embed, reindex, or the verify-recall gate did not pass.
+            Semantic search for that corpus may return degraded/lexical results
+            until a clean re-run. embed + reindex are idempotent; re-dispatch
+            reembed-corpus.yml with dry_run=false after diagnosing.
+          runbook: "docs/runbooks/corpus-reembedding.md#alerts"
+
+      - alert: CorpusReembedStale
+        # reembed-corpus.yml is workflow_dispatch ONLY — there is NO cron
+        # cadence, so this threshold is NOT cadence-derived; it is an
+        # embedding-freshness SLO: a corpus whose embeddings are older than
+        # 30 days warrants a human glance, for either reason below.
+        #
+        #   (1) Timeout-kill backstop: a real run aborted at the command_timeout
+        #       (90m) / job (120m) ceiling never reaches the `if: always` .prom
+        #       write, so the timestamp gauge does not advance. The failed
+        #       workflow RUN (appleboy returns non-zero) is the immediate
+        #       signal; this is the slower metric-layer catch for a killed run
+        #       nobody re-ran.
+        #   (2) Embedding drift: the corpus grew (new ingestion) but was never
+        #       re-embedded, so search quality silently lags the data.
+        #
+        # 30 days balances nag-avoidance (a deliberately-stable corpus must not
+        # page) against bounding undetected drift / silent-failure. Tunable —
+        # raise it if re-embeds become rare-by-design post-launch. The series is
+        # absent until the first real run, so this never fires on a corpus that
+        # has simply never been embedded (empty set, like the alembic Stale
+        # rule). warning + for: 1h to ride out a node-exporter / Prometheus
+        # restart on this slow-moving comparison.
+        expr: |
+          (time() - corpus_reembed_last_run_timestamp_seconds) > 30 * 86400
+        for: 1h
+        labels:
+          severity: warning
+          service: isnad-graph
+        annotations:
+          summary: "Corpus re-embed in {{ $labels.env }} is stale (>30d, model {{ $labels.model }})"
+          description: >-
+            The last corpus re-embed in {{ $labels.env }} completed more than
+            30 days ago, or a dispatched run was killed at the timeout ceiling
+            before emitting a fresh metric. Confirm whether a re-embed is due
+            (corpus growth / model swap) or whether the most recent
+            reembed-corpus.yml run died — check the latest run in the Actions UI
+            before assuming drift.
+          runbook: "docs/runbooks/corpus-reembedding.md#alerts"
+
   - name: blackbox_probes
     rules:
       # Any of the 6 prod-route probes failing for >2m. Companion to the


### PR DESCRIPTION
## What

`reembed-corpus.yml` emits `corpus_reembed_last_run_*` textfile-collector gauges on every real run, but `infra/prometheus/alerts.yml` had **no rule keyed on them** — the signal landed in node-exporter and was never alerted on (deploy#467). This adds a `corpus_reembed` rule group (modelled on the sibling `db_migrate` group), a Grafana dashboard, and a runbook Alerts section.

## Alerts (`infra/prometheus/alerts.yml`, group `corpus_reembed`)

| Alert | Expr | `for` | Severity |
|---|---|---|---|
| `CorpusReembedFailed` | `corpus_reembed_last_run_success == 0` (per `env`,`model`) | `0m` | warning |
| `CorpusReembedStale` | `time() - corpus_reembed_last_run_timestamp_seconds > 30 * 86400` | `1h` | warning |

- **`CorpusReembedFailed`** — app-level failure (embed / reindex / `verify-recall` non-zero, workflow wrote `_success=0`). Bare equality with no freshness filter, `for: 0m` — same reasoning as `UserServiceAlembicGateFailure`: a stuck `_success=0` must not be silenced by a dedup window; the corpus stays untrustworthy until a clean re-run.
- **`CorpusReembedStale`** — catches the **timeout-kill failure mode**: appleboy/ssh-action's `command_timeout` (90m) / job `timeout-minutes` (120m) ceiling (deploy#465) aborts the SSH command **before** the `if: always` `.prom` write, so **no fresh metric is emitted** and the prior gauge goes stale (`_success` is never set to 0, so a bare `==0` rule cannot see it). Also catches embedding drift (corpus grew, never re-embedded).

## Staleness threshold rationale (30 days)

`reembed-corpus.yml` is **`workflow_dispatch`-only — there is no cron cadence**, so the threshold is *not* cadence-derived. 30 days is an embedding-freshness SLO: long enough that a deliberately-stable corpus does not nag, short enough to bound undetected drift / a silently-killed run. The failed Actions run (appleboy returns non-zero) is the *immediate* timeout signal; this staleness rule is the slower **metric-layer backstop** for a killed run nobody re-ran. The timestamp series is absent until the first real run, so the alert never fires on a never-embedded corpus (empty set, like the alembic Stale rule). Tunable — raise it if re-embeds become rare-by-design post-launch.

## Routing

Both warning severity → Alertmanager `default` receiver → Slack (`docs/runbooks/alertmanager-slack-routing.md`). Neither is a prod outage — semantic search stays up, it may just return degraded/lexical results — so `warning` (default receiver, less-frequent repeat), not `critical`. `service: isnad-graph` label added for future routing/inhibit rules (mirrors the alembic alerts' `service:` label).

## Grafana panel

Added `infra/grafana/dashboards/corpus-reembed.json` (uid `corpus-reembed`), auto-provisioned from the version-controlled dashboards dir: last-run status (OK/FAILED), time-since-last-run (amber@25d / red@30d, matching `CorpusReembedStale`), rows embedded (`-1` → "unparsed"), and run duration.

## Validation

- `promtool check rules infra/prometheus/alerts.yml` → **SUCCESS: 22 rules** (prom/prometheus:v3.4.0, same image CI's `promtool-check` job uses)
- markdownlint-cli2: 0 errors · cspell: 0 issues · sync-drift gate: OK · JSON/YAML parse: OK

Closes #467
