### PR TITLE
ci(graph-ops): IaC workflow to run da migrate/enrich against target-env Neo4j (deploy#532)

### DIFF
--- a/.github/workflows/graph-ops.yml
+++ b/.github/workflows/graph-ops.yml
@@ -1,0 +1,317 @@
+name: Graph ops (Neo4j migrate / enrich)
+
+# Repeatable, observable, env-gated Neo4j graph-remediation ops (deploy#532).
+#
+# Two graph ops need to run against stg/prod Neo4j and MUST be IaC
+# (workflow-driven, reproducible, stg-gated) — not box one-offs:
+#   1. migrate — `migrate-transmitted-hadith-ids` (da#325): canonicalize the
+#      ~2.68M TRANSMITTED_TO.hadith_id edge ids in place so chain
+#      reconstruction joins against Hadith.id (fixes the empty-isnad-chain bug).
+#   2. enrich  — `enrich` (da#326): GDS narrator centrality (sampled
+#      betweenness + pagerank + louvain + degree) surfacing transmission
+#      choke points.
+#
+# Both are driven by the data-acquisition loader image
+# (ghcr.io/noorinalabs/noorinalabs-data-acquisition-load) whose ENTRYPOINT is
+# `python -m src.cli`, so the op is just the CLI subcommand. There is no
+# existing Neo4j graph-op vehicle: db-migrate.yml is user-service
+# alembic/Postgres only, and reembed-corpus.yml is embed-specific. This
+# workflow is the missing OPERATIONAL trigger.
+#
+# Shape mirrors reembed-corpus.yml (the canonical one-shot cluster-data op):
+# SSH to the VPS as `deploy` (appleboy/ssh-action, secrets.DEPLOY_SSH_PRIVATE_KEY,
+# vars.VPS_HOST) and run a one-shot container in the compose network via the
+# profile-gated `graph-ops` compose service, with NEO4J credentials sourced from
+# the VPS .env (NEVER on argv — CWE-214) and each op's exit code observed.
+#
+# Why `docker compose run` (not raw `docker run`): the loader container attaches
+# to the live project's `backend` network from the `graph-ops` service
+# definition and reuses that service's NEO4J_* env, so creds stay in the VPS
+# .env and never reach this script's argv or the container's argv. The service
+# is profile-gated (`graph-ops`) so an ordinary deploy's `compose up` never
+# triggers it.
+#
+# stg-gated (deploy#532): prod runs ONLY as a promotion of a verified-good stg
+# run. Sequencing at run time is migrate (stg then prod) BEFORE enrich, so
+# centrality computes on the corrected graph.
+#
+# dry_run defaults to TRUE — a fat-fingered dispatch is a no-op plan, not a
+# destructive in-place edge rewrite. A real run is an explicit dry_run=false.
+
+on:
+  workflow_dispatch:
+    inputs:
+      env:
+        description: "Target env — stg or prod"
+        required: true
+        type: choice
+        options: [stg, prod]
+      operation:
+        description: "Graph op to run"
+        required: true
+        type: choice
+        options: [migrate, enrich]
+      image:
+        description: >-
+          Loader image ref. Leave empty to resolve the env-scoped default
+          `ghcr.io/noorinalabs/noorinalabs-data-acquisition-load:<env>-latest`
+          (the loader image published by da#329). Pass an explicit ref to pin a
+          specific build.
+        required: false
+        type: string
+        default: ""
+      dry_run:
+        description: "Plan/log only — issue no Cypher, rewrite no edges, compute no centrality"
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  # Serialize graph ops per env. Both ops are write-heavy against the live graph
+  # (migrate rewrites ~2.68M edge ids; enrich runs GDS on the neo4j container);
+  # two must never overlap on one env. Queue, don't cancel — a mid-run cancel
+  # could leave a partially-migrated graph.
+  group: graph-ops-${{ inputs.env }}
+  cancel-in-progress: false
+
+jobs:
+  graph-ops:
+    name: graph-ops ${{ inputs.operation }} (${{ inputs.env }})
+    runs-on: ubuntu-latest
+    # migrate rewrites ~2.68M TRANSMITTED_TO edge ids in batches; enrich runs
+    # sampled GDS betweenness + pagerank + louvain + degree on the neo4j
+    # container. Give the job a ceiling ABOVE the SSH `command_timeout` below so
+    # the runner-side never caps the SSH step short of it (mirrors
+    # reembed-corpus.yml / deploy#465). Both live UNDER the 6h (360m)
+    # GitHub-hosted-runner job hard cap. Dry-run returns in seconds, unaffected.
+    timeout-minutes: 130
+    # Maps to GH Environment protection (stg -> staging, prod -> production).
+    # prod requires manual approval; per-env secrets/host resolve from the
+    # matching Environment. Same pattern as reembed-corpus.yml / db-migrate.yml.
+    environment: ${{ inputs.env == 'prod' && 'production' || 'staging' }}
+    permissions:
+      # GHCR pull of the loader image happens on the VPS via the runtime
+      # GITHUB_TOKEN; packages:read lets that token pull.
+      contents: read
+      packages: read
+    steps:
+      - name: Resolve loader image ref
+        id: resolve
+        env:
+          ENV_NAME: ${{ inputs.env }}
+          IMAGE_INPUT: ${{ inputs.image }}
+        run: |
+          set -euo pipefail
+          img="${IMAGE_INPUT}"
+          if [ -z "${img}" ]; then
+            # Env-scoped default; mirrors reembed-corpus.yml's <env>-latest fallback.
+            img="ghcr.io/noorinalabs/noorinalabs-data-acquisition-load:${ENV_NAME}-latest"
+          fi
+          # Guard: refuse to run a graph op against prod with a stg-tagged image.
+          # The reverse (a prod tag on stg) is benign and allowed.
+          if [ "${ENV_NAME}" = "prod" ] && printf '%s' "${img}" | grep -qE ':stg(-|-latest$|$)'; then
+            echo "::error::Refusing to run a graph op on prod with a stg-tagged image ('${img}'). Pass an explicit prod image ref via the 'image' input."
+            exit 1
+          fi
+          echo "image=${img}" >> "$GITHUB_OUTPUT"
+          echo "Resolved loader image: ${img}"
+
+      - name: Run ${{ inputs.operation }} on ${{ inputs.env }} VPS
+        uses: appleboy/ssh-action@v1
+        env:
+          ENV_NAME: ${{ inputs.env }}
+          OPERATION: ${{ inputs.operation }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          IMAGE: ${{ steps.resolve.outputs.image }}
+          # GHCR pull credentials — runtime token + owner actor, same as
+          # reembed-corpus.yml. NEO4J credentials are NOT pushed through the GH
+          # Actions transport: compose sources them from the VPS .env.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.repository_owner }}
+        with:
+          host: ${{ vars.VPS_HOST }}
+          username: deploy
+          # appleboy/ssh-action defaults command_timeout to 10m — far short of a
+          # 2.68M-edge in-place rewrite or a sampled-GDS enrich. 2h gives margin
+          # while staying UNDER the 6h (360m) GitHub-hosted-runner job hard cap,
+          # and below `timeout-minutes: 130` above so the SSH timeout — not a
+          # hard runner kill — is the binding limit. Dry-run is seconds.
+          command_timeout: 2h
+          key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          envs: ENV_NAME,OPERATION,DRY_RUN,IMAGE,GITHUB_TOKEN,GITHUB_ACTOR
+          script: |
+            set -uo pipefail
+
+            cd /opt/noorinalabs-deploy
+
+            # Map the operation input to the loader CLI subcommand. The image
+            # ENTRYPOINT is `python -m src.cli`, so the subcommand is the full
+            # arg list (creds come from the container env, never argv).
+            case "${OPERATION}" in
+              migrate) SUBCMD="migrate-transmitted-hadith-ids" ;;
+              enrich)  SUBCMD="enrich" ;;
+              *) echo "ERROR: unknown operation '${OPERATION}'." >&2; exit 2 ;;
+            esac
+
+            echo "==> [${ENV_NAME}] graph op — operation=${OPERATION} (cli: ${SUBCMD}) dry_run=${DRY_RUN}"
+            echo "==> [${ENV_NAME}] image=${IMAGE}"
+
+            # .env on the VPS (mode 600, written by the deploy workflow) is the
+            # single source of truth for NEO4J credentials. compose interpolates
+            # the graph-ops service env (NEO4J_PASSWORD / ...) from it — the
+            # creds never reach this script's argv or the container's argv
+            # (CWE-214). Same .env contract as reembed-corpus.yml.
+            if [ ! -f .env ]; then
+              echo "ERROR: /opt/noorinalabs-deploy/.env is missing on ${ENV_NAME} VPS." >&2
+              echo "       The deploy workflow has never written an env-file here, or it was removed." >&2
+              exit 1
+            fi
+
+            # Pin the loader image for the compose `graph-ops` service.
+            # GRAPH_OPS_IMAGE overrides the compose default (env wins over .env).
+            export GRAPH_OPS_IMAGE="${IMAGE}"
+
+            # Same project name + compose file the deploys use, so `run` attaches
+            # to the live project's `backend` network and the live neo4j.
+            # --profile graph-ops activates the otherwise-gated service.
+            COMPOSE="docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env"
+            COMPOSE_OPS="${COMPOSE} --profile graph-ops"
+
+            # cypher-shell helper for the post-op verification gate. Runs INSIDE
+            # the live neo4j container and reads the password from that
+            # container's OWN NEO4J_AUTH (neo4j/<pw>) — never on our argv, never
+            # over the GH transport. cypher-shell honors NEO4J_USERNAME /
+            # NEO4J_PASSWORD env vars, so the credential stays in the container
+            # env and is not on cypher-shell's argv either. --format plain gives
+            # a header line + data rows. The query text ($1) is not a secret.
+            run_cypher() {
+              ${COMPOSE} exec -T neo4j sh -c \
+                'NEO4J_USERNAME=neo4j NEO4J_PASSWORD="${NEO4J_AUTH#neo4j/}" exec cypher-shell --format plain "$1"' \
+                _ "$1"
+            }
+
+            if [ "${DRY_RUN}" = "true" ]; then
+              echo "==> [${ENV_NAME}] DRY RUN — no Cypher issued, no edges rewritten, no centrality computed."
+              echo "    image: ${GRAPH_OPS_IMAGE}"
+              echo "    would run (compose service graph-ops, network backend):"
+              echo "      docker compose --profile graph-ops run --rm --no-deps graph-ops ${SUBCMD}"
+              echo "    would then verify (cypher-shell in the neo4j container):"
+              if [ "${OPERATION}" = "migrate" ]; then
+                echo "      - da#325 validation query queries/validation/transmitted_to_hadith_ref.cypher: dangling-ref count == 0"
+                echo "      - sample chain reconstructs non-empty"
+              else
+                echo "      - MATCH (n:Narrator) WHERE n.betweenness_centrality IS NOT NULL RETURN count(n) > 0"
+                echo "      - echo top-k narrators by betweenness"
+              fi
+              # Read-only: confirm the graph-ops service resolves under the live
+              # .env (catches config/secret drift without issuing any Cypher).
+              if ${COMPOSE_OPS} config graph-ops >/dev/null 2>&1; then
+                echo "    compose config: graph-ops resolves OK under live .env"
+              else
+                echo "    WARNING: compose config for graph-ops did not resolve under live .env" >&2
+              fi
+              echo "==> [${ENV_NAME}] dry run complete (exit 0)."
+              exit 0
+            fi
+
+            # GHCR login so the loader image can be pulled; trap logs out at
+            # end-of-run so no credentials persist on the box.
+            trap 'docker logout ghcr.io >/dev/null 2>&1 || true' EXIT
+            echo "${GITHUB_TOKEN}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin \
+              || { echo "ERROR: [${ENV_NAME}] GHCR login failed." >&2; exit 1; }
+
+            echo "==> [${ENV_NAME}] pulling loader image ${GRAPH_OPS_IMAGE} ..."
+            ${COMPOSE_OPS} pull graph-ops \
+              || { echo "ERROR: [${ENV_NAME}] compose pull graph-ops (${GRAPH_OPS_IMAGE}) failed." >&2; exit 1; }
+
+            # --- run the op (--no-deps: DBs are already up on the live stack;
+            #     do NOT let `run` recreate neo4j) ---
+            echo "==> [${ENV_NAME}] docker compose --profile graph-ops run --rm --no-deps graph-ops ${SUBCMD}"
+            RC=0
+            ${COMPOSE_OPS} run --rm --no-deps graph-ops "${SUBCMD}" || RC=$?
+            if [ "${RC}" -ne 0 ]; then
+              echo "ERROR: [${ENV_NAME}] graph op '${OPERATION}' (${SUBCMD}) failed (rc=${RC})." >&2
+              exit "${RC}"
+            fi
+
+            # --- post-op verification gate ---
+            if [ "${OPERATION}" = "migrate" ]; then
+              echo "==> [${ENV_NAME}] verify: da#325 dangling-ref count (queries/validation/transmitted_to_hadith_ref.cypher, shipped in the image)"
+              # Read the shipped validation query out of the loader image and run
+              # it against the live graph. It RETURNs distinct dangling edge ids
+              # (LIMIT 100); a healthy graph returns 0 data rows. --entrypoint cat
+              # overrides `python -m src.cli` to print the baked query file.
+              VQUERY="$(${COMPOSE_OPS} run --rm --no-deps --entrypoint cat graph-ops queries/validation/transmitted_to_hadith_ref.cypher)" \
+                || { echo "ERROR: [${ENV_NAME}] could not read the validation query from the image." >&2; exit 1; }
+              VOUT="$(run_cypher "${VQUERY}")" \
+                || { echo "ERROR: [${ENV_NAME}] validation query failed to execute." >&2; exit 1; }
+              printf '%s\n' "${VOUT}"
+              # --format plain emits a header line then one line per dangling id.
+              DANGLING="$(printf '%s\n' "${VOUT}" | tail -n +2 | grep -c . || true)"
+              echo "    dangling TRANSMITTED_TO.hadith_id refs: ${DANGLING}"
+              if [ "${DANGLING}" -ne 0 ]; then
+                echo "ERROR: [${ENV_NAME}] migrate verification FAILED — ${DANGLING} dangling TRANSMITTED_TO.hadith_id ref(s) still join no Hadith node (da#325)." >&2
+                exit 1
+              fi
+
+              echo "==> [${ENV_NAME}] verify: a sample chain reconstructs non-empty"
+              # Pick one edge's hadith_id and confirm it (a) joins an existing
+              # Hadith node and (b) yields a non-empty set of chain edges — the
+              # exact join GET /graph/hadith/{id}/chain performs.
+              CHAIN_Q='MATCH ()-[t:TRANSMITTED_TO]->() WHERE t.hadith_id IS NOT NULL AND t.hadith_id <> "" WITH t.hadith_id AS hid LIMIT 1 MATCH (:Hadith {id: hid}) MATCH p=()-[:TRANSMITTED_TO {hadith_id: hid}]->() RETURN count(p) AS chain_edges'
+              COUT="$(run_cypher "${CHAIN_Q}")" \
+                || { echo "ERROR: [${ENV_NAME}] sample-chain query failed to execute." >&2; exit 1; }
+              printf '%s\n' "${COUT}"
+              CHAIN_EDGES="$(printf '%s\n' "${COUT}" | tail -n +2 | head -n1 | tr -dc '0-9')"
+              CHAIN_EDGES="${CHAIN_EDGES:-0}"
+              if [ "${CHAIN_EDGES}" -le 0 ]; then
+                echo "ERROR: [${ENV_NAME}] migrate verification FAILED — sample chain reconstructed EMPTY (0 chain edges for the sampled hadith)." >&2
+                exit 1
+              fi
+              echo "    sample chain reconstructs non-empty (chain_edges=${CHAIN_EDGES})."
+              echo "==> [${ENV_NAME}] migrate verified — dangling-ref=0, sample chain non-empty."
+
+            else
+              echo "==> [${ENV_NAME}] verify: narrator betweenness_centrality is populated"
+              BOUT="$(run_cypher 'MATCH (n:Narrator) WHERE n.betweenness_centrality IS NOT NULL RETURN count(n) AS cnt')" \
+                || { echo "ERROR: [${ENV_NAME}] centrality-count query failed to execute." >&2; exit 1; }
+              printf '%s\n' "${BOUT}"
+              CNT="$(printf '%s\n' "${BOUT}" | tail -n +2 | head -n1 | tr -dc '0-9')"
+              CNT="${CNT:-0}"
+              if [ "${CNT}" -le 0 ]; then
+                echo "ERROR: [${ENV_NAME}] enrich verification FAILED — no Narrator has betweenness_centrality set (da#326)." >&2
+                exit 1
+              fi
+              echo "    narrators with betweenness_centrality: ${CNT}"
+              echo "==> [${ENV_NAME}] top-k choke-point narrators by betweenness:"
+              run_cypher 'MATCH (n:Narrator) WHERE n.betweenness_centrality IS NOT NULL RETURN n.id AS id, n.name_arabic AS name, n.betweenness_centrality AS bc ORDER BY bc DESC LIMIT 10' \
+                || echo "    WARNING: top-k echo query failed (non-fatal)." >&2
+              echo "==> [${ENV_NAME}] enrich verified — betweenness_centrality populated on ${CNT} narrators."
+            fi
+
+            echo "==> [${ENV_NAME}] graph op '${OPERATION}' complete — post-op verification PASSED."
+
+      - name: Report
+        if: always()
+        env:
+          ENV_NAME: ${{ inputs.env }}
+          OPERATION: ${{ inputs.operation }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          IMAGE: ${{ steps.resolve.outputs.image }}
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Graph op ${OPERATION} (${ENV_NAME}): ${JOB_STATUS}"
+            echo ""
+            echo "- **Env:** ${ENV_NAME}"
+            echo "- **Operation:** ${OPERATION}"
+            echo "- **Dry run:** ${DRY_RUN}"
+            echo "- **Image:** ${IMAGE}"
+            echo ""
+            if [ "${DRY_RUN}" = "true" ]; then
+              echo "Dry run — no Cypher issued, no edges rewritten, no centrality computed."
+            fi
+            echo "stg-gated (deploy#532): prod runs ONLY as a promotion of a verified-good stg run."
+            echo "Run order: migrate (stg then prod) BEFORE enrich, so centrality computes on the corrected graph."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -352,6 +352,85 @@ services:
     # a non-zero exit must surface (the workflow's verify-recall gate), not loop.
     restart: "no"
 
+  # -------------------------------------------------------------------------
+  # PROFILE-GATED (`graph-ops`) — one-shot Neo4j graph-remediation ops driven
+  # by the data-acquisition loader image (deploy#532). Two ops run here:
+  #   * migrate — `migrate-transmitted-hadith-ids` (da#325): canonicalize the
+  #     ~2.68M TRANSMITTED_TO.hadith_id edge ids in place so chain
+  #     reconstruction joins against Hadith.id (fixes the empty-isnad-chain bug).
+  #   * enrich  — `enrich` (da#326): GDS narrator centrality (sampled
+  #     betweenness + pagerank + louvain + degree) surfacing transmission
+  #     choke points.
+  # Both are Neo4j-ONLY (no egress, no Postgres/Redis at startup — see below),
+  # so the profile keeps the service validated by `docker compose config` while
+  # excluding it from an ordinary `docker compose up` (which app deploys run).
+  # Driven by `.github/workflows/graph-ops.yml` via
+  # `docker compose --profile graph-ops run --rm graph-ops <subcommand>`, or a
+  # deliberate break-glass with `--profile graph-ops`.
+  #
+  # NETWORKS — `backend` (internal) ONLY. Both ops issue Cypher to
+  # neo4j:7687 and need nothing off-box: the loader image (da Dockerfile.load)
+  # BAKES every dependency at build time precisely because the target Neo4j is
+  # reachable only on the internet-isolated `backend` network. No `egress`
+  # (unlike isnad-graph-embed, which needs it for a HuggingFace model swap).
+  #
+  # CREDENTIALS — reuses the SAME NEO4J_* env the api/embed services read,
+  # interpolated by compose from the VPS .env, so no password ever lands on
+  # argv (CWE-214) and no NEW required secret is added. PG_DSN / REDIS_URL are
+  # deliberately OMITTED: the loader CLI's config (da src/config.py) gives
+  # Postgres a default DSN and never reads Redis, and neither migrate nor
+  # enrich touches Postgres — so a bare NEO4J_* env is sufficient for startup
+  # and the op. GDS runs INSIDE the neo4j container; this loader container just
+  # issues the Cypher/GDS calls, hence the modest limits below.
+  graph-ops:
+    # GRAPH_OPS_IMAGE default is `prod-latest` — the FAIL-SAFE direction
+    # (deploy#470, same rationale as EMBED_IMAGE). graph-ops.yml always sets
+    # GRAPH_OPS_IMAGE explicitly per-env (<env>-latest), so this default is only
+    # hit by a manual break-glass `--profile graph-ops` on a box: on PROD it
+    # pulls the correct prod loader image; on STG a prod tag is benign per the
+    # graph-ops.yml env guard.
+    image: ${GRAPH_OPS_IMAGE:-ghcr.io/noorinalabs/noorinalabs-data-acquisition-load:prod-latest}
+    profiles: ["graph-ops"]
+    read_only: true
+    tmpfs:
+      - /tmp:size=64M
+    environment:
+      # Same DB env the api/embed services read (NEO4J_* only — the loader CLI
+      # reads NEO4J_URI / NEO4J_USER / NEO4J_PASSWORD via the NEO4J_ env_prefix).
+      - NEO4J_URI=bolt://neo4j:7687
+      - NEO4J_USER=neo4j
+      - NEO4J_PASSWORD=${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set}
+    # Safe default (break-glass `--profile graph-ops up` path): print CLI help
+    # and exit non-destructively. graph-ops.yml overrides this per operation,
+    # invoking `migrate-transmitted-hadith-ids` / `enrich` as separate
+    # `docker compose run` calls so each op's exit code is observed. The image
+    # ENTRYPOINT is `python -m src.cli`, so the command below is just args.
+    command: ["--help"]
+    depends_on:
+      neo4j:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          # The loader just issues Cypher/GDS calls and streams small result
+          # sets — the heavy betweenness/pagerank compute (and its heap
+          # headroom) is a NEO4J-container concern, NOT this container's.
+          # Verify GDS betweenness heap headroom on the neo4j container on stg
+          # first (da#326). Profile-gated so this never runs on an ordinary
+          # deploy — zero blast radius on the live stack.
+          memory: 1G
+          cpus: "1.0"
+        reservations:
+          memory: 256M
+          cpus: "0.25"
+    logging: *default-logging
+    networks:
+      - backend
+    # One-shot: never restart. A graph op is operator-triggered, not a daemon;
+    # a non-zero exit must surface (the workflow's post-op verification gate),
+    # not loop.
+    restart: "no"
+
   frontend:
     # GHCR-only — no local-build fallback. The deploy workflow logs into ghcr.io
     # using the auto-provisioned GITHUB_TOKEN (workflow `permissions: packages: read`


### PR DESCRIPTION
Closes #532

## What

Adds the IaC vehicle to run the two data-acquisition graph-remediation ops against a chosen env's Neo4j — workflow-driven, reproducible, stg-gated — instead of box one-offs. Mirrors the `isnad-graph-embed` service + `reembed-corpus.yml` pattern.

- **Compose service `graph-ops`** (`compose/docker-compose.prod.yml`) — `profiles: ["graph-ops"]`, `restart: "no"`, `read_only: true` + `tmpfs /tmp`, `backend` network **only** (both ops are Neo4j-only; no egress — the loader image bakes deps). Image `${GRAPH_OPS_IMAGE:-ghcr.io/noorinalabs/noorinalabs-data-acquisition-load:prod-latest}` (fail-safe prod-latest default, same rationale as `EMBED_IMAGE`). Env reuses `NEO4J_URI`/`NEO4J_USER`/`NEO4J_PASSWORD` interpolated from the VPS `.env` — no new secret, nothing on argv. `PG_DSN`/`REDIS_URL` deliberately omitted (verified against da `src/config.py`: Postgres has a default DSN and is untouched by these ops; Redis absent from config). `depends_on: neo4j: service_healthy`, `logging: *default-logging`, modest 1G/1cpu limits (GDS heap is a neo4j-container concern — noted inline, verify on stg). Default command `--help` (safe no-op); the workflow overrides per op.
- **Workflow `.github/workflows/graph-ops.yml`** (`workflow_dispatch`) — inputs `env` (stg/prod), `operation` (migrate|enrich), `image` (empty → `<env>-latest`), `dry_run` (default true). stg-tag-on-prod guard (mirrors reembed). On the box: `export GRAPH_OPS_IMAGE=<resolved>`; `docker compose --profile graph-ops pull graph-ops`; `docker compose --profile graph-ops run --rm --no-deps graph-ops <subcommand>` (ENTRYPOINT is `python -m src.cli`, so args = the subcommand). `command_timeout: 2h`, `timeout-minutes: 130`. Dry-run echoes the resolved image + exact command and runs no Cypher.

## CLI subcommands wired (confirmed at da `main`)

- migrate → `migrate-transmitted-hadith-ids` (CLI default `--batch-size 1000`)
- enrich → `enrich`

## Post-op verification gate

- **migrate** → runs the shipped da#325 validation query `queries/validation/transmitted_to_hadith_ref.cypher` (read out of the image via `--entrypoint cat`) and **fails if dangling-ref > 0**; also confirms a sample chain reconstructs non-empty (the exact `hadith_id`→`Hadith.id` join `GET /graph/hadith/{id}/chain` performs).
- **enrich** → asserts `MATCH (n:Narrator) WHERE n.betweenness_centrality IS NOT NULL RETURN count(n) > 0` and echoes top-k narrators by betweenness.

Verification cypher runs inside the live neo4j container via `cypher-shell`, reading the password from that container's own `NEO4J_AUTH` — never on argv, never over the GH transport.

## stg gate

prod runs **only** as a promotion of a verified-good stg run (documented in-workflow). Run order: migrate (stg→prod) before enrich, so centrality computes on the corrected graph.

## Validation

- `docker compose -f compose/docker-compose.prod.yml --env-file .env config --quiet` (CI form, no profile) — passes.
- `docker compose --profile graph-ops config` — graph-ops resolves; tier-subset check passes.
- `actionlint` (pinned 1.7.12, shellcheck on PATH) — clean.
- pre-commit (commit + pre-push stages) — all green.

## Depends on

The loader image `noorinalabs-data-acquisition-load:<env>-latest` from da#329 being published.

## Reviewers

- Lucas Ferreira
- Nino Kavtaradze

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hfJHDPdFJciPKPudSn7Q7
