### PR TITLE
infra(qa): wire non-admin test-user seed + terraform injection (#508)

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -298,6 +298,45 @@ jobs:
               echo "         successful migrate. Investigate per docs/runbooks/user-service-alembic.md#admin-bootstrap." >&2
             fi
 
+            # -------- post-migrate: seed non-admin QA test user (deploy#508) --------
+            # Idempotently create a NON-ADMIN (`reader`) email/password QA account so a
+            # known test login survives migrations AND a user-postgres DB wipe. Mirrors
+            # the admin bootstrap above: same one-shot image, DATABASE_URL, and docker
+            # network. Best-effort — it NEVER fails the migration gate:
+            #   * No-op exit 0 when TEST_USER_EMAIL / TEST_USER_PASSWORD are unset — the
+            #     seed script short-circuits. They are sourced from the VPS .env above
+            #     (the `set -a; . ./.env` sourcing), where deploy-{stg,prod}.yml's
+            #     write-deploy-env step lands them; on a first deploy before that step
+            #     has run they are simply absent and the seed correctly no-ops.
+            #   * Idempotent across deploys (`already_exists` on re-run).
+            #   * REFUSES to grant admin (enforced inside the script).
+            #   * The script only lands in the image after user-service #198 merges and
+            #     the image rebuilds; until then `docker run` exits non-zero. We LOG it
+            #     loudly but do NOT abort — the `migrated` output the promotion workflow
+            #     gates on must reflect the alembic result only, never this seed.
+            #   * Creds passed via -e (NOT argv) so the password never lands in the
+            #     one-shot container's PID-1 argv (CWE-214), matching the admin block.
+            echo "==> [${ENV_NAME}] post-migrate: seed non-admin QA test user (bootstrap_test_user.py)"
+            set +e
+            docker run --rm \
+              --network noorinalabs_user-backend \
+              -e DATABASE_URL="${DATABASE_URL}" \
+              -e TEST_USER_EMAIL="${TEST_USER_EMAIL:-}" \
+              -e TEST_USER_PASSWORD="${TEST_USER_PASSWORD:-}" \
+              "${IMAGE}" \
+              /app/.venv/bin/python scripts/bootstrap_test_user.py
+            SEED_RC=$?
+            set -e
+            if [ "${SEED_RC}" -eq 0 ]; then
+              echo "==> [${ENV_NAME}] test-user seed completed (rc=0: created / already_exists / no-op creds-unset)"
+            else
+              echo "WARNING: [${ENV_NAME}] test-user seed exited ${SEED_RC}." >&2
+              echo "         This does NOT fail the migration gate (alembic upgrade head already succeeded)." >&2
+              echo "         rc!=0 most likely means scripts/bootstrap_test_user.py is not yet in the" >&2
+              echo "         deployed image (user-service #198 not merged/rebuilt). It seeds once the" >&2
+              echo "         image carries the script. See deploy#508." >&2
+            fi
+
       - name: Record migration result
         id: record
         # Runner-side step — `$GITHUB_OUTPUT` is only writeable from runner

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -229,6 +229,11 @@ jobs:
           USER_POSTGRES_PASSWORD: ${{ secrets.USER_POSTGRES_PASSWORD }}
           USER_POSTGRES_USER: ${{ secrets.USER_POSTGRES_USER }}
           USER_REDIS_PASSWORD: ${{ secrets.USER_REDIS_PASSWORD }}
+          # QA test-user seed creds (deploy#508). TEST_USER_EMAIL is a non-secret
+          # var (an identifier); TEST_USER_PASSWORD is a secret. Both land in the
+          # host .env via env_keys below so the seed survives a user-postgres wipe.
+          TEST_USER_EMAIL: ${{ vars.TEST_USER_EMAIL }}
+          TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
         with:
           ssh_host: ${{ vars.VPS_HOST }}
           ssh_key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
@@ -260,7 +265,7 @@ jobs:
           # scripts/compose_tiered_up.sh. stg omits both → legacy single-`up`.
           gated_services: caddy frontend landing api user-service
           deferred_services: kafka kafka-init kafka-ui kafka-exporter
-          env_keys: NEO4J_PASSWORD,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,REDIS_PASSWORD,AUTH_GOOGLE_CLIENT_ID,AUTH_GOOGLE_CLIENT_SECRET,AUTH_GITHUB_CLIENT_ID,AUTH_GITHUB_CLIENT_SECRET,GRAFANA_ADMIN_PASSWORD,JWT_PRIVATE_KEY,JWT_PUBLIC_KEY,KAFKA_CLUSTER_ID,KAFKA_UI_PASSWORD,KAFKA_UI_USER,PIPELINE_B2_BUCKET,PIPELINE_B2_ENDPOINT,PIPELINE_B2_KEY,PIPELINE_B2_KEY_ID,PIPELINE_B2_REGION,BACKUP_B2_KEY_ID,BACKUP_B2_APP_KEY,BACKUP_B2_BUCKET,USER_POSTGRES_DB,USER_POSTGRES_PASSWORD,USER_POSTGRES_USER,USER_REDIS_PASSWORD
+          env_keys: NEO4J_PASSWORD,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,REDIS_PASSWORD,AUTH_GOOGLE_CLIENT_ID,AUTH_GOOGLE_CLIENT_SECRET,AUTH_GITHUB_CLIENT_ID,AUTH_GITHUB_CLIENT_SECRET,GRAFANA_ADMIN_PASSWORD,JWT_PRIVATE_KEY,JWT_PUBLIC_KEY,KAFKA_CLUSTER_ID,KAFKA_UI_PASSWORD,KAFKA_UI_USER,PIPELINE_B2_BUCKET,PIPELINE_B2_ENDPOINT,PIPELINE_B2_KEY,PIPELINE_B2_KEY_ID,PIPELINE_B2_REGION,BACKUP_B2_KEY_ID,BACKUP_B2_APP_KEY,BACKUP_B2_BUCKET,USER_POSTGRES_DB,USER_POSTGRES_PASSWORD,USER_POSTGRES_USER,USER_REDIS_PASSWORD,TEST_USER_EMAIL,TEST_USER_PASSWORD
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_actor: ${{ github.repository_owner }}
           # Slack webhook for alertmanager routing (deploy#262). Optional —
@@ -384,6 +389,83 @@ jobs:
               echo "         This does NOT fail the deploy (rollout + api health already verified)." >&2
               echo "         rc=1 means BootstrapError — most likely the 'admin' role is missing." >&2
               echo "         Investigate per docs/runbooks/user-service-alembic.md#admin-bootstrap." >&2
+            fi
+
+      # Post-deploy: seed the NON-ADMIN QA test user (deploy#508).
+      #
+      # Mirrors the admin-reassert step above, but for a NON-ADMIN (`reader`)
+      # email/password account, so a known QA login survives redeploys AND a
+      # user-postgres DB wipe. Runs on EVERY prod deploy after the stack is
+      # healthy, against the LIVE container — the same survives-the-wipe gap the
+      # admin reassert closes for the owner account.
+      #
+      # Idempotent + best-effort, by the same discipline as the admin reassert:
+      #   * No-op exit 0 when TEST_USER_EMAIL / TEST_USER_PASSWORD are unset — the
+      #     seed script (user-service scripts/bootstrap_test_user.py) short-circuits.
+      #   * Idempotent — a second run reports `already_exists` and exits 0.
+      #   * REFUSES to grant admin (enforced inside the script).
+      #   * Sequencing: bootstrap_test_user.py only lands in the image after
+      #     user-service #198 merges and the image rebuilds. Until then it is
+      #     ABSENT and `docker exec` exits non-zero; we LOG that loudly but NEVER
+      #     abort the deploy (rollout + api health already verified) — matching
+      #     the admin step's tolerance. The seed lands automatically once the image
+      #     carries the script.
+      #
+      # Creds flow via the step `env:` (vars.TEST_USER_EMAIL + secrets.
+      # TEST_USER_PASSWORD), passed to the container with `docker exec -e` so the
+      # password never lands on argv. DATABASE_URL resolves from the container's
+      # own compose-injected environment, exactly like the admin reassert.
+      - name: Seed QA test user (bootstrap_test_user.py)
+        uses: appleboy/ssh-action@v1
+        env:
+          TEST_USER_EMAIL: ${{ vars.TEST_USER_EMAIL }}
+          TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
+        with:
+          host: ${{ vars.VPS_HOST }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          envs: TEST_USER_EMAIL,TEST_USER_PASSWORD
+          script: |
+            set -uo pipefail
+            cd /opt/noorinalabs-deploy
+
+            CONTAINER="noorinalabs-user-service-1"
+
+            # Wait for user-service to report healthy before exec-ing into it.
+            echo "==> [prod] waiting for ${CONTAINER} to be healthy..."
+            us_health="not_found"
+            for i in $(seq 1 24); do
+              us_health=$(docker inspect --format='{{.State.Health.Status}}' "${CONTAINER}" 2>/dev/null || echo "not_found")
+              echo "Attempt $i/24: user-service=${us_health}"
+              if [ "${us_health}" = "healthy" ]; then
+                break
+              fi
+              sleep 5
+            done
+            if [ "${us_health}" != "healthy" ]; then
+              echo "WARNING: [prod] ${CONTAINER} not healthy after 120s (status=${us_health})." >&2
+              echo "         Skipping test-user seed this deploy; it will reseed on the next one." >&2
+              echo "         This does NOT fail the deploy (rollout + api health already verified)." >&2
+              exit 0
+            fi
+
+            echo "==> [prod] post-deploy: seed non-admin QA test user (bootstrap_test_user.py)"
+            set +e
+            docker exec -e PYTHONPATH=/app -w /app \
+              -e TEST_USER_EMAIL="${TEST_USER_EMAIL:-}" \
+              -e TEST_USER_PASSWORD="${TEST_USER_PASSWORD:-}" \
+              "${CONTAINER}" \
+              /app/.venv/bin/python scripts/bootstrap_test_user.py
+            SEED_RC=$?
+            set -e
+            if [ "${SEED_RC}" -eq 0 ]; then
+              echo "==> [prod] test-user seed completed (rc=0: created / already_exists / no-op creds-unset)"
+            else
+              echo "WARNING: [prod] test-user seed exited ${SEED_RC}." >&2
+              echo "         This does NOT fail the deploy (rollout + api health already verified)." >&2
+              echo "         rc!=0 most likely means scripts/bootstrap_test_user.py is not yet in the" >&2
+              echo "         deployed image (user-service #198 not merged/rebuilt). It seeds once the" >&2
+              echo "         image carries the script. See deploy#508." >&2
             fi
 
       - name: Report status

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -203,6 +203,11 @@ jobs:
           USER_POSTGRES_PASSWORD: ${{ secrets.USER_POSTGRES_PASSWORD }}
           USER_POSTGRES_USER: ${{ secrets.USER_POSTGRES_USER }}
           USER_REDIS_PASSWORD: ${{ secrets.USER_REDIS_PASSWORD }}
+          # QA test-user seed creds (deploy#508). TEST_USER_EMAIL is a non-secret
+          # var (an identifier); TEST_USER_PASSWORD is a secret. Both land in the
+          # host .env via env_keys below so the seed survives a user-postgres wipe.
+          TEST_USER_EMAIL: ${{ vars.TEST_USER_EMAIL }}
+          TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
         with:
           ssh_host: ${{ vars.VPS_HOST }}
           ssh_key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
@@ -225,7 +230,7 @@ jobs:
             SMTP_PASSWORD_FILE=smtp_password.secret
             HEALTHCHECKS_URL_FILE=healthchecks_url.secret
           base_domain: stg.noorinalabs.com
-          env_keys: NEO4J_PASSWORD,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,REDIS_PASSWORD,AUTH_GOOGLE_CLIENT_ID,AUTH_GOOGLE_CLIENT_SECRET,AUTH_GITHUB_CLIENT_ID,AUTH_GITHUB_CLIENT_SECRET,GRAFANA_ADMIN_PASSWORD,JWT_PRIVATE_KEY,JWT_PUBLIC_KEY,KAFKA_CLUSTER_ID,KAFKA_UI_PASSWORD,KAFKA_UI_USER,PIPELINE_B2_BUCKET,PIPELINE_B2_ENDPOINT,PIPELINE_B2_KEY,PIPELINE_B2_KEY_ID,PIPELINE_B2_REGION,BACKUP_B2_KEY_ID,BACKUP_B2_APP_KEY,BACKUP_B2_BUCKET,USER_POSTGRES_DB,USER_POSTGRES_PASSWORD,USER_POSTGRES_USER,USER_REDIS_PASSWORD
+          env_keys: NEO4J_PASSWORD,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,REDIS_PASSWORD,AUTH_GOOGLE_CLIENT_ID,AUTH_GOOGLE_CLIENT_SECRET,AUTH_GITHUB_CLIENT_ID,AUTH_GITHUB_CLIENT_SECRET,GRAFANA_ADMIN_PASSWORD,JWT_PRIVATE_KEY,JWT_PUBLIC_KEY,KAFKA_CLUSTER_ID,KAFKA_UI_PASSWORD,KAFKA_UI_USER,PIPELINE_B2_BUCKET,PIPELINE_B2_ENDPOINT,PIPELINE_B2_KEY,PIPELINE_B2_KEY_ID,PIPELINE_B2_REGION,BACKUP_B2_KEY_ID,BACKUP_B2_APP_KEY,BACKUP_B2_BUCKET,USER_POSTGRES_DB,USER_POSTGRES_PASSWORD,USER_POSTGRES_USER,USER_REDIS_PASSWORD,TEST_USER_EMAIL,TEST_USER_PASSWORD
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_actor: ${{ github.repository_owner }}
           # Slack webhook for alertmanager routing (deploy#262). Optional —
@@ -354,6 +359,83 @@ jobs:
               echo "         This does NOT fail the deploy (rollout + api health already verified)." >&2
               echo "         rc=1 means BootstrapError — most likely the 'admin' role is missing." >&2
               echo "         Investigate per docs/runbooks/user-service-alembic.md#admin-bootstrap." >&2
+            fi
+
+      # Post-deploy: seed the NON-ADMIN QA test user (deploy#508).
+      #
+      # Mirrors the admin-reassert step above, but for a NON-ADMIN (`reader`)
+      # email/password account, so a known QA login survives redeploys AND a
+      # user-postgres DB wipe. Runs on EVERY stg deploy after the stack is
+      # healthy, against the LIVE container — the same survives-the-wipe gap the
+      # admin reassert closes for the owner account.
+      #
+      # Idempotent + best-effort, by the same discipline as the admin reassert:
+      #   * No-op exit 0 when TEST_USER_EMAIL / TEST_USER_PASSWORD are unset — the
+      #     seed script (user-service scripts/bootstrap_test_user.py) short-circuits.
+      #   * Idempotent — a second run reports `already_exists` and exits 0.
+      #   * REFUSES to grant admin (enforced inside the script).
+      #   * Sequencing: bootstrap_test_user.py only lands in the image after
+      #     user-service #198 merges and the image rebuilds. Until then it is
+      #     ABSENT and `docker exec` exits non-zero; we LOG that loudly but NEVER
+      #     abort the deploy (rollout + api health already verified) — matching
+      #     the admin step's tolerance. The seed lands automatically once the image
+      #     carries the script.
+      #
+      # Creds flow via the step `env:` (vars.TEST_USER_EMAIL + secrets.
+      # TEST_USER_PASSWORD), passed to the container with `docker exec -e` so the
+      # password never lands on argv. DATABASE_URL resolves from the container's
+      # own compose-injected environment, exactly like the admin reassert.
+      - name: Seed QA test user (bootstrap_test_user.py)
+        uses: appleboy/ssh-action@v1
+        env:
+          TEST_USER_EMAIL: ${{ vars.TEST_USER_EMAIL }}
+          TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
+        with:
+          host: ${{ vars.VPS_HOST }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          envs: TEST_USER_EMAIL,TEST_USER_PASSWORD
+          script: |
+            set -uo pipefail
+            cd /opt/noorinalabs-deploy
+
+            CONTAINER="noorinalabs-user-service-1"
+
+            # Wait for user-service to report healthy before exec-ing into it.
+            echo "==> [stg] waiting for ${CONTAINER} to be healthy..."
+            us_health="not_found"
+            for i in $(seq 1 24); do
+              us_health=$(docker inspect --format='{{.State.Health.Status}}' "${CONTAINER}" 2>/dev/null || echo "not_found")
+              echo "Attempt $i/24: user-service=${us_health}"
+              if [ "${us_health}" = "healthy" ]; then
+                break
+              fi
+              sleep 5
+            done
+            if [ "${us_health}" != "healthy" ]; then
+              echo "WARNING: [stg] ${CONTAINER} not healthy after 120s (status=${us_health})." >&2
+              echo "         Skipping test-user seed this deploy; it will reseed on the next one." >&2
+              echo "         This does NOT fail the deploy (rollout + api health already verified)." >&2
+              exit 0
+            fi
+
+            echo "==> [stg] post-deploy: seed non-admin QA test user (bootstrap_test_user.py)"
+            set +e
+            docker exec -e PYTHONPATH=/app -w /app \
+              -e TEST_USER_EMAIL="${TEST_USER_EMAIL:-}" \
+              -e TEST_USER_PASSWORD="${TEST_USER_PASSWORD:-}" \
+              "${CONTAINER}" \
+              /app/.venv/bin/python scripts/bootstrap_test_user.py
+            SEED_RC=$?
+            set -e
+            if [ "${SEED_RC}" -eq 0 ]; then
+              echo "==> [stg] test-user seed completed (rc=0: created / already_exists / no-op creds-unset)"
+            else
+              echo "WARNING: [stg] test-user seed exited ${SEED_RC}." >&2
+              echo "         This does NOT fail the deploy (rollout + api health already verified)." >&2
+              echo "         rc!=0 most likely means scripts/bootstrap_test_user.py is not yet in the" >&2
+              echo "         deployed image (user-service #198 not merged/rebuilt). It seeds once the" >&2
+              echo "         image carries the script. See deploy#508." >&2
             fi
 
       - name: Report status

--- a/secrets/prod.env.example
+++ b/secrets/prod.env.example
@@ -43,3 +43,7 @@ PIPELINE_B2_KEY=changeme
 BACKUP_B2_KEY_ID=changeme
 BACKUP_B2_APP_KEY=changeme
 BACKUP_B2_BUCKET=changeme
+
+# QA test-user seed (deploy#508). Password only — TEST_USER_EMAIL is a
+# non-secret GH Environment variable, not tracked in this secret catalogue.
+TEST_USER_PASSWORD=changeme

--- a/secrets/stg.env.example
+++ b/secrets/stg.env.example
@@ -43,3 +43,7 @@ PIPELINE_B2_KEY=changeme
 BACKUP_B2_KEY_ID=changeme
 BACKUP_B2_APP_KEY=changeme
 BACKUP_B2_BUCKET=changeme
+
+# QA test-user seed (deploy#508). Password only — TEST_USER_EMAIL is a
+# non-secret GH Environment variable, not tracked in this secret catalogue.
+TEST_USER_PASSWORD=changeme

--- a/terraform/hetzner/envs/prod/main.tf
+++ b/terraform/hetzner/envs/prod/main.tf
@@ -17,4 +17,6 @@ module "vps" {
   user_postgres_password  = var.user_postgres_password
   user_redis_password     = var.user_redis_password
   user_service_jwt_secret = var.user_service_jwt_secret
+  test_user_email         = var.test_user_email
+  test_user_password      = var.test_user_password
 }

--- a/terraform/hetzner/envs/prod/terraform.tfvars.example
+++ b/terraform/hetzner/envs/prod/terraform.tfvars.example
@@ -19,3 +19,9 @@ ghcr_auth_b64 = "base64('username:ghcr-token')"
 user_postgres_password  = "a-strong-prod-password-at-least-16-chars"
 user_redis_password     = "a-strong-prod-password-at-least-16-chars"
 user_service_jwt_secret = "a-strong-prod-secret-at-least-32-chars"
+
+# Non-admin QA test-user seed (prod, deploy#508). Leave both empty to disable
+# the seed. test_user_email is an identifier (non-secret); test_user_password
+# must be at least 16 chars when set.
+test_user_email    = "qa+test@noorinalabs.com"
+test_user_password = "a-strong-qa-password-at-least-16-chars"

--- a/terraform/hetzner/envs/prod/variables.tf
+++ b/terraform/hetzner/envs/prod/variables.tf
@@ -54,3 +54,16 @@ variable "user_service_jwt_secret" {
   sensitive   = true
   default     = ""
 }
+
+variable "test_user_email" {
+  description = "Email of the prod NON-ADMIN QA test account (deploy#508). An identifier, not a secret; set via the `production` GH Environment variable TEST_USER_EMAIL. Empty disables the seed."
+  type        = string
+  default     = ""
+}
+
+variable "test_user_password" {
+  description = "Password for the prod NON-ADMIN QA test account (deploy#508; min 16 chars when set in the module). Set via the `production` GH Environment secret TEST_USER_PASSWORD. Empty disables the seed."
+  type        = string
+  sensitive   = true
+  default     = ""
+}

--- a/terraform/hetzner/envs/stg/main.tf
+++ b/terraform/hetzner/envs/stg/main.tf
@@ -17,4 +17,6 @@ module "vps" {
   user_postgres_password  = var.user_postgres_password
   user_redis_password     = var.user_redis_password
   user_service_jwt_secret = var.user_service_jwt_secret
+  test_user_email         = var.test_user_email
+  test_user_password      = var.test_user_password
 }

--- a/terraform/hetzner/envs/stg/terraform.tfvars.example
+++ b/terraform/hetzner/envs/stg/terraform.tfvars.example
@@ -19,3 +19,9 @@ ghcr_auth_b64 = "base64('username:ghcr-token')"
 user_postgres_password  = "a-strong-stg-password-at-least-16-chars"
 user_redis_password     = "a-strong-stg-password-at-least-16-chars"
 user_service_jwt_secret = "a-strong-stg-secret-at-least-32-chars"
+
+# Non-admin QA test-user seed (stg, deploy#508). Leave both empty to disable
+# the seed. test_user_email is an identifier (non-secret); test_user_password
+# must be at least 16 chars when set.
+test_user_email    = "qa+test@stg.noorinalabs.com"
+test_user_password = "a-strong-qa-password-at-least-16-chars"

--- a/terraform/hetzner/envs/stg/variables.tf
+++ b/terraform/hetzner/envs/stg/variables.tf
@@ -54,3 +54,16 @@ variable "user_service_jwt_secret" {
   sensitive   = true
   default     = ""
 }
+
+variable "test_user_email" {
+  description = "Email of the stg NON-ADMIN QA test account (deploy#508). An identifier, not a secret; set via the `staging` GH Environment variable TEST_USER_EMAIL. Empty disables the seed."
+  type        = string
+  default     = ""
+}
+
+variable "test_user_password" {
+  description = "Password for the stg NON-ADMIN QA test account (deploy#508; min 16 chars when set in the module). Set via the `staging` GH Environment secret TEST_USER_PASSWORD. Empty disables the seed."
+  type        = string
+  sensitive   = true
+  default     = ""
+}

--- a/terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl
+++ b/terraform/hetzner/modules/hetzner-vps/cloud-init.yaml.tpl
@@ -139,6 +139,12 @@ write_files:
       USER_POSTGRES_PASSWORD=${user_postgres_password}
       USER_REDIS_PASSWORD=${user_redis_password}
       USER_SERVICE_JWT_SECRET=${user_service_jwt_secret}
+      # Non-admin QA test-user seed (deploy#508). Injected here so the seed
+      # survives a user-postgres DB wipe; empty values disable the seed (the
+      # bootstrap_test_user.py script no-ops). TEST_USER_EMAIL is an identifier,
+      # TEST_USER_PASSWORD is a secret.
+      TEST_USER_EMAIL=${test_user_email}
+      TEST_USER_PASSWORD=${test_user_password}
 
   # Deploy directory marker
   - path: /opt/noorinalabs-deploy/.cloud-init-provisioned

--- a/terraform/hetzner/modules/hetzner-vps/main.tf
+++ b/terraform/hetzner/modules/hetzner-vps/main.tf
@@ -11,6 +11,8 @@ locals {
     user_postgres_password  = var.user_postgres_password
     user_redis_password     = var.user_redis_password
     user_service_jwt_secret = var.user_service_jwt_secret
+    test_user_email         = var.test_user_email
+    test_user_password      = var.test_user_password
   }
 }
 

--- a/terraform/hetzner/modules/hetzner-vps/variables.tf
+++ b/terraform/hetzner/modules/hetzner-vps/variables.tf
@@ -90,3 +90,26 @@ variable "user_service_jwt_secret" {
     error_message = "user_service_jwt_secret must be at least 32 characters when set."
   }
 }
+
+# Non-admin QA test-user seed (deploy#508). Threaded into the VPS
+# .env.user-service at provisioning so user-service's idempotent
+# scripts/bootstrap_test_user.py can create a known NON-ADMIN (reader)
+# email/password account that survives a user-postgres DB wipe. Empty (the
+# default) disables the seed — the script no-ops when either value is unset.
+variable "test_user_email" {
+  description = "Email/identity of the NON-ADMIN QA test account seeded by user-service's scripts/bootstrap_test_user.py (deploy#508). An identifier, not a secret. Empty disables the seed (the script no-ops)."
+  type        = string
+  default     = ""
+}
+
+variable "test_user_password" {
+  description = "Password for the NON-ADMIN QA test account seeded by user-service's scripts/bootstrap_test_user.py (deploy#508). Empty disables the seed (the script no-ops)."
+  type        = string
+  sensitive   = true
+  default     = ""
+
+  validation {
+    condition     = var.test_user_password == "" || length(var.test_user_password) >= 16
+    error_message = "test_user_password must be at least 16 characters when set."
+  }
+}


### PR DESCRIPTION
## What

Deploy-side wiring for the non-admin QA test-user seed. user-service's new
`scripts/bootstrap_test_user.py` (PR #198) idempotently creates a NON-ADMIN
(`reader`) email/password account from `TEST_USER_EMAIL` / `TEST_USER_PASSWORD`,
no-ops when unset, and refuses to grant admin. This wires it into deploy so the
test user is (re)seeded on every deploy/migrate and **survives a user-postgres
DB wipe** — mirroring the existing `bootstrap_admin.py` hook.

## Changes

1. **Host `.env` delivery** — `deploy-stg.yml` + `deploy-prod.yml`: pass
   `TEST_USER_EMAIL` (`vars`) + `TEST_USER_PASSWORD` (`secrets`) into the
   `write-deploy-env` `env:` block and append them to the `env_keys` passlist so
   both land in the host `/opt/noorinalabs-deploy/.env`.
2. **Seed step** (best-effort / non-gating, mirroring the admin step):
   - `db-migrate.yml` — one-shot `docker run` seed right after the admin
     bootstrap; creds sourced from the VPS `.env`, `DATABASE_URL` reused.
   - `deploy-stg.yml` + `deploy-prod.yml` — post-deploy `docker exec` seed after
     the admin reassert; creds via `docker exec -e` so the password never lands
     on argv. `DATABASE_URL` resolves from the container's own environment.
3. **Terraform injection** — `hetzner-vps`: sensitive `test_user_password`
   (validation `length >= 16` when non-empty, default `""`) + identifier
   `test_user_email` vars, threaded through `envs/{stg,prod}/{variables,main}.tf`
   and written into the `cloud-init` `.env.user-service` heredoc next to
   `USER_POSTGRES_PASSWORD`.
4. **Docs** — `secrets/{prod,stg}.env.example`: add `TEST_USER_PASSWORD=changeme`
   (`TEST_USER_EMAIL` is a non-secret var, not in the secret catalogue).

## Survives-DB-wipe mechanism

Two complementary, independent paths re-create the account so a `user-postgres`
data loss self-heals on the next deploy:

- **Terraform / cloud-init** writes `TEST_USER_EMAIL` + `TEST_USER_PASSWORD` into
  the host `/opt/noorinalabs-deploy/.env.user-service` at provisioning — these
  live on the host filesystem, independent of the database volume.
- **Every deploy** re-runs the seed (idempotent `already_exists` on re-run) via
  the post-deploy `docker exec` step (and the pre-deploy `db-migrate` one-shot),
  so a wiped DB is re-seeded on the very next rollout/migrate.

## Sequencing note

`scripts/bootstrap_test_user.py` only lands in the user-service image after
**user-service #198 merges and the image rebuilds**. Until then the seed step is
a best-effort **no-op**: a missing script makes `docker exec` / `docker run` exit
non-zero, which is logged loudly but **never** aborts the deploy or the migration
gate (matching the admin step's tolerance). Land us#198 first; the seed begins
working automatically once the image carries the script. With creds unset the
script also short-circuits to exit 0.

## Reviewer notes

- actionlint clean on all three changed workflows (shellcheck on PATH, so its
  shellcheck integration actually ran).
- `terraform fmt -check` clean; `terraform validate` passes for the module and
  both env roots (`-backend=false`, offline).
- `pre-commit run` green: terraform-fmt, terraform-validate, gitleaks,
  actionlint, env-example-check Passed; pre-push mypy + pytest green.
- env-validate `secret-keys` + `settings-load` pass (catalogue ⊆ passlist holds
  after adding `TEST_USER_PASSWORD`); passlist-drift OK (the `TEST_USER_*`
  "compose doesn't use" lines are informational warnings, same class as the
  existing `BACKUP_B2_*` entries, non-blocking by design).
- No real secret committed — only `changeme` / example placeholders.

Closes #508

---
TechDebt: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JbKEL6PNkDsgH7Zaxf6ZV9
