### PR TITLE
fix(cloudflare): verify Account-Owned API tokens via account endpoint in cf_token_preflight (#511)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -267,6 +267,11 @@ jobs:
       - name: Cloudflare token-scope preflight
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # Account-owned tokens verify at the account endpoint, not /user/...
+          # (#511). Account ID is public account metadata like the zone IDs
+          # above — a repo variable, not a secret. Optional: if unset the
+          # preflight falls back to the user-token verify endpoint.
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           NET_ZONE_ID: ${{ vars.CLOUDFLARE_NOORINALABS_NET_ZONE_ID }}
           ORG_ZONE_ID: ${{ vars.CLOUDFLARE_NOORINALABS_ORG_ZONE_ID }}
         run: ../../scripts/cf_token_preflight.sh
@@ -465,6 +470,11 @@ jobs:
       - name: Cloudflare token-scope preflight
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # Account-owned tokens verify at the account endpoint, not /user/...
+          # (#511). Account ID is public account metadata like the zone IDs
+          # above — a repo variable, not a secret. Optional: if unset the
+          # preflight falls back to the user-token verify endpoint.
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           NET_ZONE_ID: ${{ vars.CLOUDFLARE_NOORINALABS_NET_ZONE_ID }}
           ORG_ZONE_ID: ${{ vars.CLOUDFLARE_NOORINALABS_ORG_ZONE_ID }}
         run: ../../scripts/cf_token_preflight.sh

--- a/docs/runbooks/cloudflare-token-scope.md
+++ b/docs/runbooks/cloudflare-token-scope.md
@@ -55,7 +55,9 @@ both the `plan-cloudflare` and `apply-cloudflare` jobs of
 [`.github/workflows/terraform.yml`](../../.github/workflows/terraform.yml),
 before the `terraform` steps. It:
 
-1. Verifies the token is valid + active (`GET /user/tokens/verify`).
+1. Verifies the token is valid + active at the **token-verify endpoint** — the
+   account endpoint when `CLOUDFLARE_ACCOUNT_ID` is set, else the user endpoint
+   (see [User vs Account-Owned API tokens](#user-vs-account-owned-api-tokens-511)).
 2. Probes `GET /zones/<id>/rulesets` for each redirect zone — a non-destructive
    proxy for "the token covers this zone and can touch the rulesets API."
 
@@ -63,11 +65,59 @@ A miss fails the job early with a pointed `::error::` instead of a half-applied
 prod run. Run it locally the same way:
 
 ```bash
+# Account-owned token: set CLOUDFLARE_ACCOUNT_ID → account verify endpoint.
+CLOUDFLARE_API_TOKEN=… \
+CLOUDFLARE_ACCOUNT_ID="$(…cloudflare account id)" \
+NET_ZONE_ID="$(…noorinalabs.net zone id)" \
+ORG_ZONE_ID="$(…noorinalabs.org zone id)" \
+  scripts/cf_token_preflight.sh
+
+# User token: omit CLOUDFLARE_ACCOUNT_ID → user verify endpoint (fallback).
 CLOUDFLARE_API_TOKEN=… \
 NET_ZONE_ID="$(…noorinalabs.net zone id)" \
 ORG_ZONE_ID="$(…noorinalabs.org zone id)" \
   scripts/cf_token_preflight.sh
 ```
+
+### User vs Account-Owned API tokens (#511)
+
+Cloudflare has **two API-token kinds**, and they verify at **different
+endpoints**:
+
+| Token kind | Verify endpoint | Notes |
+|---|---|---|
+| **User API Token** | `GET /user/tokens/verify` | Tied to a user's profile; ~40-char value. |
+| **Account-Owned API Token** | `GET /accounts/{account_id}/tokens/verify` | Tied to the account; ~53-char value. |
+
+An **account-owned** token returns `success:false` with
+`code 1000 "Invalid API Token"` at the **user** endpoint even when it is valid
+and correctly scoped — it only verifies at the account endpoint. The Cloudflare
+Terraform provider (`~> 4.43`) auths with `api_token` and makes **zone-scoped**
+calls, so it works with either token kind unchanged; only the preflight's
+verify step is endpoint-sensitive.
+
+The preflight is therefore endpoint-aware: when `CLOUDFLARE_ACCOUNT_ID` is set
+it verifies at `GET /accounts/${CLOUDFLARE_ACCOUNT_ID}/tokens/verify`; otherwise
+it falls back to `GET /user/tokens/verify`. Both endpoints return the same
+envelope (`.success` / `.result.status`), so the downstream assertions are
+identical.
+
+**`CLOUDFLARE_ACCOUNT_ID` is a repo variable, not a secret** — the account ID is
+public account metadata, like the zone IDs already stored as `vars`. It is wired
+into the `Cloudflare token-scope preflight` step of both the `plan-cloudflare`
+and `apply-cloudflare` jobs as `${{ vars.CLOUDFLARE_ACCOUNT_ID }}`. Set it once
+(owner action — account IDs are not secret):
+
+```bash
+gh variable set CLOUDFLARE_ACCOUNT_ID \
+  --repo noorinalabs/noorinalabs-deploy --body <account_id>
+```
+
+Find the account ID in the Cloudflare dashboard (any zone → **Overview** →
+right-hand sidebar **Account ID**), or via
+`GET /accounts` with the token. If the variable is left unset, the preflight
+falls back to the user endpoint — which fails for the org's current
+account-owned `CLOUDFLARE_API_TOKEN`.
 
 ### Residual apply-gated gap
 

--- a/scripts/cf_token_preflight.sh
+++ b/scripts/cf_token_preflight.sh
@@ -22,7 +22,7 @@
 #   missing scope as an early, actionable CI failure instead.
 #
 # What it checks:
-#   1. Token is valid + active            (GET /user/tokens/verify)
+#   1. Token is valid + active            (token-verify endpoint, see below)
 #   2. Token can authenticate against the rulesets endpoint of EACH redirect
 #      zone (GET /zones/<id>/rulesets) — i.e. the zone is in the token's
 #      Zone Resources and the token can read rulesets. A 10000/9109 here is
@@ -37,7 +37,23 @@
 #     permission group specifically — is documented in the runbook and is the
 #     one apply-gated case that remains. See docs/runbooks/cloudflare-token-scope.md.
 #
+# User vs Account-Owned API tokens (#511):
+#   Cloudflare has two token kinds and they verify at DIFFERENT endpoints:
+#     - User API Token       → GET /user/tokens/verify
+#     - Account-Owned Token  → GET /accounts/<account_id>/tokens/verify
+#   An account-owned token returns `code 1000 "Invalid API Token"` at the user
+#   endpoint even when it is valid and correctly scoped. So step 1 is endpoint-
+#   aware: when CLOUDFLARE_ACCOUNT_ID is set we verify via the account endpoint;
+#   otherwise we fall back to the user endpoint (backward compatible). Both
+#   endpoints return the same envelope shape (.success / .result.status), so the
+#   downstream assertions are identical. CLOUDFLARE_ACCOUNT_ID is account
+#   metadata, not a secret — wired in CI as the repo variable vars.CLOUDFLARE_ACCOUNT_ID.
+#
 # Usage:
+#   # account-owned token (set CLOUDFLARE_ACCOUNT_ID → account verify endpoint):
+#   CLOUDFLARE_API_TOKEN=... CLOUDFLARE_ACCOUNT_ID=... NET_ZONE_ID=... ORG_ZONE_ID=... \
+#     scripts/cf_token_preflight.sh
+#   # user token (omit CLOUDFLARE_ACCOUNT_ID → user verify endpoint):
 #   CLOUDFLARE_API_TOKEN=... NET_ZONE_ID=... ORG_ZONE_ID=... \
 #     scripts/cf_token_preflight.sh
 #
@@ -49,6 +65,11 @@ set -euo pipefail
 : "${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN must be set}"
 : "${NET_ZONE_ID:?NET_ZONE_ID (noorinalabs.net zone id) must be set}"
 : "${ORG_ZONE_ID:?ORG_ZONE_ID (noorinalabs.org zone id) must be set}"
+# CLOUDFLARE_ACCOUNT_ID is OPTIONAL (#511): set it for an account-owned token to
+# verify via the account endpoint; leave it unset to fall back to the user
+# endpoint (a user API token). Do NOT add a `:?` required-guard here — that would
+# break the user-token fallback.
+CLOUDFLARE_ACCOUNT_ID="${CLOUDFLARE_ACCOUNT_ID:-}"
 
 CF_API="https://api.cloudflare.com/client/v4"
 
@@ -71,12 +92,24 @@ cf_get() {
 }
 
 # 1. Token validity + active status.
-verify_resp=$(cf_get "/user/tokens/verify") || {
-  err "Could not reach Cloudflare token-verify endpoint."
+#    Endpoint-aware (#511): an Account-Owned API token verifies only at the
+#    account endpoint and returns code 1000 "Invalid API Token" at the user
+#    endpoint. Pick the endpoint from whether CLOUDFLARE_ACCOUNT_ID is set.
+if [ -n "${CLOUDFLARE_ACCOUNT_ID}" ]; then
+  verify_path="/accounts/${CLOUDFLARE_ACCOUNT_ID}/tokens/verify"
+else
+  verify_path="/user/tokens/verify"
+fi
+verify_resp=$(cf_get "${verify_path}") || {
+  err "Could not reach Cloudflare token-verify endpoint (${verify_path})."
   exit 1
 }
 if [ "$(printf '%s' "${verify_resp}" | jq -r '.success')" != "true" ]; then
-  err "CLOUDFLARE_API_TOKEN failed /user/tokens/verify — the token is invalid, expired, or revoked."
+  err "CLOUDFLARE_API_TOKEN failed ${verify_path} — the token is invalid, expired, or revoked."
+  if [ -z "${CLOUDFLARE_ACCOUNT_ID}" ]; then
+    err "If this token is an Account-Owned API token it must verify at the account"
+    err "endpoint: set CLOUDFLARE_ACCOUNT_ID (CI: vars.CLOUDFLARE_ACCOUNT_ID) and re-run."
+  fi
   err "Fix: mint a new token and re-set the GH secret (see docs/runbooks/cloudflare-token-scope.md)."
   printf '%s\n' "${verify_resp}" | jq -c '.errors' >&2 || true
   exit 1
@@ -86,7 +119,7 @@ if [ "${token_status}" != "active" ]; then
   err "CLOUDFLARE_API_TOKEN status is '${token_status}', expected 'active'."
   exit 1
 fi
-echo "Token verify: OK (status=active)"
+echo "Token verify: OK (status=active, endpoint=${verify_path})"
 
 # 2. Per-zone rulesets read — proves the zone is in the token's Zone Resources
 #    and the token can touch the rulesets API on it. A miss here is the same

--- a/terraform/cloudflare/README.md
+++ b/terraform/cloudflare/README.md
@@ -99,6 +99,12 @@ Prod and stg VPS IPs are read automatically from the hetzner per-env Terraform r
 
 - [Terraform >= 1.6](https://developer.hashicorp.com/terraform/install)
 - `CLOUDFLARE_API_TOKEN` — Cloudflare API token. **Permissions:** `Zone:DNS:Edit`, `Zone:Zone Settings:Edit`, `Zone:Zone:Read`, **and `Zone:Dynamic Redirect:Edit`** (the last is required for the `.net`/`.org` canonical-redirect rulesets — DNS edit alone is insufficient for ruleset management). **Zone Resources:** must cover all three zones — `noorinalabs.com`, `noorinalabs.net`, `noorinalabs.org` (or "All zones in account"). A token scoped to `.com` only authenticates for `.com` DNS but fails the redirect apply with `Authentication error (10000)` — see [token-scope runbook](../../docs/runbooks/cloudflare-token-scope.md) and #347.
+  - **Token kind — User vs Account-Owned (#511):** Cloudflare API tokens come in two kinds. A **User API Token** verifies at `GET /user/tokens/verify`; an **Account-Owned API Token** verifies only at `GET /accounts/{account_id}/tokens/verify` and returns `code 1000 "Invalid API Token"` at the user endpoint despite being valid. The Terraform provider (`~> 4.43`) auths the same way for both (zone-scoped `api_token` calls), so **no resource change is needed** for either kind — but the CI **token-scope preflight** must hit the matching verify endpoint. The org's `CLOUDFLARE_API_TOKEN` is now account-owned, so `CLOUDFLARE_ACCOUNT_ID` (below) must be set. See the [token-scope runbook § User vs Account-Owned API tokens](../../docs/runbooks/cloudflare-token-scope.md#user-vs-account-owned-api-tokens-511).
+- `CLOUDFLARE_ACCOUNT_ID` — Cloudflare **account** ID (public metadata, **not a secret**). Required when `CLOUDFLARE_API_TOKEN` is an account-owned token so the preflight verifies at the account endpoint; omit it for a user token (the preflight falls back to `/user/tokens/verify`). In CI it is the repo variable `vars.CLOUDFLARE_ACCOUNT_ID`, wired into the `Cloudflare token-scope preflight` step of both `plan-cloudflare` and `apply-cloudflare`. Set it with:
+  ```bash
+  gh variable set CLOUDFLARE_ACCOUNT_ID --repo noorinalabs/noorinalabs-deploy --body <account_id>
+  ```
+  Find the account ID in the Cloudflare dashboard (any zone → Overview → Account ID in the sidebar).
 - `cloudflare_zone_id` — Zone ID for `noorinalabs.com` (Cloudflare dashboard → Overview → Zone ID)
 - Backblaze B2 credentials (to read hetzner remote state — same creds as the cloudflare module's own backend)
 


### PR DESCRIPTION
## Summary

`scripts/cf_token_preflight.sh` verified the Cloudflare API token against the **user** endpoint `GET /user/tokens/verify`, which only accepts **User API Tokens**. The org's `CLOUDFLARE_API_TOKEN` is now an **Account-Owned API Token** — those verify only at `GET /accounts/{account_id}/tokens/verify` and return `code 1000 "Invalid API Token"` at the user endpoint even when valid and correctly scoped. So the preflight false-failed the valid token (step-2 per-zone rulesets probe already worked unchanged).

## What changed

1. **`scripts/cf_token_preflight.sh`** — step 1 is now endpoint-aware. When `CLOUDFLARE_ACCOUNT_ID` is set it verifies via `/accounts/${CLOUDFLARE_ACCOUNT_ID}/tokens/verify`; otherwise it falls back to `/user/tokens/verify` (**backward compatible** for any repo still on a user token). `CLOUDFLARE_ACCOUNT_ID` is referenced as `${CLOUDFLARE_ACCOUNT_ID:-}` and is **optional** — no `:?` required-guard, so the user-token path keeps working. The existing `.success == true` and `.result.status == "active"` assertions are unchanged (account endpoint returns the same envelope). A failed user-endpoint verify now hints to set `CLOUDFLARE_ACCOUNT_ID` for an account-owned token. `set -euo pipefail` + `::error::` annotations + shellcheck-clean preserved.
2. **`.github/workflows/terraform.yml`** — wires `CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}` into the `Cloudflare token-scope preflight` step env of **both** `plan-cloudflare` and `apply-cloudflare`. The account ID is public account metadata like the zone-id `vars` already stored — a repo **variable**, not a secret (commented inline).
3. **Docs** — `docs/runbooks/cloudflare-token-scope.md` and `terraform/cloudflare/README.md` document User vs Account-Owned tokens, the two verify endpoints, and the `CLOUDFLARE_ACCOUNT_ID` repo variable.

## No terraform resource change

The Cloudflare TF provider (`~> 4.43`) auths with `api_token` and makes zone-scoped API calls — it works with account-owned tokens unchanged. Only the preflight's verify step is endpoint-sensitive.

## Owner action required

Set the repo variable (account IDs are **not** secret):

```bash
gh variable set CLOUDFLARE_ACCOUNT_ID --repo noorinalabs/noorinalabs-deploy --body <account_id>
```

Until it is set, the preflight falls back to the user endpoint, which fails for the current account-owned `CLOUDFLARE_API_TOKEN`. This is what blocks the `plan-cloudflare`/`apply-cloudflare` jobs (and #509's CF validation).

## Local checks (run before push)

- `shellcheck` + `bash -n` on `cf_token_preflight.sh` — clean
- `actionlint` on `terraform.yml` — clean
- `cspell` + `gitleaks` on docs — clean (via `pre-commit run`)
- pre-commit ⇄ CI sync-drift gate — OK
- pre-push stage (mypy / pytest sync-gate / pytest-scripts) — all pass
- End-to-end endpoint selection verified with a stub `curl`: `CLOUDFLARE_ACCOUNT_ID` set → `/accounts/<id>/tokens/verify`; unset → `/user/tokens/verify`.

Closes #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)
