### PR TITLE
deploy#521: grant actions:write to trigger-prod-deploy

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1026,6 +1026,19 @@ jobs:
     # tag is consumed by reembed-corpus.yml, not by a VPS rollout.
     if: ${{ always() && needs.plan.result == 'success' && needs.retag.result == 'success' && (needs.plan.outputs.api_short != '' || needs.plan.outputs.frontend_short != '' || needs.plan.outputs.user_service_short != '' || needs.plan.outputs.landing_short != '') }}
     runs-on: ubuntu-latest
+    permissions:
+      # `actions: write` is required to dispatch another workflow
+      # (`gh workflow run deploy-prod.yml`) via the workflow_dispatch API.
+      # The workflow-level `permissions:` block (contents:read, packages:write,
+      # issues:write) omits `actions:` entirely, and a job-level `permissions:`
+      # block fully REPLACES the workflow-level one at YAML resolution time (same
+      # mechanic noted on `gate-stg-verify` above) — so without re-listing here,
+      # the dispatch 403s "Resource not accessible by integration" and the prod
+      # VPS rollout silently never fires after a successful retag (deploy#521).
+      actions: write
+      # `contents: read` re-listed because the job-level block replaces the
+      # workflow-level grant; `gh` reads repo context for the dispatch target.
+      contents: read
     # NOT env-gated — the approval already happened at retag.
     # Firing deploy-prod.yml here is the rollout-execution step.
     #


### PR DESCRIPTION
## Summary

`promote.yml`'s `trigger-prod-deploy` job dispatches `deploy-prod.yml` via `gh workflow run`, but carried **no job-level `permissions:` block**, so it inherited the workflow-level grant (`contents: read`, `packages: write`, `issues: write`) — which omits `actions`. Dispatching another workflow requires **`actions: write`**, so the dispatch returned HTTP 403 "Resource not accessible by integration" and the prod VPS rollout silently never fired after a successful `retag`; operators have been dispatching `deploy-prod.yml` by hand.

## Fix

Added a **scoped job-level `permissions:` block** to `trigger-prod-deploy`:
- `actions: write` — required for the `gh workflow run deploy-prod.yml` dispatch.
- `contents: read` — re-listed because a job-level block **fully replaces** the workflow-level one at YAML resolution time (same mechanic already documented on the sibling `gate-stg-verify` job).

Kept to **least privilege** on the single job — did NOT broaden the workflow-level block.

## Validation
- `actionlint .github/workflows/promote.yml` → clean (rc=0), shellcheck on PATH.
- YAML parses (`yaml.safe_load`).
- `pre-commit run --files .github/workflows/promote.yml` → all applicable hooks pass (actionlint, gitleaks).

## Runtime gate (NOT verified in this PR)
End-to-end proof — a real promotion dispatching `deploy-prod.yml` with **no 403** — is a **runtime/prod-state gate verified at the next promotion window**. This PR delivers the mechanic fix + a lint-valid workflow only; the E2E prod dispatch is deliberately **not** claimed as verified here.

TechDebt: none. Follow-up is runtime confirmation at the next promotion window (tracked on #521), not code debt.

Closes #521
