### PR TITLE
docs(README): document required pre-commit + pre-push hook install (#477)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# noorinalabs-deploy
+
+Deployment orchestration — Terraform, Docker Compose, GitHub Actions workflows.
+
+This repo owns everything that runs on the production server: VPS provisioning
+(`terraform/`), the production stack (`compose/`), the reverse proxy (`caddy/`),
+the observability stack (`infra/`), backup units (`systemd/`), operational
+scripts (`scripts/`), and the deploy/verify workflows (`.github/workflows/`).
+Service repos own what they build; this repo owns what runs on the server. See
+[`CLAUDE.md`](CLAUDE.md) for the full architecture and deployment flow.
+
+## Git hooks (required)
+
+This repo mirrors its CI checks locally via [pre-commit](https://pre-commit.com/).
+After cloning, install BOTH hook stages once:
+
+```bash
+pre-commit install                       # commit-stage checks
+pre-commit install --hook-type pre-push  # push-stage checks
+```
+
+- **Commit stage** runs: `terraform-fmt`, `terraform-validate`, `gitleaks`,
+  `actionlint`, `ruff-format`, `ruff-lint`, and `env-example-check`.
+- **Pre-push stage** runs: `mypy` (over `scripts/`, `.github/workflows/scripts/`,
+  and `.claude/hooks/` when present), `pytest` for the sync-gate unit tests
+  (`.claude/lib/tests/`), and `pytest` for the scripts tests (`scripts/tests/`).
+
+These mirror the repo's CI workflows (`terraform.yml`, `lint-workflows.yml` /
+`docs.yml`, `hooks-lint.yml`, `compose-validate.yml`, `precommit-ci-sync.yml`) so
+failures surface locally before a PR — running BOTH installs is mandatory under
+the org-wide local⇄CI parity rule (noorinalabs-main#684). The
+`Pre-commit ⇄ CI sync-drift gate` (`.claude/lib/pre_commit_ci_sync.py`) fails the
+build if a check CI enforces is dropped from this mirror.
+
+Never bypass a hook with `--no-verify`, and never push, PR, or merge with a
+known-failing check without explicit owner permission. If `pre-commit install`
+"cowardly refuses" because `core.hooksPath` is set (some clones inherited a stale
+path from a repo rename), unset it first so hooks resolve to this repo's own
+`.git/hooks`:
+
+```bash
+git config --unset core.hooksPath
+```


### PR DESCRIPTION
## Summary

Adds this repo's first `README.md`: project title, one-line description
("Deployment orchestration — Terraform, Docker Compose, GitHub Actions
workflows"), a short "what's here" pointer to the directory layout, and a
**"Git hooks (required)"** section documenting the mandatory one-time install of
BOTH pre-commit hook stages so a fresh clone does not silently run zero checks
before CI.

The hooks section is anchored on this repo's actual config (read at HEAD):

- **Commit stage:** `terraform-fmt`, `terraform-validate`, `gitleaks`,
  `actionlint`, `ruff-format`, `ruff-lint`, `env-example-check`.
- **Pre-push stage:** `mypy`, sync-gate `pytest` (`.claude/lib/tests/`), and
  scripts `pytest` (`scripts/tests/`).

It references the CI workflows these mirror (`terraform.yml`,
`lint-workflows.yml` / `docs.yml`, `hooks-lint.yml`, `compose-validate.yml`,
`precommit-ci-sync.yml`) and the sync-drift gate, states the org-wide local⇄CI
parity rule (noorinalabs-main#684), the no-`--no-verify` stance, and the
`core.hooksPath` unset workaround for clones that inherited a stale path.

Note: this repo has **no single `ci.yml`** — its CI is split across the
workflow files above, so the README references them rather than a nonexistent
file.

## Verification

- `pre-commit run --files README.md` (commit stage) — pass
- `pre-commit run --hook-stage pre-push --all-files` — all pass
- `markdownlint-cli2` — 0 errors (root README covered by docs.yml `**/*.md`)
- Only relative link is `CLAUDE.md` (exists); external URL excluded by `.lychee.toml`

Closes #477
Part of cross-repo meta noorinalabs-main#718.

Needs 2 reviewers per charter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011VLZ8rFDwEBDqWJRK8ebzM
