### PR TITLE
deploy#523: api semantic-search embedder parity (MiniLM) — model-capable image + sizing + smoke gate

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -30,6 +30,8 @@ diffable
 dispatchable
 distiluse
 dryrun
+embedder
+embedders
 emptively
 exfiltrates
 fawaz
@@ -85,6 +87,7 @@ pubkeys
 Rashidi
 reembed
 regen
+reindex
 reloadable
 Renaud
 retag

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -156,8 +156,14 @@ jobs:
             fi
           }
           # Cover every service compose pulls on stg (PULL_SERVICES =
-          # api frontend landing user-service).
-          check "ghcr.io/noorinalabs/noorinalabs-isnad-graph:$AF_TAG"
+          # api frontend landing user-service). The api pulls the model-capable
+          # `-embed` image, NOT the torch-free `isnad-graph` runtime image
+          # (deploy#523): it shares AF_TAG (embed:<env>-<sha> is built on the same
+          # isnad-graph main push), so this pre-flight must inspect the embed manifest
+          # — otherwise it would guard a manifest nothing pulls and let a missing
+          # embed:$AF_TAG surface only as a mid-deploy `compose pull` error (the exact
+          # deploy#418 hazard this gate exists to prevent).
+          check "ghcr.io/noorinalabs/noorinalabs-isnad-graph-embed:$AF_TAG"
           check "ghcr.io/noorinalabs/noorinalabs-isnad-graph-frontend:$AF_TAG"
           check "ghcr.io/noorinalabs/noorinalabs-user-service:$US_TAG"
           check "ghcr.io/noorinalabs/noorinalabs-landing-page:$LD_TAG"

--- a/compose/.env.example
+++ b/compose/.env.example
@@ -111,10 +111,12 @@ CACHEBUST=1
 # model-capable `noorinalabs-isnad-graph-embed` image so it queries semantic search
 # with the SAME MiniLM embedder the corpus was embedded with (the torch-free
 # `noorinalabs-isnad-graph` image silently fell back to the lexical HashingEmbedder
-# → 200-with-garbage). This var is NOT written by the write-deploy-env composite, so
-# the compose default governs on the real boxes; it exists as a break-glass rollback
-# lever — set it to `ghcr.io/noorinalabs/noorinalabs-isnad-graph` (and drop the api's
-# EMBEDDING_MODEL) to revert the api to the torch-free image without a compose PR.
+# → 200-with-garbage). This var is NOT written by the write-deploy-env composite
+# (which TRUNCATES .env on every deploy), so a hand-set value in a box `.env` does NOT
+# persist — it reverts on the next deploy. It is an IaC rollback SEAM only: revert the
+# api to the torch-free image by flipping this default (or `git revert`) in a PR and
+# redeploying (drop the api's EMBEDDING_MODEL in the same change). For local dev this
+# default just documents the image the compose file resolves to.
 API_IMAGE=ghcr.io/noorinalabs/noorinalabs-isnad-graph-embed
 # Ingest pipeline workers (deploy#440). Independent per-service tag (deploy#418
 # routing) — the `pipeline` compose profile is OFF by default, so this is only

--- a/compose/.env.example
+++ b/compose/.env.example
@@ -107,6 +107,15 @@ KAFKA_UI_READONLY=true
 IMAGE_TAG=latest
 USER_SERVICE_IMAGE_TAG=latest
 CACHEBUST=1
+# API image indirection (deploy#523). The `api` service defaults to the
+# model-capable `noorinalabs-isnad-graph-embed` image so it queries semantic search
+# with the SAME MiniLM embedder the corpus was embedded with (the torch-free
+# `noorinalabs-isnad-graph` image silently fell back to the lexical HashingEmbedder
+# → 200-with-garbage). This var is NOT written by the write-deploy-env composite, so
+# the compose default governs on the real boxes; it exists as a break-glass rollback
+# lever — set it to `ghcr.io/noorinalabs/noorinalabs-isnad-graph` (and drop the api's
+# EMBEDDING_MODEL) to revert the api to the torch-free image without a compose PR.
+API_IMAGE=ghcr.io/noorinalabs/noorinalabs-isnad-graph-embed
 # Ingest pipeline workers (deploy#440). Independent per-service tag (deploy#418
 # routing) — the `pipeline` compose profile is OFF by default, so this is only
 # consumed once ingest-platform#83 publishes the worker image and brings the

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -133,12 +133,15 @@ services:
     # api image (built on the same isnad-graph main push) — so it serves
     # `uvicorn src.api.app:create_app` with NO isnad-graph change. Repointing this one
     # compose file (shared by BOTH stg and prod boxes) preserves stg↔prod parity by
-    # construction. `API_IMAGE` is an indirection var for clean break-glass rollback:
-    # set it to `ghcr.io/noorinalabs/noorinalabs-isnad-graph` in the VPS .env to
-    # revert the api to the torch-free image without a compose PR (drop the
-    # `EMBEDDING_MODEL` env below in the same step, else the model-less image raises
-    # constructing the embedder → 503). `${IMAGE_TAG}` keeps the api version-aligned
-    # with the deploy sha (embed:<env>-<sha> == the isnad-graph sha).
+    # construction. `API_IMAGE` is an IaC rollback SEAM: to revert the api to the
+    # torch-free image, flip this default (or `git revert` this change) in a one-line
+    # PR and redeploy — durable + reviewable — and drop the `EMBEDDING_MODEL` env below
+    # in the same change (else the model-less image raises constructing the embedder →
+    # 503). Do NOT hand-set API_IMAGE in the VPS `.env`: `write-deploy-env` TRUNCATES
+    # `.env` on every deploy and does not re-emit API_IMAGE, so a box-edit silently
+    # reverts on the next deploy (owner directive: rollback is IaC, not a box one-off).
+    # `${IMAGE_TAG}` keeps the api version-aligned with the deploy sha
+    # (embed:<env>-<sha> == the isnad-graph sha).
     image: ${API_IMAGE:-ghcr.io/noorinalabs/noorinalabs-isnad-graph-embed}:${IMAGE_TAG:-latest}
     expose:
       - "8000"
@@ -194,13 +197,14 @@ services:
       interval: 15s
       timeout: 10s
       retries: 5
-      # Extended 20s → 60s for the MiniLM cold-start (deploy#523). The api now loads
-      # torch + the sentence-transformer model at startup (per uvicorn worker, from
-      # the baked weights — no network download), which the torch-free image never
-      # did. 20s risked the container flapping to `unhealthy` mid-model-load on
-      # rollout (and blocking the frontend/caddy `service_healthy` gates); 60s covers
-      # the cold load on the constrained VPS before the retries×interval unhealthy
-      # window opens.
+      # Conservative 20s → 60s slack for the heavier `-embed` image (deploy#523). NOTE
+      # the model is NOT loaded at startup: isnad-graph `get_embedder()` is @lru_cache
+      # and constructs the SentenceTransformer lazily from the semantic-search REQUEST
+      # handler (src/api/routes/search.py), never from `lifespan` — so /health does not
+      # gate on model load and this is not a startup/outage concern. The cold-load cost
+      # is FIRST-semantic-request latency per uvicorn worker, not container readiness
+      # (eager warmup tracked in ig#1175). 60s is just harmless headroom for the larger
+      # image's general init; it does not — and need not — cover a startup model load.
       start_period: 60s
     depends_on:
       neo4j:
@@ -212,18 +216,21 @@ services:
     deploy:
       resources:
         limits:
-          # 2G → 4G (deploy#523): the api now loads torch + MiniLM. Each uvicorn
-          # worker imports torch and loads the model independently (no cross-process
-          # share) — the same envelope the one-shot embed job needed 2G→4G for
-          # (deploy#465). Paired with `--workers 4 → 2` below so ~2 × ~1.5–3G fits
-          # under this ceiling with headroom on the 16G box. Prod is the constraining
-          # box (measured ~8.2G available / 3G swap in use before this change);
-          # `--workers 2` ≈ ~3G keeps ~5G headroom vs `--workers 4` which would push
-          # prod hard into swap.
+          # 2G → 4G (deploy#523): each uvicorn worker loads MiniLM independently on
+          # first search (no cross-process share) — the same model the one-shot embed
+          # job needed 2G→4G for (deploy#465), though single-query INFERENCE RSS is
+          # lower than that batch job. `--workers 2` × ~1.5–3G spans ~3–6G against this
+          # 4G HARD cap: fine at the realistic low end, container-level OOM (api only,
+          # NOT host-wide) at the pessimistic high end. So validate real api RSS on stg
+          # after rollout BEFORE promoting prod (runbook step); if RSS nears 4G, drop to
+          # `--workers 1` or raise the cap within prod's ~8.2G headroom. `--workers 4`
+          # would exceed 4G and/or push the 16G box into swap — hence 2.
           memory: 4G
           cpus: "2.0"
         reservations:
-          # 512M → 1G so the scheduler guarantees room for the model resident set.
+          # 512M → 1G — a SOFT/advisory reservation (compose outside Swarm does NOT
+          # enforce it like `limits`; it is a scheduling hint only), raised to reflect
+          # the model's larger resident set. The enforced ceiling is `limits.memory` 4G.
           memory: 1G
           cpus: "0.5"
     logging: *default-logging
@@ -233,9 +240,10 @@ services:
     # Uses the venv baked into the image at build time — NOT `uv run`, which would
     # trigger a full dependency reinstall at startup and fail on a read_only filesystem.
     # This is the single source of truth for the uvicorn command (Dockerfile has no CMD).
-    # --workers 2 (was 4): each worker loads torch + MiniLM independently, so worker
-    # count multiplies the model's memory footprint (deploy#523). 2 fits the 4G limit
-    # above with headroom on the constraining prod box; 4 would swap.
+    # --workers 2 (was 4): each worker loads MiniLM independently on first search, so
+    # worker count multiplies the resident model footprint (deploy#523). 2 fits the 4G
+    # hard cap above at realistic single-query inference RSS (validate on stg — see the
+    # runbook); 4 would risk the cap and/or push the 16G box into swap.
     command: /app/.venv/bin/uvicorn src.api.app:create_app --factory --host 0.0.0.0 --port 8000 --workers 2
     restart: unless-stopped
 

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -120,7 +120,26 @@ services:
     # at pull — that's intentional; deploys go through the workflow. See the
     # cutover meta (noorinalabs-main#145) and #103 for the rationale (VPS has no
     # Node toolchain, so the previous local-build path was never viable).
-    image: ghcr.io/noorinalabs/noorinalabs-isnad-graph:${IMAGE_TAG:-latest}
+    #
+    # Semantic-search embedder parity (deploy#523). The api serves queries with the
+    # SAME embedder the corpus was embedded with (paraphrase-multilingual-MiniLM-
+    # L12-v2). The torch-free `noorinalabs-isnad-graph` runtime image cannot load
+    # MiniLM, so `src/config.py` silently fell back to the lexical HashingEmbedder —
+    # a query↔corpus mismatch that returns HTTP 200 with a MEANINGLESS ranking (both
+    # are vector(384), so cosine raises no error). The decoupled `-embed` image
+    # (built `--target embed --extra ml`, ig#1089) already carries fastapi +
+    # uvicorn[standard] + the `src` wheel + torch + sentence-transformers + baked
+    # MiniLM weights, and is published with the SAME `<env>-<sha>` tag scheme as the
+    # api image (built on the same isnad-graph main push) — so it serves
+    # `uvicorn src.api.app:create_app` with NO isnad-graph change. Repointing this one
+    # compose file (shared by BOTH stg and prod boxes) preserves stg↔prod parity by
+    # construction. `API_IMAGE` is an indirection var for clean break-glass rollback:
+    # set it to `ghcr.io/noorinalabs/noorinalabs-isnad-graph` in the VPS .env to
+    # revert the api to the torch-free image without a compose PR (drop the
+    # `EMBEDDING_MODEL` env below in the same step, else the model-less image raises
+    # constructing the embedder → 503). `${IMAGE_TAG}` keeps the api version-aligned
+    # with the deploy sha (embed:<env>-<sha> == the isnad-graph sha).
+    image: ${API_IMAGE:-ghcr.io/noorinalabs/noorinalabs-isnad-graph-embed}:${IMAGE_TAG:-latest}
     expose:
       - "8000"
     # Security: read_only prevents runtime writes to the container filesystem.
@@ -161,12 +180,28 @@ services:
       - AUTH_OAUTH_REDIRECT_BASE_URL=https://users.${BASE_DOMAIN}
       - AUTH_OAUTH_POST_LOGIN_URL=https://isnad.${BASE_DOMAIN}/auth/callback
       - AUTH_USER_SERVICE_URL=http://user-service:8000
+      # Semantic-search embedder parity (deploy#523). The api MUST embed queries with
+      # the SAME model the corpus was embedded with (the one-shot isnad-graph-embed
+      # job bakes this exact model into the pgvector table). Set explicitly even
+      # though the `-embed` image bakes it as its default — documents intent, matches
+      # src/config.py's expectation, and pins the api to MiniLM if the image default
+      # ever drifts. MUST stay 384-dim (the pgvector column is vector(384) with a
+      # write-time dimension guard); a different-width model would raise or 200-with-
+      # garbage. See the `image:` note above for the break-glass rollback interaction.
+      - EMBEDDING_MODEL=paraphrase-multilingual-MiniLM-L12-v2
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/health')\" || exit 1"]
       interval: 15s
       timeout: 10s
       retries: 5
-      start_period: 20s
+      # Extended 20s → 60s for the MiniLM cold-start (deploy#523). The api now loads
+      # torch + the sentence-transformer model at startup (per uvicorn worker, from
+      # the baked weights — no network download), which the torch-free image never
+      # did. 20s risked the container flapping to `unhealthy` mid-model-load on
+      # rollout (and blocking the frontend/caddy `service_healthy` gates); 60s covers
+      # the cold load on the constrained VPS before the retries×interval unhealthy
+      # window opens.
+      start_period: 60s
     depends_on:
       neo4j:
         condition: service_healthy
@@ -177,10 +212,19 @@ services:
     deploy:
       resources:
         limits:
-          memory: 2G
+          # 2G → 4G (deploy#523): the api now loads torch + MiniLM. Each uvicorn
+          # worker imports torch and loads the model independently (no cross-process
+          # share) — the same envelope the one-shot embed job needed 2G→4G for
+          # (deploy#465). Paired with `--workers 4 → 2` below so ~2 × ~1.5–3G fits
+          # under this ceiling with headroom on the 16G box. Prod is the constraining
+          # box (measured ~8.2G available / 3G swap in use before this change);
+          # `--workers 2` ≈ ~3G keeps ~5G headroom vs `--workers 4` which would push
+          # prod hard into swap.
+          memory: 4G
           cpus: "2.0"
         reservations:
-          memory: 512M
+          # 512M → 1G so the scheduler guarantees room for the model resident set.
+          memory: 1G
           cpus: "0.5"
     logging: *default-logging
     networks:
@@ -189,7 +233,10 @@ services:
     # Uses the venv baked into the image at build time — NOT `uv run`, which would
     # trigger a full dependency reinstall at startup and fail on a read_only filesystem.
     # This is the single source of truth for the uvicorn command (Dockerfile has no CMD).
-    command: /app/.venv/bin/uvicorn src.api.app:create_app --factory --host 0.0.0.0 --port 8000 --workers 4
+    # --workers 2 (was 4): each worker loads torch + MiniLM independently, so worker
+    # count multiplies the model's memory footprint (deploy#523). 2 fits the 4G limit
+    # above with headroom on the constraining prod box; 4 would swap.
+    command: /app/.venv/bin/uvicorn src.api.app:create_app --factory --host 0.0.0.0 --port 8000 --workers 2
     restart: unless-stopped
 
   # One-shot corpus re-embedding runner (deploy#461, ADR 0008). Re-embeds the

--- a/docs/runbooks/corpus-reembedding.md
+++ b/docs/runbooks/corpus-reembedding.md
@@ -79,6 +79,14 @@ docker buildx imagetools inspect \
 
 Only then dispatch `reembed-corpus.yml` with `env=prod`.
 
+> **Second consumer of the embed prod tag (deploy#523):** the live `api` service now
+> *runs* the `-embed` image too (it needs torch + `MiniLM` to embed queries in parity
+> with the corpus). Unlike this re-embed prerequisite — which promotes `embed` **alone**
+> — an `api` rollout needs `embed:prod-<sha>` at the **same sha as the stack**, so a
+> prod promotion must include embed in the stack set
+> (`images=api,frontend,user-service,landing,embed`), not promote it separately. See
+> [semantic-embedder-parity-523.md](semantic-embedder-parity-523.md).
+
 ## Expected duration
 
 - **Default model:** no download — it is baked into the embed image and populates `st_model_cache` on first run. Only a model **swap** (a non-baked `EMBEDDING_MODEL`) adds a one-time ~470 MB download (a few minutes on the VPS link).

--- a/docs/runbooks/semantic-embedder-parity-523.md
+++ b/docs/runbooks/semantic-embedder-parity-523.md
@@ -30,13 +30,18 @@ compose file drives both boxes). A plain "200 + non-empty" probe passes on the b
   serves `uvicorn src.api.app:create_app` with **no isnad-graph change**.
 - **`EMBEDDING_MODEL=paraphrase-multilingual-MiniLM-L12-v2`** added to the `api`
   environment (explicit even though baked into the image).
-- **`--workers 4` → `--workers 2`** — each worker imports torch + loads the model
-  independently (no cross-process share), so worker count multiplies the memory
+- **`--workers 4` → `--workers 2`** — each worker loads MiniLM independently on first
+  search (no cross-process share), so worker count multiplies the resident model
   footprint.
-- **`mem_limit` 2G → 4G**, reservations 512M → 1G — the measured envelope
-  (`--workers 2` × ~1.5–3G) with headroom on the constraining prod box.
-- **Healthcheck `start_period` 20s → 60s** — absorbs the model cold-load so the
-  container does not flap to `unhealthy` mid-load on rollout.
+- **`mem_limit` 2G → 4G** (hard cap), reservations 512M → 1G (soft/advisory outside
+  Swarm) — the envelope `--workers 2` × ~1.5–3G ≈ 3–6G spans against the 4G cap:
+  fine at the realistic inference low end, container-level OOM risk (api only) at the
+  high end → **validate stg api RSS before promoting prod** (stg capacity check below).
+- **Healthcheck `start_period` 20s → 60s** — conservative slack for the heavier
+  image. NOTE this does **not** cover a startup model load: `get_embedder()` is
+  `@lru_cache` and loads MiniLM lazily from the semantic-search **request** handler,
+  never `lifespan`, so `/health` does not gate on it. The cold-load cost is
+  first-semantic-request latency **per worker** (eager warmup tracked in ig#1175).
 - **stg pre-flight** (`deploy-stg.yml`) now inspects the `-embed` manifest for `api`
   (it shares `AF_TAG`), not the torch-free image — otherwise the deploy#418 tag
   pre-flight would guard a manifest nothing pulls.
@@ -52,7 +57,25 @@ Merge the compose PR first (staging deploys automatically on merge to main).
 1. **stg** — the api + smoke change deploy together. `embed:stg-<sha>` already exists
    for every push, so the stg rollout pulls it with no extra step. Verify: the new
    `semantic /search (patience)` + `semantic /search (prayer)` smoke rows PASS.
-2. **prod** — promote, then approve the prod deploy. See the caveat below **before**
+2. **stg capacity check (gate before prod).** The 4G limit is a HARD cap and each
+   worker's model RSS loads lazily on first search, so real footprint only appears
+   under traffic. After warming both workers (hit `/api/v1/search/semantic` a few
+   times — see the first-hit latency note below), check api RSS on the stg box:
+
+   ```bash
+   ssh <stg> 'docker stats --no-stream noorinalabs-api-1'   # MEM USAGE / LIMIT
+   ```
+
+   If RSS sits comfortably below 4G (expected for single-query inference), promote
+   prod as-is. If it approaches 4G, **do not promote** — drop to `--workers 1` (or
+   raise `limits.memory` within prod's ~8.2G headroom) in a follow-up PR first. A
+   container-level OOM would restart-loop the api (api only, not host-wide).
+
+   > First-hit latency: because the model loads lazily per worker, the first
+   > semantic query each worker serves is several seconds slower (cold load). The
+   > smoke's 15s `SEMANTIC_TIMEOUT` tolerates one cold load; a deterministic per-worker
+   > warmup is the ig#1175 follow-up.
+3. **prod** — promote, then approve the prod deploy. See the caveat below **before**
    promoting.
 
 ## CRITICAL prod caveat — the prod promotion MUST include `embed`
@@ -82,14 +105,27 @@ is registry-side retag (IaC), not a VPS one-off. `stg` needs no such step.
 
 ## Rollback
 
-- **Tag rollback** (`rollback.yml -f service=all -f image_tag=prod-<older-sha>`) works
-  only if `embed:prod-<older-sha>` exists — i.e. that older sha was promoted **with
-  embed**. Make "include embed" the standing prod-promotion habit so every promoted
-  sha is rollback-eligible.
-- **Break-glass image revert** — set `API_IMAGE=ghcr.io/noorinalabs/noorinalabs-isnad-graph`
-  in the VPS `.env` and drop the api's `EMBEDDING_MODEL`, then redeploy: reverts the
-  api to the torch-free image without a compose PR. (Semantic search returns to
-  consistent-lexical `hashing`, not garbage — acceptable as a temporary floor.)
+Rollback is **IaC, never a hand-edit on the box** (owner directive). Two paths:
+
+1. **Tag rollback** (`rollback.yml -f service=all -f image_tag=prod-<older-sha>`) —
+   rolls image tags back to an earlier promoted sha. Works only if
+   `embed:prod-<older-sha>` exists, i.e. that older sha was promoted **with embed**.
+   Make "include embed" the standing prod-promotion habit so every promoted sha is
+   rollback-eligible.
+2. **Image revert to the torch-free API** (reverts the parity change itself, back to
+   consistent-lexical `hashing` — a degraded-but-not-broken floor): **`git revert`**
+   the compose change (or a one-line PR flipping the `API_IMAGE` default back to
+   `ghcr.io/noorinalabs/noorinalabs-isnad-graph` **and** dropping the api's
+   `EMBEDDING_MODEL`), then redeploy. Durable, reviewed, and survives the next deploy.
+
+> Do **NOT** rely on hand-setting `API_IMAGE` in the VPS `.env`: `write-deploy-env`
+> **truncates** `.env` on every deploy and does not re-emit `API_IMAGE`, so a box-edit
+> silently reverts on the next deploy. If an operator must intervene between deploys as
+> a stop-gap, treat any SSH `.env` override as **ephemeral** (reapply, or land the IaC
+> revert above). A durable fast-override would require threading `API_IMAGE` as a
+> `deploy-{stg,prod}.yml` input into the persisted env write — a possible follow-up if
+> PR-speed rollback proves too slow (it should not: lexical-vs-garbage is degradation,
+> not an outage).
 
 ## Follow-up (not a blocker)
 
@@ -98,3 +134,9 @@ release-critical (previously it mattered only for re-embed jobs). It already bui
 every isnad-graph main push; hardening it into the required publish set — and making
 `embed` part of the default prod-promotion set now that the stack depends on it — is
 worth a follow-up.
+
+- **ig#1175** — eager MiniLM warmup in isnad-graph `lifespan` (+ deterministic
+  per-worker post-deploy warmup) so the first-semantic-request cold load doesn't land
+  on a real user. App-side fix; do not implement from this repo.
+- Review comments already filed as out-of-scope follow-ups: **ig#1174** (embed-image
+  Trivy scan gap) and **deploy#526** (promote digest-gate).

--- a/docs/runbooks/semantic-embedder-parity-523.md
+++ b/docs/runbooks/semantic-embedder-parity-523.md
@@ -1,0 +1,100 @@
+# Runbook: semantic-search embedder parity rollout (deploy#523)
+
+> ROLLOUT runbook for the `compose/docker-compose.prod.yml` `api`-service change that
+> moves the API onto the model-capable `-embed` image. NON-MUTATING to write; the
+> owner/orchestrator runs the stg → prod sequence deliberately. This repo's PR only
+> ships the IaC; it does not deploy.
+
+Author: Weronika Zielinska (Platform Architect, noorinalabs-deploy)
+Context: [deploy#523](https://github.com/noorinalabs/noorinalabs-deploy/issues/523)
+· discovered during isnad-graph ig#1148 / PR #1164.
+
+## Why
+
+The `api` service ran the **torch-free** `noorinalabs-isnad-graph` runtime image with
+no `EMBEDDING_MODEL`, so `src/config.py` fell back to the lexical `HashingEmbedder`
+for **query** embedding — while the corpus was embedded with
+`paraphrase-multilingual-MiniLM-L12-v2` (`MiniLM`). Both produce `vector(384)`, so the
+cosine comparison raises **no** error: `GET /api/v1/search/semantic` returns **HTTP
+200 with a meaningless ranking** (silent garbage), on **both** stg and prod (one
+compose file drives both boxes). A plain "200 + non-empty" probe passes on the bug.
+
+## The change (this PR — IaC only)
+
+`compose/docker-compose.prod.yml`, `api` service only:
+
+- **Image** → `${API_IMAGE:-ghcr.io/noorinalabs/noorinalabs-isnad-graph-embed}:${IMAGE_TAG:-latest}`.
+  The `-embed` image already carries fastapi + `uvicorn[standard]` + the `src` wheel +
+  torch + sentence-transformers + baked `MiniLM` weights, and is published with the
+  same `<env>-<sha>` tag scheme (built on the same isnad-graph main push) — so it
+  serves `uvicorn src.api.app:create_app` with **no isnad-graph change**.
+- **`EMBEDDING_MODEL=paraphrase-multilingual-MiniLM-L12-v2`** added to the `api`
+  environment (explicit even though baked into the image).
+- **`--workers 4` → `--workers 2`** — each worker imports torch + loads the model
+  independently (no cross-process share), so worker count multiplies the memory
+  footprint.
+- **`mem_limit` 2G → 4G**, reservations 512M → 1G — the measured envelope
+  (`--workers 2` × ~1.5–3G) with headroom on the constraining prod box.
+- **Healthcheck `start_period` 20s → 60s** — absorbs the model cold-load so the
+  container does not flap to `unhealthy` mid-load on rollout.
+- **stg pre-flight** (`deploy-stg.yml`) now inspects the `-embed` manifest for `api`
+  (it shares `AF_TAG`), not the torch-free image — otherwise the deploy#418 tag
+  pre-flight would guard a manifest nothing pulls.
+- **Smoke gate** (`verify_stg_smoke.sh` / `verify_prod_smoke.sh`) gains a semantic
+  topical-relevance check (mirrors isnad-graph `scripts/semantic_smoke.py`): a
+  hashing↔`MiniLM` mismatch now fails the post-deploy smoke instead of passing on
+  garbage.
+
+## Rollout sequence
+
+Merge the compose PR first (staging deploys automatically on merge to main).
+
+1. **stg** — the api + smoke change deploy together. `embed:stg-<sha>` already exists
+   for every push, so the stg rollout pulls it with no extra step. Verify: the new
+   `semantic /search (patience)` + `semantic /search (prayer)` smoke rows PASS.
+2. **prod** — promote, then approve the prod deploy. See the caveat below **before**
+   promoting.
+
+## CRITICAL prod caveat — the prod promotion MUST include `embed`
+
+The `-embed` image has **no `prod-<sha>` tags** today: embed promotion is **opt-in**
+(deploy#470) — a normal `api,frontend,user-service,landing` promotion does **not**
+retag embed to prod. Because the `api` now *pulls* the embed image, the prod
+promotion **must explicitly include `embed`** so `embed:prod-<sha>` exists before the
+prod rollout pulls it — with the **same `source_sha`** as the stack, so the api's
+`IMAGE_TAG` (`prod-<sha>`) resolves to a real embed manifest:
+
+```bash
+gh workflow run promote.yml --repo noorinalabs/noorinalabs-deploy --ref main \
+  -f source_sha=<sha> \
+  -f images=api,frontend,user-service,landing,embed
+# approve the `production` Environment gate on the retag job
+```
+
+Omitting `embed` → prod `api` fails at `docker compose pull` (missing manifest). This
+is registry-side retag (IaC), not a VPS one-off. `stg` needs no such step.
+
+> Note: this is a **new consumer** of the embed image's prod tag. The
+> [corpus-reembedding runbook](corpus-reembedding.md) § "Prerequisite for `prod`"
+> documents the *re-embed job's* dependency on `embed:prod-latest`; here the **live
+> api** depends on `embed:prod-<sha>`, so — unlike the re-embed prerequisite — you
+> must promote embed **alongside** the stack (same sha), not alone.
+
+## Rollback
+
+- **Tag rollback** (`rollback.yml -f service=all -f image_tag=prod-<older-sha>`) works
+  only if `embed:prod-<older-sha>` exists — i.e. that older sha was promoted **with
+  embed**. Make "include embed" the standing prod-promotion habit so every promoted
+  sha is rollback-eligible.
+- **Break-glass image revert** — set `API_IMAGE=ghcr.io/noorinalabs/noorinalabs-isnad-graph`
+  in the VPS `.env` and drop the api's `EMBEDDING_MODEL`, then redeploy: reverts the
+  api to the torch-free image without a compose PR. (Semantic search returns to
+  consistent-lexical `hashing`, not garbage — acceptable as a temporary floor.)
+
+## Follow-up (not a blocker)
+
+With the api sourced from the embed image, the embed **publish** is now
+release-critical (previously it mattered only for re-embed jobs). It already builds on
+every isnad-graph main push; hardening it into the required publish set — and making
+`embed` part of the default prod-promotion set now that the stack depends on it — is
+worth a follow-up.

--- a/scripts/verify_prod_smoke.sh
+++ b/scripts/verify_prod_smoke.sh
@@ -51,6 +51,9 @@ USER_SERVICE_BASE_URL="${USER_SERVICE_BASE_URL:-https://users.noorinalabs.com}"
 LANDING_BASE_URL="${LANDING_BASE_URL:-https://noorinalabs.com}"
 SMOKE_REPORT="${SMOKE_REPORT:-smoke-report.md}"
 TIMEOUT="${TIMEOUT:-5}"
+# Semantic-search probe (check 8) gets a longer timeout than the static routes:
+# the query is embedded at request time (torch+MiniLM), slower than a plain GET.
+SEMANTIC_TIMEOUT="${SEMANTIC_TIMEOUT:-15}"
 
 # Result tracking ----------------------------------------------------
 PASS=0
@@ -89,6 +92,69 @@ read_body() {
 
 ms_from_secs() {
   awk -v t="$1" 'BEGIN { printf("%d", t * 1000) }'
+}
+
+# semantic_keywords <query> → space-separated topical keywords.
+# Mirrors isnad-graph src/enrich/embeddings.py `_RECALL_KEYWORDS` so this HTTP smoke
+# and the DB-side `isnad verify-recall` gate judge topical relevance identically.
+semantic_keywords() {
+  case "$1" in
+    patience) echo "patience patient sabr persever endur" ;;
+    prayer)   echo "prayer pray salah salat worship" ;;
+    *)        echo "$1" ;;
+  esac
+}
+
+# semantic_probe <query> — exercise GET /api/v1/search/semantic and assert it is
+# FUNCTIONAL, not merely reachable (deploy#523 / ig#1148). The endpoint-level
+# counterpart of `isnad verify-recall`: a plain "200 + non-empty" probe passes on
+# garbage, so we additionally require a strictly-positive top similarity AND a
+# topical keyword in the top-5 hits' title/title_ar. That last assertion catches the
+# SILENT failure this guards against — an environment whose API queries with a
+# different embedder (lexical hashing) than the corpus was embedded with (MiniLM):
+# both are vector(384) so cosine raises no error → HTTP 200 with results but a
+# meaningless ranking. A graceful 503 (embeddings not provisioned) also fails, with
+# a distinguishing detail.
+semantic_probe() {
+  local q="$1" url out code secs body ms top_score hay matched kw
+  local keywords=()
+  url="${ISNAD_BASE_URL}/api/v1/search/semantic?q=${q}&limit=5"
+  out="$(curl -sS -o "$SMOKE_BODY" -w '%{http_code} %{time_total}' \
+              --max-time "$SEMANTIC_TIMEOUT" "$url" 2>/dev/null || echo '000 0')"
+  code="$(echo "$out" | awk '{print $1}')"
+  secs="$(echo "$out" | awk '{print $2}')"
+  body="$(read_body)"
+  ms="$(ms_from_secs "$secs")"
+  if [ "$code" = "503" ]; then
+    record "semantic /search ($q)" fail "$ms" "HTTP 503 — semantic search not provisioned here (embeddings/pgvector absent)"
+    return
+  fi
+  if [ "$code" != "200" ]; then
+    record "semantic /search ($q)" fail "$ms" "HTTP $code (expected 200)"
+    return
+  fi
+  if ! echo "$body" | jq -e '.results | length > 0' >/dev/null 2>&1; then
+    record "semantic /search ($q)" fail "$ms" "HTTP 200 but empty result set — corpus embeddings not backfilled"
+    return
+  fi
+  top_score="$(echo "$body" | jq -r '.results[0].score // 0')"
+  if ! awk -v s="$top_score" 'BEGIN { exit (s > 0 ? 0 : 1) }'; then
+    record "semantic /search ($q)" fail "$ms" "HTTP 200 with results but non-positive top similarity (degenerate embeddings)"
+    return
+  fi
+  hay="$(echo "$body" | jq -r '[.results[:5][] | (.title // "") + " " + (.title_ar // "")] | join(" ") | ascii_downcase')"
+  read -r -a keywords <<<"$(semantic_keywords "$q")"
+  matched=0
+  for kw in "${keywords[@]}"; do
+    case "$hay" in
+      *"$kw"*) matched=1; break ;;
+    esac
+  done
+  if [ "$matched" = "1" ]; then
+    record "semantic /search ($q)" pass "$ms" "HTTP 200, top_score=$top_score, topical keyword match"
+  else
+    record "semantic /search ($q)" fail "$ms" "HTTP 200 + results but none topically relevant — query embedder likely != corpus embedder (embedder/corpus mismatch, deploy#523)"
+  fi
 }
 
 # --- 1. isnad-graph /health -----------------------------------------
@@ -255,6 +321,13 @@ ms_from_secs() {
     record "runtime-config.js" pass "$ms" "HTTP 200 + JS, RUNTIME_CONFIG → $us_host"
   fi
 }
+
+# --- 8. semantic search topical relevance (deploy#523 / ig#1148) ----
+# Guards the query↔corpus embedder-parity regression: the api must serve semantic
+# queries with the SAME embedder (MiniLM) the corpus was embedded with. Probes the
+# verify-recall vocabulary; both must pass (a hashing↔MiniLM mismatch fails BOTH).
+semantic_probe "patience"
+semantic_probe "prayer"
 
 # --- Summary --------------------------------------------------------
 END_NS="$(date +%s%N)"

--- a/scripts/verify_stg_smoke.sh
+++ b/scripts/verify_stg_smoke.sh
@@ -68,6 +68,9 @@ USER_SERVICE_BASE_URL="${USER_SERVICE_BASE_URL:-https://users.stg.noorinalabs.co
 LANDING_BASE_URL="${LANDING_BASE_URL:-https://stg.noorinalabs.com}"
 SMOKE_REPORT="${SMOKE_REPORT:-smoke-report.md}"
 TIMEOUT="${TIMEOUT:-5}"
+# Semantic-search probe (check 8) gets a longer timeout than the static routes:
+# the query is embedded at request time (torch+MiniLM), slower than a plain GET.
+SEMANTIC_TIMEOUT="${SEMANTIC_TIMEOUT:-15}"
 
 # Runtime budget: 5 minutes. Looser than prod's 60s because stg runs on a
 # smaller box (CPX21 vs CPX41) and may be mid-deploy-settle when this
@@ -113,6 +116,69 @@ read_body() {
 
 ms_from_secs() {
   awk -v t="$1" 'BEGIN { printf("%d", t * 1000) }'
+}
+
+# semantic_keywords <query> → space-separated topical keywords.
+# Mirrors isnad-graph src/enrich/embeddings.py `_RECALL_KEYWORDS` so this HTTP smoke
+# and the DB-side `isnad verify-recall` gate judge topical relevance identically.
+semantic_keywords() {
+  case "$1" in
+    patience) echo "patience patient sabr persever endur" ;;
+    prayer)   echo "prayer pray salah salat worship" ;;
+    *)        echo "$1" ;;
+  esac
+}
+
+# semantic_probe <query> — exercise GET /api/v1/search/semantic and assert it is
+# FUNCTIONAL, not merely reachable (deploy#523 / ig#1148). The endpoint-level
+# counterpart of `isnad verify-recall`: a plain "200 + non-empty" probe passes on
+# garbage, so we additionally require a strictly-positive top similarity AND a
+# topical keyword in the top-5 hits' title/title_ar. That last assertion catches the
+# SILENT failure this guards against — an environment whose API queries with a
+# different embedder (lexical hashing) than the corpus was embedded with (MiniLM):
+# both are vector(384) so cosine raises no error → HTTP 200 with results but a
+# meaningless ranking. A graceful 503 (embeddings not provisioned) also fails, with
+# a distinguishing detail.
+semantic_probe() {
+  local q="$1" url out code secs body ms top_score hay matched kw
+  local keywords=()
+  url="${ISNAD_BASE_URL}/api/v1/search/semantic?q=${q}&limit=5"
+  out="$(curl -sS -o "$SMOKE_BODY" -w '%{http_code} %{time_total}' \
+              --max-time "$SEMANTIC_TIMEOUT" "$url" 2>/dev/null || echo '000 0')"
+  code="$(echo "$out" | awk '{print $1}')"
+  secs="$(echo "$out" | awk '{print $2}')"
+  body="$(read_body)"
+  ms="$(ms_from_secs "$secs")"
+  if [ "$code" = "503" ]; then
+    record "semantic /search ($q)" fail "$ms" "HTTP 503 — semantic search not provisioned here (embeddings/pgvector absent)"
+    return
+  fi
+  if [ "$code" != "200" ]; then
+    record "semantic /search ($q)" fail "$ms" "HTTP $code (expected 200)"
+    return
+  fi
+  if ! echo "$body" | jq -e '.results | length > 0' >/dev/null 2>&1; then
+    record "semantic /search ($q)" fail "$ms" "HTTP 200 but empty result set — corpus embeddings not backfilled"
+    return
+  fi
+  top_score="$(echo "$body" | jq -r '.results[0].score // 0')"
+  if ! awk -v s="$top_score" 'BEGIN { exit (s > 0 ? 0 : 1) }'; then
+    record "semantic /search ($q)" fail "$ms" "HTTP 200 with results but non-positive top similarity (degenerate embeddings)"
+    return
+  fi
+  hay="$(echo "$body" | jq -r '[.results[:5][] | (.title // "") + " " + (.title_ar // "")] | join(" ") | ascii_downcase')"
+  read -r -a keywords <<<"$(semantic_keywords "$q")"
+  matched=0
+  for kw in "${keywords[@]}"; do
+    case "$hay" in
+      *"$kw"*) matched=1; break ;;
+    esac
+  done
+  if [ "$matched" = "1" ]; then
+    record "semantic /search ($q)" pass "$ms" "HTTP 200, top_score=$top_score, topical keyword match"
+  else
+    record "semantic /search ($q)" fail "$ms" "HTTP 200 + results but none topically relevant — query embedder likely != corpus embedder (embedder/corpus mismatch, deploy#523)"
+  fi
 }
 
 # --- 1. isnad-graph /health -----------------------------------------
@@ -280,6 +346,13 @@ ms_from_secs() {
     record "runtime-config.js" pass "$ms" "HTTP 200 + JS, RUNTIME_CONFIG → $us_host"
   fi
 }
+
+# --- 8. semantic search topical relevance (deploy#523 / ig#1148) ----
+# Guards the query↔corpus embedder-parity regression: the api must serve semantic
+# queries with the SAME embedder (MiniLM) the corpus was embedded with. Probes the
+# verify-recall vocabulary; both must pass (a hashing↔MiniLM mismatch fails BOTH).
+semantic_probe "patience"
+semantic_probe "prayer"
 
 # --- Summary --------------------------------------------------------
 END_NS="$(date +%s%N)"


### PR DESCRIPTION
## What

IaC-only fix for **semantic-search embedder parity** (`deploy#523`). The `api` service
ran the **torch-free** `noorinalabs-isnad-graph` runtime image with **no**
`EMBEDDING_MODEL`, so `src/config.py` fell back to the lexical `HashingEmbedder` for
**query** embedding — while the corpus is `paraphrase-multilingual-MiniLM-L12-v2`
(MiniLM). Both are `vector(384)`, so the cosine compare raises no error:
`GET /api/v1/search/semantic` returns **HTTP 200 with a meaningless ranking** (silent
garbage), on **both** stg and prod (one compose file drives both boxes).

Owner-decided **Option 1**: repoint the api to the model-capable `-embed` image and
query with MiniLM. The `-embed` image already carries fastapi + `uvicorn[standard]` +
the `src` wheel + torch + sentence-transformers + baked MiniLM weights, and is
published with the same `<env>-<sha>` tag scheme (built on the same isnad-graph main
push) — so it serves `uvicorn src.api.app:create_app` with **no isnad-graph change**.

## The change

`compose/docker-compose.prod.yml` — **`api` service only** (the one file both boxes
deploy, so parity holds by construction):

| Change | From → To | Why |
|---|---|---|
| `image` | `…isnad-graph:${IMAGE_TAG}` → `${API_IMAGE:-…isnad-graph-embed}:${IMAGE_TAG}` | model-capable image; `API_IMAGE` is an **IaC** rollback seam (see rollback) |
| `EMBEDDING_MODEL` | *(unset)* → `paraphrase-multilingual-MiniLM-L12-v2` | query embedder = corpus embedder; explicit intent |
| `--workers` | `4` → `2` | each worker loads MiniLM independently on first search (no share) |
| `mem_limit` | `2G` → `4G` (reservation `512M`→`1G`, soft/advisory) | 4G hard cap; validate stg RSS before prod |
| healthcheck `start_period` | `20s` → `60s` | conservative slack for the heavier image — **not** a startup model load (model loads lazily per worker on first search; ig#1175) |

**Also in this PR:**
- **`deploy-stg.yml` tag pre-flight** now inspects the **`-embed`** manifest for `api`
  (it shares `AF_TAG`). Without this the deploy#418 pre-flight would guard a manifest
  nothing pulls, and a missing `embed:$AF_TAG` would surface only as a mid-deploy
  `docker compose pull` error — the exact hazard the pre-flight exists to prevent.
- **Smoke gate** (`verify_stg_smoke.sh` / `verify_prod_smoke.sh`) gains a **semantic
  topical-relevance check** (mirrors isnad-graph `scripts/semantic_smoke.py`, ig#1148):
  requires `200` + positive top score + a topical keyword (verify-recall vocabulary)
  in the top-5 hits' title/title_ar. A hashing↔MiniLM regression now **fails** the
  post-deploy smoke instead of passing on garbage. Done **in-repo** (curl+jq mirror,
  no cross-repo dep on the `src` package) — see the "smoke wiring" note below.
- **`API_IMAGE`** documented in `compose/.env.example`.
- **New runbook** `docs/runbooks/semantic-embedder-parity-523.md` (+ cross-ref from
  `corpus-reembedding.md`).

## Memory-envelope rationale (workers 2 / 4G) + risk

Prod is the constraining box: measured ~8.2G available / **3G swap already in use**,
neo4j 4.8G resident. Each uvicorn worker loads MiniLM independently on first search
(no cross-process share). `--workers 2` × ~1.5–3G ≈ **3–6G against a 4G HARD cap**:
fine at the realistic single-query-inference low end, **container-level OOM** (api
only, not host-wide) at the pessimistic high end. So the rollout **gates on a real
stg api-RSS check before promoting prod** (runbook step 2): if RSS nears 4G, drop to
`--workers 1` or raise the cap within prod's headroom. `--workers 4` would exceed 4G
and/or swap the box — hence 2. Reservation `512M→1G` is a **soft/advisory** hint
(compose outside Swarm does not enforce it like `limits`).

## Review round 1 — folded in (head `f82659d`)

Aisha's ChangesRequested (SRE), all in-scope:

- **[BLOCKING] durable rollback.** `write-deploy-env` truncates `.env` every deploy and
  never re-emits `API_IMAGE`, so a hand-set `.env` value evaporates — and a box edit
  violates the owner's "IaC, not one-offs" directive. Rollback is now documented as an
  **IaC path** (`git revert` / one-line PR flipping the `API_IMAGE` default +
  dropping `EMBEDDING_MODEL` → redeploy); any SSH `.env` override is marked ephemeral.
  compose + `.env.example` + runbook all corrected.
- **[correctness] healthcheck.** `get_embedder()` is `@lru_cache`, called from the
  search **request** handler, never `lifespan` — no startup model load. 60s reframed
  as conservative slack; real cost is first-request latency per worker. Filed
  **ig#1175** (eager warmup) as the app-side follow-up.
- **[correctness] reservation.** Corrected to note `deploy.reservations` is
  soft/advisory outside Swarm.
- **[sizing] workers 2 / 4G kept**, risk made explicit + stg-RSS gate added (above).

## Rollout (orchestrator drives — this PR does NOT deploy)

1. **Merge** → staging deploys automatically. `embed:stg-<sha>` exists for every push,
   so stg pulls it with no extra step. Verify the new `semantic /search (patience|prayer)`
   smoke rows PASS.
2. **prod** — promote, then approve the prod deploy.

### ⚠️ CRITICAL prod caveat — the prod promotion MUST include `embed`

The `-embed` image has **no `prod-<sha>` tags today** — embed promotion is **opt-in**
(deploy#470); a normal `api,frontend,user-service,landing` promotion does **not**
retag embed to prod. Because the api now *pulls* embed, the prod promotion must
include it **at the same `source_sha`** as the stack:

```bash
gh workflow run promote.yml --repo noorinalabs/noorinalabs-deploy --ref main \
  -f source_sha=<sha> -f images=api,frontend,user-service,landing,embed
```

Omitting `embed` → prod `api` fails at `docker compose pull` (missing manifest). stg
needs no such step. Full detail + rollback options in the new runbook.

## Verification (green-before-push)

- `docker compose -f compose/docker-compose.prod.yml --env-file <ci-.env> config --quiet`
  → resolves api to `…isnad-graph-embed:…`, `EMBEDDING_MODEL` set, `--workers 2`, `4G`.
- service-tier subset gate (`check_service_tier_subset.py`) → OK (25 services).
- `shellcheck` + `bash -n` on both smoke scripts → clean.
- `actionlint` on `deploy-stg.yml` → clean.
- passlist-drift → OK (`API_IMAGE`/`EMBEDDING_MODEL` are not `:?`-required, no drift).
- `env_validate.py secret-keys` → OK.
- `cspell` + `markdownlint-cli2` on changed docs → clean.
- pre-commit (commit + push stages: gitleaks, actionlint, cspell, mypy, all pytest
  suites) → all Passed.
- GHCR: `embed:stg-<sha>` tags present (stg can pull); **no** `embed:prod-<sha>` tags
  (validates the caveat above).

## Smoke wiring — in-repo vs follow-up

The canonical `scripts/semantic_smoke.py` lives in isnad-graph and imports the `src`
package (`src.enrich.embeddings._RECALL_KEYWORDS`), which the deploy verify job does
not have. Rather than a fragile cross-repo hack, I reimplemented the same assertion
in-repo as a curl+jq check inside the existing smoke batteries, mirroring the
canonical logic (200 + positive top score + topical keyword in top-5 title/title_ar,
using the same verify-recall vocabulary). A future consolidation onto the shared
script (once the deploy image can import `src`) is a reasonable follow-up.

## Follow-up (not a blocker)

With the api sourced from the embed image, the embed **publish** is now
release-critical (previously only for re-embed jobs). It builds on every isnad-graph
main push; hardening it into the required publish set — and making `embed` part of the
default prod-promotion set now that the stack depends on it — is worth a follow-up.

## Reviewers

Suggested: **Aisha Idrissi** (SRE) + **Nino Kavtaradze** (Security), coordinated by the
orchestrator. Not self-reviewing, not merging.

Closes #523