### PR TITLE
fix(graph-ops): refresh box checkout to origin/main before compose (deploy#536)

### DIFF
--- a/.github/workflows/graph-ops.yml
+++ b/.github/workflows/graph-ops.yml
@@ -144,6 +144,22 @@ jobs:
 
             cd /opt/noorinalabs-deploy
 
+            # Refresh the on-box checkout to origin/main BEFORE any compose
+            # command, exactly as the sibling deploy-isnad-graph.yml does after
+            # its cd. The box's /opt/noorinalabs-deploy holds a git checkout that
+            # deploys refresh, but this op-workflow did not — so it ran against a
+            # stale pre-#533 compose file that lacked the profile-gated graph-ops
+            # service (added deploy#533; migrate index pre-step deploy#535),
+            # failing at `compose pull` with "no such service: graph-ops"
+            # (deploy#536). Placed above the dry-run early-exit so BOTH the
+            # dry-run (compose config) and real (compose pull/run) paths validate
+            # against the current compose file. Idempotent; updates the on-disk
+            # files only — graph-ops uses `run --rm`, not `up`, so the running
+            # stack is untouched.
+            echo "==> Pulling latest deploy config..."
+            git fetch origin main
+            git reset --hard origin/main
+
             # Map the operation input to the loader CLI subcommand. The image
             # ENTRYPOINT is `python -m src.cli`, so the subcommand is the full
             # arg list (creds come from the container env, never argv).

--- a/.github/workflows/graph-ops.yml
+++ b/.github/workflows/graph-ops.yml
@@ -157,8 +157,15 @@ jobs:
             # files only — graph-ops uses `run --rm`, not `up`, so the running
             # stack is untouched.
             echo "==> Pulling latest deploy config..."
-            git fetch origin main
-            git reset --hard origin/main
+            # Guarded (this script runs `set -uo pipefail`, NO -e): an unguarded
+            # `git fetch` failure would not abort, and the following
+            # `reset --hard origin/main` would succeed against the STALE
+            # remote-tracking ref — leaving the box on an old tree, the exact
+            # failure mode this PR fixes. Match the script's `|| { echo ERROR; exit 1; }` idiom.
+            git fetch origin main \
+              || { echo "ERROR: [${ENV_NAME}] git fetch origin main failed — refusing to run against a stale checkout." >&2; exit 1; }
+            git reset --hard origin/main \
+              || { echo "ERROR: [${ENV_NAME}] git reset --hard origin/main failed." >&2; exit 1; }
 
             # Map the operation input to the loader CLI subcommand. The image
             # ENTRYPOINT is `python -m src.cli`, so the subcommand is the full


### PR DESCRIPTION
Closes #536

`graph-ops.yml` `cd`s into `/opt/noorinalabs-deploy` but never refreshed the box's on-disk checkout, so it ran the stale pre-#533 compose (no `graph-ops` service) and failed at `compose pull` with `no such service: graph-ops`. This adds the same `git fetch origin main && git reset --hard origin/main` box-sync the sibling `deploy-isnad-graph.yml` runs after its `cd`, placed right after the `cd` (above the dry-run early-exit) so both the dry-run and real paths validate against the current compose file. Idempotent; touches on-disk files only (`run --rm`, not `up`).

Reviewers: Lucas Ferreira and Nino Kavtaradze.
