### PR TITLE
fix(promote): pass --repo to gh workflow run in Trigger prod VPS rollout (no checkout in job)

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1003,7 +1003,14 @@ jobs:
           echo "  user-service: ${user_service_tag:-<unset — will fall back to prod-latest>}"
           echo "  landing:      ${landing_tag:-<unset — will fall back to prod-latest>}"
 
+          # This job has NO actions/checkout step, so `gh` has no git remote to
+          # infer the target repo from and aborts with
+          # "failed to run git: fatal: not a git repository" — silently skipping
+          # the prod rollout after the retag gate was approved (promote run
+          # 27734863228). Pass --repo explicitly so the dispatch never depends on
+          # a checkout. Keep this flag on any gh call added to a checkout-less job.
           gh workflow run deploy-prod.yml \
+            --repo "${{ github.repository }}" \
             --ref "${{ github.ref }}" \
             -f api_frontend_tag="$api_frontend_tag" \
             -f user_service_tag="$user_service_tag" \


### PR DESCRIPTION
## What

Add `--repo "${{ github.repository }}"` to the `gh workflow run deploy-prod.yml` call in the `trigger-prod-deploy` job ("Trigger prod VPS rollout") of `promote.yml`, plus a comment explaining why.

## Root cause

That job has **no `actions/checkout` step**, so `gh` had no git remote to resolve the target repo from and aborted with:

```
failed to run git: fatal: not a git repository
```

After the owner approved the prod retag gate, the `deploy-prod.yml` dispatch silently failed and prod was never rolled out.

## Evidence

Promote run **27734863228** failed exactly here — all per-service retags succeeded, only the final dispatch step died with `not a git repository`. P5W5 prod-cutover blocker.

## Scope / sweep

Swept the whole workflow for other checkout-less jobs that shell out to `gh`. Only `trigger-prod-deploy` qualifies — the three `gh api` calls live in `gate-stg-verify`, which already has `actions/checkout@v6`. So this is the complete fix for the class, not just the one line. The comment tells future editors to keep `--repo` on any gh call added to a checkout-less job.

## Verification

- `actionlint .github/workflows/promote.yml` — clean (with shellcheck on PATH)
- `pre-commit run --files .github/workflows/promote.yml` — gitleaks + actionlint Passed
- `pre_commit_ci_sync.py .` — config mirrors all CI-enforced checks

Closes #475
