### PR TITLE
promote embed image to prod tag + fail-safe compose default (deploy#470)

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -49,7 +49,17 @@ on:
         required: false
         default: ""
       images:
-        description: "Comma-separated image set to promote (default: all)."
+        description: >-
+          Comma-separated image set to promote. Default promotes the four
+          daemon-stack services. `embed`
+          (noorinalabs-isnad-graph-embed) is also promotable but is OPT-IN
+          (deploy#470): it is a one-shot, profile-gated re-embed image with
+          its own lifecycle — not part of the prod VPS stack roll — so it is
+          only retagged when explicitly requested (e.g. `images=embed` for a
+          prod re-embed cutover, or `api,frontend,user-service,landing,embed`
+          to move it alongside a stack promotion). An `embed`-only promotion
+          writes `prod-<short>`/`prod-latest` for the embed image and does NOT
+          trigger a prod VPS rollout (see trigger-prod-deploy guard below).
         required: false
         default: "api,frontend,user-service,landing"
       skip_stg_verify:
@@ -220,8 +230,20 @@ jobs:
               "frontend":     "noorinalabs/noorinalabs-isnad-graph-frontend",
               "user-service": "noorinalabs/noorinalabs-user-service",
               "landing":      "noorinalabs/noorinalabs-landing-page",
+              # Opt-in (deploy#470): the decoupled one-shot re-embed image
+              # (isnad-graph#1089). Retagged stg -> prod via the same
+              # sha-<short>-sourced imagetools path as the stack services so a
+              # prod re-embed (reembed-corpus.yml, env=prod) has a `prod-latest`
+              # to pull instead of falling back to a stg tag. NOT in the default
+              # set and NOT part of the prod VPS stack roll — see trigger-prod-deploy.
+              "embed":        "noorinalabs/noorinalabs-isnad-graph-embed",
           }
-          raw = os.environ.get("IMAGES_INPUT", "").strip() or ",".join(mapping)
+          # Implicit "all" (empty input) = the four daemon-stack services only.
+          # `embed` is opt-in (deploy#470) and must be named explicitly — it is
+          # NOT swept in by the empty-input fallback (that would give an
+          # implicit promotion an unexpected embed retag).
+          _default_set = ["api", "frontend", "user-service", "landing"]
+          raw = os.environ.get("IMAGES_INPUT", "").strip() or ",".join(_default_set)
           requested = [s.strip() for s in raw.split(",") if s.strip()]
           unknown = [s for s in requested if s not in mapping]
           if unknown:
@@ -994,7 +1016,15 @@ jobs:
     # only on the DIRECT needs instead — `retag` already encodes the
     # gate-stg-verify + migrate-prod acceptability, so retag==success is
     # sufficient. Same pattern `retag` uses to ignore a skipped ancestor.
-    if: ${{ always() && needs.plan.result == 'success' && needs.retag.result == 'success' }}
+    # The final clause gates the prod VPS rollout on at least one DAEMON-STACK
+    # service being in the promotion set. `embed` (deploy#470) is a one-shot,
+    # profile-gated re-embed image that deploy-prod.yml does NOT roll — so an
+    # `embed`-only promotion leaves all four stack shorts empty. Without this
+    # clause, deploy-prod.yml would be dispatched with all-empty tags and fall
+    # back to `prod-latest` for EVERY stack service, silently re-rolling the
+    # entire prod stack as a side effect of an embed-only retag. The embed prod
+    # tag is consumed by reembed-corpus.yml, not by a VPS rollout.
+    if: ${{ always() && needs.plan.result == 'success' && needs.retag.result == 'success' && (needs.plan.outputs.api_short != '' || needs.plan.outputs.frontend_short != '' || needs.plan.outputs.user_service_short != '' || needs.plan.outputs.landing_short != '') }}
     runs-on: ubuntu-latest
     # NOT env-gated — the approval already happened at retag.
     # Firing deploy-prod.yml here is the rollout-execution step.

--- a/compose/.env.example
+++ b/compose/.env.example
@@ -117,8 +117,14 @@ INGEST_IMAGE_TAG=stg-latest
 # one-shot `isnad-graph-embed` service; the `embed` compose profile is OFF by
 # default, so this is only consumed when reembed-corpus.yml (or a break-glass
 # `--profile embed` up) runs. The workflow overrides EMBED_IMAGE per-dispatch
-# with the env-scoped resolved tag. Defaults to the stg embed image in compose
-# if unset.
+# with the env-scoped resolved tag (`<env>-latest`), so this value is NOT what
+# a re-embed run uses.
+# NOTE (deploy#470): the VPS `.env` is written by the write-deploy-env composite
+# action, which emits ONLY enumerated keys and does NOT emit EMBED_IMAGE — so on
+# the actual stg/prod boxes the compose *default* governs a manual break-glass
+# `--profile embed up`. That default is `prod-latest` (the fail-safe direction:
+# stg-on-prod is blocked by reembed-corpus.yml's env guard, prod-on-stg is
+# benign). This line is a LOCAL-DEV convenience only.
 EMBED_IMAGE=ghcr.io/noorinalabs/noorinalabs-isnad-graph-embed:stg-latest
 
 # Pipeline object storage (Backblaze B2 in prod, MinIO in local dev).

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -228,7 +228,15 @@ services:
   # PG_DSN / REDIS_URL), interpolated by compose from the VPS .env, so no
   # password ever lands on argv (CWE-214) and no NEW required secret is added.
   isnad-graph-embed:
-    image: ${EMBED_IMAGE:-ghcr.io/noorinalabs/noorinalabs-isnad-graph-embed:stg-latest}
+    # EMBED_IMAGE default is `prod-latest` — the FAIL-SAFE direction (deploy#470).
+    # reembed-corpus.yml always sets EMBED_IMAGE explicitly per-env (<env>-latest),
+    # so this default is only hit by a manual break-glass `--profile embed up`.
+    # This compose file is shared by both VPS boxes; defaulting to `prod-latest`
+    # means a manual break-glass on PROD pulls the correct prod embed image
+    # (previously it silently defaulted to a stg tag on prod — the cross-env
+    # hazard flagged in deploy#470), while on STG the reverse (a prod tag on stg)
+    # is explicitly benign per the reembed-corpus.yml env guard.
+    image: ${EMBED_IMAGE:-ghcr.io/noorinalabs/noorinalabs-isnad-graph-embed:prod-latest}
     profiles: ["embed"]
     read_only: true
     tmpfs:

--- a/docs/runbooks/corpus-reembedding.md
+++ b/docs/runbooks/corpus-reembedding.md
@@ -49,6 +49,36 @@ Each step is a one-shot `--rm` container from the profile-gated `isnad-graph-emb
 
 Re-embed `stg` first, eyeball search quality, then `prod`. There is no automatic stg→prod chaining — each env is a separate dispatch (and prod is approval-gated).
 
+### Prerequisite for `prod`: promote the embed image to a prod tag (deploy#470)
+
+Unlike the stack services, the `isnad-graph-embed` image is **not** promoted by a
+routine `deploy-prod` roll — it is a one-shot, profile-gated image with its own
+lifecycle. A prod re-embed resolves its default image to
+`ghcr.io/noorinalabs/noorinalabs-isnad-graph-embed:prod-latest`, and
+`reembed-corpus.yml` **refuses to re-embed `prod` with a `stg-*`-tagged image**
+(env guard). So before the first prod re-embed, that `prod-*` tag must exist.
+
+`promote.yml` can now promote the embed image (opt-in — it is NOT in the default
+promotion set). Promote it **alone** so no prod VPS stack roll is triggered:
+
+```bash
+gh workflow run promote.yml --repo noorinalabs/noorinalabs-deploy \
+  --ref main -f images=embed
+# approve the `production` Environment gate on the retag job when prompted
+```
+
+This writes `prod-<short>` + `prod-latest` for `noorinalabs-isnad-graph-embed`
+via a registry-side retag of its current `stg-latest` digest (no VPS rollout —
+the `trigger-prod-deploy` job is guarded to skip when only `embed` is promoted).
+Confirm the tag landed:
+
+```bash
+docker buildx imagetools inspect \
+  ghcr.io/noorinalabs/noorinalabs-isnad-graph-embed:prod-latest
+```
+
+Only then dispatch `reembed-corpus.yml` with `env=prod`.
+
 ## Expected duration
 
 - **Default model:** no download — it is baked into the embed image and populates `st_model_cache` on first run. Only a model **swap** (a non-baked `EMBEDDING_MODEL`) adds a one-time ~470 MB download (a few minutes on the VPS link).


### PR DESCRIPTION
## Summary

Unblocks the **prod corpus re-embed** (deploy#470 / blocks ig#1148). The two original blockers in the issue title — stale prod compose (missing `isnad-graph-embed` service) and empty prod corpus — were **both resolved in the 06-19 cutover** (embed service is in prod compose; prod Neo4j corpus loaded + verified). The **only remaining gap** (root-caused in the issue's 06-19 comment) is that **no `prod-*` tag exists for `noorinalabs-isnad-graph-embed`**:

- `reembed-corpus.yml` (env=`prod`) resolves its default image to `…-embed:prod-latest` and **refuses a stg-tagged image on prod** (env guard) — correct, but `prod-latest` doesn't exist.
- `promote.yml` retagged only api/frontend/user-service/landing — the embed image was omitted.

## Changes

- **`promote.yml`** — add `embed` as an **opt-in** promotable image (not in the default set; not swept in by the empty-input fallback). Retagged stg→prod via the same `sha-<short>`-sourced `imagetools` path as the stack services. **Guarded `trigger-prod-deploy`** so an `embed`-only promotion (all four stack shorts empty) does **not** dispatch `deploy-prod.yml` — without the guard it would fall back to `prod-latest` for every stack service and silently re-roll the whole prod stack.
- **`compose/docker-compose.prod.yml`** — default `EMBED_IMAGE` to `prod-latest` (fail-safe). `write-deploy-env` never emits `EMBED_IMAGE` to the box `.env`, so the compose default governs a manual break-glass on the box; `stg`-on-`prod` is the dangerous direction (already guarded by the reembed workflow), `prod`-on-`stg` is benign.
- **`compose/.env.example`** — correct the now-stale "defaults to stg" comment; document the box-`.env`-omits-`EMBED_IMAGE` split.
- **`docs/runbooks/corpus-reembedding.md`** — document the prod embed-promote prerequisite.

The compose `isnad-graph-embed` service (image/weights-cache volume/networks/env) is already consistent with staging because `docker-compose.prod.yml` is the **single compose file shared by both VPS boxes** (per-env differences come from `.env`).

## Orchestrator cutover + reembed commands (owner-authorized; do NOT run against prod from this task)

```bash
# 1. Promote the embed image to a prod tag (embed-only → no prod stack roll).
#    Approve the `production` Environment gate on the retag job when prompted.
gh workflow run promote.yml --repo noorinalabs/noorinalabs-deploy \
  --ref main -f images=embed

# 2. Confirm prod-latest landed for the embed image.
docker buildx imagetools inspect \
  ghcr.io/noorinalabs/noorinalabs-isnad-graph-embed:prod-latest

# 3. Dry-run the prod re-embed (writes nothing; validates service resolves under live .env).
gh workflow run reembed-corpus.yml --repo noorinalabs/noorinalabs-deploy \
  --ref main -f env=prod -f dry_run=true

# 4. Real prod re-embed (approve the production Environment gate).
gh workflow run reembed-corpus.yml --repo noorinalabs/noorinalabs-deploy \
  --ref main -f env=prod -f dry_run=false
```

## Verify

- `verify-recall` (the workflow gate) is green → recall trustworthy; `corpus_reembed_last_run_success{env="prod"}=1` gauge set.
- Semantic search returns **200** (not 500) against prod, e.g. `GET /api/v1/search/semantic?q=…` returns ranked results.
- Embeddings present: prod Postgres `SELECT count(*) FROM <embedding table> WHERE embedding IS NOT NULL` > 0 (34,028-row corpus).

## CI / local⇄CI parity

Ran locally (green): `actionlint` (+shellcheck on PATH), `docker compose config` (compose-validate), service-tier-subset check, `env_validate.py` hermetic checks, `cspell` + `markdownlint-cli2` on the runbook. Pre-commit + pre-push hooks all passed.

Closes #470

---

**Reviewers:** Weronika Zielinska (peer / platform architect), Nino Kavtaradze (secondary / security). No tech debt introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvQH5QhX7z6dAVM1rtTAXJ