### PR TITLE
deploy#546: deploy-data-load.yml — IaC batch Neo4j load from B2

### DIFF
--- a/.github/workflows/deploy-data-load.yml
+++ b/.github/workflows/deploy-data-load.yml
@@ -1,0 +1,413 @@
+name: Deploy data load (batch Neo4j graph load from B2)
+
+# Repeatable, observable, env-gated batch Neo4j data-load — the missing
+# OPERATIONAL trigger for the full node/edge graph load (deploy#546).
+#
+# This retires the `scripts/load_staging.sh` build-host one-off (in
+# noorinalabs-data-acquisition): that script rsync'd curated + staging Parquet
+# from a workstation to the VPS, `docker build`-t the loader image ON the box,
+# and ran it against the live neo4j. That is exactly the kind of un-repeatable
+# box one-off the owner directed us to put behind IaC (main#… IaC-over-one-offs).
+# This workflow reproduces the LOAD behavior but:
+#   * sources the Parquet from the `noorinalabs-pipeline` B2 bucket (SSE-B2 at
+#     rest) via rclone ON THE VPS — the large Parquet set never transits the
+#     GitHub-hosted runner,
+#   * runs the PUBLISHED loader image via a profile-gated compose service
+#     (`graph-load`) — no on-VPS `docker build`,
+#   * sources the NEO4J password from compose interpolation of the VPS `.env`
+#     (never on argv/in logs — CWE-214), exactly like graph-ops.yml, and
+#   * gates prod behind the `production` GH Environment approval.
+#
+# DIVISION OF LABOR (what this workflow does NOT do):
+#   * The RESOLVE half (NER → disambiguate → dedup → the curated
+#     `narrators_canonical` / `narrator_mentions_resolved*` Parquet + the
+#     edge-bearing staging Parquet) stays a documented VM/pipeline step. Its
+#     output MUST be published to `noorinalabs-pipeline` under the object prefix
+#     you then pass as `parquet_ref` (see the CONTRACT below). Publishing that
+#     Parquet set to B2 is a separate data-acquisition helper — NOT this
+#     workflow. This workflow CONSUMES an already-published `parquet_ref`.
+#   * The in-graph remediation ops — migrate-transmitted-hadith-ids, enrich
+#     (GDS centrality), prune-orphans — remain in graph-ops.yml. This workflow
+#     is ONLY the batch node/edge LOAD.
+#
+# CONTRACT — the B2 object layout `parquet_ref` must point at:
+#   noorinalabs-pipeline/<parquet_ref>/curated/narrators_canonical.parquet
+#   noorinalabs-pipeline/<parquet_ref>/curated/narrator_mentions_resolved.parquet
+#   noorinalabs-pipeline/<parquet_ref>/curated/narrator_mentions_resolved_muhaddithat.parquet
+#   noorinalabs-pipeline/<parquet_ref>/staging/hadiths_*.parquet
+#   noorinalabs-pipeline/<parquet_ref>/staging/collections_*.parquet
+#   noorinalabs-pipeline/<parquet_ref>/staging/narrator_mentions_*.parquet   (full load only)
+#   noorinalabs-pipeline/<parquet_ref>/staging/network_edges_*.parquet       (full load only)
+#   noorinalabs-pipeline/<parquet_ref>/staging/parallel_links.parquet        (full load only)
+# `parquet_ref` is a bucket-relative prefix (no bucket name, no leading slash),
+# e.g. `staged/narrator-resolve/2026-07-08-<sha>`. Version it per resolve run so
+# a load is reproducible and a prior good set is always re-loadable.
+#
+# CREDENTIALS:
+#   * B2 read — rclone native env (`RCLONE_CONFIG_PIPELINE_*`, no CLI-flag
+#     secrets), the same credential-safe pattern scripts/backup.sh uses. The
+#     pipeline B2 key (secrets PIPELINE_B2_KEY_ID / PIPELINE_B2_KEY) is passed
+#     env-scoped through the SSH transport, never on argv.
+#   * GHCR pull — runtime GITHUB_TOKEN + owner actor (same as graph-ops.yml).
+#   * NEO4J password — NEVER transported: compose interpolates it from the VPS
+#     `.env` into the graph-load service env (CWE-214-safe).
+#
+# stg-gated: prod runs ONLY as a promotion of a verified-good stg load. dry_run
+# defaults to TRUE — a fat-fingered dispatch verifies B2 presence + prints the
+# load plan, and writes NOTHING to the graph. A real load is an explicit
+# dry_run=false.
+
+on:
+  workflow_dispatch:
+    inputs:
+      env:
+        description: "Target env — stg or prod"
+        required: true
+        type: choice
+        options: [stg, prod]
+      parquet_ref:
+        description: >-
+          Bucket-relative B2 prefix of the resolved Parquet set to load (under
+          noorinalabs-pipeline), e.g. `staged/narrator-resolve/2026-07-08-<sha>`.
+          Must contain curated/ and staging/ subprefixes per the CONTRACT in the
+          workflow header. No bucket name, no leading slash.
+        required: true
+        type: string
+      load_args:
+        description: "Loader mode — full nodes+edges, or nodes only"
+        required: true
+        type: choice
+        options: ["load", "load --nodes-only"]
+        default: "load"
+      image:
+        description: >-
+          Loader image ref. Leave empty to resolve the env-scoped default
+          `ghcr.io/noorinalabs/noorinalabs-data-acquisition-load:<env>-latest`
+          (the loader image published by da#329, same image family graph-ops.yml
+          uses). Pass an explicit ref to pin a specific build.
+        required: false
+        type: string
+        default: ""
+      dry_run:
+        description: "Plan/log only — verify B2 presence + print the load plan; issue NO loader write"
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  # Serialize loads per env. A load MERGEs large node/edge sets against the live
+  # graph; two must never overlap on one env. Queue, don't cancel — a mid-load
+  # cancel leaves a partial (but idempotent-MERGE-recoverable) graph, so let the
+  # in-flight load finish rather than interrupt it.
+  group: data-load-${{ inputs.env }}
+  cancel-in-progress: false
+
+jobs:
+  data-load:
+    name: data-load ${{ inputs.load_args }} (${{ inputs.env }})
+    runs-on: ubuntu-latest
+    # A full load reads large curated + staging Parquet and MERGEs nodes, edges,
+    # and parallels — heavier than graph-ops' in-place edge rewrite (#723's stage
+    # edge-load ran ~2h). Give a generous ceiling ABOVE the SSH `command_timeout`
+    # below so the runner side never caps the SSH step short of it, while staying
+    # UNDER the 6h (360m) GitHub-hosted-runner job hard cap. Dry-run returns in
+    # seconds, unaffected.
+    timeout-minutes: 300
+    # Maps to GH Environment protection (stg -> staging, prod -> production).
+    # prod requires manual approval; per-env secrets/host resolve from the
+    # matching Environment. Same pattern as graph-ops.yml / reembed-corpus.yml.
+    environment: ${{ inputs.env == 'prod' && 'production' || 'staging' }}
+    permissions:
+      # GHCR pull of the loader image happens on the VPS via the runtime
+      # GITHUB_TOKEN; packages:read lets that token pull.
+      contents: read
+      packages: read
+    steps:
+      - name: Resolve loader image ref
+        id: resolve
+        env:
+          ENV_NAME: ${{ inputs.env }}
+          IMAGE_INPUT: ${{ inputs.image }}
+        run: |
+          set -euo pipefail
+          img="${IMAGE_INPUT}"
+          if [ -z "${img}" ]; then
+            # Env-scoped default; mirrors graph-ops.yml's <env>-latest fallback.
+            img="ghcr.io/noorinalabs/noorinalabs-data-acquisition-load:${ENV_NAME}-latest"
+          fi
+          # Guard: refuse to run a load against prod with a stg-tagged image.
+          # The reverse (a prod tag on stg) is benign and allowed.
+          if [ "${ENV_NAME}" = "prod" ] && printf '%s' "${img}" | grep -qE ':stg(-|-latest$|$)'; then
+            echo "::error::Refusing to run a load on prod with a stg-tagged image ('${img}'). Pass an explicit prod image ref via the 'image' input."
+            exit 1
+          fi
+          echo "image=${img}" >> "$GITHUB_OUTPUT"
+          echo "Resolved loader image: ${img}"
+
+      - name: Run batch load on ${{ inputs.env }} VPS
+        uses: appleboy/ssh-action@v1
+        env:
+          ENV_NAME: ${{ inputs.env }}
+          PARQUET_REF: ${{ inputs.parquet_ref }}
+          LOAD_ARGS: ${{ inputs.load_args }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          IMAGE: ${{ steps.resolve.outputs.image }}
+          # B2 read credentials for the pipeline bucket — consumed by rclone on
+          # the VPS as native RCLONE_CONFIG_* env (never on argv). Env-scoped
+          # secrets: prod values resolve from the `production` Environment.
+          PIPELINE_B2_KEY_ID: ${{ secrets.PIPELINE_B2_KEY_ID }}
+          PIPELINE_B2_KEY: ${{ secrets.PIPELINE_B2_KEY }}
+          # GHCR pull credentials — runtime token + owner actor, same as
+          # graph-ops.yml. NEO4J credentials are NOT pushed through the GH
+          # Actions transport: compose sources them from the VPS .env.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.repository_owner }}
+        with:
+          host: ${{ vars.VPS_HOST }}
+          username: deploy
+          # A full load can run well beyond graph-ops' 2h window (large Parquet
+          # read + node/edge/parallel MERGE). 4h gives margin while staying UNDER
+          # the 6h (360m) hard cap, and below `timeout-minutes: 300` above so the
+          # SSH timeout — not a hard runner kill — is the binding limit. If a load
+          # ever outruns this window, the loaders MERGE on stable ids, so a
+          # re-dispatch simply converges (idempotent). Dry-run is seconds.
+          command_timeout: 4h
+          key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          envs: ENV_NAME,PARQUET_REF,LOAD_ARGS,DRY_RUN,IMAGE,PIPELINE_B2_KEY_ID,PIPELINE_B2_KEY,GITHUB_TOKEN,GITHUB_ACTOR
+          script: |
+            set -uo pipefail
+
+            cd /opt/noorinalabs-deploy
+
+            # Refresh the on-box checkout to origin/main BEFORE any compose
+            # command, exactly as deploy-isnad-graph.yml / graph-ops.yml do. The
+            # box's /opt/noorinalabs-deploy holds a git checkout that deploys
+            # refresh; this op-workflow must too, so `compose` sees the current
+            # file (with the profile-gated `graph-load` service added in this PR).
+            # Guarded (this script runs `set -uo pipefail`, NO -e): an unguarded
+            # `git fetch` failure would not abort, and the following
+            # `reset --hard origin/main` would succeed against a STALE
+            # remote-tracking ref — leaving the box on an old tree.
+            echo "==> Pulling latest deploy config..."
+            git fetch origin main \
+              || { echo "ERROR: [${ENV_NAME}] git fetch origin main failed — refusing to run against a stale checkout." >&2; exit 1; }
+            git reset --hard origin/main \
+              || { echo "ERROR: [${ENV_NAME}] git reset --hard origin/main failed." >&2; exit 1; }
+
+            echo "==> [${ENV_NAME}] batch load — parquet_ref=${PARQUET_REF} load_args='${LOAD_ARGS}' dry_run=${DRY_RUN}"
+            echo "==> [${ENV_NAME}] image=${IMAGE}"
+
+            # --- input validation: parquet_ref must be a clean bucket-relative prefix ---
+            case "${PARQUET_REF}" in
+              "" ) echo "ERROR: [${ENV_NAME}] parquet_ref is empty." >&2; exit 1 ;;
+              /* ) echo "ERROR: [${ENV_NAME}] parquet_ref must NOT start with '/' (it is a bucket-relative prefix)." >&2; exit 1 ;;
+              noorinalabs-pipeline/* )
+                echo "ERROR: [${ENV_NAME}] parquet_ref must NOT include the bucket name; pass only the prefix under noorinalabs-pipeline (e.g. staged/narrator-resolve/<ver>)." >&2
+                exit 1 ;;
+            esac
+
+            # .env on the VPS (mode 600, written by the deploy workflow) is the
+            # single source of truth for NEO4J credentials. compose interpolates
+            # the graph-load service env (NEO4J_PASSWORD / ...) from it — the
+            # creds never reach this script's argv or the container's argv
+            # (CWE-214). Same .env contract as graph-ops.yml.
+            if [ ! -f .env ]; then
+              echo "ERROR: /opt/noorinalabs-deploy/.env is missing on ${ENV_NAME} VPS." >&2
+              echo "       The deploy workflow has never written an env-file here, or it was removed." >&2
+              exit 1
+            fi
+
+            # --- rclone B2 config (pipeline bucket) via native env (no CLI-flag
+            #     secrets — same credential-safe pattern as scripts/backup.sh). The
+            #     key never lands on argv; rclone reads RCLONE_CONFIG_PIPELINE_*. ---
+            : "${PIPELINE_B2_KEY_ID:?PIPELINE_B2_KEY_ID must be set (env-scoped secret)}"
+            : "${PIPELINE_B2_KEY:?PIPELINE_B2_KEY must be set (env-scoped secret)}"
+            export RCLONE_CONFIG_PIPELINE_TYPE="b2"
+            export RCLONE_CONFIG_PIPELINE_ACCOUNT="${PIPELINE_B2_KEY_ID}"
+            export RCLONE_CONFIG_PIPELINE_KEY="${PIPELINE_B2_KEY}"
+            B2_BUCKET="noorinalabs-pipeline"
+            B2_BASE="pipeline:${B2_BUCKET}/${PARQUET_REF}"
+
+            if ! command -v rclone >/dev/null 2>&1; then
+              echo "ERROR: [${ENV_NAME}] rclone not found on the VPS (expected pre-installed, per scripts/backup.sh)." >&2
+              exit 1
+            fi
+
+            # Required curated files (needed by BOTH load modes — narrator nodes
+            # load from narrators_canonical, chain narrator_ids come from the
+            # resolved mentions; reading staging mentions gave hollow chains, the
+            # #723 defect). Full load additionally needs the edge-bearing staging
+            # Parquet; nodes-only needs only hadiths_*/collections_*.
+            CURATED_REQUIRED="narrators_canonical.parquet narrator_mentions_resolved.parquet narrator_mentions_resolved_muhaddithat.parquet"
+
+            # verify_present <b2-dir> <required-basename...>: fail loudly if any
+            # required object is absent under the B2 prefix. rclone lsf lists
+            # basenames; the credential is in env, the paths are not secrets.
+            verify_present() {
+              _dir="$1"; shift
+              echo "    listing ${_dir}/ ..."
+              _listing="$(rclone lsf "${_dir}/" 2>/dev/null || true)"
+              if [ -z "${_listing}" ]; then
+                echo "ERROR: [${ENV_NAME}] no objects found under ${_dir}/ — is parquet_ref '${PARQUET_REF}' correct and published?" >&2
+                exit 1
+              fi
+              for _want in "$@"; do
+                if ! printf '%s\n' "${_listing}" | grep -qx "${_want}"; then
+                  echo "ERROR: [${ENV_NAME}] required object missing in B2: ${_dir}/${_want}" >&2
+                  exit 1
+                fi
+              done
+            }
+
+            # glob-present <b2-dir> <shell-glob>: assert at least one object under
+            # the prefix matches the glob (for the wildcarded staging shards).
+            glob_present() {
+              _dir="$1"; _glob="$2"
+              _listing="$(rclone lsf "${_dir}/" 2>/dev/null || true)"
+              # shellcheck disable=SC2254  # $_glob is an intentional case pattern.
+              _hit=0
+              for _f in ${_listing}; do
+                case "${_f}" in
+                  ${_glob}) _hit=1; break ;;
+                esac
+              done
+              if [ "${_hit}" -ne 1 ]; then
+                echo "ERROR: [${ENV_NAME}] no object matching '${_glob}' under ${_dir}/ — cannot ${LOAD_ARGS}." >&2
+                exit 1
+              fi
+            }
+
+            echo "==> [${ENV_NAME}] verify B2 presence under ${B2_BASE}"
+            # shellcheck disable=SC2086  # CURATED_REQUIRED is an intentional word list.
+            verify_present "${B2_BASE}/curated" ${CURATED_REQUIRED}
+            glob_present "${B2_BASE}/staging" "hadiths_*.parquet"
+            glob_present "${B2_BASE}/staging" "collections_*.parquet"
+            case "${LOAD_ARGS}" in
+              *--nodes-only*) : ;;  # nodes-only: hadiths_*/collections_* suffice
+              *)
+                glob_present "${B2_BASE}/staging" "network_edges_*.parquet"
+                glob_present "${B2_BASE}/staging" "parallel_links.parquet"
+                ;;
+            esac
+            echo "    B2 presence check PASSED."
+
+            if [ "${DRY_RUN}" = "true" ]; then
+              echo "==> [${ENV_NAME}] DRY RUN — B2 presence verified; NO Parquet downloaded, NO loader run, NO graph write."
+              echo "    would rclone-pull curated/ + staging/ from ${B2_BASE} into the load data dir, then run:"
+              echo "      docker compose --profile graph-load run --rm --no-deps graph-load ${LOAD_ARGS}"
+              echo "    (loader image ${IMAGE}; NEO4J creds from the VPS .env via compose interpolation)"
+              echo "==> [${ENV_NAME}] dry run complete (exit 0)."
+              exit 0
+            fi
+
+            # ===================== real load =====================
+            # Stable, git-untracked data dir OUTSIDE the /opt checkout (so the
+            # git reset above never touches it). rclone-pull the Parquet here,
+            # then bind-mount it read-only into the loader container.
+            LOAD_DATA_ROOT="${HOME}/.cache/noorinalabs-graph-load"
+            LOAD_DATA_DIR="${LOAD_DATA_ROOT}/data"
+            rm -rf "${LOAD_DATA_DIR}"
+            mkdir -p "${LOAD_DATA_DIR}/curated" "${LOAD_DATA_DIR}/staging"
+
+            echo "==> [${ENV_NAME}] rclone pull curated/ -> ${LOAD_DATA_DIR}/curated"
+            rclone copy "${B2_BASE}/curated/" "${LOAD_DATA_DIR}/curated/" \
+              --include "narrators_canonical.parquet" \
+              --include "narrator_mentions_resolved.parquet" \
+              --include "narrator_mentions_resolved_muhaddithat.parquet" \
+              --log-level INFO \
+              || { echo "ERROR: [${ENV_NAME}] rclone pull of curated Parquet failed." >&2; exit 1; }
+
+            # Staging include set mirrors scripts/load_staging.sh: nodes-only pulls
+            # only hadiths_*/collections_*; full load also pulls the edge-bearing
+            # mentions/network_edges/parallel_links.
+            echo "==> [${ENV_NAME}] rclone pull staging/ -> ${LOAD_DATA_DIR}/staging (mode: ${LOAD_ARGS})"
+            case "${LOAD_ARGS}" in
+              *--nodes-only*)
+                rclone copy "${B2_BASE}/staging/" "${LOAD_DATA_DIR}/staging/" \
+                  --include "hadiths_*.parquet" --include "collections_*.parquet" \
+                  --log-level INFO \
+                  || { echo "ERROR: [${ENV_NAME}] rclone pull of staging Parquet (nodes-only) failed." >&2; exit 1; }
+                ;;
+              *)
+                rclone copy "${B2_BASE}/staging/" "${LOAD_DATA_DIR}/staging/" \
+                  --include "hadiths_*.parquet" --include "collections_*.parquet" \
+                  --include "narrator_mentions_*.parquet" --include "network_edges_*.parquet" \
+                  --include "parallel_links.parquet" \
+                  --log-level INFO \
+                  || { echo "ERROR: [${ENV_NAME}] rclone pull of staging Parquet (full) failed." >&2; exit 1; }
+                ;;
+            esac
+            echo "    pulled: $(find "${LOAD_DATA_DIR}" -name '*.parquet' | wc -l) Parquet file(s)."
+
+            # Pin the loader image for the compose graph-load service and point
+            # the service's read-only data bind-mount at the pulled dir. Both are
+            # exported env (env wins over .env); no .env edit needed.
+            export GRAPH_LOAD_IMAGE="${IMAGE}"
+            export GRAPH_LOAD_DATA_DIR="${LOAD_DATA_DIR}"
+
+            COMPOSE="docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env"
+            COMPOSE_LOAD="${COMPOSE} --profile graph-load"
+
+            # GHCR login so the loader image can be pulled; trap logs out at
+            # end-of-run so no credentials persist on the box.
+            trap 'docker logout ghcr.io >/dev/null 2>&1 || true' EXIT
+            echo "${GITHUB_TOKEN}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin \
+              || { echo "ERROR: [${ENV_NAME}] GHCR login failed." >&2; exit 1; }
+
+            echo "==> [${ENV_NAME}] pulling loader image ${GRAPH_LOAD_IMAGE} ..."
+            ${COMPOSE_LOAD} pull graph-load \
+              || { echo "ERROR: [${ENV_NAME}] compose pull graph-load (${GRAPH_LOAD_IMAGE}) failed." >&2; exit 1; }
+
+            # --- run the load (--no-deps: DBs are already up on the live stack;
+            #     do NOT let `run` recreate neo4j). LOAD_ARGS is a controlled
+            #     choice input ('load' or 'load --nodes-only'); leave it UNQUOTED
+            #     so it word-splits into the loader CLI subcommand + flag. Creds
+            #     come from the container env (compose .env interpolation), never
+            #     argv. ---
+            echo "==> [${ENV_NAME}] docker compose --profile graph-load run --rm --no-deps graph-load ${LOAD_ARGS}"
+            RC=0
+            # shellcheck disable=SC2086  # LOAD_ARGS is an intentional arg split.
+            ${COMPOSE_LOAD} run --rm --no-deps graph-load ${LOAD_ARGS} || RC=$?
+            if [ "${RC}" -ne 0 ]; then
+              echo "ERROR: [${ENV_NAME}] batch load '${LOAD_ARGS}' failed (rc=${RC})." >&2
+              exit "${RC}"
+            fi
+
+            # --- post-load read-back (informational): source_corpus distribution.
+            #     cypher-shell runs INSIDE the live neo4j container and reads the
+            #     password from that container's OWN NEO4J_AUTH — never on our
+            #     argv, never over the GH transport. Non-fatal: the load already
+            #     succeeded above; this is a sanity echo, not a gate. ---
+            echo "==> [${ENV_NAME}] post-load read-back: Hadith count by source_corpus"
+            ${COMPOSE} exec -T neo4j sh -c \
+              'NEO4J_USERNAME=neo4j NEO4J_PASSWORD="${NEO4J_AUTH#neo4j/}" exec cypher-shell --format plain "MATCH (h:Hadith) RETURN h.source_corpus AS source_corpus, count(*) AS hadiths ORDER BY hadiths DESC"' \
+              || echo "    WARNING: [${ENV_NAME}] post-load read-back query failed (non-fatal)." >&2
+
+            echo "==> [${ENV_NAME}] batch load '${LOAD_ARGS}' complete (rc=0)."
+
+      - name: Report
+        if: always()
+        env:
+          ENV_NAME: ${{ inputs.env }}
+          PARQUET_REF: ${{ inputs.parquet_ref }}
+          LOAD_ARGS: ${{ inputs.load_args }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          IMAGE: ${{ steps.resolve.outputs.image }}
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Batch data load (${ENV_NAME}): ${JOB_STATUS}"
+            echo ""
+            echo "- **Env:** ${ENV_NAME}"
+            echo "- **parquet_ref:** \`${PARQUET_REF}\`"
+            echo "- **Load args:** \`${LOAD_ARGS}\`"
+            echo "- **Dry run:** ${DRY_RUN}"
+            echo "- **Image:** ${IMAGE}"
+            echo ""
+            if [ "${DRY_RUN}" = "true" ]; then
+              echo "Dry run — B2 presence verified; no Parquet downloaded, no loader run, no graph write."
+            fi
+            echo "Source: \`noorinalabs-pipeline/${PARQUET_REF}\` (B2) → rclone on the VPS → loader compose service."
+            echo "stg-gated: prod runs ONLY as a promotion of a verified-good stg load."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -431,6 +431,94 @@ services:
     # not loop.
     restart: "no"
 
+  # -------------------------------------------------------------------------
+  # PROFILE-GATED (`graph-load`) — one-shot BATCH node/edge graph load driven
+  # by the data-acquisition loader image (deploy#546). This is the IaC
+  # replacement for the `scripts/load_staging.sh` build-host one-off: it runs
+  # the loader CLI `load` (full nodes+edges) / `load --nodes-only` subcommand
+  # against the live neo4j, reading resolved+staging Parquet from a host bind
+  # mount that `.github/workflows/deploy-data-load.yml` populates via rclone
+  # from the `noorinalabs-pipeline` B2 bucket.
+  #
+  # WHY A SEPARATE SERVICE FROM graph-ops (not a reuse): graph-ops is
+  # Cypher-only (migrate/enrich issue small result sets, 1G limit, NO data
+  # mount). A batch LOAD instead READS large curated + staging Parquet into
+  # PyArrow and MERGEs nodes/edges/parallels — it needs (a) a data volume the
+  # Parquet is mounted through and (b) real memory headroom. Hence its own
+  # profile + a bigger limit. Same published loader image family as graph-ops
+  # (ghcr.io/noorinalabs/noorinalabs-data-acquisition-load), so this is still
+  # "reuse the published image", NOT an on-VPS `docker build`.
+  #
+  # NETWORKS — `backend` (internal) ONLY. The loader issues bolt writes to
+  # neo4j:7687 and needs nothing off-box (the image bakes every dependency at
+  # build time precisely because the target Neo4j is on the internet-isolated
+  # `backend` network). No `egress`.
+  #
+  # DATA MOUNT — `${GRAPH_LOAD_DATA_DIR}` (a host dir the workflow rclone-pulls
+  # the Parquet into) is bind-mounted READ-ONLY at `/app/data`, the path the
+  # loader CLI reads DATA_CURATED_DIR / DATA_STAGING_DIR under. Read-only: the
+  # loader's outputs go to Neo4j over the network, never back to the Parquet
+  # dir, so the mount is inputs-only. The `:-...` default lets `docker compose
+  # config` validate this service without the var set (the workflow always
+  # exports it for a real run).
+  #
+  # CREDENTIALS — reuses the SAME NEO4J_* env the api/graph-ops services read,
+  # interpolated by compose from the VPS .env, so no password ever lands on
+  # argv (CWE-214) and no NEW required secret is added. The B2 read key lives
+  # only on the runner→VPS transport (rclone native env), never here.
+  graph-load:
+    # GRAPH_LOAD_IMAGE default is `prod-latest` — the FAIL-SAFE direction
+    # (deploy#470, same rationale as GRAPH_OPS_IMAGE / EMBED_IMAGE).
+    # deploy-data-load.yml always sets GRAPH_LOAD_IMAGE explicitly per-env
+    # (<env>-latest), so this default is only hit by a manual break-glass
+    # `--profile graph-load` on a box: on PROD it pulls the correct prod loader
+    # image; on STG a prod tag is benign per the deploy-data-load.yml env guard.
+    image: ${GRAPH_LOAD_IMAGE:-ghcr.io/noorinalabs/noorinalabs-data-acquisition-load:prod-latest}
+    profiles: ["graph-load"]
+    # read_only rootfs like graph-ops; the loader writes only to Neo4j + /tmp.
+    # PyArrow may spill to /tmp on large Parquet reads, so give it more room
+    # than graph-ops' Cypher-only 64M.
+    read_only: true
+    tmpfs:
+      - /tmp:size=512M
+    volumes:
+      # Resolved+staging Parquet, rclone-pulled by the workflow. READ-ONLY —
+      # inputs only. Host path is the workflow-exported GRAPH_LOAD_DATA_DIR.
+      - ${GRAPH_LOAD_DATA_DIR:-/opt/noorinalabs-deploy/.graph-load-data/data}:/app/data:ro
+    environment:
+      # Same DB env the api/graph-ops services read (NEO4J_* only — the loader
+      # CLI reads NEO4J_URI / NEO4J_USER / NEO4J_PASSWORD via the NEO4J_ prefix).
+      - NEO4J_URI=bolt://neo4j:7687
+      - NEO4J_USER=neo4j
+      - NEO4J_PASSWORD=${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set}
+    # Safe default (break-glass `--profile graph-load up` path): print CLI help
+    # and exit non-destructively. deploy-data-load.yml overrides this with
+    # `load` / `load --nodes-only`. The image ENTRYPOINT is `python -m src.cli`,
+    # so the command below is just args.
+    command: ["--help"]
+    depends_on:
+      neo4j:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          # A full load reads large curated + staging Parquet into PyArrow and
+          # batches MERGEs — sized like the embed one-shot (4G), well within the
+          # 16G box's headroom for a profile-gated op that never runs on an
+          # ordinary deploy. The heavy work is this container's Parquet read +
+          # MERGE batching (unlike graph-ops, where GDS heap is a neo4j concern).
+          memory: 4G
+          cpus: "2.0"
+        reservations:
+          memory: 1G
+          cpus: "0.5"
+    logging: *default-logging
+    networks:
+      - backend
+    # One-shot: never restart. A batch load is operator-triggered, not a daemon;
+    # a non-zero exit must surface (the workflow fails the job), not loop.
+    restart: "no"
+
   frontend:
     # GHCR-only — no local-build fallback. The deploy workflow logs into ghcr.io
     # using the auto-provisioned GITHUB_TOKEN (workflow `permissions: packages: read`

--- a/docs/runbooks/prod-data-reload-723.md
+++ b/docs/runbooks/prod-data-reload-723.md
@@ -26,8 +26,9 @@ the verify checks below can false-red even on correct data.
    `promote.yml`; approve the `production` GH Environment gate). See `prod-promote-723.md` and the
    deploy `RUNBOOK.md` "Prod deploy" section.
 2. Confirm prod is healthy: `gh workflow run verify-deploy.yml -f target=prod` → green.
-3. Build the reload from the **same W20/W21 SHAs** (`scripts/load_staging.sh` builds `Dockerfile.load`
-   from the working tree — check out the promoted SHA before running it).
+3. Produce the reload Parquet from the **same W20/W21 SHAs** (§3), and load it via the published
+   loader image at those SHAs — the `<env>-latest` loader image `deploy-data-load.yml` resolves
+   must be built from the promoted SHA (or pass an explicit `image` ref).
 4. THEN run this runbook.
 
 ---
@@ -223,30 +224,83 @@ make validate  # gate: strict data-quality validation → data/reports/validatio
 
 ## 4. Load corrected data to prod  [OWNER-RUN]
 
-Use `scripts/load_staging.sh`, pointed at prod. It builds a self-contained loader image
-(`Dockerfile.load`) and runs it attached to the prod `noorinalabs_backend` docker network; the Neo4j
-password is read from the running prod neo4j container's `NEO4J_AUTH` on the remote host (no secret
-crosses this machine's shell history).
+> **SUPERSEDES `scripts/load_staging.sh`.** The batch load is now behind IaC —
+> the `deploy-data-load.yml` workflow (deploy#546) — instead of the build-host
+> one-off. `load_staging.sh` (rsync Parquet from a workstation + `docker build`
+> the loader on the box) is retired for routine loads: it is an un-repeatable,
+> box-local step and the owner directed repeatable data loads behind GH Actions +
+> IaC. The workflow sources the Parquet from B2 on the VPS (never through the
+> runner), reuses the published loader image via a profile-gated compose service
+> (no on-VPS build), sources the NEO4J password from the VPS `.env` via compose
+> (never on argv/logs), and gates prod behind the `production` Environment.
 
-```bash
-cd <REPO_ROOT>/noorinalabs-data-acquisition   # same checkout as section 3, with data/staging/ populated
+The load is now a two-step flow: **publish the resolved Parquet to B2** (§4a),
+then **dispatch `deploy-data-load.yml`** (§4b).
 
-# Full nodes + edges load to PROD (LOAD_ARGS="load" → not the default nodes-only):
-SSH_HOST=noorinalabs-prod LOAD_ARGS="load" scripts/load_staging.sh
+### 4a. Publish the §3 Parquet set to the pipeline B2 bucket
+
+Upload the curated + staging Parquet produced in §3 to `noorinalabs-pipeline`
+under a **versioned prefix** you will pass as `parquet_ref`. The workflow's
+contract (see its header block) expects this exact layout:
+
+```text
+noorinalabs-pipeline/<parquet_ref>/curated/narrators_canonical.parquet
+noorinalabs-pipeline/<parquet_ref>/curated/narrator_mentions_resolved.parquet
+noorinalabs-pipeline/<parquet_ref>/curated/narrator_mentions_resolved_muhaddithat.parquet
+noorinalabs-pipeline/<parquet_ref>/staging/hadiths_*.parquet
+noorinalabs-pipeline/<parquet_ref>/staging/collections_*.parquet
+noorinalabs-pipeline/<parquet_ref>/staging/narrator_mentions_*.parquet   # full load only
+noorinalabs-pipeline/<parquet_ref>/staging/network_edges_*.parquet       # full load only
+noorinalabs-pipeline/<parquet_ref>/staging/parallel_links.parquet        # full load only
 ```
 
-- `SSH_HOST=noorinalabs-prod` is the prod target (default is `noorinalabs-stg`); `LOAD_ARGS="load"`
-  does the **full** load (nodes + edges incl. `APPEARS_IN`, `STUDIED_UNDER`, `PARALLEL_OF`,
-  `GRADED_BY`) — the default `load --nodes-only` would NOT populate the chains/edges that criteria
-  #2 and #4 depend on, so the explicit `LOAD_ARGS="load"` is required.
-- The loader MERGEs narrator date props (`birth_year_ah`, `death_year_ah`, `generation`) and the
-  segmented narrators/edges. It is idempotent.
-- The script's step `[4/5]` reads back the `source_corpus` distribution (Hadith per corpus) — sanity
-  check it matches the expected corpus set before moving to verify.
-- **Postgres / pgvector:** the loader upserts relational + embedding rows as part of the load; the
-  semantic-search index is rebuilt from this. (If semantic search still 500s in section 5.3 because
-  the pgvector backend was not provisioned for an env, that is an environment-provisioning item, not
-  a data defect — note it but don't block on it.)
+- Choose a reproducible `parquet_ref`, e.g. `staged/narrator-resolve/$(date -u +%Y-%m-%d)-<SHA>`
+  (the W20/W21 SHA from §0), so the load is reproducible and a prior good set is
+  always re-loadable. It is a **bucket-relative prefix** — no bucket name, no
+  leading slash.
+- Publishing is a data-acquisition helper (owner/da item, not this workflow).
+  The credential-safe pattern is rclone native env against the pipeline bucket
+  (mirror `scripts/backup.sh`: `RCLONE_CONFIG_*` env, no CLI-flag secrets) using
+  the pipeline B2 key (`PIPELINE_B2_KEY_ID` / `PIPELINE_B2_KEY`).
+
+### 4b. Dispatch `deploy-data-load.yml`
+
+```bash
+# Dry-run FIRST (default) — verifies the B2 objects exist + prints the load plan,
+# writes NOTHING to the graph:
+gh workflow run deploy-data-load.yml \
+  -f env=prod \
+  -f parquet_ref='staged/narrator-resolve/<YYYY-MM-DD>-<SHA>' \
+  -f load_args='load' \
+  -f dry_run=true
+
+# Review the dry-run summary, then the REAL load (approve the `production`
+# Environment gate when prompted):
+gh workflow run deploy-data-load.yml \
+  -f env=prod \
+  -f parquet_ref='staged/narrator-resolve/<YYYY-MM-DD>-<SHA>' \
+  -f load_args='load' \
+  -f dry_run=false
+```
+
+- `env=prod` maps to the `production` GH Environment → **manual approval gate**;
+  `env=stg` (the validated pre-prod gate) does not. Per stg-gate policy, prod is
+  a promotion of a verified-good stg load — run the stg load + §5 verify first.
+- `load_args='load'` does the **full** load (nodes + edges incl. `APPEARS_IN`,
+  `STUDIED_UNDER`, `PARALLEL_OF`, `GRADED_BY`) — `load --nodes-only` would NOT
+  populate the chains/edges that criteria #2 and #4 depend on, so `load` is
+  required here.
+- The loader MERGEs narrator date props (`birth_year_ah`, `death_year_ah`,
+  `generation`) and the segmented narrators/edges. It is idempotent — an SSH-drop
+  mid-load is recoverable by re-dispatching (MERGE converges).
+- The workflow's post-load step reads back the `source_corpus` distribution
+  (Hadith per corpus) into the job log — sanity-check it matches the expected
+  corpus set before moving to verify.
+- **Postgres / pgvector:** the loader upserts relational + embedding rows as part
+  of the load; the semantic-search index is rebuilt from this. (If semantic
+  search still 500s in section 5.3 because the pgvector backend was not
+  provisioned for an env, that is an environment-provisioning item, not a data
+  defect — note it but don't block on it.)
 
 ---
 
@@ -366,9 +420,11 @@ sudo --preserve-env=B2_KEY_ID,B2_APP_KEY,B2_BUCKET \
 | Purge (dry-run) | `POST /api/v1/admin/data/purge {"source_corpus":C,"dry_run":true}` | isnad-graph API |
 | Purge (real) | `POST .../purge {"source_corpus":C,"dry_run":false,"confirmation":C}` | isnad-graph API |
 | Produce Parquet | `make acquire parse resolve validate` | data-acquisition repo |
-| Load to prod | `SSH_HOST=noorinalabs-prod LOAD_ARGS="load" scripts/load_staging.sh` | data-acquisition repo |
+| Publish Parquet to B2 | rclone upload §3 output to `noorinalabs-pipeline/<parquet_ref>/{curated,staging}/` | data-acquisition repo / VM |
+| Load to prod | `gh workflow run deploy-data-load.yml -f env=prod -f parquet_ref=<ref> -f load_args=load -f dry_run=false` | deploy repo (approve `production` gate) |
 | Verify search | `GET /api/v1/search?q=…`, `/search/semantic?q=…`, `/parallels` | isnad-graph API |
 | Prod smoke | `gh workflow run verify-deploy.yml -f target=prod` | deploy repo |
 
 **Secret NAMES referenced (never inline a value):** `B2_KEY_ID`, `B2_APP_KEY`, `B2_BUCKET`,
-`NEO4J_AUTH` / `NEO4J_PASSWORD`, `SUNNAH_API_KEY`, `KAGGLE_USERNAME`, `KAGGLE_KEY`.
+`PIPELINE_B2_KEY_ID`, `PIPELINE_B2_KEY`, `NEO4J_AUTH` / `NEO4J_PASSWORD`, `SUNNAH_API_KEY`,
+`KAGGLE_USERNAME`, `KAGGLE_KEY`.


### PR DESCRIPTION
Closes #546.

## What

Adds `deploy-data-load.yml` — the missing OPERATIONAL trigger for the batch
node/edge Neo4j graph load — putting the data load behind IaC and retiring the
`scripts/load_staging.sh` build-host one-off (in `noorinalabs-data-acquisition`).

## Design (mirrors `graph-ops.yml`, heavy work ON the VPS)

- **`workflow_dispatch` inputs:** `env` (stg|prod), `parquet_ref` (bucket-relative
  B2 prefix under `noorinalabs-pipeline`), `load_args` (`load` | `load --nodes-only`),
  `image` (env-scoped `<env>-latest` default + refuse-prod-with-stg-image guard),
  `dry_run` (default **true**).
- **B2 on the VPS:** Parquet is pulled from the `noorinalabs-pipeline` bucket via
  `rclone` **on the VPS** (native `RCLONE_CONFIG_*` env, no CLI-flag secrets — the
  same credential-safe pattern as `scripts/backup.sh`). The large Parquet set never
  transits the GitHub-hosted runner. Missing ref/objects fail loudly.
- **Loader:** runs the **published** loader image (same family as `graph-ops`) via a
  new profile-gated compose service `graph-load` (`docker compose run --rm --no-deps`)
  — no on-VPS `docker build`. The read-only `/app/data` bind mount exposes the pulled
  Parquet; the service is sized (4G) for the Parquet read + MERGE batching.
- **NEO4J password** is sourced from the VPS `.env` via compose interpolation — never
  on argv or in logs (CWE-214). Post-load `source_corpus` read-back uses `cypher-shell`
  inside the neo4j container (in-container `NEO4J_AUTH`), non-fatal.
- **Safety:** `dry_run=true` verifies B2 presence + prints the plan and writes nothing;
  `prod` maps to the `production` GH Environment approval gate (`stg` does not).

## Files

- `.github/workflows/deploy-data-load.yml` — new workflow.
- `compose/docker-compose.prod.yml` — new profile-gated `graph-load` service (zero
  blast radius on ordinary deploys; validated by `docker compose config`, default
  service set unchanged).
- `docs/runbooks/prod-data-reload-723.md` — §4 rewritten as resolve → publish-to-B2
  (§4a) → dispatch `deploy-data-load.yml` (§4b), superseding the `load_staging.sh`
  step; quick-ref + secret-name list updated.

## Contract (out of scope here)

The RESOLVE half and the da-side "publish resolved Parquet to B2" helper remain a
documented VM/da step (orchestrator owns). This workflow CONSUMES an already-published
`parquet_ref`; the expected B2 object layout is documented in the workflow header.
`migrate` / `enrich` / `prune-orphans` stay in `graph-ops.yml`.

## Validation

- `actionlint` (with `shellcheck` on PATH) — clean.
- `docker compose config --quiet` + `--profile graph-load config graph-load` — resolve;
  non-profile service set unchanged.
- Full pre-commit + pre-push hook set (gitleaks, cspell, mypy, pytest) — green.

## Reviewers

Requesting **Aisha Idrissi** (SRE — workflow/deploy domain) and **Nino Kavtaradze**
(Security — SSH / B2 creds / NEO4J-password handling). Please post verdicts as PR
comments in the charter Hook-4 format.
