### PR TITLE
fix(integration): read OAuth token from URL fragment + disable test rate limiter (#490)

### DIFF
--- a/integration-tests/docker-compose.test.yml
+++ b/integration-tests/docker-compose.test.yml
@@ -41,6 +41,13 @@ services:
       JWT_ALGORITHM: RS256
       JWT_ACCESS_TOKEN_EXPIRE_MINUTES: "15"
       JWT_REFRESH_TOKEN_EXPIRE_DAYS: "7"
+      # Disable the per-IP auth rate limiter for the hermetic E2E. All test
+      # traffic originates from a single runner IP, so the limiter (token /
+      # login / refresh / validate / callback buckets) trips and returns 429,
+      # which is not what these functional flows exercise. user-service config
+      # explicitly sanctions disabling it "for local dev / tests where the
+      # speed-bump gets in the way" (config.py AUTH_RATE_LIMIT_ENABLED).
+      AUTH_RATE_LIMIT_ENABLED: "false"
       CORS_ORIGINS: '["http://testnet"]'
       AUTH_OAUTH_REDIRECT_BASE_URL: http://user-service:8000
       AUTH_GOOGLE_CLIENT_ID: fake-google-client-id

--- a/integration-tests/tests/test_auth_flow.py
+++ b/integration-tests/tests/test_auth_flow.py
@@ -153,8 +153,13 @@ async def test_oauth_callback_to_token_issue(
             f"callback redirected with error={qs.get('error')} — check user-service "
             f"logs for the provider/exchange failure. Location={location}"
         )
-        assert qs.get("token"), f"no token in callback redirect: {location}"
-        access_token = qs["token"][0]
+        # Per user-service#68, the access token is delivered in the URL *fragment*
+        # (`#token=<access>`) so it never leaks via the Referer header / server
+        # logs; the non-secret flags (is_new_user, needs_verification, error) stay
+        # as query params. Read the token from the fragment, the flags from query.
+        frag = parse_qs(parsed.fragment)
+        assert frag.get("token"), f"no token in callback redirect fragment: {location}"
+        access_token = frag["token"][0]
         assert qs.get("is_new_user") == ["1"], (
             f"expected a newly-created user on first callback; got is_new_user="
             f"{qs.get('is_new_user')}"


### PR DESCRIPTION
## What & why

Fix-first PR to turn the **pre-existing red `Full stack end-to-end` job green** before noorinalabs-deploy#489 (Dockerfile base-pin rollout) merges. Both root causes are harness-side in this repo's `integration-tests/` — no user-service code change.

## Root cause

1. **Token moved to the URL fragment (user-service#68).** The OAuth post-login redirect now delivers the access token in the URL **fragment** (`#token=<access>`) so it never leaks via the `Referer` header / server logs; the non-secret flags (`is_new_user`, `needs_verification`, `error`) stay as query params. `test_oauth_callback_to_token_issue` still parsed the **query** for the token → `no token in callback redirect: /auth/callback/google?is_new_user=1&needs_verification=0#token=***`. Intended, documented user-service behavior — so the test must read the fragment.
2. **Per-IP rate limiter trips in the hermetic E2E.** All test traffic comes from one runner IP, so the auth limiter returns `429`, cascading through `conftest.py:317 issue_token_for` into the rbac/sessions/subscription/perf/verification setups.

## Changes

- `integration-tests/tests/test_auth_flow.py` — read the access token from `parsed.fragment`; flags stay on `parsed.query`.
- `integration-tests/docker-compose.test.yml` — `AUTH_RATE_LIMIT_ENABLED: "false"` on the `user-service` test container (the disable-for-tests path user-service `config.py` explicitly sanctions; the flag short-circuits `enforce_ip_rate_limit`).

## Verification

- Fragment-parse reproduced against the exact observed `Location` — token reads from fragment, `is_new_user==["1"]` from query.
- `docker-compose.test.yml` parses; the rate-limit flag is honored by `services/rate_limit.py` (`if not settings.AUTH_RATE_LIMIT_ENABLED: return`).
- pre-commit + pre-push clean; ruff clean on the touched test (added lines introduce no format drift; integration-tests Python is outside the repo's ruff scope anyway).
- The authoritative check is CI's `Full stack end-to-end` going green on this PR — see the run linked in checks.

## Reviewers

- Peer reviewer: **Weronika Zielinska** (platform_architect_weronika)
- Secondary reviewer: **Aisha Idrissi** (sre_engineer_aisha)

## Tech debt

None. Removes a standing E2E red; no shortcuts taken (no user-service contract was bent — the test now matches the #68 contract).

Closes #490
Part of noorinalabs-main#744
