### PR TITLE
chore(memory): seed in-repo .claude/memory — 10 deploy-specific memories (deploy#479, from main#740)

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,0 +1,22 @@
+# Project Memory — noorinalabs-deploy
+
+In-repo, version-controlled memory index for the deployment-orchestration repo. One
+line per memory; the topic files (`.claude/memory/*.md`) are read on demand when a
+line looks relevant. Seeded from `noorinalabs-main` in the org/repo memory split
+(deploy#479, from main#740 / driver main#732) — these are the deploy-specific
+memories that previously lived in the org-level corpus.
+
+Some bodies carry `[[wikilinks]]` to org-level memories that stay in
+`noorinalabs-main`; those are soft cross-repo pointers and may dangle here (this
+repo imports only its own `.claude/memory/`).
+
+- [Compose env change rollback safety](feedback_compose_env_change_rollback_safety.md) — compose config migration MUST keep old env form; rollback.yml rewrites only image tag. deploy#403.
+- [compose up --wait: non-app service aborts rollout](feedback_compose_up_wait_non_app_abort.md) — prod compose up --wait health-gates WHOLE stack; unhealthy kafka → 521; tier the rollout.
+- [db-migrate gate EXPECTED_MERGE_HEAD drift](feedback_db_migrate_gate_expected_head_drift.md) — gate fails on any compose PR when pin lags us stg-latest alembic head; pre-existing. PR#409.
+- [stg deploy per-service tag routing](feedback_stg_deploy_per_service_tag_routing.md) — deploy-stg must route dispatch sha to ONLY that service's tag; shared IMAGE_TAG → wrong image. deploy#418.
+- [CF plan doesn't validate expr; close-on-verified-live](feedback_cf_ruleset_apply_validation.md) — ruleset exprs validate at APPLY not plan; close after live-verify.
+- [Ruleset empty required_status_checks 422](feedback_ruleset_empty_checks_422.md) — rulesets API 422s on empty checks; path-filtered-CI repos must OMIT the rule. #322.
+- [Grafana forward_auth credential-carry](project_grafana_forward_auth.md) — SSO 3-repo; /grafana carries no credential (token localStorage-only). deploy#460.
+- [Promote gate stg-verify refresh](project_promote_gate_stg_verify_refresh.md) — promote.yml v2 honors only workflow_run-triggered verify; refresh via deploy-stg. deploy#423.
+- [Streaming E2E prereqs](project_streaming_e2e_prereqs.md) — Kafka pipeline E2E on stg deferred past P4W6 (#601 met via batch); dispatch-needs-main. deploy#443.
+- [Staging Neo4j/frontend unreachable from sandbox](project_staging_unreachable_from_sandbox.md) — bolt/frontend resolve only in-cluster; ssh stg → cypher-shell or -L tunnel. da#73.

--- a/.claude/memory/feedback_cf_ruleset_apply_validation.md
+++ b/.claude/memory/feedback_cf_ruleset_apply_validation.md
@@ -1,0 +1,20 @@
+---
+name: feedback_cf_ruleset_apply_validation
+description: Cloudflare ruleset expressions validate at apply-time not plan-time; and close prod-apply-gated issues on verified-live not on merge
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 255c7ede-88bb-41ac-864c-67035ac0d582
+---
+
+Two coupled lessons from deploy#348 (P3W11 CF canonical-redirect import, 2026-05-24):
+
+**1. A clean `terraform plan` does NOT validate Cloudflare ruleset expressions.** CF validates `target_url` / filter (wirefilter) expressions only at APPLY time, via the API. So plan-green + two-reviewer-green can still fail at apply. deploy#349's plan was clean (`2 import, 0 add, 2 change, 0 destroy`) but apply failed: the `target_url` used `if()`/`len()` (unsupported in CF's redirect expression language — "unknown identifier"). That expression came from the original #166 code and had never been API-validated because every prior apply died earlier at the "ruleset already exists" stage. Fix was `concat("https://noorinalabs.com", http.request.uri)` (`http.request.uri` = path+query together; no conditional needed).
+
+**Why:** plan only checks TF-side schema/graph, not provider-API semantic validity of expression strings. **How to apply:** for CF ruleset / expression changes, treat APPLY as the validation gate — don't claim "verified" on a clean plan; sanity-check expressions against CF Rules-language docs (supported functions/fields) before apply; expect that the first real apply is where expression bugs surface. Sibling to [[feedback_runtime_gate_scoping]].
+
+**2. For issues whose acceptance is a runtime/apply-time outcome (prod apply succeeds + live behavior), use `Refs #N` on the PR, NOT `Closes #N`; close the issue manually only after the live verification.** deploy#349 merged with "Closes #348" → #348 auto-closed on merge — but the apply then failed, leaving it closed-but-not-done. Had to reopen. The fix PR #350 used "Refs #348" and #348 was closed only after `curl` confirmed live 301s.
+
+**Why:** `Closes #N` fires on default-branch merge, which is BEFORE the prod apply runs (apply is a separate, environment-gated main-push run). Merge ≠ live. **How to apply:** when an issue's real acceptance is a gated prod apply or live behavior, PR body says "Refs #N"; orchestrator closes #N after the post-merge apply + verification (e.g. curl). Extends [[feedback_wave_branch_issue_close]] (which is about wave-branch vs default-branch) to the runtime-acceptance dimension.
+
+Bonus pattern: CF phase-entrypoint rulesets are named `"default"` (fixed convention) and `name` is ForceNew — adopting an existing entrypoint via `import {}` requires `name = "default"` in config, else the plan shows destroy+recreate (`-/+`, "2 to destroy") instead of in-place update.

--- a/.claude/memory/feedback_compose_env_change_rollback_safety.md
+++ b/.claude/memory/feedback_compose_env_change_rollback_safety.md
@@ -1,0 +1,14 @@
+---
+name: feedback_compose_env_change_rollback_safety
+description: "Compose env-var changes must stay rollback-compatible — rollback.yml rewrites only the image tag against CURRENT compose, so removing an old image's env vars bricks rollback."
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 7e042acd-06d6-4813-a40c-4eac8f291ea2
+---
+
+When a compose env change switches a service from one config form to another (e.g. interpolated `DATABASE_URL`/`REDIS_URL` → discrete `DATABASE_*`/`REDIS_*` component vars, deploy#403/PR#415), do NOT remove the old form — KEEP both.
+
+**Why:** `rollback.yml` does `actions/checkout` of the CURRENT ref + `sed`-rewrites only the image-tag env var in `.env` + `docker compose up --force-recreate` against the CURRENT `compose/docker-compose.prod.yml`. It does NOT check out a historical compose. So rolling a service back to an OLD image that reads only the removed env form runs against a compose that no longer provides it → the app falls back to in-image localhost defaults → bricks the container exactly when rollback is needed. Forward deploy looks fine, masking the regression.
+
+**How to apply:** For a config-form migration in compose, ship BOTH forms keyed to the same secrets. The new image ignores the old form when the new trigger is set (e.g. us#151 ignores `DATABASE_URL` when `DATABASE_HOST` is set), an old rolled-back image uses the retained form. Strictly safe both directions; passlist-drift gate tolerates extra keys. Verify the rollback workflow's actual mechanism (checkout ref + what it rewrites) before claiming "no breakage window" — state it for forward AND rollback. Aisha-caught, P4W1. Related: [[feedback_runtime_gate_scoping]], [[feedback_verify_diagnosis_before_delegating]].

--- a/.claude/memory/feedback_compose_up_wait_non_app_abort.md
+++ b/.claude/memory/feedback_compose_up_wait_non_app_abort.md
@@ -1,0 +1,22 @@
+---
+name: feedback_compose_up_wait_non_app_abort
+description: "Prod `docker compose up --wait` health-gates the ENTIRE stack — an unhealthy NON-app service (e.g. the kafka pipeline broker) aborts the bring-up and can leave caddy(reverse-proxy)+frontend stuck 'Created' → TOTAL edge outage (521), even when the app's own deps are healthy. Scope the prod rollout `up` to the app+edge tier; never gate the app on pipeline-tier health."
+metadata:
+  node_type: memory
+  type: feedback
+  originSessionId: 090bf6d5-0d19-47c9-9b85-67bfff1c5396
+---
+
+P4W3, first real **v2** prod ship (deploy#420 login fix, 2026-06-12). Approving the promote → retag → deploy-prod chain caused a **full prod outage** — not from the app change, but from deploy-path fragility. Three distinct gaps surfaced, all filed (deploy#427/#428/#429):
+
+1. **#429 — `compose up --wait` aborts the whole bring-up on ANY unhealthy service.** deploy-prod runs `docker compose up --wait` over the FULL stack. Kafka (the ingestion broker) crash-looped, so `--wait` aborted the dependency-ordered bring-up *before* it reached caddy + frontend (later in the graph) → both stuck in **`Created`**. api came up healthy on the new tag, but **caddy (reverse proxy) never started → all public endpoints 521 (Cloudflare origin-unreachable) → total outage.** The app's own deps (neo4j/postgres/redis) were all healthy and the new image was correct — the app was hostage to an unrelated pipeline broker's health. **Fix: scope the prod `up` to the app+edge tier (api/frontend/caddy + their real deps); bring up the pipeline tier non-gating (exclude from the `--wait` set).** Recovery was a targeted `docker compose ... up -d frontend caddy` (neither depends on kafka) → ~30s, 521s cleared, fix live.
+
+2. **#428 — prod-only dirty kafka volume + preflight blind spot.** Kafka crash-looped because prod's `noorinalabs_kafka_data` volume carried a leftover bitnami-era `config/` dir at the KRaft log-dir root; apache/kafka:3.9.2 LogManager fatally rejects non-topic dirs. STG was clean (migrated onto a fresh volume in the bitnami→apache cutover #385/#100); prod kept the old layout. The #393 re-bootstrap runbook (`docs/runbooks/kafka-cluster-id-rebootstrap.md`) covers this CLASS but its `write-deploy-env` preflight only compares cluster-id, so the stray-dir variant slipped through to `compose up`. Remediation = wipe+reformat the volume (pipeline replays from B2 by design — accepted in #385/#100). **Volume wipe is pipeline-owner-gated (Bereket/Nurul) — do NOT wipe without sign-off.**
+
+3. **#427 — auto-rollout silently skipped.** `trigger-prod-deploy` in promote.yml has no explicit `if:`, so its implicit `if: success()` evaluates the **transitive** needs closure. A skipped `migrate-prod` (user-service not in an api/frontend-only promotion) made it return false → the VPS rollout job skipped silently, even though its direct needs [plan, retag] both succeeded. So the auto-rollout had effectively NEVER fired for a no-user-service promote; Aisha had to dispatch deploy-prod.yml manually. Fix: `if: ${{ always() && needs.plan.result=='success' && needs.retag.result=='success' }}` (same guard `retag` already uses).
+
+**General lessons (reusable):**
+- A monolithic `compose up --wait` couples app availability to EVERY service's health. Tier the rollout: app+edge must come up independently of pipeline/analytics/monitoring services. A broker hiccup must never down the reverse proxy.
+- GitHub Actions implicit `if: success()` is evaluated over the **transitive** needs graph, not just direct `needs`. A skipped ancestor (even one a mid-job survived via `if: always()`) silently skips no-`if:` downstream jobs. Give rollout/finalizer jobs an explicit `always() && <direct-needs>=='success'` guard.
+- Staging green ≠ prod green when the divergence is **volume/state**, not code/image: stg migrated onto a clean volume; prod inherited dirty state. State-migration parity is its own check. Companion to [[feedback_passing_repro_masks_bug]].
+- Incident discipline that worked: SSH ground-truth (`docker compose ps`) corrected an optimistic "app probably rolled fine" read (caddy=`Created` was the real outage); targeted non-destructive restore (start only the stuck app+edge containers) before any destructive infra fix; destructive kafka volume wipe held for explicit pipeline-owner authorization.

--- a/.claude/memory/feedback_db_migrate_gate_expected_head_drift.md
+++ b/.claude/memory/feedback_db_migrate_gate_expected_head_drift.md
@@ -1,0 +1,16 @@
+---
+name: feedback_db_migrate_gate_expected_head_drift
+description: "deploy db-migrate-ci-gate fails on ANY compose-touching PR when its EXPECTED_MERGE_HEAD pin lags the user-service stg-latest image's alembic head."
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 7e042acd-06d6-4813-a40c-4eac8f291ea2
+---
+
+noorinalabs-deploy's `db-migrate-ci-gate.yml` triggers on `compose/docker-compose.prod.yml` changes and pulls `ghcr.io/noorinalabs/noorinalabs-user-service:stg-latest`, then asserts the image's alembic head == `EXPECTED_MERGE_HEAD` pinned in `db-migrate.yml` (L70). When a user-service migration lands and advances `stg-latest` (e.g. 0040→0041) WITHOUT a matching deploy-repo PR bumping that pin, the gate fails `alembic_version mismatch — got '0041', expected '0040'` on EVERY subsequent compose-touching PR — even ones with zero DB relevance (e.g. caddy/alloy healthcheck edits, P4W1 deploy#402 / PR #409 2026-06-02).
+
+**Why:** the pin is a cross-repo coupling that only the deploy repo can bump, but it's invalidated by a user-service merge — classic drift where "local green" (the user-service PR) leaves a sibling red.
+
+**Tracking issue:** deploy#407 (diagnosed by Idris, fixed by Aisha in PR #411 — bump 0040→0041, +8/-5 to db-migrate.yml — folded into P4W1; merged with all 18 checks green incl. the alembic dry-run gate). I (Lucas) was second reviewer on #411 and independently confirmed 0041 is the sole user-service alembic head before approving.
+
+**How to apply:** (1) When triaging a compose PR's red `db-migrate-ci-gate`, check whether the diff actually touches migrations/db-migrate.yml; if not, it's this drift, NOT your bug — attribute it as pre-existing and surface separately. (2) The real fix is a deploy PR bumping `EXPECTED_MERGE_HEAD` in `db-migrate.yml` in lockstep with the user-service migration (the workflow comment at L67-70/L192 says exactly this). (3) Recurrence-prevention follow-up (Idris, NOT yet implemented as of PR #411): either derive the expected head from checked-out user-service source rather than a literal, OR a user-service-side CI gate that fails a migration-adding PR unless deploy's `EXPECTED_MERGE_HEAD` is bumped in lockstep (org pattern: machine-enforce cross-artifact sync, cf. pre-commit⇄CI sync-drift gate). Companion to [[feedback_cross_repo_wave_ref_resolution]] and the general "local clean must not diverge from CI/sibling" theme.

--- a/.claude/memory/feedback_ruleset_empty_checks_422.md
+++ b/.claude/memory/feedback_ruleset_empty_checks_422.md
@@ -1,0 +1,16 @@
+---
+name: feedback_ruleset_empty_checks_422
+description: "GitHub /rulesets API 422s on an empty required_status_checks array; path-filtered-CI repos must OMIT the rule, not pass []"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 7e042acd-06d6-4813-a40c-4eac8f291ea2
+---
+
+When applying a GitHub repository ruleset via `gh api repos/<repo>/rulesets -X POST --input <json>`, a `required_status_checks` rule whose `required_status_checks` array is **empty** is **rejected**: `HTTP 422 Validation Failed — Invalid parameter required_status_checks: Expected at least 1 elements, got 0`.
+
+For **path-filtered-CI repos** (CI `ci.yml` has a `paths:` filter, so gate jobs don't run on out-of-scope PRs — e.g. noorinalabs-main, noorinalabs-deploy), you cannot require any unconditional status check (it would deadlock a docs/status-only PR waiting on a check that never reports). The fix is to **OMIT the entire `required_status_checks` rule object** from the `rules` array — NOT include it with `[]`. The ruleset then enforces PR-only + no-force-push/branch-delete; per-PR merge-on-red stays with Hook 14 (`validate_pr_ci_status`).
+
+**Why:** The canonical branch-protection `ruleset-main.json` for path-filtered repos was authored with an empty-array `required_status_checks` — a delivered-but-never-applicable artifact (deploy carried 0 live rulesets, confirming it never applied). Exactly the case the W14-retro delivered-vs-applied charter rule exists to catch.
+
+**How to apply:** When applying or authoring a ruleset for a path-filtered-CI repo, drop the `required_status_checks` rule entirely. For repos with unconditional CI, keep it with live-verified job-name contexts. ALWAYS re-confirm each context against `gh api repos/<repo>/commits/<default-sha>/check-runs --jq '.check_runs[].name'` at apply time — matrix jobs expand (`ci` → `ci (20.x)`), so an exact-name context can silently never match. Read-back-verify every applied ruleset at origin (`gh api .../rulesets/<id>`). Admin always-bypass (actor_id 5) preserves the orchestrator's direct contents-API status/ontology pushes to main — prove it with a probe PUT after applying. P3W15 #322 8/8 apply, 2026-06-01.

--- a/.claude/memory/feedback_stg_deploy_per_service_tag_routing.md
+++ b/.claude/memory/feedback_stg_deploy_per_service_tag_routing.md
@@ -1,0 +1,14 @@
+---
+name: feedback_stg_deploy_per_service_tag_routing
+description: "deploy-stg must route the dispatching service's sha to ONLY that service's image tag; a single shared IMAGE_TAG breaks cross-service (user-service sha pulled the isnad frontend → not found)."
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 080813cd-f3b8-434d-974c-badf58620c96
+---
+
+`noorinalabs-deploy/.github/workflows/deploy-stg.yml` originally resolved a single `IMAGE_TAG=stg-<dispatch-sha>` from *any* `repository_dispatch`, but compose binds `IMAGE_TAG` to **both api and frontend** (isnad-graph images) while user-service/landing have their own tag vars. So a **user-service** merge (dispatch `deploy-noorinalabs-user-service`, sha e.g. `bfe16c9`) made api/frontend try to pull `stg-bfe16c9` — a tag that only exists in the *user-service* GHCR package → `frontend: not found`. Every user-service-only stg deploy failed; it only self-healed when an isnad-graph push happened to follow. Fixed in deploy#418 / PR #419 (2026-06-10).
+
+**Why:** each service has an independent commit stream and its own GHCR package. One dispatch sha is meaningful for exactly one service's images. `deploy-prod.yml` already did this right (separate `API_FRONTEND_TAG`/`USER_SERVICE_TAG`/`LANDING_TAG`, each → `*-latest` fallback); stg was the outlier.
+
+**How to apply:** when a fan-in deploy is triggered by a service dispatch, key on `github.event.action` and route the sha to ONLY that service's image tag; every other service falls back to `stg-latest` (its last-good pointer), passed via the composite's `extra_image_tags`. Add a pre-flight GHCR manifest-existence check (`docker buildx imagetools inspect` on the runner, after `docker login`) over **all** services `PULL_SERVICES` lists, before touching the VPS — a missing image then fails fast with a named `MISS` line instead of a raw daemon error mid-deploy. Monitor the dispatched run with `/watch-deploy stg <sha>` (main#623). Verify each service publishes `stg-latest` before relying on the fallback.

--- a/.claude/memory/project_grafana_forward_auth.md
+++ b/.claude/memory/project_grafana_forward_auth.md
@@ -1,0 +1,16 @@
+---
+name: project_grafana_forward_auth
+description: "deploy#458 Grafana SSO bridge is 3-repo; forward_auth has no credential to validate on a /grafana nav (token is localStorage-only)"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: b923c0f4-c87a-4bed-b4b8-91a79287509b
+---
+
+deploy#458 "admin-gated Grafana via forward_auth RBAC" is the DEPLOY slice of a 3-repo feature, not a deploy-only fix. The deploy slice (PR deploy#460, P5W4): `caddy/Caddyfile` `handle /grafana/*` → strip client X-Webauth-* → `forward_auth user-service:8000 /auth/forward-auth` → copy_headers → reverse_proxy grafana; `compose/docker-compose.prod.yml` grafana `GF_AUTH_PROXY_*` (trust X-WEBAUTH-USER, whitelist RFC1918); runbook `docs/runbooks/grafana-forward-auth-sso.md`.
+
+KEY NON-OBVIOUS FINDING: a top-level browser NAVIGATION to isnad.*/grafana/ carries NO credential forward_auth can use — the app access token lives ONLY in the SPA localStorage (sent as Authorization: Bearer on fetches), and the refresh cookie is host-only on users.* path=/auth. So `/auth/token/validate` (Bearer-only) is the WRONG endpoint. End-to-end SSO REQUIRES 2 companions: (a) user-service cookie-based `GET /auth/forward-auth`, (b) frontend change to carry a session credential to isnad.* on link-click (ig#1073 only HID the links). Carry approach (parent-domain cookie vs oauth2-proxy vs OIDC) needed OWNER SIGN-OFF (#458 flagged "security-sensitive") — RESOLVED, see OWNER DECISION block below.
+
+HARD CUTOVER: once forward_auth is live, Grafana's own login form is unreachable through Caddy → do NOT promote to stg/prod before user-service `/auth/forward-auth` ships (else /grafana 502s). Break-glass = SSH-tunnel to grafana:3000. Loki kept INTERNAL (no public /loki/* route — would expose raw Loki API); admin logs via Grafana Explore.
+
+**OWNER DECISION 2026-06-14 (resolved):** carry approach = **parent-domain session cookie** (Domain=noorinalabs.com, HttpOnly+Secure+SameSite=Lax, short TTL, RS256-signed from app bearer). Owner accepted the all-subdomain cookie-surface trade-off; rejected oauth2-proxy sidecar / user-service-OIDC alternatives. Companions filed P5W4: **user-service#171** (mint endpoint + cookie-based `GET /auth/forward-auth` → 2xx+X-Webauth-User/Role for admins, 401 no-cookie, 403 non-admin; impl Idris Yusuf, rev Anya Kowalczyk+Nadia Khoury) and **isnad-graph#1081** (frontend carry on /grafana click + re-enable ig#1073-hidden links; builds against us#171 contract). deploy#460 reviewed by Nino Kavtaradze+Weronika Zielinska; merge to wave branch OK on approval, but STILL do-not-promote until us#171 lands on target env.

--- a/.claude/memory/project_promote_gate_stg_verify_refresh.md
+++ b/.claude/memory/project_promote_gate_stg_verify_refresh.md
@@ -1,0 +1,21 @@
+---
+name: project_promote_gate_stg_verify_refresh
+description: "How to satisfy deploy promote.yml's v2 stg-verify gate before a prod promotion (workflow_run-only; refresh via deploy-stg)"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 090bf6d5-0d19-47c9-9b85-67bfff1c5396
+---
+
+deploy `promote.yml`'s Schema-v2 "Gate — stg verify-deploy success" (deploy#199) honors ONLY `workflow_run`-triggered verify-deploy runs (the ones auto-fired after a "Deploy to staging" run completes). A manual `gh workflow run verify-deploy.yml -f target=stg` (event=`workflow_dispatch`) is **deliberately ignored** by the gate — it walks runs and `continue`s on any `event != workflow_run`.
+
+So when promote is blocked because the latest qualifying stg-verify artifact is stale or its digests diverge from current `stg-latest`, the refresh is:
+1. `gh workflow run deploy-stg.yml --ref main -f image_tag=stg-<short>` (redeploy current stg-latest to stg; idempotent).
+2. That completion auto-fires a `workflow_run` verify-deploy that snapshots the **current** stg-latest per-service digests into a fresh `stg-verify-result` artifact.
+3. Re-run `promote.yml`. The gate now compares plan-resolved stg-latest digests vs that fresh artifact.
+
+Other promote mechanics confirmed 2026-06-12 (P4W3, deploy#420 prod-login fix):
+- `promote.yml` empty `source_sha` = promote whatever `stg-latest` points to (resolves via `:stg-latest`); non-empty = explicit `sha-<short>` path (resolves via `:sha-<short>`). Both resolve via `docker buildx imagetools inspect --format '{{.Manifest.Digest}}'`.
+- Scope with `-f images="api,frontend"` to promote only the isnad-graph build and skip the user-service alembic gate (per per-service tag routing [[feedback_stg_deploy_per_service_tag_routing]]).
+- The `production` GH-environment has `deployment_branch_policy: null` (no branch restriction), so promote can be dispatched from a wave branch (`--ref deployments/phase-4/wave-3`) and still get the production environment + owner-approval gate — no main hotfix required for a gate fix that lands on the wave branch.
+- The v2 per-service gate had a real defect that blocked ALL v2 promotions (deploy#423): its `verify_digest` extraction passed the service key as a trailing python ARG (`python3 -c "…os.environ['K']…" K="$key"`) instead of an env PREFIX (`K="$key" python3 -c …`), so `os.environ['K']` raised KeyError → swallowed by `2>/dev/null||echo ""` → empty verify_digest → false "N of N divergence" every run. Real fix = env-prefix (PR #425). NB #424 (whitespace-strip) was a WRONG-RCA first attempt (hypothesised `\r`); harmless but didn't fix it — my local repro masked the bug by accidentally using the prefix form. Lesson: reproduce the EXACT command form (argv vs env-prefix matters). See [[feedback_prod_frontend_runtime_config_lag]].

--- a/.claude/memory/project_staging_unreachable_from_sandbox.md
+++ b/.claude/memory/project_staging_unreachable_from_sandbox.md
@@ -1,0 +1,64 @@
+---
+name: project_staging_unreachable_from_sandbox
+description: Staging Neo4j (bolt://neo4j:7687) and the isnad-graph frontend host are reachable only from inside the cluster — not from the CI/dev sandbox; load+screenshot are post-merge runtime gates.
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 080813cd-f3b8-434d-974c-badf58620c96
+---
+
+The **staging Neo4j** (`bolt://neo4j:7687`) and the staging frontend host
+(`https://isnad-graph.noorinalabs.com`) do **not resolve** from the CI/dev
+sandbox — they live on the Hetzner cluster's internal compose network. The dev
+box also has **no usable Docker** (WSL: docker binary present but "could not be
+found in this WSL 2 distro"), so you can't stand up a local Neo4j either.
+
+Live outbound HTTP **does** work from the sandbox (e.g. `sunnah.com` scrape
+returned 200/151KB).
+
+**BUT there IS a working path: SSH to the cluster box.** `ssh noorinalabs-stg`
+(user `deploy`, key `~/.ssh/noorinalabs_deploy`; host 87.99.137.225) works. The
+staging Neo4j runs there as container `noorinalabs-neo4j-1`. da#73 loaded 47 real
+hadiths into it this way:
+- No ingestion image on the box, and `apoc.import.file.enabled` + container
+  rootfs are hardened **off** — so don't try to run the Python loader or
+  `apoc.load.json` there.
+- Instead: parse locally → generate self-contained Cypher with the rows as
+  **inline Cypher map literals** (mirror the loader's MERGE shapes) → `scp` →
+  `docker cp` → `docker exec -i noorinalabs-neo4j-1 cypher-shell -u neo4j -p
+  "$NEO4J_AUTH_pw" -f file.cypher`. Get the password from the container env:
+  `docker inspect ... NEO4J_AUTH=neo4j/<pw>`.
+- The staging API (`noorinalabs-api-1`, port 8000) `/health` confirms neo4j up;
+  `/api/v1/collections` + `/api/v1/hadiths` exist but 401 without a JWT — so the
+  final *frontend screenshot* still needs an authenticated browser session.
+
+**How to satisfy a "load into staging Neo4j + view in frontend" acceptance
+criterion (da#73 pattern):**
+- Verify the full data→Cypher→graph mapping on REAL data in CI via the project's
+  in-process mock Neo4j client (`tests/test_graph/conftest.py MockNeo4jClient`),
+  asserting exact node/edge counts + id keying. This is genuine verification, not
+  a synthetic-acceptance dodge.
+- The actual cluster write + frontend screenshot is a **post-merge runtime step**
+  run from inside the cluster (`NEO4J_*` → staging), documented as an unchecked
+  Test-Plan box. Per [[feedback_runtime_gate_scoping]] that's NOT a PR-time gate.
+
+The ingestion loader (`isnad-ingest load` / `src/graph load_all`) targets
+whatever `NEO4J_*` resolves to, so the same script loads staging when run on a
+cluster box. da#73's `scripts/first_light/run_slice.py` + `docs/first-light-slice.md`
+are the reproducible carrier for that runtime step.
+
+**BETTER PATH (verified 2026-06-16, da#175): run the REAL Python loader from the
+sandbox via an SSH tunnel to the container's bridge IP.** bolt is NOT published on
+the staging host (`docker port noorinalabs-neo4j-1` empty; host has no 7687
+listener), but the host CAN reach the container's bridge IP. So:
+`IP=$(ssh noorinalabs-stg docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' noorinalabs-neo4j-1)` (was `172.18.0.3`), then
+`ssh -o ExitOnForwardFailure=yes -N -L 7688:$IP:7687 noorinalabs-stg` (run via
+Bash `run_in_background:true` — a foregrounded `ssh -fN` HANGS the Bash tool by
+holding its stdout pipe). Then `NEO4J_URI=bolt://127.0.0.1:7688 NEO4J_USER=neo4j
+NEO4J_PASSWORD=<pw> uv run isnad-ingest load`. Plain bolt (no TLS), direct (not
+`neo4j://`, so no routing-address rewrite). Verified the neo4j driver + live query
+through it. The production loader is additive (MERGE, `strict=False` skips missing
+file types — load only the parquet you place in `data/staging/`), so this is safe
+on the populated staging DB. This supersedes the "no Python loader, Cypher-only"
+constraint for the *load* step (apoc still off, but you no longer need apoc — the
+driver writes directly). Frontend screenshot still needs an authed browser.

--- a/.claude/memory/project_streaming_e2e_prereqs.md
+++ b/.claude/memory/project_streaming_e2e_prereqs.md
@@ -1,0 +1,43 @@
+---
+name: project_streaming_e2e_prereqs
+description: "Kafka streaming-pipeline E2E on staging (B2→Kafka→workers→Neo4j) prerequisites + gotchas — deferred past P4W6; #601 met via batch load instead"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 44d2d904-df74-40d3-b13d-f18441e349aa
+---
+
+P4W6 satisfied main#601 ("data pipeline runs E2E to Neo4j on staging") via the
+**batch** path (da#141 `scripts/narrator_graph/run.py --skip-resolve` loads
+pre-produced parquets directly into staging Neo4j). The **Kafka streaming** path
+(ip#83 workers: dedup/enrich/normalize/graph-load) was deliberately left
+**deployable-but-down** — bringing the workers up now would idle them (no
+producer feeds `pipeline.raw.landed` yet). Bjørn's verified prerequisites for the
+future streaming E2E (don't re-discover these):
+
+1. **`ghcr-publish.yml` must be on `main` before `workflow_dispatch` works** —
+   GitHub only registers a dispatch workflow once it's on the default branch.
+   `gh workflow run … --ref <wave>` 404s until then. Merging ip→main publishes
+   `latest`+`stg-<sha>`+`stg-latest` and does NOT deploy (no deploy fan-in by design).
+2. **First GHCR publish = PRIVATE package → the box (anonymous pull) 404s.**
+   Sibling app packages are public. After first publish, flip
+   `noorinalabs-isnad-ingest-platform` visibility → Public via GitHub UI
+   (Packages → Settings → Danger Zone; no reliable REST flip). Verify:
+   `gh api /orgs/noorinalabs/packages/container/noorinalabs-isnad-ingest-platform --jq .visibility`.
+3. **Stale Kafka topics on the box** — created by the OLD `init-topics.sh`
+   (`pipeline.raw.new`/`pipeline.norm.done`); workers consume canonical
+   `pipeline.raw.landed`…`pipeline.normalize.done` with auto-create OFF.
+   `kafka-init` is a completed one-shot — compose won't re-run it on file change.
+   Force: `docker compose … up -d --force-recreate --no-deps kafka-init` then verify topics.
+4. **A producer must feed `pipeline.raw.landed`** (acquire→B2→Kafka) — NOT built
+   this wave. Without it the "offsets advance" assertion can't pass even with
+   healthy workers. This is the real remaining gap for streaming E2E.
+
+Compose delivery: box `/opt/noorinalabs-deploy` tracks `main`; wave-6 deploy =
+main + deploy#440 only (4 workers + kafka-init; zero app-service changes; `.env`
+gitignored so secrets preserved). Bring-up: name the 4 services explicitly, no
+`--remove-orphans`; box Compose v2.40.3 ≥2.20 so later app `up -d --remove-orphans`
+won't reap profiled workers. One-click bring-up tracked as deploy#443.
+Trivy in the publish workflow runs AFTER push (`exit-code:1`) — a red publish run
+still means the image IS on GHCR; check the digest. Full runbook: ip#83 PR #86 RUNBOOK.md.
+See [[project_staging_pipeline_not_wired]], [[feedback_appears_in_merge_null]].

--- a/.cspell.json
+++ b/.cspell.json
@@ -24,6 +24,7 @@
     ".claude/team/charter.md"
   ],
   "ignorePaths": [
+    ".claude/memory/**",
     "node_modules/**",
     ".venv/**"
   ]

--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -36,6 +36,7 @@ Ferreira
 firstname
 Fjkb
 footgun
+frontmatter
 gatekeeping
 Hadid
 hadiths

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -34,6 +34,10 @@ exclude = [
 
 # Skip generated/vendored trees.
 exclude_path = [
+  # In-repo project-memory corpus (seeded deploy#479, from main#740 / driver
+  # main#732) — uses [[wikilink]] shorthand and bare refs, not lychee-checkable
+  # relative links; excluded like the other append-only records.
+  ".claude/memory",
   "node_modules",
   ".venv",
 ]

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -51,6 +51,12 @@
     "**/*.md"
   ],
   "ignores": [
+    // .claude/memory/** — the version-controlled in-repo project-memory corpus
+    // (seeded deploy#479, from main#740 / driver main#732). Same rationale as the
+    // parent's exclusion: dense append-only personal-note prose (names, SHAs,
+    // [[wikilinks]], Arabic), not published docs — linting it to a style guide adds
+    // noise without catching real rendering breakage.
+    ".claude/memory/**",
     "node_modules/**",
     ".venv/**"
   ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,18 @@ This file provides guidance to Claude Code when working in the deployment orches
 - `terraform/hetzner/main.tf` — VPS provisioning
 - `scripts/verify_deployment.sh` — post-deploy verification script
 
+## Project Memory
+
+Project memory for this repo is **version-controlled in-repo** at `.claude/memory/`, not in the user-space auto-memory directory. This makes the accumulated state **transferable**: a developer who pulls a branch gets the memory with it, with zero per-machine setup. The index below is auto-loaded into every session via this committed CLAUDE.md import:
+
+@.claude/memory/MEMORY.md
+
+`MEMORY.md` is the always-loaded index (one line per memory); the individual topic files in `.claude/memory/*.md` are read on demand when a line looks relevant. This repo is **self-contained** — it imports only its own `.claude/memory/`, never the parent org corpus or sibling repos. The deploy-specific memories here were split out of the org-level `noorinalabs-main` corpus (deploy#479, from main#740 / driver main#732).
+
+**Recording a memory:** create or edit `.claude/memory/<kebab-slug>.md` with the standard frontmatter (`name`, `description`, `metadata.type` = `user` | `feedback` | `project` | `reference`), add a one-line pointer to `MEMORY.md` (`- [Title](file.md) — hook`), and **commit it** so it travels with the branch. Link related memories with `[[other-slug]]`; cross-repo links into the org-level corpus are acceptable soft pointers and may dangle here. Before adding, check for an existing file covering the same fact and update it instead of duplicating; delete memories that turn out to be wrong.
+
+> `.claude/memory/**` is excluded from the markdown/cspell/lychee linters (dense append-only note prose with names, SHAs, `[[wikilinks]]`, and Arabic) — same rationale as the org corpus, mirrored into this repo's `.markdownlint-cli2.jsonc`, `.cspell.json`, and `.lychee.toml`.
+
 ## Team
 
 | Role | Level | Name | Roster File |


### PR DESCRIPTION
## Summary

Seeds an in-repo, version-controlled `.claude/memory/` corpus for `noorinalabs-deploy`, receiving the 10 deploy-specific memories split out of the org-level `noorinalabs-main` corpus (org/repo memory split — meta main#740, driver main#732). This makes deploy's accumulated operational memory **transferable**: a developer who pulls a branch gets the memory with it, zero per-machine setup, auto-loaded each session via a committed CLAUDE.md `@import`.

## What changed

- **`.claude/memory/` (11 files)** — 10 deploy-specific memories (exact content, copied from the parent corpus) + a `MEMORY.md` index (one line per memory, lifted verbatim from the parent index, plus a header). `[[wikilinks]]` to org-level memories that stay in `main` are kept as-is — acceptable soft cross-repo pointers.
  - feedback: compose env-change rollback safety, compose `up --wait` non-app abort, db-migrate gate EXPECTED_MERGE_HEAD drift, stg per-service tag routing, CF ruleset apply-time validation, ruleset empty-checks 422
  - project: grafana forward_auth, promote-gate stg-verify refresh, streaming E2E prereqs, staging unreachable from sandbox
- **`CLAUDE.md`** — adds a `## Project Memory` section with the `@.claude/memory/MEMORY.md` import + recording convention, adapted from the parent for deploy (self-contained — imports only this repo's own corpus).
- **Lint exclusions** so CI stays green on the dense append-only note prose (names, SHAs, `[[wikilinks]]`):
  - `.markdownlint-cli2.jsonc` → `ignores` adds `.claude/memory/**`
  - `.cspell.json` → `ignorePaths` adds `.claude/memory/**`
  - `.lychee.toml` → `exclude_path` adds `.claude/memory`
  - `.cspell/project-words.txt` → adds `frontmatter` (the one new word the CLAUDE.md prose introduces; `CLAUDE.md` is inside cspell's `files` scope so the corpus exclusion alone is not enough)
- **No `.pre-commit-config.yaml` change** — this repo's pre-commit/push has no md/cspell/lychee hooks (those run in CI via `docs.yml`), so there is nothing in the local hook set to exclude.

## Verification

- `markdownlint-cli2 **/*.md` → 0 errors, 66 files linted (memory corpus excluded)
- `cspell` (CI `files` scope: docs/, RUNBOOK, CLAUDE.md, charter) → 0 issues
- `lychee` config exclusion mirrors the parent exactly (`.claude/memory`); binary not available locally, CI `lychee-action` covers it. MEMORY.md's `[Title](file.md)` links resolve to real sibling files regardless.
- Full pre-commit + pre-push suite (terraform fmt/validate, gitleaks, actionlint, ruff, mypy, pytest, pytest-scripts) → all Passed/Skipped, green before push.

Closes #479

TechDebt: None. Additive seed only — no production code, infra, or workflow logic touched; the only behavioral surface is lint-config scoping, verified green. The `[[wikilink]]` cross-repo pointers into the org corpus are intentional soft links, not dangling-reference debt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BLKGHMFG8c38aJ8aK8i9Gt
