### PR TITLE
tech-debt(ci-parity): mirror cspell into pre-commit + classify cspell kind (rollout of main#684)

### DIFF
--- a/.claude/lib/pre_commit_ci_sync.py
+++ b/.claude/lib/pre_commit_ci_sync.py
@@ -32,11 +32,15 @@ step vs a `ruff` pre-commit `id:`). We normalize both sides to a small set of
 kind tokens so they compare:
 
     ruff-lint, ruff-format, mypy, pytest, eslint, typescript, prettier,
-    terraform-fmt, gitleaks, actionlint, astro-check, pip-audit, build
+    terraform-fmt, gitleaks, actionlint, astro-check, pip-audit, build,
+    cspell
 
 Unknown tools are ignored (neither side gates on a kind we can't classify),
 which keeps the gate conservative — it never fails on something it doesn't
-understand.
+understand. Closing a blind spot here means ADDING the kind to
+`_KIND_PATTERNS` (cf. `cspell`, noorinalabs-main#684) so a CI job that runs it
+starts demanding a pre-commit mirror — an un-classified CI check is silently
+un-mirrored, which is the exact divergence this gate exists to prevent.
 
 Input Language
 ==============
@@ -86,6 +90,14 @@ _KIND_PATTERNS: dict[str, tuple[str, ...]] = {
     "actionlint": ("actionlint",),
     "pip-audit": ("pip-audit", "pip audit"),
     "build": ("build-and-validate", "build-and-test", "npm run build"),
+    # `cspell` closes the spell-check blind spot (noorinalabs-main#684): the CI
+    # `Spellcheck (cspell)` job (docs.yml) runs the
+    # `streetsidesoftware/cspell-action`, but until this kind existed an
+    # un-classified spell gate produced ZERO drift signal — so this repo could
+    # enforce cspell in CI with no pre-commit mirror, and new infra/domain
+    # vocabulary would fail only after push. Patterns cover the action ref, the
+    # bundled-CLI step, and the generic job/step word.
+    "cspell": ("cspell", "spellcheck", "streetsidesoftware/cspell"),
 }
 
 # `ruff-lint` is a substring of nothing problematic, but `ruff format` also

--- a/.claude/lib/tests/test_pre_commit_ci_sync.py
+++ b/.claude/lib/tests/test_pre_commit_ci_sync.py
@@ -94,6 +94,85 @@ jobs:
         self.assertNotIn("ruff-lint", kinds)
 
 
+class CspellKindClassification(unittest.TestCase):
+    """noorinalabs-main#684: the spell-check blind spot. The `Spellcheck (cspell)`
+    CI job (docs.yml) must classify as the `cspell` kind on EITHER expression —
+    the `streetsidesoftware/cspell-action` `uses:` ref, the bundled-CLI `cspell`
+    step/run, or the generic `spellcheck` word — and a pre-commit cspell hook must
+    classify too, so a CI spell gate with no local mirror produces harmful drift
+    instead of silence."""
+
+    def test_cspell_action_uses_ref_classified(self) -> None:
+        wf = """
+jobs:
+  spellcheck:
+    name: Spellcheck (cspell)
+    steps:
+      - name: cspell
+        uses: streetsidesoftware/cspell-action@de2a73e # v8.4.0
+"""
+        self.assertIn("cspell", kinds_from_ci(wf))
+
+    def test_cspell_cli_run_step_classified(self) -> None:
+        wf = """
+jobs:
+  spell:
+    steps:
+      - run: npx cspell --config .cspell.json "**/*.md"
+"""
+        self.assertIn("cspell", kinds_from_ci(wf))
+
+    def test_generic_spellcheck_word_classified(self) -> None:
+        # A repo that names the step/run with the generic word still registers.
+        self.assertIn("cspell", kinds_from_ci("      - run: make spellcheck\n"))
+
+    def test_precommit_cspell_hook_classified(self) -> None:
+        cfg = """
+repos:
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.4.0
+    hooks:
+      - id: cspell
+        name: cspell
+"""
+        self.assertIn("cspell", kinds_from_precommit(cfg))
+
+    def test_ci_cspell_without_precommit_is_harmful_drift(self) -> None:
+        # The exact divergence #684 exists to catch: CI enforces cspell, the
+        # pre-commit config does not mirror it.
+        wf = """
+jobs:
+  spellcheck:
+    steps:
+      - uses: streetsidesoftware/cspell-action@de2a73e
+"""
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: actionlint
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertIn("cspell", harmful)
+
+    def test_ci_cspell_with_precommit_mirror_no_drift(self) -> None:
+        wf = """
+jobs:
+  spellcheck:
+    steps:
+      - uses: streetsidesoftware/cspell-action@de2a73e
+"""
+        cfg = """
+repos:
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.4.0
+    hooks:
+      - id: cspell
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertNotIn("cspell", harmful)
+
+
 class BuildKindNarrowing(unittest.TestCase):
     """deploy-specific: runtime `docker buildx`/`docker build` lines are this
     repo's job, NOT a mirrorable CI build-quality gate, so they must not

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,29 @@ repos:
       - id: actionlint
         name: actionlint
 
+  # --- Spellcheck (mirrors the `Spellcheck (cspell)` job in docs.yml) ---
+  # The sync-drift gate now classifies the `cspell` kind (noorinalabs-main#684),
+  # so a CI-enforced spell gate not mirrored here turns the gate red — same
+  # contract as actionlint above. New infra/domain vocabulary then fails
+  # `pre-commit run` locally instead of only surfacing as a CI red after push.
+  # Pinned to v8.4.0 of cspell-cli to match the exact cspell the
+  # `streetsidesoftware/cspell-action@…v8.4.0` CI step bundles — same engine +
+  # dictionaries on both sides. `language: node`, so pre-commit provisions its
+  # own node/cspell env (no system cspell required).
+  #
+  # `files` is the regex equivalent of the CI action's authored-prose glob set
+  # (docs/, RUNBOOK, CLAUDE.md, the team charter — identical to docs.yml's
+  # `files:` and .cspell.json's `files`); `--config .cspell.json` reuses the same
+  # dictionaries + ignore rules CI loads, so a word that passes locally passes in
+  # CI and vice-versa.
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.4.0
+    hooks:
+      - id: cspell
+        name: cspell
+        args: ["--no-must-find-files", "--no-progress", "--no-summary", "--config", ".cspell.json"]
+        files: ^(docs/.*\.md|RUNBOOK\.md|CLAUDE\.md|\.claude/team/charter\.md)$
+
   # --- Python lint/format (mirrors hooks-lint.yml + compose-validate.yml) ---
   # Pinned to ruff 0.15.11 (the org-canonical pin — matches ig/da/us/ingest/main).
   # Scoped to the repo's Python:


### PR DESCRIPTION
## Summary

Rollout of the parent **cspell CI⇄pre-commit parity** fix (meta: noorinalabs-main#684) to `noorinalabs-deploy`. Closes the spell-check blind spot in this repo's sync-drift gate and mirrors the CI cspell job locally so new domain vocabulary fails `pre-commit run` instead of only surfacing as a CI red after push.

## Changes

**Part 1 — sync-drift gate (`.claude/lib/pre_commit_ci_sync.py`)**
- Add the `cspell` kind to `_KIND_PATTERNS`: `("cspell", "spellcheck", "streetsidesoftware/cspell")`. The `Spellcheck (cspell)` job in `docs.yml` was previously an un-classified blind spot (zero drift signal); it now DEMANDS a pre-commit mirror.
- Document `cspell` in the canonical-kinds list + blind-spot note.
- Add a `CspellKindClassification` test class (6 tests) covering the action `uses:` ref, the bundled-CLI run, the generic `spellcheck` word, the pre-commit hook id, and the harmful-drift / mirror-no-drift directions.

**Part 2 — mirror into `.pre-commit-config.yaml`**
- Pinned `streetsidesoftware/cspell-cli` **v8.4.0** hook — matching the exact cspell the `streetsidesoftware/cspell-action@…v8.4.0` CI step bundles.
- `--config .cspell.json` (same dictionaries + ignore rules CI loads).
- `files` is the regex equivalent of the CI action's `files:` glob set: `^(docs/.*\.md|RUNBOOK\.md|CLAUDE\.md|\.claude/team/charter\.md)$`.

## Pinned version
`streetsidesoftware/cspell-cli` **v8.4.0** (lockstep with the CI `cspell-action@…v8.4.0`).

## Verification
- `python3 .claude/lib/pre_commit_ci_sync.py .` → exit 0 (`OK: pre-commit config mirrors all CI-enforced checks`).
- `pytest .claude/lib/tests/test_pre_commit_ci_sync.py -q` → **17 passed**.
- `pre-commit run cspell --all-files` → **Passed** (no new project-words needed; no wrong spelling blessed).
- ruff format/lint clean at the org pin (0.15.11); pre-push mypy + pytest green.

Closes #486
Part of noorinalabs-main#684

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2U19RpdPtzAv8qfjQwacx
