### PR TITLE
docs(runbooks): concrete admin-JWT mint command in prod-data-reload §1b

### DIFF
--- a/docs/runbooks/prod-data-reload-723.md
+++ b/docs/runbooks/prod-data-reload-723.md
@@ -59,7 +59,23 @@ sudo --preserve-env=B2_KEY_ID,B2_APP_KEY,B2_BUCKET ./scripts/backup.sh
 As an admin user (the `/admin/data/*` router is `require_admin`-gated), capture and SAVE:
 
 ```bash
-# TOKEN = an admin JWT (mint via the normal OAuth login flow; do NOT inline any secret)
+# --- Mint an admin JWT (user-service https://users.noorinalabs.com issues it) ---
+# Email/password path — providers `email/password` is enabled. The password is
+# prompted (never echoed / never in shell history); no secret is hard-coded here.
+read -rs -p "Admin password: " PW; echo
+TOKEN=$(curl -s -X POST https://users.noorinalabs.com/auth/login \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg e 'YOUR_ADMIN_EMAIL' --arg p "$PW" '{email:$e, password:$p}')" \
+  | jq -r '.access_token')
+unset PW
+# Sanity-check without dumping the JWT:  echo "${TOKEN:0:18}…"
+# The /auth/login response is {access_token, refresh_token, token_type:"bearer"}.
+#
+# If /auth/login returns 401 (admin account is OAuth-only, no password set): log in
+# via the browser, then take the access token from the post-login redirect URL
+# *fragment* (…#token=<access>), or from devtools → Network → the `Authorization:
+# Bearer` header on any API XHR. The admin endpoints are role-gated, so the token
+# must belong to your admin account.
 BASE=https://isnad.noorinalabs.com
 curl -sS -H "Authorization: Bearer $TOKEN" "$BASE/api/v1/admin/data/overview" | tee before_overview.json
 curl -sS -H "Authorization: Bearer $TOKEN" "$BASE/api/v1/admin/data/sources"  | tee before_sources.json


### PR DESCRIPTION
## Summary
Replaces the vague placeholder in `prod-data-reload-723.md` §1b — `# TOKEN = an admin JWT (mint via the normal OAuth login flow…)` — with a concrete, working command to mint the admin JWT, requested by the owner during the live #723 reload.

## What's added
- **Email/password path:** `POST https://users.noorinalabs.com/auth/login` → `.access_token`. Password is **prompted via `read -rs`** (never echoed, never in shell history); the body is built with `jq -nc` so no secret is hard-coded in the runbook. Response shape documented (`{access_token, refresh_token, token_type:"bearer"}`).
- **OAuth-only fallback:** if `/auth/login` 401s (admin account has no password), take the access token from the post-login redirect URL **fragment** (`…#token=<access>`) or devtools → Network → the `Authorization: Bearer` header on any API XHR.
- Note that admin endpoints are role-gated (token must be the admin account).

## Verification (against prod)
- `POST https://users.noorinalabs.com/auth/login` with empty body → **HTTP 422** (route live, validates).
- `GET /auth/providers` → `email`/`password` **enabled** (+ google/github OAuth).
- Endpoint/response shape cross-checked against user-service `src/app/routers/auth.py` (`@router.post("/login")`, prefix `/auth`) and `schemas/auth.py` (`LoginRequest`, `TokenResponse`).

## Body-vs-diff
Single-file docs change: `docs/runbooks/prod-data-reload-723.md`.

TechDebt: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
