### PR TITLE
data-load: honest loader rc → outcome mapping (skip read-back only on a true failure) [#569 + #570]

### DIFF
--- a/.github/workflows/deploy-data-load.yml
+++ b/.github/workflows/deploy-data-load.yml
@@ -443,16 +443,48 @@ jobs:
             RC=0
             # shellcheck disable=SC2086  # LOAD_ARGS is an intentional arg split.
             ${COMPOSE_LOAD} run --rm --no-deps graph-load ${LOAD_ARGS} || RC=$?
-            if [ "${RC}" -ne 0 ]; then
-              echo "ERROR: [${ENV_NAME}] batch load '${LOAD_ARGS}' failed (rc=${RC})." >&2
-              exit "${RC}"
-            fi
+
+            # --- classify the loader rc against da's exit-code contract ---
+            # NOT every non-zero rc is a failed load (deploy#569/#570). The loader
+            # (da src/exit_codes.py, da#372/#384) has a rich exit space:
+            #   * rc=5 VALIDATION_FINDINGS — the load COMMITTED; post-load
+            #     validation merely reported data-quality findings. The graph IS
+            #     written, so we MUST still run the read-back below and surface the
+            #     findings as a WARNING — not report a failure and hide the
+            #     read-back, which is exactly the bug #569/#570 fix.
+            #   * rc=1 LOAD_FAILED / rc=8 DB_UNREACHABLE (nothing committed),
+            #     rc=6 REFUSED_ROWS (malformed-id / partial-graph data loss), or
+            #     any other non-zero — a TRUE failure: fail the job AND skip the
+            #     read-back.
+            # The rc->decision mapping is a single source of truth in
+            # scripts/classify_load_rc.sh (unit-tested in scripts/tests/), not
+            # re-encoded inline here. It runs from the /opt/noorinalabs-deploy
+            # checkout git-reset above, so the file is present. It always exits 0
+            # on a real rc; the DECISION is the stdout token.
+            LOAD_DECISION="$(sh scripts/classify_load_rc.sh "${RC}")"
+            case "${LOAD_DECISION}" in
+              FAILURE)
+                echo "ERROR: [${ENV_NAME}] batch load '${LOAD_ARGS}' FAILED (loader rc=${RC}) — no acceptable graph was committed; skipping read-back. See the da repo src/exit_codes.py for what rc=${RC} means." >&2
+                exit "${RC}"
+                ;;
+              FINDINGS)
+                echo "WARNING: [${ENV_NAME}] batch load '${LOAD_ARGS}' COMMITTED WITH FINDINGS (loader rc=${RC}, VALIDATION_FINDINGS): the graph WAS written, but post-load validation reported findings — review the loader log above. Proceeding to the read-back; NOT failing the job." >&2
+                ;;
+              SUCCESS)
+                : # clean committed load — proceed to read-back
+                ;;
+              *)
+                echo "ERROR: [${ENV_NAME}] internal: classify_load_rc.sh returned unexpected decision '${LOAD_DECISION}' for rc=${RC}; failing closed." >&2
+                exit 1
+                ;;
+            esac
 
             # --- post-load read-back (informational): source_corpus distribution.
+            #     Reached for any COMMITTED load — rc=0 (clean) OR rc=5 (findings).
             #     cypher-shell runs INSIDE the live neo4j container and reads the
             #     password from that container's OWN NEO4J_AUTH — never on our
             #     argv, never over the GH transport. Non-fatal: the load already
-            #     succeeded above; this is a sanity echo, not a gate. The trailing
+            #     committed above; this is a sanity echo, not a gate. The trailing
             #     `|| echo …` keeps it non-fatal under `set -e` too — the exec is
             #     the left arm of an OR list, which `-e` does not act on, and the
             #     echo makes the list succeed. Do not drop that arm. ---
@@ -461,7 +493,7 @@ jobs:
               'NEO4J_USERNAME=neo4j NEO4J_PASSWORD="${NEO4J_AUTH#neo4j/}" exec cypher-shell --format plain "MATCH (h:Hadith) RETURN h.source_corpus AS source_corpus, count(*) AS hadiths ORDER BY hadiths DESC"' \
               || echo "    WARNING: [${ENV_NAME}] post-load read-back query failed (non-fatal)." >&2
 
-            echo "==> [${ENV_NAME}] batch load '${LOAD_ARGS}' complete (rc=0)."
+            echo "==> [${ENV_NAME}] batch load '${LOAD_ARGS}' complete — graph committed (loader rc=${RC})."
 
       - name: Report
         if: always()

--- a/scripts/classify_load_rc.sh
+++ b/scripts/classify_load_rc.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+# classify_load_rc.sh — map a graph-loader process exit code to a load-outcome
+# decision for the deploy-data-load.yml batch load step (deploy#569 + #570).
+#
+# THE BUG THIS FIXES
+# ------------------
+# deploy-data-load.yml used to treat EVERY non-zero loader rc as "batch load
+# failed", print an error, and `exit "${RC}"` — which ALSO skipped the post-load
+# read-back. That is wrong for one specific, common, load-critical case:
+#
+#   rc=5  VALIDATION_FINDINGS  — the load SUCCEEDED and is COMMITTED to the
+#                               graph; post-load validation merely surfaced
+#                               data-quality findings (da#354, routed from
+#                               _cmd_load by da#372).
+#
+# So a fully-committed load was reported as "batch load failed (rc=4)"/(rc=5)
+# and the operator never saw the read-back that proves what actually landed.
+# For the #928 re-run — whose whole point is a TRUSTWORTHY load outcome — the
+# workflow must stop lying: a committed-with-findings load is a WARNING with a
+# read-back, not a failure.
+#
+# THE CONTRACT THIS MAPS TO  (authoritative: da repo src/exit_codes.py, da#384)
+# ---------------------------------------------------------------------------
+# The loader has a rich exit-code space. The ONLY distinction this classifier
+# needs is "did the load COMMIT a graph I should read back, and is the outcome
+# acceptable?":
+#
+#   rc   name (da src/exit_codes.py)   committed?         -> decision
+#   ---  --------------------------    ----------------   ----------
+#   0    (success)                     graph fully written  SUCCESS
+#   5    VALIDATION_FINDINGS           graph committed,     FINDINGS
+#                                      findings present
+#   1    LOAD_FAILED                   nothing written      FAILURE
+#   6    REFUSED_ROWS                  graph MINUS refused   FAILURE  (see note)
+#                                      rows (malformed-id
+#                                      data loss)
+#   8    DB_UNREACHABLE                nothing written      FAILURE
+#   3/4/7/9/10/11 (other stages)       n/a for `load`       FAILURE  (fail-closed)
+#   any other non-zero                 unknown              FAILURE  (fail-closed)
+#
+# Note on rc=6 REFUSED_ROWS: the graph IS partially committed, but refused rows
+# are silent data loss — an incomplete graph is NOT an acceptable load for a
+# re-run that must be trustworthy, so we deliberately classify it FAILURE (fail
+# the job, do not bless the partial load). This matches the deploy#569/#570
+# direction: the malformed-id class is a true failure, not a findings warning.
+#
+# Only rc=5 is the "committed but non-fatal" code. Every OTHER non-zero rc maps
+# to FAILURE — fail-closed by construction. If da ever adds another
+# committed-but-acceptable code, add it here EXPLICITLY (an unlisted new code
+# stays a FAILURE, which is the safe direction). da's exit_codes.py commits to
+# NOT renumbering existing codes ("The fix is not to renumber"), so hardcoding
+# the single value 5 here is stable, not a stale-table hazard.
+#
+# WHY A STANDALONE SCRIPT (not inline in the YAML): the workflow runs this over
+# SSH on the VPS from /opt/noorinalabs-deploy (a git checkout of this repo), so
+# the file is present at run time. Extracting it makes the rc->decision mapping
+# a single source of truth that is unit-tested directly
+# (scripts/tests/test_classify_load_rc.py) rather than re-encoded inside a YAML
+# heredoc no test can reach — same pattern as scripts/kafka_logdir_preflight.sh.
+#
+# POSIX sh on purpose (no bashisms): it is sourced/invoked from the same
+# `set -euo pipefail` remote shell as the rest of the load step.
+#
+# Usage:  classify_load_rc.sh <loader-rc>
+# Output: exactly one decision token on stdout — SUCCESS | FINDINGS | FAILURE
+# Exit:   0 on a successful classification (the DECISION is the stdout token,
+#         never this script's own status); 2 only on misuse (missing or
+#         non-integer argument — a caller bug, surfaced fail-closed under set -e).
+set -eu
+
+rc="${1:-}"
+case "$rc" in
+	'')
+		echo "usage: classify_load_rc.sh <loader-rc>" >&2
+		exit 2
+		;;
+	*[!0-9]*)
+		echo "classify_load_rc.sh: <loader-rc> must be a non-negative integer, got '$rc'" >&2
+		exit 2
+		;;
+esac
+
+case "$rc" in
+0) echo "SUCCESS" ;;                      # everything the load meant to write
+5) echo "FINDINGS" ;;                     # VALIDATION_FINDINGS — committed, findings present
+*) echo "FAILURE" ;;                      # LOAD_FAILED / DB_UNREACHABLE / REFUSED_ROWS / any other non-zero
+esac
+exit 0

--- a/scripts/tests/test_classify_load_rc.py
+++ b/scripts/tests/test_classify_load_rc.py
@@ -1,0 +1,132 @@
+"""Unit tests for scripts/classify_load_rc.sh (deploy#569 + #570).
+
+The batch load step in deploy-data-load.yml classifies the graph-loader's exit
+code into a load-outcome decision. The bug these tests lock down: the workflow
+used to treat EVERY non-zero rc as "load failed" and skip the post-load
+read-back, so a COMMITTED-with-findings load (rc=5 VALIDATION_FINDINGS) was
+mis-reported as a failure and its read-back was hidden.
+
+The rc->decision contract (see the script header, authoritative source is the
+da repo's src/exit_codes.py, da#384):
+
+    rc=0  ............... SUCCESS   (graph fully written)
+    rc=5  VALIDATION_FINDINGS  FINDINGS  (graph committed; findings present)
+    everything else non-zero  FAILURE   (nothing / incomplete / other stage)
+
+The workflow reads the stdout token: SUCCESS and FINDINGS both run the
+read-back (the graph committed); only FINDINGS emits a warning; FAILURE skips
+the read-back and fails the job. These tests exercise the pure classifier the
+same way scripts/tests/test_kafka_logdir_preflight.py exercises its detector.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent.parent / "classify_load_rc.sh"
+
+
+def _classify(rc: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["sh", str(SCRIPT), rc],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_script_exists() -> None:
+    assert SCRIPT.is_file(), f"classifier script missing at {SCRIPT}"
+
+
+def test_success_rc_zero() -> None:
+    """A clean committed load -> SUCCESS (read-back runs, job green)."""
+    result = _classify("0")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "SUCCESS"
+
+
+def test_validation_findings_rc_five_is_committed_not_failure() -> None:
+    """rc=5 VALIDATION_FINDINGS is a COMMITTED load -> FINDINGS, NOT FAILURE.
+
+    This is the core deploy#569/#570 regression: the graph WAS written, so the
+    workflow must read it back and warn, never report a failure and hide the
+    read-back.
+    """
+    result = _classify("5")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "FINDINGS"
+
+
+def test_load_failed_rc_one_is_failure() -> None:
+    """rc=1 LOAD_FAILED — nothing committed -> FAILURE (skip read-back, fail)."""
+    result = _classify("1")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "FAILURE"
+
+
+def test_db_unreachable_rc_eight_is_failure() -> None:
+    """rc=8 DB_UNREACHABLE — nothing written -> FAILURE."""
+    result = _classify("8")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "FAILURE"
+
+
+def test_refused_rows_rc_six_is_failure_not_findings() -> None:
+    """rc=6 REFUSED_ROWS — malformed-id/partial-graph data loss -> FAILURE.
+
+    The graph is partially committed, but an incomplete load is not an
+    acceptable outcome for a trustworthy re-run; it must fail the job, not be
+    downgraded to a findings warning.
+    """
+    result = _classify("6")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "FAILURE"
+
+
+def test_missing_dependency_rc_four_is_failure_not_findings() -> None:
+    """rc=4 is MISSING_DEPENDENCY (a resolve-stage abort), NOT findings.
+
+    Guards against the stale framing that rc=4 == VALIDATION_FINDINGS: the
+    authoritative da contract puts VALIDATION_FINDINGS at 5 and MISSING_DEPENDENCY
+    at 4, so rc=4 must map to FAILURE.
+    """
+    result = _classify("4")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "FAILURE"
+
+
+@pytest.mark.parametrize("rc", ["3", "7", "9", "10", "11", "255"])
+def test_other_stage_and_unknown_codes_fail_closed(rc: str) -> None:
+    """Every other non-zero rc (other stages / unknown) fails closed -> FAILURE."""
+    result = _classify(rc)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "FAILURE"
+
+
+def test_exactly_one_token_on_stdout() -> None:
+    """The workflow reads a single decision token — nothing else on stdout."""
+    for rc in ("0", "5", "1"):
+        out = _classify(rc).stdout
+        assert out.strip() in {"SUCCESS", "FINDINGS", "FAILURE"}
+        assert len(out.splitlines()) == 1, f"rc={rc} produced multi-line stdout: {out!r}"
+
+
+def test_missing_argument_is_usage_error() -> None:
+    result = subprocess.run(
+        ["sh", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert "usage" in result.stderr.lower()
+
+
+def test_non_integer_argument_is_usage_error() -> None:
+    result = _classify("abc")
+    assert result.returncode == 2
+    assert "non-negative integer" in result.stderr


### PR DESCRIPTION
## What

`deploy-data-load.yml` treated **every** non-zero loader rc as "batch load failed", printed an error, and `exit`ed — which **also skipped the post-load read-back**. That is wrong for a committed-with-findings load, and it makes the #928 re-run's load outcome untrustworthy.

Fixes both:
- **#569** — a SUCCESSFUL committed load with findings was reported as "batch load failed (rc=…)" and the read-back was skipped.
- **#570** — every non-zero rc was treated as failure → read-back never ran on a committed-with-findings load.

## The rc → outcome mapping (matches da `src/exit_codes.py`, da#372/#384)

| loader rc | da name | committed? | decision | job | read-back |
|-----------|---------|-----------|----------|-----|-----------|
| `0` | *(success)* | fully written | `SUCCESS` | pass | ✅ runs |
| `5` | `VALIDATION_FINDINGS` | committed, findings | `FINDINGS` | **pass (warn)** | ✅ **runs** |
| `1` | `LOAD_FAILED` | nothing written | `FAILURE` | fail | ⛔ skipped |
| `6` | `REFUSED_ROWS` | partial (malformed-id data loss) | `FAILURE` | fail | ⛔ skipped |
| `8` | `DB_UNREACHABLE` | nothing written | `FAILURE` | fail | ⛔ skipped |
| `3/4/7/9/10/11`, any other non-zero | other stages / unknown | n/a for `load` | `FAILURE` (fail-closed) | fail | ⛔ skipped |

Key correction vs. the issue framing: `VALIDATION_FINDINGS` is **rc=5, not rc=4**. rc=4 is `MISSING_DEPENDENCY` (a resolve-stage abort = a true failure), so rc=4 → `FAILURE`. I mapped to the authoritative da contract read at HEAD, not the issue's stale table. `rc=6 REFUSED_ROWS` commits a *partial* graph but is deliberately a `FAILURE` (silent data loss is not an acceptable load for a trustworthy re-run), matching the "malformed-id class is a true failure" direction.

## How it's built

- New `scripts/classify_load_rc.sh` — POSIX `sh` classifier, the **single source of truth** for the rc → `SUCCESS|FINDINGS|FAILURE` mapping. Only `rc=5` is the committed-but-non-fatal code; every other non-zero fails closed. It runs on the VPS from the git-reset `/opt/noorinalabs-deploy` checkout, same pattern as `scripts/kafka_logdir_preflight.sh`.
- The workflow's rc block now drives off `classify_load_rc.sh` instead of `[ "${RC}" -ne 0 ]`.

## Test

- New `scripts/tests/test_classify_load_rc.py` (16 cases) — locks in rc=5→FINDINGS (committed, not failure), rc=4→FAILURE (the stale-framing guard), rc=6/rc=1/rc=8→FAILURE, the 3/7/9/10/11/255 fail-closed set, single-token stdout, and usage errors. Runs in `compose-validate.yml`'s `scripts-pytest` job (and the `pytest-scripts` pre-push hook).

## Green-before-push

`pytest scripts/tests` (146 passed) · ruff check + format · mypy · shellcheck · `sh -n` · actionlint · pre_commit_ci_sync (no drift) — all green. pre-commit + pre-push hooks all passed.

Closes #569
Closes #570
