### PR TITLE
ci(base-pin): roll Dockerfile base-image pinning gate into CI + pre-commit + README (#488)

### DIFF
--- a/.claude/lib/check_dockerfile_base_pin.py
+++ b/.claude/lib/check_dockerfile_base_pin.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Lint Dockerfile `FROM` statements for digest-pin + distro-upgrade compliance.
+
+Deterministic conversion of `.claude/team/charter/tech-decisions.md § Base Image
+Pinning` (noorinalabs-main#735, the charter-prose-inventory worklist item #4 /
+epic #726). The section requires every `FROM` to use a **digest-pinned tag**
+(`image:tag@sha256:<digest>`) **combined with an in-image package upgrade**, to
+close the two failure modes it names — floating-tag drift and within-tag package
+drift (the shape isnad-graph#853 hit).
+
+What this gate enforces (verbatim from the section's distro table)
+================================================================
+For every `FROM` that is not exempt:
+
+1. The image reference MUST carry an `@sha256:` digest pin.
+2. The stage MUST run the package-manager upgrade matching the base distro:
+
+   | Family      | Pin shape               | Upgrade command                                 |
+   |-------------|-------------------------|-------------------------------------------------|
+   | Alpine      | image:tag@sha256:digest | `RUN apk upgrade --no-cache`                    |
+   | Debian-slim | image:tag@sha256:digest | `apt-get update && apt-get -y upgrade && clean` |
+   | Distroless  | image:tag@sha256:digest | none — no package manager (pinned-only is fine) |
+
+   The distro family is inferred from the image name: `alpine` → Alpine,
+   `distroless` → Distroless (no upgrade required), otherwise the glibc/Debian
+   default (an apt upgrade is required). A genuinely-other base that has no
+   package manager should carry the `# RATIONALE:` exemption below.
+
+Exemptions honored (verbatim from the section)
+=============================================
+- **`scratch`** final/any layer — no package manager; the upstream stages that
+  produced its contents still follow the rule and are checked on their own
+  `FROM`.
+- **Distroless** — pinned-only is sufficient (no package manager); the digest
+  pin is still required.
+- **Multi-stage stage reference** — a `FROM <earlier-stage>` inherits the
+  upstream stage's pin, so it is not re-checked (the named stage was checked at
+  its defining `FROM`).
+- **Vendor images** documented with an inline `# RATIONALE:` comment on the
+  `FROM` line (or the comment line immediately above it).
+
+CLI
+===
+    python3 .claude/lib/check_dockerfile_base_pin.py <Dockerfile> [<Dockerfile> ...]
+
+Exit codes:
+    0 — every FROM in every file is compliant (or exempt)
+    1 — at least one violation (each printed as `path:line: FROM <image> — <why>`)
+    2 — usage / file-not-found error
+
+This is a reusable template (same CLI/exit-code shape as
+`.claude/lib/pre_commit_ci_sync.py`) so it wires identically into a repo's
+pre-commit config and its CI. The parent repo `noorinalabs-main` ships no
+Dockerfiles itself; the cross-repo rollout that points this at each child's
+Dockerfiles is a #735 follow-up.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# `FROM` is the only keyword we parse; Dockerfile keywords are case-insensitive.
+_FROM_RE = re.compile(r"^\s*FROM\s+(?P<rest>\S.*?)\s*$", re.IGNORECASE)
+# A leading `--platform=...` flag precedes the image and must be stripped.
+_PLATFORM_RE = re.compile(r"^--platform=\S+\s+", re.IGNORECASE)
+# A trailing `AS <stage>` names the build stage.
+_AS_RE = re.compile(r"\s+AS\s+(?P<stage>\S+)\s*$", re.IGNORECASE)
+
+# Upgrade-command signatures per distro family (searched over the stage body).
+_ALPINE_UPGRADE_RE = re.compile(r"\bapk\s+upgrade\b", re.IGNORECASE)
+# `apt-get update && apt-get -y upgrade` / `apt upgrade` — an apt invocation
+# followed (in the same command segment) by `upgrade`. `apt-get update` alone
+# does NOT match (that is "update", not "upgrade").
+_DEBIAN_UPGRADE_RE = re.compile(r"\bapt(?:-get)?\s+(?:-{1,2}\S+\s+)*upgrade\b", re.IGNORECASE)
+
+_RATIONALE_RE = re.compile(r"#\s*RATIONALE:", re.IGNORECASE)
+
+
+class FromStatement:
+    """One parsed `FROM` line: its image ref, optional stage name, exemptions."""
+
+    def __init__(self, lineno: int, image: str, stage: str | None, has_rationale: bool) -> None:
+        self.lineno = lineno
+        self.image = image
+        self.stage = stage
+        self.has_rationale = has_rationale
+
+
+def _preceding_comment_has_rationale(lines: list[str], from_idx: int) -> bool:
+    """True if the comment line(s) immediately above `from_idx` carry RATIONALE."""
+    j = from_idx - 1
+    while j >= 0:
+        stripped = lines[j].strip()
+        if stripped == "":
+            j -= 1
+            continue
+        if stripped.startswith("#"):
+            return bool(_RATIONALE_RE.search(stripped))
+        return False
+    return False
+
+
+def parse_froms(text: str) -> list[FromStatement]:
+    """Parse every `FROM` statement in a Dockerfile, in source order."""
+    lines = text.splitlines()
+    froms: list[FromStatement] = []
+    for idx, raw in enumerate(lines):
+        m = _FROM_RE.match(raw)
+        if not m:
+            continue
+        rest = m.group("rest")
+        has_rationale = bool(_RATIONALE_RE.search(raw)) or _preceding_comment_has_rationale(
+            lines, idx
+        )
+        # Drop any trailing inline comment, then a leading --platform flag.
+        code = rest.split("#", 1)[0].strip()
+        code = _PLATFORM_RE.sub("", code).strip()
+        stage: str | None = None
+        as_m = _AS_RE.search(code)
+        if as_m is not None:
+            stage = as_m.group("stage")
+            code = code[: as_m.start()].strip()
+        image = code.split()[0] if code.split() else ""
+        froms.append(FromStatement(idx + 1, image, stage, has_rationale))
+    return froms
+
+
+def _stage_body(text: str, from_lineno: int, next_from_lineno: int | None) -> str:
+    """Return the text between a `FROM` (exclusive) and the next `FROM`/EOF."""
+    lines = text.splitlines()
+    start = from_lineno  # from_lineno is 1-based; body starts on the next line
+    end = (next_from_lineno - 1) if next_from_lineno is not None else len(lines)
+    return "\n".join(lines[start:end])
+
+
+def check_dockerfile_text(path: str, text: str) -> list[str]:
+    """Return a list of human-readable violation strings for one Dockerfile."""
+    violations: list[str] = []
+    froms = parse_froms(text)
+    defined_stages: set[str] = set()
+    for i, stmt in enumerate(froms):
+        next_lineno = froms[i + 1].lineno if i + 1 < len(froms) else None
+        image_l = stmt.image.lower()
+
+        # Exemptions, in order. `scratch` and stage-references have no package
+        # manager / inherit the upstream pin; a documented vendor RATIONALE opts
+        # out explicitly. Record this stage's own name for later references.
+        is_exempt = image_l == "scratch" or image_l in defined_stages or stmt.has_rationale
+        if stmt.stage:
+            defined_stages.add(stmt.stage.lower())
+        if is_exempt:
+            continue
+
+        if "@sha256:" not in stmt.image:
+            violations.append(
+                f"{path}:{stmt.lineno}: FROM {stmt.image} — not digest-pinned "
+                f"(require image:tag@sha256:<digest>)"
+            )
+
+        body = _stage_body(text, stmt.lineno, next_lineno)
+        if "distroless" in image_l:
+            continue  # distroless has no package manager; pinned-only is sufficient
+        if "alpine" in image_l:
+            if not _ALPINE_UPGRADE_RE.search(body):
+                violations.append(
+                    f"{path}:{stmt.lineno}: FROM {stmt.image} — missing Alpine upgrade "
+                    f"step (RUN apk upgrade --no-cache)"
+                )
+        elif not _DEBIAN_UPGRADE_RE.search(body):
+            violations.append(
+                f"{path}:{stmt.lineno}: FROM {stmt.image} — missing Debian upgrade step "
+                f"(RUN apt-get update && apt-get -y upgrade && apt-get clean)"
+            )
+    return violations
+
+
+def check_file(path: Path) -> list[str]:
+    return check_dockerfile_text(str(path), path.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str]) -> int:
+    paths = argv[1:]
+    if not paths:
+        print(
+            "usage: check_dockerfile_base_pin.py <Dockerfile> [<Dockerfile> ...]",
+            file=sys.stderr,
+        )
+        return 2
+
+    all_violations: list[str] = []
+    for p in paths:
+        path = Path(p)
+        if not path.is_file():
+            print(f"ERROR: not a file: {p}", file=sys.stderr)
+            return 2
+        all_violations.extend(check_file(path))
+
+    if all_violations:
+        print("Base Image Pinning violations (tech-decisions.md § Base Image Pinning, #735):")
+        for v in all_violations:
+            print(f"  {v}")
+        print(
+            "\nEvery FROM must be digest-pinned (image:tag@sha256:<digest>) AND carry "
+            "the matching distro upgrade (apk/apt). Exemptions: scratch, distroless "
+            "(pin-only), a FROM that references an earlier stage, or a vendor image with "
+            "an inline `# RATIONALE:` comment on the FROM line."
+        )
+        return 1
+
+    print("OK: all Dockerfile FROM statements are digest-pinned with the required upgrade.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.claude/lib/pre_commit_ci_sync.py
+++ b/.claude/lib/pre_commit_ci_sync.py
@@ -98,6 +98,14 @@ _KIND_PATTERNS: dict[str, tuple[str, ...]] = {
     # vocabulary would fail only after push. Patterns cover the action ref, the
     # bundled-CLI step, and the generic job/step word.
     "cspell": ("cspell", "spellcheck", "streetsidesoftware/cspell"),
+    # `dockerfile-base-pin` tracks the Base Image Pinning gate
+    # (.claude/lib/check_dockerfile_base_pin.py, tech-decisions.md § Base Image
+    # Pinning / noorinalabs-main#735, #744). deploy builds Dockerfiles (the
+    # integration-tests runner, the fake-oauth stub, the neo4j+GDS image), so a
+    # CI base-pin gate must be mirrored by a local pre-commit hook or this gate
+    # goes red. Patterns cover the script ref (both sides reference the module)
+    # and the generic kind word used in job/hook ids.
+    "dockerfile-base-pin": ("check_dockerfile_base_pin", "dockerfile-base-pin"),
 }
 
 # `ruff-lint` is a substring of nothing problematic, but `ruff format` also

--- a/.claude/lib/tests/test_check_dockerfile_base_pin.py
+++ b/.claude/lib/tests/test_check_dockerfile_base_pin.py
@@ -1,0 +1,195 @@
+"""Tests for check_dockerfile_base_pin — the Base Image Pinning gate (#735).
+
+Verifies the deterministic conversion of `tech-decisions.md § Base Image
+Pinning`: every FROM must be digest-pinned AND carry the matching distro
+upgrade, with the section's exact exemptions (scratch, distroless, stage
+references, vendor `# RATIONALE:`). Positive cases use the real required pattern
+the section documents; negative cases use the exact prohibited shapes it names
+(floating tag, pin-only, apk-only).
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from check_dockerfile_base_pin import (  # noqa: E402
+    check_dockerfile_text,
+    main,
+    parse_froms,
+)
+
+# A real digest (truncated only for readability is NOT allowed by the checker —
+# it needs the literal `@sha256:` marker, which these carry in full shape).
+_DIGEST = "@sha256:0272e4609f1b5f3a2d8c9e1a4b6c8d0e2f4a6b8c0d2e4f6a8b0c2d4e6f8a0b2c4"
+
+
+class CompliantFromsPass(unittest.TestCase):
+    def test_alpine_pinned_with_apk_upgrade(self) -> None:
+        df = f"""# Digest-pinned tag + apk upgrade for defense-in-depth
+FROM nginx:stable-alpine3.23{_DIGEST}
+RUN apk upgrade --no-cache
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_debian_slim_pinned_with_apt_upgrade(self) -> None:
+        df = f"""FROM python:3.12-slim{_DIGEST}
+RUN apt-get update && apt-get -y upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_distroless_pin_only_is_sufficient(self) -> None:
+        # Distroless has no package manager — pinned-only passes, no upgrade.
+        df = f"FROM gcr.io/distroless/static-debian12{_DIGEST}\n"
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_multistage_scratch_final_layer_exempt(self) -> None:
+        df = f"""FROM golang:1.22-alpine{_DIGEST} AS builder
+RUN apk upgrade --no-cache
+RUN go build -o /app
+
+FROM scratch
+COPY --from=builder /app /app
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_multistage_stage_reference_inherits_pin(self) -> None:
+        # `FROM builder` references an earlier stage; it inherits the pin and is
+        # not re-checked for a digest or an upgrade.
+        df = f"""FROM python:3.12-slim{_DIGEST} AS builder
+RUN apt-get update && apt-get -y upgrade && apt-get clean
+
+FROM builder
+RUN pip install .
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_vendor_rationale_inline_comment_exempts(self) -> None:
+        df = "FROM vendor/proprietary:1.4  # RATIONALE: not redistributable digest-pinned\n"
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_vendor_rationale_preceding_comment_exempts(self) -> None:
+        df = """# RATIONALE: vendor image, not available as a digest-pinned ref
+FROM vendor/proprietary:1.4
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_platform_flag_is_stripped(self) -> None:
+        df = f"""FROM --platform=linux/amd64 node:20-alpine{_DIGEST}
+RUN apk upgrade --no-cache
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+
+class ProhibitedShapesFlagged(unittest.TestCase):
+    def test_floating_tag_flagged(self) -> None:
+        # WRONG (floating tag): no digest, no upgrade — both defenses missing.
+        violations = check_dockerfile_text("Dockerfile", "FROM nginx:alpine\n")
+        self.assertEqual(len(violations), 2)
+        self.assertTrue(any("not digest-pinned" in v for v in violations))
+        self.assertTrue(any("Alpine upgrade" in v for v in violations))
+
+    def test_pin_only_alpine_missing_upgrade(self) -> None:
+        # INSUFFICIENT (pin-only): tag frozen but Alpine packages drift — the
+        # exact shape isnad-graph#853 hit.
+        df = f"FROM nginx:stable-alpine3.23{_DIGEST}\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("missing Alpine upgrade", violations[0])
+
+    def test_apk_only_missing_digest(self) -> None:
+        # INSUFFICIENT (apk-only): upgrade present but base layer is unpinned.
+        df = "FROM nginx:alpine\nRUN apk upgrade --no-cache\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("not digest-pinned", violations[0])
+
+    def test_debian_pinned_missing_apt_upgrade(self) -> None:
+        df = f"FROM python:3.12-slim{_DIGEST}\nRUN pip install .\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("missing Debian upgrade", violations[0])
+
+    def test_apt_update_only_is_not_an_upgrade(self) -> None:
+        # `apt-get update` is not `apt-get upgrade`; pin present, upgrade absent.
+        df = f"FROM debian:bookworm-slim{_DIGEST}\nRUN apt-get update\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("missing Debian upgrade", violations[0])
+
+    def test_line_number_reported(self) -> None:
+        df = """# header comment
+FROM nginx:alpine
+RUN apk upgrade --no-cache
+"""
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("Dockerfile:2:", violations[0])
+
+
+class MultiStageMixed(unittest.TestCase):
+    def test_compliant_builder_but_bad_runtime_flags_only_runtime(self) -> None:
+        df = f"""FROM golang:1.22-alpine{_DIGEST} AS builder
+RUN apk upgrade --no-cache
+RUN go build -o /app
+
+FROM nginx:alpine
+COPY --from=builder /app /app
+"""
+        violations = check_dockerfile_text("Dockerfile", df)
+        # builder is clean; only the floating runtime FROM is flagged (pin+upgrade).
+        self.assertEqual(len(violations), 2)
+        self.assertTrue(all("FROM nginx:alpine" in v for v in violations))
+
+
+class ParserBehavior(unittest.TestCase):
+    def test_parse_collects_stage_names_and_images(self) -> None:
+        df = f"""FROM python:3.12-slim{_DIGEST} AS builder
+FROM scratch
+"""
+        froms = parse_froms(df)
+        self.assertEqual(len(froms), 2)
+        self.assertEqual(froms[0].stage, "builder")
+        self.assertTrue(froms[0].image.startswith("python:3.12-slim@sha256:"))
+        self.assertEqual(froms[1].image, "scratch")
+
+    def test_from_keyword_case_insensitive(self) -> None:
+        df = f"from nginx:alpine{_DIGEST} as web\nRUN apk upgrade --no-cache\n"
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+
+class CliBehavior(unittest.TestCase):
+    def test_clean_file_exits_zero(self) -> None:
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".dockerfile", delete=False) as fh:
+            fh.write(f"FROM nginx:stable-alpine3.23{_DIGEST}\nRUN apk upgrade --no-cache\n")
+            name = fh.name
+        try:
+            self.assertEqual(main(["check_dockerfile_base_pin.py", name]), 0)
+        finally:
+            Path(name).unlink()
+
+    def test_violating_file_exits_one(self) -> None:
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".dockerfile", delete=False) as fh:
+            fh.write("FROM nginx:alpine\n")
+            name = fh.name
+        try:
+            self.assertEqual(main(["check_dockerfile_base_pin.py", name]), 1)
+        finally:
+            Path(name).unlink()
+
+    def test_no_args_is_usage_error(self) -> None:
+        self.assertEqual(main(["check_dockerfile_base_pin.py"]), 2)
+
+    def test_missing_file_is_error(self) -> None:
+        self.assertEqual(main(["check_dockerfile_base_pin.py", "/no/such/Dockerfile"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/lib/tests/test_pre_commit_ci_sync.py
+++ b/.claude/lib/tests/test_pre_commit_ci_sync.py
@@ -173,6 +173,61 @@ repos:
         self.assertNotIn("cspell", harmful)
 
 
+class DockerfileBasePinKindClassification(unittest.TestCase):
+    """noorinalabs-main#744/#735: the Base Image Pinning gate
+    (check_dockerfile_base_pin.py) must classify as the `dockerfile-base-pin`
+    kind on EITHER side — the CI `run:` line that invokes the script and a
+    pre-commit hook that does the same — so a CI base-pin gate without a local
+    mirror is caught as harmful drift (#327 fail-fast contract)."""
+
+    def test_ci_run_step_classified(self) -> None:
+        wf = """
+jobs:
+  dockerfile-base-pin:
+    steps:
+      - run: python3 .claude/lib/check_dockerfile_base_pin.py infra/neo4j/Dockerfile
+"""
+        self.assertIn("dockerfile-base-pin", kinds_from_ci(wf))
+
+    def test_precommit_hook_classified(self) -> None:
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: dockerfile-base-pin
+        entry: python3 .claude/lib/check_dockerfile_base_pin.py
+"""
+        self.assertIn("dockerfile-base-pin", kinds_from_precommit(cfg))
+
+    def test_ci_without_precommit_is_harmful_drift(self) -> None:
+        wf = """
+jobs:
+  dockerfile-base-pin:
+    steps:
+      - run: python3 .claude/lib/check_dockerfile_base_pin.py infra/neo4j/Dockerfile
+"""
+        cfg = "repos: []\n"
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertIn("dockerfile-base-pin", harmful)
+
+    def test_ci_with_precommit_mirror_no_drift(self) -> None:
+        wf = """
+jobs:
+  dockerfile-base-pin:
+    steps:
+      - run: python3 .claude/lib/check_dockerfile_base_pin.py infra/neo4j/Dockerfile
+"""
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: dockerfile-base-pin
+        entry: python3 .claude/lib/check_dockerfile_base_pin.py
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertNotIn("dockerfile-base-pin", harmful)
+
+
 class BuildKindNarrowing(unittest.TestCase):
     """deploy-specific: runtime `docker buildx`/`docker build` lines are this
     repo's job, NOT a mirrorable CI build-quality gate, so they must not

--- a/.github/workflows/dockerfile-base-pin.yml
+++ b/.github/workflows/dockerfile-base-pin.yml
@@ -1,0 +1,68 @@
+name: CI — Dockerfile base-image pinning
+
+# Enforces tech-decisions.md § Base Image Pinning (noorinalabs-main#735, the
+# cross-repo rollout #744): every `FROM` in every Dockerfile must be
+# digest-pinned (image:tag@sha256:<digest>) AND carry the matching distro
+# upgrade (apk/apt), with the section's exemptions (scratch, distroless,
+# stage references, vendor `# RATIONALE:`). This closes the two drift modes the
+# section names — floating-tag drift and within-tag package drift.
+#
+# deploy builds three Dockerfiles (the integration-tests runner, the fake-oauth
+# stub, and the neo4j+GDS image), so this gate applies here. The same check runs
+# locally as the `dockerfile-base-pin` pre-commit hook; the pre-commit ⇄ CI
+# sync-drift gate classifies the `dockerfile-base-pin` kind so this CI gate
+# cannot drift ahead of that local mirror (#327 fail-fast parity).
+#
+# Triggered when a Dockerfile, the check script, its tests, or this workflow
+# changes.
+
+on:
+  push:
+    branches: [main, "deployments/**"]
+    paths:
+      - "**/Dockerfile"
+      - "**/Dockerfile.*"
+      - ".claude/lib/check_dockerfile_base_pin.py"
+      - ".claude/lib/tests/test_check_dockerfile_base_pin.py"
+      - ".github/workflows/dockerfile-base-pin.yml"
+  pull_request:
+    branches: [main, "deployments/**"]
+    paths:
+      - "**/Dockerfile"
+      - "**/Dockerfile.*"
+      - ".claude/lib/check_dockerfile_base_pin.py"
+      - ".claude/lib/tests/test_check_dockerfile_base_pin.py"
+      - ".github/workflows/dockerfile-base-pin.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  base-pin:
+    name: Dockerfile base-pin gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Lint every Dockerfile FROM (digest pin + distro upgrade)
+        # Collect all Dockerfiles repo-wide and run the gate over them. -print0 /
+        # -0 are null-delimited so paths with spaces are safe; -r skips the run
+        # when there are no Dockerfiles (script would otherwise exit 2 on no args).
+        run: |
+          find . -type f \( -name 'Dockerfile' -o -name 'Dockerfile.*' \) \
+            -not -path './.git/*' -print0 \
+            | xargs -0 -r python3 .claude/lib/check_dockerfile_base_pin.py
+
+  base-pin-tests:
+    name: Base-pin gate unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: pip install pytest
+      - name: Run check_dockerfile_base_pin tests
+        run: python3 -m pytest .claude/lib/tests/test_check_dockerfile_base_pin.py -q

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,6 +99,21 @@ repos:
   # --- Local hooks ---
   - repo: local
     hooks:
+      # Dockerfile Base Image Pinning gate (mirrors dockerfile-base-pin.yml).
+      # Enforces tech-decisions.md § Base Image Pinning (noorinalabs-main#735,
+      # #744): every FROM digest-pinned (image:tag@sha256:<digest>) AND carrying
+      # the matching distro upgrade, with the section's exemptions (scratch,
+      # distroless, stage refs, vendor `# RATIONALE:`). Runs over staged
+      # Dockerfiles at commit time; CI runs the same script over ALL Dockerfiles.
+      # The sync-drift gate classifies this as the `dockerfile-base-pin` kind, so
+      # the CI gate cannot drift ahead of this local mirror. pass_filenames=true:
+      # pre-commit hands the matched Dockerfile paths to the script as argv.
+      - id: dockerfile-base-pin
+        name: dockerfile-base-pin
+        entry: python3 .claude/lib/check_dockerfile_base_pin.py
+        language: system
+        files: (^|/)Dockerfile(\.[^/]+)?$
+        stages: [pre-commit]
       # mypy over .claude/hooks (mirrors hooks-lint.yml) + scripts/ and
       # .github/workflows/scripts/ (mirrors compose-validate.yml's python-lint
       # job, noorinalabs-main#326). Heavier, so pre-push. The .claude/hooks/

--- a/README.md
+++ b/README.md
@@ -20,17 +20,27 @@ pre-commit install --hook-type pre-push  # push-stage checks
 ```
 
 - **Commit stage** runs: `terraform-fmt`, `terraform-validate`, `gitleaks`,
-  `actionlint`, `ruff-format`, `ruff-lint`, and `env-example-check`.
+  `actionlint`, `cspell`, `ruff-format`, `ruff-lint`, the Dockerfile base-image
+  pinning gate (`dockerfile-base-pin`), and `env-example-check`.
 - **Pre-push stage** runs: `mypy` (over `scripts/`, `.github/workflows/scripts/`,
   and `.claude/hooks/` when present), `pytest` for the sync-gate unit tests
   (`.claude/lib/tests/`), and `pytest` for the scripts tests (`scripts/tests/`).
 
 These mirror the repo's CI workflows (`terraform.yml`, `lint-workflows.yml` /
-`docs.yml`, `hooks-lint.yml`, `compose-validate.yml`, `precommit-ci-sync.yml`) so
-failures surface locally before a PR — running BOTH installs is mandatory under
-the org-wide local⇄CI parity rule (noorinalabs-main#684). The
-`Pre-commit ⇄ CI sync-drift gate` (`.claude/lib/pre_commit_ci_sync.py`) fails the
-build if a check CI enforces is dropped from this mirror.
+`docs.yml`, `hooks-lint.yml`, `compose-validate.yml`, `dockerfile-base-pin.yml`,
+`precommit-ci-sync.yml`) so failures surface locally before a PR — running BOTH
+installs is mandatory under the org-wide local⇄CI parity rule
+(noorinalabs-main#684). The `Pre-commit ⇄ CI sync-drift gate`
+(`.claude/lib/pre_commit_ci_sync.py`) fails the build if a check CI enforces
+(including `cspell` and `dockerfile-base-pin`) is dropped from this mirror.
+
+The `dockerfile-base-pin` gate (`.claude/lib/check_dockerfile_base_pin.py`)
+enforces `tech-decisions.md § Base Image Pinning` (noorinalabs-main#735): every
+Dockerfile `FROM` must be digest-pinned (`image:tag@sha256:<digest>`) AND carry
+the matching distro upgrade (`apk`/`apt`), exempting `scratch`, distroless
+(pin-only), stage references, and a vendor image documented with an inline
+`# RATIONALE:` comment. Refresh a digest when bumping a base tag with
+`docker buildx imagetools inspect <image>:<tag>`.
 
 Never bypass a hook with `--no-verify`, and never push, PR, or merge with a
 known-failing check without explicit owner permission. If `pre-commit install`

--- a/infra/neo4j/Dockerfile
+++ b/infra/neo4j/Dockerfile
@@ -8,6 +8,12 @@
 #   https://graphdatascience.ninja/versions.json
 
 ARG NEO4J_VERSION=5-community
+# The official `neo4j` vendor image is consumed as-is, with the version chosen by
+# the NEO4J_VERSION build-arg so Neo4j<->GDS compatibility stays adjustable at
+# build time (see the GDS-version note above). A `@sha256:` digest pin would
+# hard-code the version and defeat that parameterization, and we add no
+# app-controlled package layer here (only the GDS jar below).
+# RATIONALE: build-arg-parameterized vendor base (tech-decisions.md § Base Image Pinning, noorinalabs-main#735); digest-pin + apt-upgrade intentionally exempted for this single FROM.
 FROM neo4j:${NEO4J_VERSION}
 
 ARG GDS_VERSION=2.13.8

--- a/integration-tests/Dockerfile.runner
+++ b/integration-tests/Dockerfile.runner
@@ -1,5 +1,11 @@
 # Minimal pytest runner image — just httpx + asyncpg + redis + pytest.
-FROM python:3.12-slim
+# Base pinned to a digest + in-image apt upgrade per tech-decisions.md
+# § Base Image Pinning (noorinalabs-main#735); refresh the digest when bumping
+# the python tag (docker buildx imagetools inspect python:3.12-slim).
+FROM python:3.12-slim@sha256:d764629ce0ddd8c71fd371e9901efb324a95789d2315a47db7e4d27e78f1b0e9
+
+# Close within-tag package drift: upgrade the base distro packages.
+RUN apt-get update && apt-get -y upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/integration-tests/fake_oauth/Dockerfile
+++ b/integration-tests/fake_oauth/Dockerfile
@@ -1,9 +1,15 @@
-FROM python:3.14-slim
+# Base pinned to a digest + in-image apt upgrade per tech-decisions.md
+# § Base Image Pinning (noorinalabs-main#735); refresh the digest when bumping
+# the python tag (docker buildx imagetools inspect python:3.14-slim).
+FROM python:3.14-slim@sha256:44dd04494ee8f3b538294360e7c4b3acb87c8268e4d0a4828a6500b1eff50061
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# Close within-tag package drift: upgrade the base distro packages.
+RUN apt-get update && apt-get -y upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
## What & why

Deploy slice of the cross-repo rollout: wire the Dockerfile **Base Image Pinning** gate (`check_dockerfile_base_pin.py`) into this repo's CI + pre-commit mirror (parent **noorinalabs-main#744**), and document the local hooks in the README (**noorinalabs-main#718**). deploy builds three Dockerfiles, so the rule from `tech-decisions.md § Base Image Pinning` (noorinalabs-main#735) applies here.

## Changes

**#744 — wire the gate**
- Vendor `check_dockerfile_base_pin.py` + its unit test into `.claude/lib/` (verbatim from the parent canonical gate).
- New `dockerfile-base-pin` pre-commit hook (commit stage) over Dockerfiles + new `dockerfile-base-pin.yml` CI workflow (gate over all Dockerfiles + unit tests).
- Sync-drift gate learns the `dockerfile-base-pin` kind (+ a `DockerfileBasePinKindClassification` test class) so the CI gate can't drift ahead of the local mirror.
- Fix-forward the violations the first run surfaced:
  - `integration-tests/Dockerfile.runner` — pin `python:3.12-slim` to its digest + add an apt-upgrade layer.
  - `integration-tests/fake_oauth/Dockerfile` — pin `python:3.14-slim` to its digest + add an apt-upgrade layer.
  - `infra/neo4j/Dockerfile` — inline `# RATIONALE:` exemption: the official `neo4j` vendor image is version-selected by the `NEO4J_VERSION` build-arg (a digest pin would defeat that) and we add no app-controlled package layer (only the GDS jar).

**#718 — docs**
- Update the README "Git hooks (required)" section to list the new `dockerfile-base-pin` gate and the previously-missing `cspell` gate, mirroring noorinalabs-main `CLAUDE.md` § Local Hooks.

## Verification

- `42` `.claude/lib` tests pass; sync gate exits `0` (no harmful drift).
- base-pin check exits `0` over all three Dockerfiles (digests resolved via `docker buildx imagetools inspect`).
- pre-commit (commit + pre-push stages) all pass: actionlint, gitleaks, cspell, ruff-format/lint, mypy, pytest, dockerfile-base-pin.
- markdownlint + cspell clean on the README.

## Reviewers

- Peer reviewer: **Weronika Zielinska** (platform_architect_weronika)
- Secondary reviewer: **Aisha Idrissi** (sre_engineer_aisha)

## Tech debt

None introduced. The neo4j FROM carries a documented `# RATIONALE:` exemption rather than a digest pin, by design (build-arg-parameterized vendor base).

Closes #488
Part of noorinalabs-main#744
Part of noorinalabs-main#718
