### PR TITLE
infra(neo4j): codify stage/prod Neo4j memory + host swap as IaC (#504)

### DIFF
--- a/compose/.env.example
+++ b/compose/.env.example
@@ -9,6 +9,18 @@ POSTGRES_PASSWORD=changeme
 POSTGRES_DB=isnad_graph
 REDIS_PASSWORD=changeme
 
+# Neo4j memory + cpu sizing (deploy#504, from the #723 data-reload rehearsal
+# OOM). OPTIONAL overrides — the compose neo4j service hard-defaults to these
+# values via ${NEO4J_*:-<default>}, and env/base.env sets them for CI deploys,
+# so a manual bring-up does not need to set them. Shared stg/prod baseline:
+# both hosts are 15 GB RAM / 8 vCPU. The loader needs headroom alongside Neo4j,
+# so heap+pagecache were raised and the container mem/cpu limits widened (paired
+# with an 8 GB host swapfile provisioned by scripts/bootstrap-vps.sh).
+NEO4J_HEAP_MAX=5G
+NEO4J_PAGECACHE=3G
+NEO4J_MEM_LIMIT=10G
+NEO4J_CPUS=6.0
+
 # OAuth credentials
 AUTH_GOOGLE_CLIENT_ID=
 AUTH_GOOGLE_CLIENT_SECRET=

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -30,8 +30,8 @@ services:
     environment:
       NEO4J_AUTH: "neo4j/${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set}"
       NEO4J_PLUGINS: '["apoc", "graph-data-science"]'
-      NEO4J_server_memory_heap_max__size: 4G
-      NEO4J_server_memory_pagecache_size: 2G
+      NEO4J_server_memory_heap_max__size: ${NEO4J_HEAP_MAX:-5G}
+      NEO4J_server_memory_pagecache_size: ${NEO4J_PAGECACHE:-3G}
     volumes:
       - neo4j_data:/data
       - neo4j_logs:/logs
@@ -44,8 +44,8 @@ services:
     deploy:
       resources:
         limits:
-          memory: 8G
-          cpus: "4.0"
+          memory: ${NEO4J_MEM_LIMIT:-10G}
+          cpus: "${NEO4J_CPUS:-6.0}"
         reservations:
           memory: 4G
           cpus: "2.0"

--- a/env/base.env
+++ b/env/base.env
@@ -26,3 +26,14 @@ USER_SERVICE_IMAGE_TAG=latest
 PIPELINE_B2_BUCKET=noorinalabs-pipeline
 PIPELINE_B2_ENDPOINT=https://s3.us-east-005.backblazeb2.com
 PIPELINE_B2_REGION=us-east-005
+
+# Neo4j memory + cpu sizing (deploy#504, from #723 rehearsal OOM). Shared
+# baseline for BOTH stg and prod — both hosts are 15 GB RAM / 8 vCPU, so a
+# single tier suffices; only override in env/<env>.env if a host ever differs.
+# Consumed by compose/docker-compose.prod.yml's neo4j service via
+# ${NEO4J_*:-<default>} (the committed compose defaults equal these values, so
+# the bump holds even if a manual bring-up omits this file).
+NEO4J_HEAP_MAX=5G
+NEO4J_PAGECACHE=3G
+NEO4J_MEM_LIMIT=10G
+NEO4J_CPUS=6.0

--- a/scripts/bootstrap-vps.sh
+++ b/scripts/bootstrap-vps.sh
@@ -44,6 +44,13 @@ REPO_URL="https://github.com/noorinalabs/noorinalabs-deploy.git"
 INSTALL_DIR="/opt/noorinalabs-deploy"
 DEPLOY_USER="deploy"
 
+# Host swapfile size (Step 5). Both stg + prod are 15 GB RAM / 0-swap hosts;
+# the #723 data-reload OOM-killed the graph-load loader because Neo4j (heap
+# 5G + pagecache 3G + overhead) left too little headroom and there was no
+# swap to absorb the spike. 8 GB is the default; override with SWAP_SIZE.
+SWAP_SIZE="${SWAP_SIZE:-8G}"
+SWAPFILE="/swapfile"
+
 # Auxiliary repo directories pre-provisioned under /opt/ (see Step 3).
 # Single source of truth. To add a new repo to the deploy pipeline: append
 # it here, re-run this
@@ -128,7 +135,7 @@ fi
 # Residual value of the merge (post-exclusion): operators who add PERSONAL admin
 # keys to /root/.ssh/authorized_keys post-provision and want them reachable from
 # the deploy user too. Idempotent append-with-fingerprint-dedup (#287).
-echo "==> [1/4] Merging /root/.ssh/authorized_keys → deploy (idempotent)..."
+echo "==> [1/5] Merging /root/.ssh/authorized_keys → deploy (idempotent)..."
 DEPLOY_AUTH_KEYS="/home/$DEPLOY_USER/.ssh/authorized_keys"
 mkdir -p "/home/$DEPLOY_USER/.ssh"
 touch "$DEPLOY_AUTH_KEYS"
@@ -224,7 +231,7 @@ fi
 # /opt/ is root-owned by default, so the deploy user cannot create
 # $INSTALL_DIR itself on a first run. Pre-create + chown it first (same shape
 # as the Step 3 aux-repo dirs below), then clone into it as the deploy user.
-echo "==> [2/4] Refreshing $INSTALL_DIR as $DEPLOY_USER (idempotent)..."
+echo "==> [2/5] Refreshing $INSTALL_DIR as $DEPLOY_USER (idempotent)..."
 mkdir -p "$INSTALL_DIR"
 chown "$DEPLOY_USER:$DEPLOY_USER" "$INSTALL_DIR"
 if [ -d "$INSTALL_DIR/.git" ]; then
@@ -249,7 +256,7 @@ chown -R "$DEPLOY_USER:$DEPLOY_USER" "$INSTALL_DIR"
 # these dirs — until that gap is closed, this script is the canonical place
 # they live. To add a new repo to the deploy pipeline: append it to
 # AUX_REPOS at the top of this script, re-run (idempotent).
-echo "==> [3/4] Pre-provisioning auxiliary repo directories under /opt/..."
+echo "==> [3/5] Pre-provisioning auxiliary repo directories under /opt/..."
 for repo in "${AUX_REPOS[@]}"; do
   dir="/opt/$repo"
   if [ ! -d "$dir" ]; then
@@ -272,7 +279,7 @@ echo "    Auxiliary repo dirs ready."
 # so we no longer write a CHANGE-ME stub here. For first-time MANUAL
 # bring-ups (no CI yet), copy compose/env.example and edit by hand:
 #   cp $INSTALL_DIR/compose/env.example $INSTALL_DIR/.env && chmod 600 $INSTALL_DIR/.env
-echo "==> [4/4] Installing backup timer..."
+echo "==> [4/5] Installing backup timer..."
 if [ -f "$INSTALL_DIR/systemd/isnad-backup.service" ]; then
   install -m 644 "$INSTALL_DIR/systemd/isnad-backup.service"               /etc/systemd/system/
   install -m 644 "$INSTALL_DIR/systemd/isnad-backup.timer"                 /etc/systemd/system/
@@ -299,6 +306,57 @@ if [ -f "$INSTALL_DIR/systemd/isnad-backup.service" ]; then
   echo "    Start with: systemctl start isnad-backup.timer"
 else
   echo "    Backup systemd files not found, skipping (did the repo refresh in Step 2 succeed?)."
+fi
+
+# ── Step 5: Ensure a persistent host swapfile (deploy#504) ──────────────────
+# CLOUD-INIT GAP: the 15 GB stg/prod hosts ship with 0 swap. The #723 prod
+# data-reload rehearsal OOM-killed the graph-load loader on stg because Neo4j
+# (heap 5G + pagecache 3G + JVM/page-cache overhead, capped at a 10G container
+# limit) left too little headroom on a swapless box. The operator hand-added an
+# 8 GB swapfile to unblock the rehearsal, but it was ephemeral (no /etc/fstab
+# entry → lost on reboot). This step codifies that swapfile as IaC so it is
+# provisioned on bootstrap AND persists across reboots — for stg today and prod
+# before its data-load.
+#
+# Idempotent: if ANY swap is already active (e.g. the operator's live swapfile,
+# or a swap partition), it is left untouched. Otherwise the file is created only
+# if absent, then activated; the /etc/fstab entry is added only if not already
+# present. Re-runs are safe. Size is overridable via SWAP_SIZE (default 8G).
+echo "==> [5/5] Ensuring persistent host swap (size ${SWAP_SIZE}, override with SWAP_SIZE)..."
+if [ "$(swapon --show --noheadings | wc -l)" -gt 0 ]; then
+  echo "    Swap already active — leaving existing swap untouched:"
+  swapon --show | sed 's/^/      /'
+else
+  if [ ! -e "$SWAPFILE" ]; then
+    echo "    No active swap and $SWAPFILE absent — creating ${SWAP_SIZE} swapfile..."
+    # Prefer fallocate; fall back to dd if the backing FS doesn't support it.
+    if ! fallocate -l "$SWAP_SIZE" "$SWAPFILE" 2>/dev/null; then
+      echo "    fallocate unsupported on this FS — falling back to dd..."
+      # Strip a trailing G/g suffix for the dd MiB count (8G -> 8192 x 1MiB).
+      swap_gib="${SWAP_SIZE%[Gg]}"
+      dd if=/dev/zero of="$SWAPFILE" bs=1M count="$((swap_gib * 1024))" status=none
+    fi
+    chmod 600 "$SWAPFILE"
+    mkswap "$SWAPFILE" >/dev/null
+  else
+    echo "    $SWAPFILE already exists but is not active — (re)activating it..."
+    chmod 600 "$SWAPFILE"
+    # mkswap only if it lacks a swap signature (avoid clobbering live data).
+    if ! blkid "$SWAPFILE" 2>/dev/null | grep -q 'TYPE="swap"'; then
+      mkswap "$SWAPFILE" >/dev/null
+    fi
+  fi
+  swapon "$SWAPFILE"
+  echo "    Swap activated:"
+  swapon --show | sed 's/^/      /'
+fi
+
+# Persist across reboots via /etc/fstab — guarded so re-runs don't duplicate.
+if ! grep -qE "^[[:space:]]*${SWAPFILE}[[:space:]]+none[[:space:]]+swap[[:space:]]" /etc/fstab; then
+  echo "${SWAPFILE} none swap sw 0 0" >> /etc/fstab
+  echo "    Added persistent /etc/fstab entry: ${SWAPFILE} none swap sw 0 0"
+else
+  echo "    /etc/fstab already has a ${SWAPFILE} swap entry — not duplicating."
 fi
 
 # ── Done ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Codifies as IaC two live, repo-divergent hand-edits the operator made on the
**stage** host to unblock the #723 prod data-reload rehearsal, so the next
deploy is correct and **prod inherits them before its own data-load**.

During the rehearsal the graph-load loader was OOM-killed: stage is 15 GB RAM /
8 vCPU with **0 swap**, Neo4j was capped at 8 GB, leaving too little headroom.
The loader memory bug itself was already fixed upstream (parquet streaming in
`noorinalabs-data-acquisition`). To unblock, the operator hand-edited the live
stack — **none of which was in this repo**:

1. Neo4j memory bumped: heap `4G→5G`, pagecache `2G→3G`, container mem limit
   `8G→10G`, cpus `4.0→6.0`.
2. An ephemeral 8 GB `/swapfile` (`fallocate`/`mkswap`/`swapon`) with **no
   `/etc/fstab` entry** — lost on reboot.

Both stage and prod are 15 GB / 8 vCPU, so a single shared baseline serves both.

## What changed

- **`compose/docker-compose.prod.yml`** — parameterize the neo4j service memory,
  committed defaults equal to the **new** (bumped) values so the bump is the
  baseline:
  - `NEO4J_server_memory_heap_max__size: ${NEO4J_HEAP_MAX:-5G}`
  - `NEO4J_server_memory_pagecache_size: ${NEO4J_PAGECACHE:-3G}`
  - `deploy.resources.limits.memory: ${NEO4J_MEM_LIMIT:-10G}`
  - `deploy.resources.limits.cpus: "${NEO4J_CPUS:-6.0}"`
  - Reservations left as-is (repo doesn't parameterize them).
- **`env/base.env`** — shared stg+prod baseline: `NEO4J_HEAP_MAX=5G`,
  `NEO4J_PAGECACHE=3G`, `NEO4J_MEM_LIMIT=10G`, `NEO4J_CPUS=6.0`. base is the
  correct tier (env-invariant; both hosts 15 GB) — not duplicated into
  stg.env/prod.env since they don't differ today.
- **`compose/.env.example`** — document the four optional overrides.
- **`scripts/bootstrap-vps.sh`** — new idempotent **Step 5/5**: provision a
  `${SWAP_SIZE:-8G}` `/swapfile` (fallocate, dd fallback, `chmod 600`, `mkswap`,
  `swapon`) only when no swap is active and the file is absent, plus a guarded
  `/etc/fstab` entry (`/swapfile none swap sw 0 0`) so it survives reboot.
  Re-runs are safe; size overridable via `SWAP_SIZE`.

## Env-schema note

There is no separate env "schema" file to register into: the `env-validate` gate
is constraint-based — it validates `${VAR:?}`-**required** compose vars + the
secret-catalogue⊆passlist subset. The four new vars are non-secret and
`:-`-**defaulted** (optional), so no passlist/schema entry is required, and the
`passlist-drift` gate neither requires them (not `:?`) nor warns (they are
compose-referenced). Confirmed by running `env_validate.py`.

## Rollback safety

The container env var `NEO4J_server_memory_heap_max__size` (etc.) is still
*always* set — now defaulted — so a rolled-back Neo4j image still receives it.
No removed-env-form footgun (per `feedback_compose_env_change_rollback_safety`).

## Verification

- `docker compose -f compose/docker-compose.prod.yml --env-file <assembled> config`
  resolves neo4j to **heap 5G / pagecache 3G / limit 10 GiB (10737418240) /
  cpus 6**; reservations unchanged (4 GiB / 2 cpu). Both the compose-default
  path and the base.env-override path render identically.
- `python3 scripts/env_validate.py settings-load` + `secret-keys` → **OK**.
  (`os-environ` flags only pre-existing sibling-repo `src/` hits when the full
  org tree is checked out locally; it is a no-op in deploy's own CI — unrelated
  to this change.)
- `bash -n scripts/bootstrap-vps.sh` + `shellcheck` → **clean**.
- `pytest scripts/tests` → **44 passed**; pre-commit + pre-push hooks green.

## Scope / safety

Repo-only. Does **NOT** redeploy or recreate any container — a #723 data-load is
in flight on stage using the already-live-bumped Neo4j. This PR only lands the
IaC so the *next* deploy is correct; the prod apply is a later owner-signed-off
step.

## Reviewers

Requesting per charter (2 reviewers + security for the privileged host-bootstrap
change):
- **Weronika Zielinska** (Platform Architect) — compose/env topology
- **Aisha Idrissi** (SRE) — peer SRE review
- **Nino Kavtaradze** (Security) — `bootstrap-vps.sh` runs as root, edits
  `/etc/fstab` + creates a `chmod 600` swapfile

Closes #504

TechDebt: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
