### PR TITLE
deploy#527: authenticate smoke check 8 (semantic parity) — unblock stg-verify gate

### DIFF
--- a/.github/workflows/verify-deploy.yml
+++ b/.github/workflows/verify-deploy.yml
@@ -84,11 +84,23 @@ jobs:
       # `users.stg.noorinalabs.com` cutover lives in the wave's Caddyfile.
       ISNAD_BASE_URL: https://isnad.stg.noorinalabs.com
       USER_SERVICE_BASE_URL: https://users.stg.noorinalabs.com
-      # Stg test-user creds. No-op for the 3 health tests that currently
-      # run remote-mode (those don't authenticate); #204 expands coverage
-      # by populating these as the per-test refactor lands.
-      STG_TEST_USER_EMAIL: ${{ secrets.STG_TEST_USER_EMAIL }}
-      STG_TEST_USER_PASSWORD: ${{ secrets.STG_TEST_USER_PASSWORD }}
+      # QA test-user creds for the smoke's authenticated semantic probe
+      # (check 8 / deploy#527). This is the SAME identity the deploy seeds
+      # via bootstrap_test_user.py (deploy#508): TEST_USER_EMAIL is a
+      # non-secret var (qa-stg@noorinalabs.com), TEST_USER_PASSWORD the
+      # secret. Both are ENVIRONMENT-scoped on `staging`, which the job's
+      # `environment: staging` above makes resolvable — the previous
+      # `secrets.STG_TEST_USER_*` names never existed (no repo/env secret by
+      # that name) so they resolved BLANK, which is why check 8 hit the
+      # semantic endpoint unauthenticated and 401'd (the deploy#527 bug).
+      TEST_USER_EMAIL: ${{ vars.TEST_USER_EMAIL }}
+      TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
+      # Integration suite (conftest/run-tests.sh) keys its refresh-token
+      # auth_session flow off STG_TEST_USER_EMAIL; point it at the same var
+      # so the identity is honest (was `secrets.STG_TEST_USER_EMAIL`, which
+      # never existed → blank). STG_TEST_USER_REFRESH_TOKEN remains unset, so
+      # those auth_session tests still skip until it is provisioned (#204).
+      STG_TEST_USER_EMAIL: ${{ vars.TEST_USER_EMAIL }}
     if: >-
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.name == 'Deploy to staging' &&
@@ -131,6 +143,9 @@ jobs:
       # landing is the apex stg.noorinalabs.com (vs prod's noorinalabs.com),
       # so it's set here rather than at job level. The script defaults to
       # the same values if the env is unset (see scripts/verify_stg_smoke.sh).
+      # TEST_USER_EMAIL / TEST_USER_PASSWORD are inherited from the job env
+      # too — they drive check 8's authenticated semantic probe (deploy#527);
+      # absent, that check degrades to an auth-gated reachability assertion.
       - name: Run stg smoke battery (fast-fail gate)
         working-directory: noorinalabs-deploy
         env:

--- a/scripts/verify_prod_smoke.sh
+++ b/scripts/verify_prod_smoke.sh
@@ -2,9 +2,14 @@
 # verify_prod_smoke.sh — Prod post-deploy smoke battery (<60s budget).
 #
 # Runs a tight set of route-reachability checks against the prod URLs.
-# By design this script does NOT mint real auth tokens (no test creds in
-# prod, per Bereket sign-off in deploy#87). The full login+refresh flow
-# is exercised by the integration suite pre-deploy (see verify-stg).
+# Token-minting contract (deploy#527): checks 1–7 are stateless and mint no
+# tokens. Check 8 (semantic ranking) CAN authenticate — it is kept structurally
+# identical to the stg battery (verify_stg_smoke.sh is the canonical twin, keep
+# in sync) — but in prod no QA creds are wired by default (no test creds in prod,
+# per Bereket sign-off in deploy#87), so check 8 DEGRADES to an auth-gated
+# reachability assertion (401/403) here. The full ranking assertion is exercised
+# on stg (where the promote-gating verify runs) and the login+refresh flow is
+# exercised by the integration suite pre-deploy (see verify-stg).
 #
 # Checks:
 #   1. isnad-graph /health    → HTTP 200, JSON .status in {healthy,degraded,ok}
@@ -29,6 +34,12 @@
 #                                  user-service origin. Anti-drift guard
 #                                  for the prod-lagging-stg login bug —
 #                                  see deploy#420.
+#   8. /api/v1/search/semantic → embedder/corpus parity guard (deploy#523/#527).
+#                                  Authenticated (Bearer) 200 + positive top
+#                                  similarity + topical keyword when TEST_USER
+#                                  creds are supplied; auth-gated (401/403)
+#                                  reachability degrade otherwise — which is the
+#                                  default in prod (no creds wired).
 #
 # Env (post-#245-carve-out topology): frontend + isnad-graph API live on
 # `isnad.noorinalabs.com`; the pure user-service API surface (health, JWKS,
@@ -43,6 +54,10 @@
 #   SMOKE_REPORT            Path to write GH-summary-formatted markdown
 #                           (default: smoke-report.md)
 #   TIMEOUT                 Per-check curl timeout, seconds (default: 5)
+#   TEST_USER_EMAIL         QA test-user email for check 8's authenticated
+#                           semantic probe (vars.TEST_USER_EMAIL). Unset in prod
+#                           by default → check 8 degrades to a reachability check.
+#   TEST_USER_PASSWORD      That QA user's password (secrets.TEST_USER_PASSWORD).
 
 set -euo pipefail
 
@@ -54,6 +69,11 @@ TIMEOUT="${TIMEOUT:-5}"
 # Semantic-search probe (check 8) gets a longer timeout than the static routes:
 # the query is embedded at request time (torch+MiniLM), slower than a plain GET.
 SEMANTIC_TIMEOUT="${SEMANTIC_TIMEOUT:-15}"
+# QA test-user creds for check 8's authenticated semantic probe. Both must be
+# present for the ranking assertion to run; absent → auth-gated reachability
+# degrade (the prod default per Bereket sign-off). See deploy#527.
+TEST_USER_EMAIL="${TEST_USER_EMAIL:-}"
+TEST_USER_PASSWORD="${TEST_USER_PASSWORD:-}"
 
 # Result tracking ----------------------------------------------------
 PASS=0
@@ -94,6 +114,31 @@ ms_from_secs() {
   awk -v t="$1" 'BEGIN { printf("%d", t * 1000) }'
 }
 
+# mint_access_token — POST the QA creds to user-service /auth/login and echo
+# the access_token (empty on any failure). Result is cached in
+# SMOKE_ACCESS_TOKEN so the two semantic probes share ONE login — faster and
+# kind to user-service's per-IP login rate-limiter. Returns empty (never
+# errors) so callers decide how to treat a failed mint. The JSON body is
+# built with jq -n so a password containing quotes/backslashes is safe.
+SMOKE_ACCESS_TOKEN=""
+SMOKE_TOKEN_TRIED=0
+mint_access_token() {
+  if [ "$SMOKE_TOKEN_TRIED" = "1" ]; then
+    printf '%s' "$SMOKE_ACCESS_TOKEN"
+    return
+  fi
+  SMOKE_TOKEN_TRIED=1
+  local resp
+  resp="$(curl -sS --max-time "$TIMEOUT" \
+               -H 'Content-Type: application/json' \
+               -X POST "${USER_SERVICE_BASE_URL}/auth/login" \
+               -d "$(jq -nc --arg e "$TEST_USER_EMAIL" --arg p "$TEST_USER_PASSWORD" \
+                        '{email: $e, password: $p}')" \
+               2>/dev/null || echo '')"
+  SMOKE_ACCESS_TOKEN="$(printf '%s' "$resp" | jq -r '.access_token // empty' 2>/dev/null || echo '')"
+  printf '%s' "$SMOKE_ACCESS_TOKEN"
+}
+
 # semantic_keywords <query> → space-separated topical keywords.
 # Mirrors isnad-graph src/enrich/embeddings.py `_RECALL_KEYWORDS` so this HTTP smoke
 # and the DB-side `isnad verify-recall` gate judge topical relevance identically.
@@ -106,25 +151,60 @@ semantic_keywords() {
 }
 
 # semantic_probe <query> — exercise GET /api/v1/search/semantic and assert it is
-# FUNCTIONAL, not merely reachable (deploy#523 / ig#1148). The endpoint-level
-# counterpart of `isnad verify-recall`: a plain "200 + non-empty" probe passes on
-# garbage, so we additionally require a strictly-positive top similarity AND a
-# topical keyword in the top-5 hits' title/title_ar. That last assertion catches the
-# SILENT failure this guards against — an environment whose API queries with a
-# different embedder (lexical hashing) than the corpus was embedded with (MiniLM):
-# both are vector(384) so cosine raises no error → HTTP 200 with results but a
-# meaningless ranking. A graceful 503 (embeddings not provisioned) also fails, with
-# a distinguishing detail.
+# FUNCTIONAL, not merely reachable (deploy#523 / ig#1148 / deploy#527). The
+# endpoint-level counterpart of `isnad verify-recall`: a plain "200 + non-empty"
+# probe passes on garbage, so we additionally require a strictly-positive top
+# similarity AND a topical keyword in the top-5 hits' title/title_ar. That last
+# assertion catches the SILENT failure this guards against — an environment whose
+# API queries with a different embedder (lexical hashing) than the corpus was
+# embedded with (MiniLM): both are vector(384) so cosine raises no error → HTTP 200
+# with results but a meaningless ranking. A graceful 503 (embeddings not
+# provisioned) also fails, with a distinguishing detail.
+#
+# Auth (deploy#527): /api/v1/* is gated by user-service JWT (the same gate that
+# makes check 4 assert 401), so the ranking assertion needs a Bearer token. When
+# TEST_USER_EMAIL + TEST_USER_PASSWORD are set we mint one via /auth/login and run
+# the full assertion; when they are absent (the prod default) we cannot judge
+# ranking, so we DEGRADE to an auth-gated reachability assertion (expect 401/403 +
+# JSON, like check 4) rather than hard-failing an env that has no QA creds wired.
 semantic_probe() {
-  local q="$1" url out code secs body ms top_score hay matched kw
+  local q="$1" url out code secs body ms top_score hay matched kw token
   local keywords=()
+  ms=0
   url="${ISNAD_BASE_URL}/api/v1/search/semantic?q=${q}&limit=5"
+
+  # Degrade path: no creds → assert the endpoint is auth-gated and reachable.
+  if [ -z "$TEST_USER_EMAIL" ] || [ -z "$TEST_USER_PASSWORD" ]; then
+    read -r code secs <<<"$(http_check "$url")"
+    body="$(read_body)"
+    ms="$(ms_from_secs "$secs")"
+    if { [ "$code" = "401" ] || [ "$code" = "403" ]; } &&
+       echo "$body" | jq -e '.detail or .error or .message' >/dev/null 2>&1; then
+      record "semantic /search ($q)" pass "$ms" "auth-gated ($code) — ranking check skipped (no TEST_USER creds in this env)"
+    else
+      record "semantic /search ($q)" fail "$ms" "HTTP $code — expected auth gate 401/403 with JSON body when no creds; endpoint may be unprotected or down"
+    fi
+    return
+  fi
+
+  # Authenticated path: mint (or reuse) a Bearer token, then assert ranking.
+  token="$(mint_access_token)"
+  if [ -z "$token" ]; then
+    record "semantic /search ($q)" fail "$ms" "could not mint QA access token via ${USER_SERVICE_BASE_URL}/auth/login (creds supplied but login failed)"
+    return
+  fi
+
   out="$(curl -sS -o "$SMOKE_BODY" -w '%{http_code} %{time_total}' \
+              -H "Authorization: Bearer $token" \
               --max-time "$SEMANTIC_TIMEOUT" "$url" 2>/dev/null || echo '000 0')"
   code="$(echo "$out" | awk '{print $1}')"
   secs="$(echo "$out" | awk '{print $2}')"
   body="$(read_body)"
   ms="$(ms_from_secs "$secs")"
+  if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+    record "semantic /search ($q)" fail "$ms" "HTTP $code with a minted Bearer token — auth rejected a fresh QA token (token/JWKS drift?)"
+    return
+  fi
   if [ "$code" = "503" ]; then
     record "semantic /search ($q)" fail "$ms" "HTTP 503 — semantic search not provisioned here (embeddings/pgvector absent)"
     return
@@ -322,10 +402,12 @@ semantic_probe() {
   fi
 }
 
-# --- 8. semantic search topical relevance (deploy#523 / ig#1148) ----
+# --- 8. semantic search topical relevance (deploy#523 / ig#1148 / deploy#527) ----
 # Guards the query↔corpus embedder-parity regression: the api must serve semantic
 # queries with the SAME embedder (MiniLM) the corpus was embedded with. Probes the
 # verify-recall vocabulary; both must pass (a hashing↔MiniLM mismatch fails BOTH).
+# Authenticated when TEST_USER_* creds are wired (see semantic_probe); the single
+# minted token is reused across both probes.
 semantic_probe "patience"
 semantic_probe "prayer"
 

--- a/scripts/verify_stg_smoke.sh
+++ b/scripts/verify_stg_smoke.sh
@@ -19,9 +19,16 @@
 # surface that in seconds instead of paying the full suite's wall-clock
 # only to fail at the end. It is a pre-flight, not a replacement.
 #
-# Like the prod battery, this script does NOT mint real auth tokens. The
-# full login+refresh flow is exercised by the integration suite that runs
-# after this gate in the same verify-stg job.
+# Token-minting contract (deploy#527): checks 1–7 are stateless and do NOT
+# mint auth tokens. Check 8 (semantic ranking) is the ONE exception — the
+# assertion it makes (topical relevance of ranked results) can only be
+# exercised behind the `/api/v1/*` gateway auth, so when QA test-user creds
+# (TEST_USER_EMAIL + TEST_USER_PASSWORD) are supplied it mints a short-lived
+# access token via POST ${USER_SERVICE_BASE_URL}/auth/login and sends it as a
+# Bearer on the semantic request. With no creds present it degrades to an
+# auth-gated reachability assertion (like check 4). The full login+refresh
+# flow for the OTHER surfaces is still exercised by the integration suite
+# that runs after this gate in the same verify-stg job.
 #
 # Checks (mirror of verify_prod_smoke.sh):
 #   1. isnad-graph /health    → HTTP 200, JSON .status in {healthy,degraded,ok}
@@ -46,6 +53,13 @@
 #                                  user-service origin. Anti-drift guard
 #                                  for the prod-lagging-stg login bug —
 #                                  see deploy#420.
+#   8. /api/v1/search/semantic → authenticated (Bearer) HTTP 200 with a
+#                                  strictly-positive top similarity AND a
+#                                  topical keyword in the top-5 titles —
+#                                  the embedder/corpus parity guard
+#                                  (deploy#523/#527). Degrades to an
+#                                  auth-gated (401/403) reachability check
+#                                  when no TEST_USER creds are supplied.
 #
 # Env (stg topology — BASE_DOMAIN=stg.noorinalabs.com, deploy-stg.yml:158):
 # the Caddyfile is env-templated by {$BASE_DOMAIN}, so stg's vhosts are
@@ -60,6 +74,11 @@
 #   SMOKE_REPORT            Path to write GH-summary-formatted markdown
 #                           (default: smoke-report.md)
 #   TIMEOUT                 Per-check curl timeout, seconds (default: 5)
+#   TEST_USER_EMAIL         QA test-user email for check 8's authenticated
+#                           semantic probe (the identity the deploy seeds via
+#                           bootstrap_test_user.py — vars.TEST_USER_EMAIL).
+#                           Unset → check 8 degrades to a reachability check.
+#   TEST_USER_PASSWORD      That QA user's password (secrets.TEST_USER_PASSWORD).
 
 set -euo pipefail
 
@@ -71,6 +90,11 @@ TIMEOUT="${TIMEOUT:-5}"
 # Semantic-search probe (check 8) gets a longer timeout than the static routes:
 # the query is embedded at request time (torch+MiniLM), slower than a plain GET.
 SEMANTIC_TIMEOUT="${SEMANTIC_TIMEOUT:-15}"
+# QA test-user creds for check 8's authenticated semantic probe. Both must be
+# present for the ranking assertion to run; absent → auth-gated reachability
+# degrade. See deploy#527.
+TEST_USER_EMAIL="${TEST_USER_EMAIL:-}"
+TEST_USER_PASSWORD="${TEST_USER_PASSWORD:-}"
 
 # Runtime budget: 5 minutes. Looser than prod's 60s because stg runs on a
 # smaller box (CPX21 vs CPX41) and may be mid-deploy-settle when this
@@ -118,6 +142,31 @@ ms_from_secs() {
   awk -v t="$1" 'BEGIN { printf("%d", t * 1000) }'
 }
 
+# mint_access_token — POST the QA creds to user-service /auth/login and echo
+# the access_token (empty on any failure). Result is cached in
+# SMOKE_ACCESS_TOKEN so the two semantic probes share ONE login — faster and
+# kind to user-service's per-IP login rate-limiter. Returns empty (never
+# errors) so callers decide how to treat a failed mint. The JSON body is
+# built with jq -n so a password containing quotes/backslashes is safe.
+SMOKE_ACCESS_TOKEN=""
+SMOKE_TOKEN_TRIED=0
+mint_access_token() {
+  if [ "$SMOKE_TOKEN_TRIED" = "1" ]; then
+    printf '%s' "$SMOKE_ACCESS_TOKEN"
+    return
+  fi
+  SMOKE_TOKEN_TRIED=1
+  local resp
+  resp="$(curl -sS --max-time "$TIMEOUT" \
+               -H 'Content-Type: application/json' \
+               -X POST "${USER_SERVICE_BASE_URL}/auth/login" \
+               -d "$(jq -nc --arg e "$TEST_USER_EMAIL" --arg p "$TEST_USER_PASSWORD" \
+                        '{email: $e, password: $p}')" \
+               2>/dev/null || echo '')"
+  SMOKE_ACCESS_TOKEN="$(printf '%s' "$resp" | jq -r '.access_token // empty' 2>/dev/null || echo '')"
+  printf '%s' "$SMOKE_ACCESS_TOKEN"
+}
+
 # semantic_keywords <query> → space-separated topical keywords.
 # Mirrors isnad-graph src/enrich/embeddings.py `_RECALL_KEYWORDS` so this HTTP smoke
 # and the DB-side `isnad verify-recall` gate judge topical relevance identically.
@@ -130,25 +179,60 @@ semantic_keywords() {
 }
 
 # semantic_probe <query> — exercise GET /api/v1/search/semantic and assert it is
-# FUNCTIONAL, not merely reachable (deploy#523 / ig#1148). The endpoint-level
-# counterpart of `isnad verify-recall`: a plain "200 + non-empty" probe passes on
-# garbage, so we additionally require a strictly-positive top similarity AND a
-# topical keyword in the top-5 hits' title/title_ar. That last assertion catches the
-# SILENT failure this guards against — an environment whose API queries with a
-# different embedder (lexical hashing) than the corpus was embedded with (MiniLM):
-# both are vector(384) so cosine raises no error → HTTP 200 with results but a
-# meaningless ranking. A graceful 503 (embeddings not provisioned) also fails, with
-# a distinguishing detail.
+# FUNCTIONAL, not merely reachable (deploy#523 / ig#1148 / deploy#527). The
+# endpoint-level counterpart of `isnad verify-recall`: a plain "200 + non-empty"
+# probe passes on garbage, so we additionally require a strictly-positive top
+# similarity AND a topical keyword in the top-5 hits' title/title_ar. That last
+# assertion catches the SILENT failure this guards against — an environment whose
+# API queries with a different embedder (lexical hashing) than the corpus was
+# embedded with (MiniLM): both are vector(384) so cosine raises no error → HTTP 200
+# with results but a meaningless ranking. A graceful 503 (embeddings not
+# provisioned) also fails, with a distinguishing detail.
+#
+# Auth (deploy#527): /api/v1/* is gated by user-service JWT (the same gate that
+# makes check 4 assert 401), so the ranking assertion needs a Bearer token. When
+# TEST_USER_EMAIL + TEST_USER_PASSWORD are set we mint one via /auth/login and run
+# the full assertion; when they are absent we cannot judge ranking, so we DEGRADE
+# to an auth-gated reachability assertion (expect 401/403 + JSON, like check 4)
+# rather than hard-failing an env that has no QA creds wired.
 semantic_probe() {
-  local q="$1" url out code secs body ms top_score hay matched kw
+  local q="$1" url out code secs body ms top_score hay matched kw token
   local keywords=()
+  ms=0
   url="${ISNAD_BASE_URL}/api/v1/search/semantic?q=${q}&limit=5"
+
+  # Degrade path: no creds → assert the endpoint is auth-gated and reachable.
+  if [ -z "$TEST_USER_EMAIL" ] || [ -z "$TEST_USER_PASSWORD" ]; then
+    read -r code secs <<<"$(http_check "$url")"
+    body="$(read_body)"
+    ms="$(ms_from_secs "$secs")"
+    if { [ "$code" = "401" ] || [ "$code" = "403" ]; } &&
+       echo "$body" | jq -e '.detail or .error or .message' >/dev/null 2>&1; then
+      record "semantic /search ($q)" pass "$ms" "auth-gated ($code) — ranking check skipped (no TEST_USER creds in this env)"
+    else
+      record "semantic /search ($q)" fail "$ms" "HTTP $code — expected auth gate 401/403 with JSON body when no creds; endpoint may be unprotected or down"
+    fi
+    return
+  fi
+
+  # Authenticated path: mint (or reuse) a Bearer token, then assert ranking.
+  token="$(mint_access_token)"
+  if [ -z "$token" ]; then
+    record "semantic /search ($q)" fail "$ms" "could not mint QA access token via ${USER_SERVICE_BASE_URL}/auth/login (creds supplied but login failed)"
+    return
+  fi
+
   out="$(curl -sS -o "$SMOKE_BODY" -w '%{http_code} %{time_total}' \
+              -H "Authorization: Bearer $token" \
               --max-time "$SEMANTIC_TIMEOUT" "$url" 2>/dev/null || echo '000 0')"
   code="$(echo "$out" | awk '{print $1}')"
   secs="$(echo "$out" | awk '{print $2}')"
   body="$(read_body)"
   ms="$(ms_from_secs "$secs")"
+  if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+    record "semantic /search ($q)" fail "$ms" "HTTP $code with a minted Bearer token — auth rejected a fresh QA token (token/JWKS drift?)"
+    return
+  fi
   if [ "$code" = "503" ]; then
     record "semantic /search ($q)" fail "$ms" "HTTP 503 — semantic search not provisioned here (embeddings/pgvector absent)"
     return
@@ -347,10 +431,12 @@ semantic_probe() {
   fi
 }
 
-# --- 8. semantic search topical relevance (deploy#523 / ig#1148) ----
+# --- 8. semantic search topical relevance (deploy#523 / ig#1148 / deploy#527) ----
 # Guards the query↔corpus embedder-parity regression: the api must serve semantic
 # queries with the SAME embedder (MiniLM) the corpus was embedded with. Probes the
 # verify-recall vocabulary; both must pass (a hashing↔MiniLM mismatch fails BOTH).
+# Authenticated when TEST_USER_* creds are wired (see semantic_probe); the single
+# minted token is reused across both probes.
 semantic_probe "patience"
 semantic_probe "prayer"
 


### PR DESCRIPTION
## Summary

Fixes **deploy#527**: smoke check 8 (`semantic_probe`, the deploy#523 embedder/corpus parity guard) hit `/api/v1/search/semantic` **unauthenticated** and asserted HTTP 200, but `/api/v1/*` is gated by user-service JWT (the same gate check 4 asserts **401** on). So check 8 always got 401 → recorded FAIL → the `Run stg smoke battery` step (`set -e`) failed → `verify-stg` produced no fresh successful `stg-verify-result` artifact → **promote.yml's `gate-stg-verify` blocked the deploy#523 prod promotion.**

## Approach — (A) authenticate check 8 in-place

Chosen over (B) moving the assertion into the integration suite because it keeps the probe **end-to-end through gateway → api → pgvector** — exactly the three-layer path an embedder/corpus mismatch manifests in — and the issue author explicitly preferred option 1.

- `semantic_probe` mints a short-lived access token via `POST ${USER_SERVICE_BASE_URL}/auth/login` (JSON `{email,password}` → `TokenResponse.access_token`) and sends it as `Authorization: Bearer` on the semantic request, keeping the existing positive-top-score + topical-keyword assertions. One login is cached and reused across both probes (kind to the per-IP login rate-limiter).
- **Degrade guard:** with no creds present, check 8 asserts the endpoint is auth-gated (401/403 + JSON, like check 4) and records a clear "ranking check skipped — no creds" note instead of hard-failing.
- Updated the "does NOT mint tokens" docstring contract to note the check-8 exception.
- Applied symmetrically to `verify_stg_smoke.sh` and canonical `verify_prod_smoke.sh` (the `semantic_probe`/`mint_access_token` bodies are byte-identical). Prod stays **credential-less by default** (Bereket no-creds-in-prod sign-off, deploy#87) so its check 8 degrades to reachability; the promote-gating ranking assertion runs on stg.

## Secret-wiring reconciliation (second root cause)

`verify-stg` referenced `secrets.STG_TEST_USER_EMAIL` / `secrets.STG_TEST_USER_PASSWORD` — **which never existed** (no repo/env secret by those names → resolved blank). The real, existing wiring (deploy#508, seeded on every deploy by `bootstrap_test_user.py`) is **environment-scoped** on `staging`/`production`:

| Referenced (broken) | Actual (exists) |
|---|---|
| `secrets.STG_TEST_USER_EMAIL` | `vars.TEST_USER_EMAIL` = `qa-stg@noorinalabs.com` |
| `secrets.STG_TEST_USER_PASSWORD` | `secrets.TEST_USER_PASSWORD` |

The `verify-stg` job already declares `environment: staging`, so these resolve. Repointed the job env to the correct names (and fixed the dead `STG_TEST_USER_EMAIL` the integration suite reads). **No secret VALUE needed creating** — existing secrets sufficed.

## Validation (live stg, real seeded creds)

Ran the updated `verify_stg_smoke.sh` **on the stg host** (creds sourced from its `.env` so the secret never left the box), against the public stg URLs:

```
PASS: narrator /api/v1/narrators — HTTP 401 + JSON body (auth path live)
PASS: semantic /search (patience) — HTTP 200, top_score=0.5979, topical keyword match
PASS: semantic /search (prayer)   — HTTP 200, top_score=0.7670, topical keyword match
==> Stg smoke summary: 9/9 passed
```

Degrade path (no creds) also 9/9, with check 8 recording the auth-gated skip. The guard is a **real** assertion — a garbage/embedder-mismatch ranking yields `matched=0` → FAIL; it is not neutered to always-pass.

## Definition of done

- [x] Check 8 exercises an **actually-authenticated** semantic ranking assertion; passes green on healthy stg, fails on embedder/corpus mismatch.
- [x] Secret wiring reconciled to existing env-scoped `vars.TEST_USER_EMAIL` + `secrets.TEST_USER_PASSWORD`; no owner secret-VALUE action required.
- [x] `verify_stg_smoke.sh` and `verify_prod_smoke.sh` stay in sync.
- [x] Green-before-push: `bash -n`, shellcheck, actionlint, gitleaks, pre-commit + pre-push all clean.

Closes #527

## Reviewers
- **Lucas Ferreira** (SRE) — smoke/verify-gate mechanics
- **Nino Kavtaradze** (Security) — auth/token-minting + secret-wiring angle

🤖 Generated with [Claude Code](https://claude.com/claude-code)
