### PR TITLE
ci(graph-ops): sample migrate CHAIN_Q from resolving edges only (deploy#542)

### DIFF
--- a/.github/workflows/graph-ops.yml
+++ b/.github/workflows/graph-ops.yml
@@ -464,10 +464,20 @@ jobs:
               echo "    dangling refs (edges whose hadith_id joins no Hadith): ${DANGLING} — INFO ONLY; run 'prune-orphans' to remove them."
 
               echo "==> [${ENV_NAME}] verify: a sample chain reconstructs non-empty"
-              # Pick one edge's hadith_id and confirm it (a) joins an existing
-              # Hadith node and (b) yields a non-empty set of chain edges — the
-              # exact join GET /graph/hadith/{id}/chain performs.
-              CHAIN_Q='MATCH ()-[t:TRANSMITTED_TO]->() WHERE t.hadith_id IS NOT NULL AND t.hadith_id <> "" WITH t.hadith_id AS hid LIMIT 1 MATCH (:Hadith {id: hid}) MATCH p=()-[:TRANSMITTED_TO {hadith_id: hid}]->() RETURN count(p) AS chain_edges'
+              # Sample a hadith_id from a RESOLVING edge ONLY — one whose
+              # hadith_id joins an existing Hadith node — then confirm it yields
+              # a non-empty set of chain edges (the exact join
+              # GET /graph/hadith/{id}/chain performs). The `EXISTS { MATCH
+              # (:Hadith {id: t.hadith_id}) }` predicate before `LIMIT 1` is what
+              # makes this consistent with the migrate-invariant design (deploy#542):
+              # migrate verifies canonicalization + that a *resolving* chain
+              # reconstructs, independent of the pre-existing dangling fawaz
+              # orphans (whose removal is prune-orphans' job, reported info-only
+              # above). Without it, `LIMIT 1` could land on one of the ~196k
+              # dangling orphan edges — a non-deterministic pick by storage scan
+              # order — and the downstream `MATCH (:Hadith {id: hid})` would drop
+              # the row, false-failing an otherwise-correct migration.
+              CHAIN_Q='MATCH ()-[t:TRANSMITTED_TO]->() WHERE t.hadith_id IS NOT NULL AND t.hadith_id <> "" AND EXISTS { MATCH (:Hadith {id: t.hadith_id}) } WITH t.hadith_id AS hid LIMIT 1 MATCH (:Hadith {id: hid}) MATCH p=()-[:TRANSMITTED_TO {hadith_id: hid}]->() RETURN count(p) AS chain_edges'
               COUT="$(run_cypher "${CHAIN_Q}")" \
                 || { echo "ERROR: [${ENV_NAME}] sample-chain query failed to execute." >&2; exit 1; }
               printf '%s\n' "${COUT}"


### PR DESCRIPTION
## Summary

Fixes a non-deterministic false-fail in the `migrate` post-op **sample-chain** verification (`CHAIN_Q`) in `.github/workflows/graph-ops.yml`.

The check sampled an arbitrary `TRANSMITTED_TO` edge with `LIMIT 1` and no resolving filter, then joined `MATCH (:Hadith {id: hid})`. When the arbitrary pick landed on one of the ~196k pre-existing **dangling fawaz orphan edges**, the join eliminated the row and `count(p)` returned 0 — false-failing an otherwise correct-and-complete migration.

This just happened on the real prod migrate: migration was correct (edges_updated=2682069, 0 raw-form ids remaining, dangling=196160 reported info-only, exact stg parity), but the sample-chain check happened to sample a dangling edge and failed the job. It is non-deterministic by storage scan order — stg passed, prod failed.

## Fix

Add `AND EXISTS { MATCH (:Hadith {id: t.hadith_id}) }` to the sampling `WHERE` so the sampled `hadith_id` is drawn from a **resolving** edge only. This is consistent with the migrate-invariant design: migrate verifies canonicalization + that a *resolving* chain reconstructs; dangling completeness is prune-orphans' job (already reported info-only above). The downstream `MATCH (:Hadith {id: hid})` join and the path-count are unchanged.

### `CHAIN_Q` before → after

Before:
```
MATCH ()-[t:TRANSMITTED_TO]->() WHERE t.hadith_id IS NOT NULL AND t.hadith_id <> "" WITH t.hadith_id AS hid LIMIT 1 MATCH (:Hadith {id: hid}) MATCH p=()-[:TRANSMITTED_TO {hadith_id: hid}]->() RETURN count(p) AS chain_edges
```

After (added `AND EXISTS { MATCH (:Hadith {id: t.hadith_id}) }` before `WITH ... LIMIT 1`):
```
MATCH ()-[t:TRANSMITTED_TO]->() WHERE t.hadith_id IS NOT NULL AND t.hadith_id <> "" AND EXISTS { MATCH (:Hadith {id: t.hadith_id}) } WITH t.hadith_id AS hid LIMIT 1 MATCH (:Hadith {id: hid}) MATCH p=()-[:TRANSMITTED_TO {hadith_id: hid}]->() RETURN count(p) AS chain_edges
```

The adjacent comment is updated to document that the sample is now drawn from resolving edges only, mirroring the invariant rationale already in the file.

## Scope

Only the `CHAIN_Q` assignment line and its adjacent comment changed. `RAW_Q` / `DANGLING_Q` / `RESOLVING_Q` / `PRUNE_Q`, the guards, gates, prune path, `run_cypher`/`run_count`, and the enrich path are untouched.

Verified read-only on prod: raw-form=0, dangling=196160, resolving=2485909 (exact stg parity); a resolving hadith reconstructs its chain fine — migration data is correct, only the verify sampling was wrong.

## Testing

- `pre-commit` (commit + pre-push stages): actionlint (with shellcheck), gitleaks, mypy, pytest suites — all green locally.
- No graph-ops run performed against any box (per constraints).

Reviewers: **Lucas Ferreira**, **Weronika Zielinska**

Closes #542

TechDebt: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hfJHDPdFJciPKPudSn7Q7
