### PR TITLE
chore(pre-commit): bump ruff 0.11.6 → 0.15.11 (org-canonical parity)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,13 +56,14 @@ repos:
         name: actionlint
 
   # --- Python lint/format (mirrors hooks-lint.yml + compose-validate.yml) ---
-  # Pinned to ruff 0.11.6 (the org rollout pin). Scoped to the repo's Python:
+  # Pinned to ruff 0.15.11 (the org-canonical pin — matches ig/da/us/ingest/main).
+  # Scoped to the repo's Python:
   #   * .claude/hooks/ ............ mirrors hooks-lint.yml (no-op today; no hooks)
   #   * scripts/ + .github/workflows/scripts/ .. mirrors compose-validate.yml's
   #     python-lint job (noorinalabs-main#326) so local pre-commit catches the
   #     same ruff drift CI does (#327 fail-fast parity).
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.6
+    rev: v0.15.11
     hooks:
       - id: ruff-format
         name: ruff-format


### PR DESCRIPTION
## Summary
Bumps the `ruff-pre-commit` pin in `.pre-commit-config.yaml` from **v0.11.6** → **v0.15.11**, the org-canonical version already used by ig / da / us / ingest / main. This closes a real local⇄CI parity drift (#684 territory) where deploy was the lone repo on the old rollout pin.

## Verification (GREEN under 0.15.11)
- `ruff@0.15.11 check` over `scripts/` + `.github/workflows/scripts/` → **All checks passed!**
- `ruff@0.15.11 format --check` → **11 files already formatted**
- `pre-commit run --all-files` → all hooks Passed (terraform-fmt/validate, gitleaks, actionlint, ruff-format, ruff-lint, env-example-check)
- pre-push stage on push → mypy, pytest, pytest-scripts all Passed

The bump surfaced **zero** lint/format findings — no code reformatting was required; the diff is the pin (and its stale comment) only.

Closes #482