### PR TITLE
fix(data-load): make B2/rclone failures diagnosable, abort on first cause

### DIFF
--- a/.github/workflows/deploy-data-load.yml
+++ b/.github/workflows/deploy-data-load.yml
@@ -175,7 +175,7 @@ jobs:
           key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
           envs: ENV_NAME,PARQUET_REF,LOAD_ARGS,DRY_RUN,IMAGE,PIPELINE_B2_KEY_ID,PIPELINE_B2_KEY,GITHUB_TOKEN,GITHUB_ACTOR
           script: |
-            set -uo pipefail
+            set -euo pipefail
 
             cd /opt/noorinalabs-deploy
 
@@ -184,9 +184,10 @@ jobs:
             # box's /opt/noorinalabs-deploy holds a git checkout that deploys
             # refresh; this op-workflow must too, so `compose` sees the current
             # file (with the profile-gated `graph-load` service added in this PR).
-            # Guarded (this script runs `set -uo pipefail`, NO -e): an unguarded
-            # `git fetch` failure would not abort, and the following
-            # `reset --hard origin/main` would succeed against a STALE
+            # Explicitly guarded even though `set -e` is on: the guard names the
+            # real consequence. An unguarded `git fetch` failure would abort with
+            # git's own message and no hint that the danger is the following
+            # `reset --hard origin/main` succeeding against a STALE
             # remote-tracking ref — leaving the box on an old tree.
             echo "==> Pulling latest deploy config..."
             git fetch origin main \
@@ -240,19 +241,51 @@ jobs:
             # Parquet; nodes-only needs only hadiths_*/collections_*.
             CURATED_REQUIRED="narrators_canonical.parquet narrator_mentions_resolved.parquet narrator_mentions_resolved_muhaddithat.parquet"
 
+            # lsf_or_die <b2-dir>: list the basenames under a B2 prefix into the
+            # global LSF_OUT. A NON-ZERO rclone rc (401/auth, network, bad remote,
+            # throttling) and an rc=0 EMPTY listing are different facts and must
+            # not be conflated: only the latter says anything about whether
+            # parquet_ref is published. The prior `2>/dev/null || true` collapsed
+            # both into "no objects found — is parquet_ref correct and published?",
+            # and a B2 401 was reported for an hour as an unpublished ref while the
+            # objects were present the whole time (#549).
+            #
+            # On rc != 0 this prints rclone's stderr verbatim and exits WITHOUT
+            # asserting a cause. The rc is captured immediately, in the same
+            # `&& … || …` list as the assignment, before any intervening command
+            # can clobber $?. The exit is taken here, in the caller's shell, and
+            # not inside a `$( )` subshell that would only kill the subshell.
+            #
+            # rclone lsf writes basenames to stdout; the credential is in env, the
+            # paths are not secrets, so the stderr is safe to surface in the log.
+            LSF_OUT=""
+            lsf_or_die() {
+              _lsf_dir="$1"
+              _lsf_err="$(mktemp)"
+              LSF_OUT="$(rclone lsf "${_lsf_dir}/" 2>"${_lsf_err}")" && _lsf_rc=0 || _lsf_rc=$?
+              if [ "${_lsf_rc}" -ne 0 ]; then
+                echo "ERROR: [${ENV_NAME}] rclone failed to list ${_lsf_dir}/ (rc=${_lsf_rc}). This is a hard rclone failure, NOT evidence about whether parquet_ref '${PARQUET_REF}' is published. rclone stderr follows:" >&2
+                cat "${_lsf_err}" >&2
+                rm -f "${_lsf_err}"
+                exit 1
+              fi
+              rm -f "${_lsf_err}"
+            }
+
             # verify_present <b2-dir> <required-basename...>: fail loudly if any
-            # required object is absent under the B2 prefix. rclone lsf lists
-            # basenames; the credential is in env, the paths are not secrets.
+            # required object is absent under the B2 prefix. The empty-listing
+            # branch below is the ONLY one that has established the prefix really
+            # is absent — lsf_or_die has already exited on any rclone error.
             verify_present() {
               _dir="$1"; shift
               echo "    listing ${_dir}/ ..."
-              _listing="$(rclone lsf "${_dir}/" 2>/dev/null || true)"
-              if [ -z "${_listing}" ]; then
-                echo "ERROR: [${ENV_NAME}] no objects found under ${_dir}/ — is parquet_ref '${PARQUET_REF}' correct and published?" >&2
+              lsf_or_die "${_dir}"
+              if [ -z "${LSF_OUT}" ]; then
+                echo "ERROR: [${ENV_NAME}] rclone listed ${_dir}/ successfully but it holds no objects — is parquet_ref '${PARQUET_REF}' correct and published?" >&2
                 exit 1
               fi
               for _want in "$@"; do
-                if ! printf '%s\n' "${_listing}" | grep -qx "${_want}"; then
+                if ! printf '%s\n' "${LSF_OUT}" | grep -qx "${_want}"; then
                   echo "ERROR: [${ENV_NAME}] required object missing in B2: ${_dir}/${_want}" >&2
                   exit 1
                 fi
@@ -261,12 +294,14 @@ jobs:
 
             # glob-present <b2-dir> <shell-glob>: assert at least one object under
             # the prefix matches the glob (for the wildcarded staging shards).
+            # Same rc-vs-empty discipline: lsf_or_die owns the rclone-error exit,
+            # so reaching the no-match branch means the listing really lacks a hit.
             glob_present() {
               _dir="$1"; _glob="$2"
-              _listing="$(rclone lsf "${_dir}/" 2>/dev/null || true)"
-              # shellcheck disable=SC2254  # $_glob is an intentional case pattern.
+              lsf_or_die "${_dir}"
               _hit=0
-              for _f in ${_listing}; do
+              for _f in ${LSF_OUT}; do
+                # shellcheck disable=SC2254  # $_glob is an intentional case pattern.
                 case "${_f}" in
                   ${_glob}) _hit=1; break ;;
                 esac
@@ -304,10 +339,19 @@ jobs:
             # Stable, git-untracked data dir OUTSIDE the /opt checkout (so the
             # git reset above never touches it). rclone-pull the Parquet here,
             # then bind-mount it read-only into the loader container.
+            #
+            # Both the clear and the create are guarded so the FIRST cause is the
+            # one that gets printed. Unguarded, a `mkdir` denied on ${HOME}/.cache
+            # merely warned and the script (then lacking `set -e`) ran on into an
+            # `rclone copy` against a destination that did not exist, whose own
+            # error was the one anyone read — ten lines below the real cause
+            # (#552). `set -e` now aborts here regardless; these guards name why.
             LOAD_DATA_ROOT="${HOME}/.cache/noorinalabs-graph-load"
             LOAD_DATA_DIR="${LOAD_DATA_ROOT}/data"
-            rm -rf "${LOAD_DATA_DIR}"
-            mkdir -p "${LOAD_DATA_DIR}/curated" "${LOAD_DATA_DIR}/staging"
+            rm -rf "${LOAD_DATA_DIR}" \
+              || { echo "ERROR: [${ENV_NAME}] cannot clear the load data dir ${LOAD_DATA_DIR} (is \$HOME=${HOME} writable by 'deploy', and does it own the existing contents?)" >&2; exit 1; }
+            mkdir -p "${LOAD_DATA_DIR}/curated" "${LOAD_DATA_DIR}/staging" \
+              || { echo "ERROR: [${ENV_NAME}] cannot create ${LOAD_DATA_DIR} (is \$HOME=${HOME} writable by 'deploy'?)" >&2; exit 1; }
 
             echo "==> [${ENV_NAME}] rclone pull curated/ -> ${LOAD_DATA_DIR}/curated"
             rclone copy "${B2_BASE}/curated/" "${LOAD_DATA_DIR}/curated/" \
@@ -377,7 +421,10 @@ jobs:
             #     cypher-shell runs INSIDE the live neo4j container and reads the
             #     password from that container's OWN NEO4J_AUTH — never on our
             #     argv, never over the GH transport. Non-fatal: the load already
-            #     succeeded above; this is a sanity echo, not a gate. ---
+            #     succeeded above; this is a sanity echo, not a gate. The trailing
+            #     `|| echo …` keeps it non-fatal under `set -e` too — the exec is
+            #     the left arm of an OR list, which `-e` does not act on, and the
+            #     echo makes the list succeed. Do not drop that arm. ---
             echo "==> [${ENV_NAME}] post-load read-back: Hadith count by source_corpus"
             ${COMPOSE} exec -T neo4j sh -c \
               'NEO4J_USERNAME=neo4j NEO4J_PASSWORD="${NEO4J_AUTH#neo4j/}" exec cypher-shell --format plain "MATCH (h:Hadith) RETURN h.source_corpus AS source_corpus, count(*) AS hadiths ORDER BY hadiths DESC"' \

--- a/.github/workflows/deploy-data-load.yml
+++ b/.github/workflows/deploy-data-load.yml
@@ -223,6 +223,23 @@ jobs:
             #     key never lands on argv; rclone reads RCLONE_CONFIG_PIPELINE_*. ---
             : "${PIPELINE_B2_KEY_ID:?PIPELINE_B2_KEY_ID must be set (env-scoped secret)}"
             : "${PIPELINE_B2_KEY:?PIPELINE_B2_KEY must be set (env-scoped secret)}"
+
+            # Credential hygiene: rclone maps EVERY option to an RCLONE_<OPTION> env var, so an
+            # ambient RCLONE_LOG_LEVEL=DEBUG / RCLONE_VERBOSE=2 makes rclone echo
+            #   DEBUG : Setting key="<application key>" ... from environment variable ...
+            # and RCLONE_DUMP=auth makes it echo an `Authorization: Basic <base64(id:key)>` line.
+            # lsf_or_die below cats rclone's stderr into the Actions log of a PUBLIC repo, and GH
+            # masking is an exact-substring scrub that does NOT match the base64 form. Scrub every
+            # inherited RCLONE_* before setting the three we own. Nothing in this repo sets these,
+            # but sshd with `UsePAM yes` passes /etc/environment into a non-interactive session,
+            # so the pollution is operator-reachable without touching this workflow.
+            # ORDER IS LOAD-BEARING: this loop must run BEFORE the exports below, or it would
+            # unset the very credential it is protecting.
+            # shellcheck disable=SC2013  # env var names are [A-Z0-9_]; word-split is safe here.
+            for _v in $(env | sed -n 's/^\(RCLONE_[A-Z0-9_]*\)=.*/\1/p'); do
+              unset "${_v}"
+            done
+
             export RCLONE_CONFIG_PIPELINE_TYPE="b2"
             export RCLONE_CONFIG_PIPELINE_ACCOUNT="${PIPELINE_B2_KEY_ID}"
             export RCLONE_CONFIG_PIPELINE_KEY="${PIPELINE_B2_KEY}"
@@ -256,13 +273,27 @@ jobs:
             # can clobber $?. The exit is taken here, in the caller's shell, and
             # not inside a `$( )` subshell that would only kill the subshell.
             #
-            # rclone lsf writes basenames to stdout; the credential is in env, the
-            # paths are not secrets, so the stderr is safe to surface in the log.
+            # SURFACING rclone's stderr into a PUBLIC repo's Actions log is safe ONLY
+            # under two preconditions this script establishes, and NOT unconditionally:
+            #   1. the RCLONE_* scrub above has removed any inherited verbosity/dump
+            #      option (RCLONE_LOG_LEVEL=DEBUG and RCLONE_VERBOSE=2 both make rclone
+            #      echo the application key verbatim; RCLONE_DUMP=auth makes it echo an
+            #      `Authorization: Basic <base64(id:key)>` header that GH secret-masking
+            #      does NOT scrub, because masking is an exact-substring match on the
+            #      registered bytes and the base64 is a different byte string), AND
+            #   2. the `--log-level NOTICE` below pins the level explicitly, since an
+            #      explicit flag beats a hostile env — this is what the two `rclone copy`
+            #      calls further down already do with `--log-level INFO`.
+            # At NOTICE, rclone's stderr for a 401 or a connection failure carries only
+            # the remote path and the error string; the credential lives in env, and the
+            # paths are not secrets. If you raise this verbosity to chase a B2 failure —
+            # the most natural next edit to a function that exists to diagnose 401s —
+            # you reintroduce the leak. Don't; the rc and the error string are enough.
             LSF_OUT=""
             lsf_or_die() {
               _lsf_dir="$1"
               _lsf_err="$(mktemp)"
-              LSF_OUT="$(rclone lsf "${_lsf_dir}/" 2>"${_lsf_err}")" && _lsf_rc=0 || _lsf_rc=$?
+              LSF_OUT="$(rclone lsf --log-level NOTICE "${_lsf_dir}/" 2>"${_lsf_err}")" && _lsf_rc=0 || _lsf_rc=$?
               if [ "${_lsf_rc}" -ne 0 ]; then
                 echo "ERROR: [${ENV_NAME}] rclone failed to list ${_lsf_dir}/ (rc=${_lsf_rc}). This is a hard rclone failure, NOT evidence about whether parquet_ref '${PARQUET_REF}' is published. rclone stderr follows:" >&2
                 cat "${_lsf_err}" >&2

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -456,11 +456,21 @@ services:
   #
   # DATA MOUNT — `${GRAPH_LOAD_DATA_DIR}` (a host dir the workflow rclone-pulls
   # the Parquet into) is bind-mounted READ-ONLY at `/app/data`, the path the
-  # loader CLI reads DATA_CURATED_DIR / DATA_STAGING_DIR under. Read-only: the
-  # loader's outputs go to Neo4j over the network, never back to the Parquet
-  # dir, so the mount is inputs-only. The `:-...` default lets `docker compose
-  # config` validate this service without the var set (the workflow always
-  # exports it for a real run).
+  # loader CLI reads DATA_CURATED_DIR / DATA_STAGING_DIR under. The graph the
+  # loader produces goes to Neo4j over the network — but the loader ALSO writes
+  # two change-detection files back into this dir: `.manifest.json` and
+  # `.last_loaded_manifest.json` (`_cmd_load` in the image's `src/cli.py` calls
+  # `save_manifest` unconditionally). That is the design error, not the mount:
+  # a loader must not write state into its inputs. `:ro` STAYS, and the loader
+  # is being fixed to tolerate it (da#348) — same call as da#335, where
+  # `write_audit_entry` was made best-effort against a read-only fs. Until that
+  # lands, `load` against this service dies on `OSError: [Errno 30]` before any
+  # Neo4j mutation (`_check_neo4j` and `save_manifest` both precede `load_all`),
+  # so the graph is never left partially written. `graph-ops` shares the image
+  # but exercises `enrich`, which never touches the manifest — which is why the
+  # mount survived review. The `:-...` default lets `docker compose config`
+  # validate this service without the var set (the workflow always exports it
+  # for a real run).
   #
   # CREDENTIALS — reuses the SAME NEO4J_* env the api/graph-ops services read,
   # interpolated by compose from the VPS .env, so no password ever lands on
@@ -475,15 +485,19 @@ services:
     # image; on STG a prod tag is benign per the deploy-data-load.yml env guard.
     image: ${GRAPH_LOAD_IMAGE:-ghcr.io/noorinalabs/noorinalabs-data-acquisition-load:prod-latest}
     profiles: ["graph-load"]
-    # read_only rootfs like graph-ops; the loader writes only to Neo4j + /tmp.
-    # PyArrow may spill to /tmp on large Parquet reads, so give it more room
-    # than graph-ops' Cypher-only 64M.
+    # read_only rootfs like graph-ops. The loader's writes go to Neo4j, to /tmp,
+    # and — incorrectly, see the DATA MOUNT note above — to `.manifest.json` in
+    # /app/data, which this `:ro` mount deliberately refuses. PyArrow may spill
+    # to /tmp on large Parquet reads, so give it more room than graph-ops'
+    # Cypher-only 64M.
     read_only: true
     tmpfs:
       - /tmp:size=512M
     volumes:
-      # Resolved+staging Parquet, rclone-pulled by the workflow. READ-ONLY —
-      # inputs only. Host path is the workflow-exported GRAPH_LOAD_DATA_DIR.
+      # Resolved+staging Parquet, rclone-pulled by the workflow. READ-ONLY by
+      # intent — the loader's manifest write-back here is a loader bug (da#348),
+      # not a reason to loosen the mount. Host path is GRAPH_LOAD_DATA_DIR,
+      # exported by the workflow.
       - ${GRAPH_LOAD_DATA_DIR:-/opt/noorinalabs-deploy/.graph-load-data/data}:/app/data:ro
     environment:
       # Same DB env the api/graph-ops services read (NEO4J_* only — the loader


### PR DESCRIPTION
## Summary

`deploy-data-load.yml` has had **zero successful runs** since it merged (deploy#546/#547). Three latent defects sat in sequence, each hidden by the one before it. The first two are cleared operationally — the owner rotated the stale `PIPELINE_B2_*` secret, and `/home/deploy` was chowned off root. This PR fixes the third: the workflow's own error handling, which is what made finding the first two take an hour.

Closes #549
Closes #552
Closes #553

## 1. Swallowed rclone stderr (#549, code half)

`verify_present()` and `glob_present()` both did `rclone lsf "${_dir}/" 2>/dev/null || true`, collapsing every rclone failure mode — 401, network, bad remote, missing binary — into the empty-listing branch, which then asserted a *specific and wrong* cause.

Both now route through a new `lsf_or_die()`. It captures rclone's rc **immediately**, in the same `&& … || …` list as the assignment, before any intervening command can clobber `$?`; and it takes the `exit` in the caller's shell rather than inside a `$( )` subshell that would only kill the subshell.

**Before** — a B2 401, reported for an hour as an unpublished `parquet_ref` while the objects were present the whole time:

```
    listing pipeline:noorinalabs-pipeline/staged/x/curated/ ...
ERROR: [stg] no objects found under pipeline:noorinalabs-pipeline/staged/x/curated/ — is parquet_ref 'staged/x' correct and published?
```

**After** — the 401 surfaces as a 401:

```
    listing pipeline:b/curated/ ...
ERROR: [stg] rclone failed to list pipeline:b/curated/ (rc=1). This is a hard rclone failure, NOT evidence about whether parquet_ref 'staged/x' is published. rclone stderr follows:
2026/07/09 15:39:44 Failed to create file system for "pipeline:noorinalabs-pipeline/x/curated/": failed to authorize account: failed to authenticate: (401 bad_auth_token)
```

The `rc == 0 && empty listing` case — the only one that actually establishes the prefix is absent — keeps the "published?" wording:

```
ERROR: [stg] rclone listed pipeline:b/curated/ successfully but it holds no objects — is parquet_ref 'staged/x' correct and published?
```

## 2. Remote script lacks `set -e` (#552)

Added `-e`. A denied `mkdir -p ${HOME}/.cache/...` previously only warned; the script continued into an `rclone copy` against a destination that did not exist, and *that* second error was the one anyone read. The `rm -rf` / `mkdir -p` pair is now explicitly guarded with a diagnostic naming the real cause (`is $HOME writable by 'deploy'?`).

**I read the whole script block for constructs that legitimately tolerate a non-zero exit, and verified each still behaves under `-e`:**

| Construct | Under `set -e` | Verified |
|---|---|---|
| post-load read-back `… \|\| echo WARNING` | stays **non-fatal** — left arm of an OR list, which `-e` does not act on | yes, bash + dash |
| loader `… \|\| RC=$?` then explicit check | rc captured, not aborted | yes, bash + dash |
| `echo "pulled: $(find … \| wc -l)"` under `pipefail` | failing substitution does not set `echo`'s status | yes |
| `git fetch \|\| { …; exit 1; }`, `rclone copy \|\| { … }`, `docker login \|\| { … }` | already guarded | yes |

I added a comment on the read-back explaining *why* the `|| echo` arm must not be dropped, since under `-e` removing it would silently turn an informational query into a load failure.

## 3. False compose comment (#553)

Three comment sites (not two — the `DATA MOUNT` header paragraph at 457-463 carried the same claim as lines 478 and 485-486) stated the loader "writes only to Neo4j + /tmp" and that `/app/data` is "inputs only". It is not: `_cmd_load` calls `save_manifest` unconditionally, writing `.manifest.json` and `.last_loaded_manifest.json` into `/app/data`.

Corrected to state the truth: the mount is deliberately `:ro`, the write-back is a **loader** bug being fixed in da#348 (same call as da#335, where `write_audit_entry` was made best-effort against a read-only fs), and `graph-ops` survived review only because `enrich` never touches the manifest.

**`:ro`, `read_only: true`, and the tmpfs are unchanged.** Proven, not asserted — `yaml.safe_load` of the file compares equal to `origin/main`:

```
parsed compose identical to origin/main (comment-only change): True
graph-load read_only : True
graph-load volumes   : ['${GRAPH_LOAD_DATA_DIR:-...}:/app/data:ro']
```

## Also

Moved a `# shellcheck disable=SC2254` that sat above `_hit=0` rather than above the `case` it was meant to cover — it was suppressing nothing. Now it takes effect.

## Testing

I cannot reach the live VPS, so this is unit-mechanic verification. I extracted the helpers **from the workflow itself** (via `yaml.safe_load`, not a retyped copy) and drove them against a stubbed `rclone` under both `bash` and `dash`:

| Case | rclone | Expected | Result |
|---|---|---|---|
| A | rc=1, 401 stderr | 401 verbatim, exit 1 | pass |
| B | rc=143, network | hard error, no "published?" claim | pass |
| C | rc=0, empty | "published?" message | pass |
| D | rc=0, all required present | silent pass | pass |
| E | rc=0, one required missing | names the missing object | pass |
| F | `glob_present`, rc=1 | 401 verbatim, not "no object matching" | pass |
| G | `glob_present`, rc=0 hit | pass | pass |
| H | `glob_present`, rc=0 no hit | "no object matching" | pass |

## Commands run

```
$ command -v shellcheck                 # /home/parameterization/.local/bin/shellcheck (0.10.0)
$ actionlint .github/workflows/deploy-data-load.yml           # rc=0
$ shellcheck -s bash --severity=warning <remote script>       # CLEAN
$ pre-commit run --files .github/workflows/deploy-data-load.yml compose/docker-compose.prod.yml
    gitleaks Passed / actionlint Passed / env-example-check Passed
$ pre-commit run --hook-stage pre-push --all-files
    terraform-fmt, terraform-validate, gitleaks, actionlint, cspell,
    ruff-format, ruff-lint, mypy, pytest, pytest-scripts,
    pytest-integration-scripts .......................... all Passed
$ python3 .claude/lib/pre_commit_ci_sync.py .    # OK: mirrors all CI-enforced checks
$ python3 scripts/structural_ontology.py check   # OK: current with source
```

`actionlint` was run with **shellcheck on PATH** (it silently skips shellcheck otherwise, making a local "clean" meaningless). Note actionlint only shellchecks `run:` blocks, **not** an ssh-action `with: script:` body — so I extracted the remote script and shellchecked it directly. That is why the misplaced SC2254 directive had gone unnoticed.

## Contradicting the issue diagnoses

- **#553 says two comment sites; there are three.** The `DATA MOUNT` header paragraph (compose 457-463) makes the same false "inputs-only" claim and would have been left standing.
- **#549's suggested snippet is not drop-in**, as it flags: `echo "... (rc=$?)"` reads `$?` of the *`if`*, not of rclone, and its `exit 1` inside a `_listing="$(...)"` call site would exit only the subshell. Both are handled.
- **#552's premise checks out**, and `rm -rf` was indeed also unchecked. Nothing contradicts it.

## Out of scope (per brief)

Loader code and mount semantics untouched — da#348 owns the loader fix; `:ro` stays by owner decision.
