### PR TITLE
fix(reembed): raise SSH command_timeout + add collection-scope input (#529)

### DIFF
--- a/.github/workflows/reembed-corpus.yml
+++ b/.github/workflows/reembed-corpus.yml
@@ -2,9 +2,10 @@ name: Re-embed corpus (isnad-graph semantic search)
 
 # Repeatable, observable, env-gated corpus re-embedding (deploy#461, ADR 0008).
 #
-# Semantic search returns lexically-arbitrary results because the 34,028-hadith
-# corpus is embedded with the dependency-free HashingEmbedder (token-overlap,
-# not meaning). The application already supports a real model via
+# Semantic search returns lexically-arbitrary results because the Hadith corpus
+# (776,239 nodes total — ~650,983 bulk `sanadset` + ~125,256 canonical) is
+# embedded with the dependency-free HashingEmbedder (token-overlap, not
+# meaning). The application already supports a real model via
 # EMBEDDING_MODEL; this workflow is the missing OPERATIONAL trigger to re-embed
 # the corpus on the cluster with a real 384-dim multilingual model, rebuild the
 # pgvector index, and verify recall.
@@ -64,6 +65,10 @@ on:
           NOT here. Passed through verbatim as a single comma-separated value;
           if the isnad-graph CLI lands a repeatable `--exclude-collections`
           form instead, the script below must repeat the flag per name.
+          REQUIRES an embed image built from isnad-graph#1177 (the image that
+          adds the `--exclude-collections` CLI flag) — against a pre-#1177
+          image the flag fails loud at arg-parse (non-destructive: nothing is
+          embedded). Leave EMPTY when running a pre-#1177 image.
         required: false
         type: string
         default: ""

--- a/.github/workflows/reembed-corpus.yml
+++ b/.github/workflows/reembed-corpus.yml
@@ -53,6 +53,20 @@ on:
         required: false
         type: string
         default: "256"
+      exclude_collections:
+        description: >-
+          Comma-separated collection names to EXCLUDE from the embed. Maps to
+          `isnad embed-hadiths --exclude-collections <value>` (isnad-graph#1177).
+          Leave EMPTY to embed the full corpus (unchanged default — every
+          collection). Set to `sanadset` to load only the canonical corpus
+          (~125k rows, ~3.3h) — the bulk `sanadset` collection (~650k, ~20h) is
+          embedded separately by the detached long-running job (deploy#530),
+          NOT here. Passed through verbatim as a single comma-separated value;
+          if the isnad-graph CLI lands a repeatable `--exclude-collections`
+          form instead, the script below must repeat the flag per name.
+        required: false
+        type: string
+        default: ""
       dry_run:
         description: "Plan/log only — write no embeddings, rebuild no index"
         required: false
@@ -80,12 +94,16 @@ jobs:
   reembed:
     name: re-embed corpus (${{ inputs.env }})
     runs-on: ubuntu-latest
-    # A real run embeds the full 34,028-hadith corpus on the VPS CPU, then
-    # rebuilds the pgvector index and verifies recall — minutes-to-tens-of-minutes,
-    # well past the GH default per-step budget. Give the job a generous ceiling so
-    # the runner-side never caps the SSH step short of `command_timeout` below
-    # (deploy#465). The dry-run path returns in seconds and is unaffected.
-    timeout-minutes: 120
+    # A real run embeds the corpus on the VPS CPU, then rebuilds the pgvector
+    # index and verifies recall. At the measured ~640 rows/min the CANONICAL
+    # (non-`sanadset`) corpus of ~125k rows is a ~3.3h embed (deploy#529), well
+    # past the GH default per-step budget. Give the job a ceiling ABOVE the SSH
+    # `command_timeout` below so the runner-side never caps the SSH step short of
+    # it (deploy#465). NOTE: GitHub-hosted runners hard-cap a job at 6h (360m),
+    # so this ceiling AND `command_timeout` both live under 360m — the full
+    # 650k-row `sanadset` embed (~20h) can't run here at all and is a separate
+    # detached job (deploy#530). The dry-run path returns in seconds, unaffected.
+    timeout-minutes: 330
     # Maps to GH Environment protection (stg -> staging, prod -> production).
     # prod requires manual approval; per-env secrets/host resolve from the
     # matching Environment. Same pattern as db-migrate.yml / terraform.yml.
@@ -123,6 +141,7 @@ jobs:
           ENV_NAME: ${{ inputs.env }}
           MODEL: ${{ inputs.model }}
           BATCH_SIZE: ${{ inputs.batch_size }}
+          EXCLUDE_COLLECTIONS: ${{ inputs.exclude_collections }}
           DRY_RUN: ${{ inputs.dry_run }}
           IMAGE: ${{ steps.resolve.outputs.image }}
           # GHCR pull credentials — runtime token + owner actor, same as
@@ -134,15 +153,19 @@ jobs:
           host: ${{ vars.VPS_HOST }}
           username: deploy
           # appleboy/ssh-action defaults command_timeout to 10m — far short of a
-          # real CPU embed of the 34,028-hadith corpus + reindex + verify-recall,
-          # which the prior stg run (deploy#465) hit at the 10m mark while still
-          # mid-embed. The first successful stg run took ~47.5m (2853s); 90m gives
-          # comfortable margin over that for the slower/larger prod run (deploy#468),
-          # capped below the job-level timeout-minutes above. The dry-run path is
-          # seconds, so this only affects real runs.
-          command_timeout: 90m
+          # real CPU embed + reindex + verify-recall. The earlier 90m ceiling
+          # (deploy#465) was itself too short: a CANONICAL (non-`sanadset`) embed
+          # of ~125k rows is ~3.3h at ~640 rows/min (deploy#529), so the full
+          # embed → reindex → verify-recall never finished in one SSH session and
+          # the run went red on this timeout mid-embed. 5h gives comfortable
+          # margin over a canonical embed while staying UNDER the 6h (360m)
+          # GitHub-hosted-runner job hard cap, and below `timeout-minutes: 330`
+          # above so the SSH timeout — not a hard runner kill — is the binding
+          # limit. The bulk 650k `sanadset` embed (~20h) does NOT fit here and is
+          # a separate detached job (deploy#530). Dry-run is seconds, unaffected.
+          command_timeout: 5h
           key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
-          envs: ENV_NAME,MODEL,BATCH_SIZE,DRY_RUN,IMAGE,GITHUB_TOKEN,GITHUB_ACTOR
+          envs: ENV_NAME,MODEL,BATCH_SIZE,EXCLUDE_COLLECTIONS,DRY_RUN,IMAGE,GITHUB_TOKEN,GITHUB_ACTOR
           script: |
             set -uo pipefail
 
@@ -180,11 +203,25 @@ jobs:
               ${COMPOSE} run --rm --no-deps -e EMBEDDING_MODEL="${MODEL}" isnad-graph-embed "$@"
             }
 
+            # Assemble the embed-hadiths arg list once (used by both the dry-run
+            # preview and the real run). When EXCLUDE_COLLECTIONS is set, scope
+            # the embed to non-excluded collections (e.g. `sanadset` ->
+            # canonical-only ~125k rows, deploy#529 / isnad-graph#1177); empty =
+            # embed the full corpus (unchanged default). Passed as a single
+            # comma-separated value matching the isnad-graph `--exclude-collections`
+            # flag; if that CLI ships a repeatable form instead, repeat the flag
+            # per name here. Collection names are simple tokens (no spaces), so the
+            # word-split of ${EMBED_ARGS} below is intentional.
+            EMBED_ARGS="embed-hadiths --batch-size ${BATCH_SIZE}"
+            if [ -n "${EXCLUDE_COLLECTIONS}" ]; then
+              EMBED_ARGS="${EMBED_ARGS} --exclude-collections ${EXCLUDE_COLLECTIONS}"
+            fi
+
             if [ "${DRY_RUN}" = "true" ]; then
               echo "==> [${ENV_NAME}] DRY RUN — no embeddings written, no index rebuilt."
               echo "    image: ${EMBED_IMAGE}"
               echo "    would run (compose service isnad-graph-embed, networks backend+egress):"
-              echo "      isnad embed-hadiths --batch-size ${BATCH_SIZE}"
+              echo "      isnad ${EMBED_ARGS}"
               echo "      isnad reindex-embeddings"
               echo "      isnad verify-recall   (exit code = gate)"
               # Read-only: confirm the embed service resolves under the live .env
@@ -212,8 +249,9 @@ jobs:
             RC=0
 
             # --- embed ---
-            echo "==> [${ENV_NAME}] isnad embed-hadiths --batch-size ${BATCH_SIZE}"
-            EMBED_OUT="$(embed_run isnad embed-hadiths --batch-size "${BATCH_SIZE}" 2>&1)" || RC=$?
+            echo "==> [${ENV_NAME}] isnad ${EMBED_ARGS}"
+            # shellcheck disable=SC2086  # intentional word-split of the assembled arg list
+            EMBED_OUT="$(embed_run isnad ${EMBED_ARGS} 2>&1)" || RC=$?
             printf '%s\n' "${EMBED_OUT}"
             # Best-effort rows-embedded parse from a final "embedded <n>" line.
             # Degrades to -1 (unknown) if the shape changes — never fails the run.


### PR DESCRIPTION
## What & why

`reembed-corpus.yml` (env=prod) failed on the **SSH `command_timeout`**, not a data error: `isnad embed-hadiths` ran the full **90m** window and the `appleboy/ssh-action` session was killed mid-embed, so `reindex-embeddings` + `verify-recall` never executed and the run went red (corpus neither indexed nor gated). Even a **canonical-only** corpus (~125k rows, ~3.3h at ~640 rows/min) exceeds 90m, so the workflow could not drive any full embed to completion.

Closes #529.

## Changes (`.github/workflows/reembed-corpus.yml`)

1. **Timeout raise.** `command_timeout: 90m → 5h` on the re-embed step, and job `timeout-minutes: 120 → 330`.
   - **Why 5h, not the 6h suggested in the issue:** GitHub-hosted runners (`runs-on: ubuntu-latest`) **hard-cap a job at 6h (360m)** — the runner force-kills the job at 360m regardless of `timeout-minutes`, so `timeout-minutes` cannot be set *above* 360. The file's existing design invariant (comment at the job level) is that the job ceiling must sit **above** `command_timeout` so the SSH action's own timeout — not a hard runner kill — is the binding limit with a clean error. A 6h `command_timeout` would equal the runner cap and break that ordering. So: `command_timeout: 5h` (comfortably over the ~3.3h canonical embed + reindex + verify) < `timeout-minutes: 330` < 360m runner cap. The full 650k `sanadset` embed (~20h) still cannot run here — that stays the separate detached job (**#530**).
2. **Collection-scope input.** New `exclude_collections` `workflow_dispatch` input (string, default `""`), plumbed through the ssh-action `env:` block + `envs:` list, mapping to `isnad embed-hadiths --exclude-collections <value>` when set and **omitted when empty** (unchanged full-corpus default). e.g. `exclude_collections: sanadset` → canonical-only load.
   - **Flag syntax:** comma-separated single value, matching isnad-graph **#1177** (`--exclude-collections sanadset`). That CLI flag is not yet merged (no PR open); if it ships a *repeatable* form instead of comma-separated, the assembled `EMBED_ARGS` in the script must repeat the flag per name — called out in an inline comment.
3. **Preserved intact:** dry-run path (now previews the assembled command incl. the flag) and the stg-tag-on-prod image guard. The embed arg list is assembled once and shared by both the dry-run echo and the real run.

## Testing

- `actionlint .github/workflows/reembed-corpus.yml` → clean (shellcheck on PATH).
- `pre-commit run` (commit + pre-push stages) → all green: gitleaks, actionlint, structural-ontology-staleness, mypy, pytest suites.
- No live dispatch (prod embed is a multi-hour op; sequencing owned by the orchestrator alongside isnad-graph #1177 + image promote).

## Reviewers

Author (requesting review): Aisha Idrissi. Two reviews requested:

- Weronika Zielinska (Platform Architect) — timeout/runner-cap reasoning + workflow contract.
- Lucas Ferreira (SRE) — SSH script arg-assembly + scope passthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hfJHDPdFJciPKPudSn7Q7
