### PR TITLE
Bind the prune to the graph's own load provenance — refuse a valid-but-wrong ref (#580)

### DIFF
--- a/.github/workflows/deploy-data-load.yml
+++ b/.github/workflows/deploy-data-load.yml
@@ -145,6 +145,7 @@ jobs:
           echo "Resolved loader image: ${img}"
 
       - name: Run batch load on ${{ inputs.env }} VPS
+        id: load
         uses: appleboy/ssh-action@v1
         env:
           ENV_NAME: ${{ inputs.env }}
@@ -423,6 +424,68 @@ jobs:
             COMPOSE="docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env"
             COMPOSE_LOAD="${COMPOSE} --profile graph-load"
 
+            # run_cypher <query>: run a query INSIDE the live neo4j container, reading the
+            # password from that container's OWN NEO4J_AUTH — never on our argv, never over
+            # the GH transport (CWE-214). Same helper graph-prune-narrators.yml uses.
+            run_cypher() {
+              # SC2016: the ${NEO4J_AUTH#neo4j/} and "$1" are single-quoted ON PURPOSE —
+              # they must expand inside the neo4j container's `sh -c` (reading THAT
+              # container's NEO4J_AUTH), not on the VPS host. The query text is not a secret.
+              # shellcheck disable=SC2016
+              ${COMPOSE} exec -T neo4j sh -c \
+                'NEO4J_USERNAME=neo4j NEO4J_PASSWORD="${NEO4J_AUTH#neo4j/}" exec cypher-shell --format plain "$1"' \
+                _ "$1"
+            }
+
+            # =====================================================================
+            # GRAPH-SIDE LOAD PROVENANCE (deploy#580) — stamp the ref we are loading
+            # =====================================================================
+            # graph-prune-narrators.yml prunes the graph to the canonical set of whatever
+            # parquet_ref an operator types, and EVERY gate it has is derived from that
+            # parquet — so they can only ever confirm the prune obeyed the keep-set, never
+            # that it was the RIGHT keep-set. A genuine but OLDER, SMALLER run passes all of
+            # them (valid record, matching md5, ids a SUBSET of the graph so missing=0) while
+            # the prune deletes every narrator loaded since. No parquet-derived gate can see
+            # that, because the parquet is internally perfect.
+            #
+            # This is the other half of the only gate that can: the LOAD records which ref it
+            # loaded, and the prune refuses unless it is pruning against that same ref.
+            #
+            # STATUS IS STAMPED IN TWO PHASES, AND THE ORDER IS THE SAFETY PROPERTY:
+            #   in_progress  BEFORE the loader touches the graph
+            #   complete     ONLY after it commits (rc classified SUCCESS or FINDINGS)
+            # A load that dies mid-write therefore leaves the graph stamped `in_progress`,
+            # and the prune gate refuses it AGAINST ANY REF — including its own. That is the
+            # fail-closed direction and it is deliberate: a half-loaded graph holds narrators
+            # that no keep-set names, and a prune deletes exactly those. Re-run the load to
+            # clear it.
+            #
+            # The Cypher is BUILT BY scripts/graph_load_provenance.sh, not assembled here.
+            # PARQUET_REF and IMAGE are free-text workflow_dispatch inputs interpolated into
+            # a single-quoted Cypher literal, so the script whitelists their charset (a `'`
+            # here is an injection into a statement with graph write access) — and being a
+            # script, that guard is EXECUTED by scripts/tests/test_load_provenance.py rather
+            # than pinned by grepping this file's text, which is what let a forged manifest
+            # ship green twice (deploy#574/#581).
+            stamp_provenance() {
+              _stamp_status="$1"
+              _stamp_cypher=""
+              _stamp_rc=0
+              # NOT `2>&1`: the output IS the Cypher statement, so folding stderr into it
+              # would splice a diagnostic into a query we are about to run against the graph
+              # (deploy#584 — stderr is COMMENTARY, not DATA). Diagnostics flow to the log.
+              _stamp_cypher="$(PARQUET_REF="${PARQUET_REF}" LOAD_STATUS="${_stamp_status}" \
+                IMAGE="${IMAGE}" LOAD_ARGS="${LOAD_ARGS}" \
+                bash scripts/graph_load_provenance.sh stamp)" || _stamp_rc=$?
+              if [ "${_stamp_rc}" -ne 0 ] || [ -z "${_stamp_cypher}" ]; then
+                echo "ERROR: [${ENV_NAME}] could not build the load-provenance stamp (rc=${_stamp_rc}). Refusing to load a graph we cannot stamp: an unstamped graph is one the prune gate can never trust, and the prune is the operation that cannot be undone." >&2
+                return 1
+              fi
+              run_cypher "${_stamp_cypher}" >/dev/null \
+                || { echo "ERROR: [${ENV_NAME}] failed to write the load-provenance stamp (status=${_stamp_status}) to the graph." >&2; return 1; }
+              echo "    stamped: parquet_ref=${PARQUET_REF} load_status=${_stamp_status}"
+            }
+
             # GHCR login so the loader image can be pulled; trap logs out at
             # end-of-run so no credentials persist on the box.
             trap 'docker logout ghcr.io >/dev/null 2>&1 || true' EXIT
@@ -432,6 +495,12 @@ jobs:
             echo "==> [${ENV_NAME}] pulling loader image ${GRAPH_LOAD_IMAGE} ..."
             ${COMPOSE_LOAD} pull graph-load \
               || { echo "ERROR: [${ENV_NAME}] compose pull graph-load (${GRAPH_LOAD_IMAGE}) failed." >&2; exit 1; }
+
+            # Stamp BEFORE the write. If this fails we have not touched the graph, and we
+            # must not: a load nobody can attribute to a ref is a graph nobody can prune.
+            echo "==> [${ENV_NAME}] load-provenance: stamping parquet_ref BEFORE the load (in_progress)"
+            stamp_provenance in_progress \
+              || { echo "ERROR: [${ENV_NAME}] refusing to run the load — the graph could not be stamped." >&2; exit 1; }
 
             # --- run the load (--no-deps: DBs are already up on the live stack;
             #     do NOT let `run` recreate neo4j). LOAD_ARGS is a controlled
@@ -479,6 +548,17 @@ jobs:
                 ;;
             esac
 
+            # --- load COMMITTED: promote the stamp to `complete` ------------------
+            # Reached ONLY on SUCCESS (rc=0) or FINDINGS (rc=5) — both of which committed a
+            # graph. The FAILURE arm above has already exited, deliberately leaving the stamp
+            # at `in_progress`, which the prune gate refuses against ANY ref. That is the
+            # whole point of the two-phase stamp: rc=6 (REFUSED_ROWS) can leave a PARTIAL
+            # graph, and a partial graph holds narrators that no keep-set names — so pruning
+            # it, against any ref at all, deletes exactly those. Re-run the load to clear it.
+            echo "==> [${ENV_NAME}] load-provenance: load committed — stamping complete"
+            stamp_provenance complete \
+              || { echo "ERROR: [${ENV_NAME}] the load COMMITTED but the graph could not be stamped 'complete'. The graph holds ${PARQUET_REF} but does not say so, and the prune gate will refuse it. Re-run this load to reconcile the stamp." >&2; exit 1; }
+
             # --- post-load read-back (informational): source_corpus distribution.
             #     Reached for any COMMITTED load — rc=0 (clean) OR rc=5 (findings).
             #     cypher-shell runs INSIDE the live neo4j container and reads the
@@ -519,5 +599,13 @@ jobs:
               echo "Dry run — B2 presence verified; no Parquet downloaded, no loader run, no graph write."
             fi
             echo "Source: \`noorinalabs-pipeline/${PARQUET_REF}\` (B2) → rclone on the VPS → loader compose service."
+            if [ "${DRY_RUN}" != "true" ]; then
+              echo ""
+              echo "**Load provenance (deploy#580):** a committed load stamps \`parquet_ref\` onto the graph"
+              echo "(\`(:LoadProvenance {scope:'graph'})\`), and \`graph-prune-narrators.yml\` REFUSES to prune"
+              echo "against any other ref. \`in_progress\` is stamped before the write and \`complete\` only after"
+              echo "the loader commits — so a load that dies mid-write leaves a graph the prune refuses against"
+              echo "ANY ref, including its own. Re-run this load to clear it."
+            fi
             echo "stg-gated: prod runs ONLY as a promotion of a verified-good stg load."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/graph-prune-narrators.yml
+++ b/.github/workflows/graph-prune-narrators.yml
@@ -583,6 +583,57 @@ jobs:
 
             NARR_Q='MATCH (n:Narrator) RETURN count(n) AS narrators'
 
+            # =====================================================================
+            # LOAD-PROVENANCE GATE (deploy#580) — the ONLY gate derived from the GRAPH
+            # =====================================================================
+            # Everything above this — the provenance gate, the completeness binding, `missing`,
+            # and Gates A-D below — is derived from the KEEP-SET. They prove the prune obeyed
+            # the parquet. NOT ONE OF THEM CAN ASK WHETHER IT WAS THE RIGHT PARQUET.
+            #
+            # The case they all miss is a GENUINE BUT OLDER, SMALLER run — not corrupt, not
+            # foreign, a real earlier resolve run:
+            #   * its _resolve_run.txt is valid and its tally agrees with its parquet (they
+            #     were published together), so the provenance gate PASSES;
+            #   * its md5 matches, so the byte-integrity check PASSES;
+            #   * its ids are a SUBSET of what the graph now holds, so `missing` is ~0 —
+            #     `missing` does not merely miss this case, it CERTIFIES it;
+            #   * the completeness equality PASSES, because the parquet really does hold
+            #     exactly what its producing run declared;
+            #   * and expected_canonical_ids, if supplied, AGREES — because it is that run's
+            #     real count.
+            # Every automated check goes green and the prune deletes every narrator loaded
+            # since. `missing` is structurally blind here and no fix to it can help: it bounds
+            # `canonical − graph`, none of which can be DELETED. The over-deletion lives
+            # entirely in `graph − canonical` — precisely the set this tool exists to delete.
+            #
+            # The graph, however, knows which ref it was loaded from, because
+            # deploy-data-load.yml stamps it. That stamp is independent of BOTH the parquet
+            # and the operator — which is exactly what makes it worth having, since the
+            # parquet cannot vouch for itself and the operator has no independently-sourced
+            # number either (the pipeline's only count is a read-back of the artifact).
+            #
+            # It also turns the hazard the `parquet_ref` input help text has been NAMING and
+            # LEAVING UNENFORCED — "this MUST be the SAME parquet_ref that was loaded" — from
+            # a doc comment into a gate.
+            #
+            # Runs for dry_run TOO, and that is not pedantry: a dry run against the wrong ref
+            # prints a confident "would delete N" that is the most reassuring possible prelude
+            # to an operator setting dry_run=false.
+            echo "==> [${ENV_NAME}] load-provenance gate: is this the ref the graph was LOADED from?"
+            PROV_Q=""
+            PROV_Q="$(bash scripts/graph_load_provenance.sh read-query)" \
+              || { echo "ERROR: [${ENV_NAME}] could not build the load-provenance read-back query." >&2; exit 1; }
+            GRAPH_PROV=""
+            GRAPH_PROV="$(run_cypher "${PROV_Q}")" \
+              || { echo "ERROR: [${ENV_NAME}] the load-provenance read-back query FAILED TO EXECUTE. A gate that cannot read its instrument is a STOP, never a pass — an unreadable stamp is not an absent one, and neither is a licence to prune." >&2; exit 1; }
+            LOADPROV_RC=0
+            PRUNE_PARQUET_REF="${PARQUET_REF}" PROVENANCE_OUTPUT="${GRAPH_PROV}" \
+              bash scripts/graph_load_provenance.sh verify || LOADPROV_RC=$?
+            if [ "${LOADPROV_RC}" -ne 0 ]; then
+              echo "ERROR: [${ENV_NAME}] load-provenance gate REFUSED this prune (rc=${LOADPROV_RC}). NO deletion was attempted." >&2
+              exit 1
+            fi
+
             # GHCR login so the loader image can be pulled; trap logs out at
             # end-of-run so no credentials persist on the box.
             trap 'docker logout ghcr.io >/dev/null 2>&1 || true' EXIT
@@ -860,6 +911,13 @@ jobs:
               echo ""
             fi
 
+            echo "**The graph vouches for the ref.** \`deploy-data-load.yml\` stamps the \`parquet_ref\` it loaded"
+            echo "onto the graph, and this prune REFUSES unless it is pruning against that same ref (deploy#580)."
+            echo "It is the only gate here derived from neither the parquet nor the operator — and it is the only"
+            echo "one that can see a **genuine but older, smaller** run: that run's record is valid, its md5 matches,"
+            echo "its ids are a SUBSET of the graph so \`missing\` is 0, and the completeness equality passes — every"
+            echo "parquet-derived check goes green while the prune deletes every narrator loaded since."
+            echo ""
             echo "The keep-set is bound to its producing run. \`curated/_resolve_run.txt\` — written by RESOLVE"
             echo "from its in-memory tally BEFORE the write — declares the canonical-id count and that the run"
             echo "completed; \`curated/_manifest.txt\` declares only the md5 of the bytes published. The prune"

--- a/scripts/graph_load_provenance.sh
+++ b/scripts/graph_load_provenance.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+# =============================================================================
+# graph_load_provenance.sh — the GRAPH-side load-provenance binding (deploy#580).
+#
+# THE HOLE THIS CLOSES
+#
+# graph-prune-narrators.yml prunes the graph down to the canonical set of whatever
+# `parquet_ref` the operator types. Every gate in it is sound RELATIVE TO THAT REF:
+# the resolve record declares the count, the count binds the parquet, the md5 binds
+# the bytes, `missing` rejects a foreign keep-set.
+#
+# Not one of them can ask whether it was the RIGHT ref.
+#
+# The residual case is a GENUINE BUT OLDER, SMALLER run — not corrupt, not foreign,
+# a real earlier resolve run:
+#
+#   * its _resolve_run.txt is valid and its tally agrees with its parquet (they were
+#     published together);
+#   * its md5 matches;
+#   * `missing` is ~0, because that run's ids are a SUBSET of what the graph now holds;
+#   * the completeness equality passes, because the parquet really does hold exactly
+#     what its producing run declared;
+#   * and if the operator supplies expected_canonical_ids they will supply THAT RUN'S
+#     count, which agrees — because it is that run's real count.
+#
+# Every automated check goes green, and the prune deletes every narrator loaded since.
+#
+# `missing` is STRUCTURALLY BLIND here and no fix to it can help: it bounds
+# `canonical − graph`, and NONE of those elements can be deleted. The over-deletion
+# lives entirely in `graph − canonical` — which is exactly the set the tool exists to
+# delete. NO GATE DERIVED FROM THE PARQUET CAN SEE THIS, because the parquet is
+# internally perfect. The artifact cannot vouch for itself, and per the deploy#574
+# review the operator has no independently-sourced number either (the pipeline's only
+# count is a read-back of the artifact — da `src/resolve/__init__.py:344`).
+#
+# A gate derived from the GRAPH can see it, and is the only thing that can:
+#
+#   1. deploy-data-load.yml STAMPS the parquet_ref it loaded onto the graph.
+#   2. graph-prune-narrators.yml READS IT BACK and refuses unless the ref it is
+#      pruning against is the ref the graph was actually loaded from.
+#
+# This is the only check in the system independent of BOTH the parquet and the
+# operator. That independence is the entire value; do not "simplify" it by deriving
+# any part of it from the keep-set.
+#
+# WHY ONE FILE OWNS ALL THREE MODES
+#
+# `stamp` writes the properties, `read-query` projects them, `verify` parses the
+# projection. A rename or reorder in any one of those silently narrows the next
+# (deploy#589 — a paraphrase in the PRODUCT does not break the parser, it QUIETLY
+# NARROWS it, and the guard downstream stops guarding while every test stays green).
+# Keeping the writer, the projector and the parser within twenty lines of each other,
+# under one test file that runs all three against each other, is what makes that drift
+# a red test instead of a silent hole.
+#
+# WHY A SCRIPT AND NOT TEN LINES OF THE WORKFLOW'S ssh BLOCK
+#
+# Because a guard that lives in an ssh `script:` block can only ever be pinned by
+# grepping the workflow's TEXT, and this team has already proved twice what that is
+# worth: a forged manifest in the gate (10 passed) and the identical forge relocated
+# to the caller (still green). A guard asserted by substring is not a guard. Living
+# under scripts/ this is EXECUTED by scripts/tests/test_load_provenance.py against
+# fixtures, and shellcheck-linted in CI — which an ssh `with: script:` body is not
+# (deploy#555).
+#
+# ---------------------------------------------------------------------------------
+# MODES
+#
+#   stamp        env: PARQUET_REF LOAD_STATUS IMAGE LOAD_ARGS
+#                out: the Cypher MERGE that records what this load loaded.
+#
+#   read-query   out: the Cypher that projects the stamp as ONE machine-readable line:
+#                     GRAPH_LOAD_PROVENANCE parquet_ref=<ref> load_status=<s> ...
+#
+#   verify       env: PRUNE_PARQUET_REF PROVENANCE_OUTPUT
+#                rc 0 only if the graph was loaded from PRUNE_PARQUET_REF by a load
+#                that COMPLETED. Otherwise non-zero, with a diagnostic naming BOTH refs.
+#
+# LOAD_STATUS is stamped `in_progress` BEFORE the loader runs and `complete` only
+# after it commits. A load that dies mid-write therefore leaves the graph stamped
+# `in_progress`, and this gate refuses to prune it AGAINST ANY REF — including its
+# own. That is deliberate and it is the fail-closed direction: a half-loaded graph
+# holds narrators no keep-set names, and pruning it deletes exactly those. Re-run the
+# load to clear it. Backups have never actually run (deploy#558/#559/#560), so a
+# wrong-ref prune is UNRECOVERABLE and every ambiguity here resolves to "refuse".
+# =============================================================================
+set -euo pipefail
+
+# The one place the stamp's shape is defined. `stamp` writes these, `read-query`
+# projects them, `verify` parses them.
+NODE_LABEL="LoadProvenance"
+NODE_SCOPE="graph"
+LINE_KEYWORD="GRAPH_LOAD_PROVENANCE"
+STATUS_IN_PROGRESS="in_progress"
+STATUS_COMPLETE="complete"
+
+die() {
+    echo "ERROR: [load-provenance] $1" >&2
+    shift
+    for _l in "$@"; do echo "  ${_l}" >&2; done
+    echo "  NO node was deleted." >&2
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# safe_literal <name> <value> <allowed-charclass>
+#
+# Every value below is interpolated into a single-quoted Cypher string literal, so a
+# value containing `'` or `\` is a CYPHER INJECTION into a statement that runs with
+# write access to the graph. `parquet_ref` and `image` are BOTH free-text
+# workflow_dispatch inputs; treating them as trusted because "only maintainers can
+# dispatch" is exactly the reasoning that makes an injection bug ship.
+#
+# So the values are whitelisted, not escaped: no quote, no backslash, no newline, no
+# brace can reach the statement at all. Refuse rather than sanitise — a rejected input
+# is a typo the operator fixes in ten seconds; a sanitised one is a guess about intent.
+# ---------------------------------------------------------------------------
+safe_literal() {
+    _name="$1"
+    _val="$2"
+    _allowed="$3"
+    [ -n "${_val}" ] || die "${_name} is empty — refusing to stamp an unidentifiable load."
+    # shellcheck disable=SC2254  # ${_allowed} is an intentional bracket-expression body.
+    case "${_val}" in
+        *[!${_allowed}]*)
+            die "${_name}='${_val}' contains a character outside [${_allowed}]." \
+                "It is interpolated into a single-quoted Cypher literal, so a quote or a" \
+                "backslash here is an injection into a statement with write access to the" \
+                "graph. Fix the input; this check is not the thing to relax."
+            ;;
+    esac
+}
+
+# validate_parquet_ref <ref> — the STRUCTURAL rules, on top of the charset.
+#
+# A trailing slash is REJECTED rather than trimmed. `staged/x/` and `staged/x` are the
+# same B2 prefix but two different strings, and this gate is a STRING EQUALITY against
+# what the load stamped. Canonicalising here and not in the prune's input would make a
+# correct prune refuse itself; canonicalising in both is one more thing to keep in
+# lockstep. Rejecting at the point of the stamp means only one spelling can ever be
+# stamped, so the equality is safe without any normalisation anywhere.
+validate_parquet_ref() {
+    _ref="$1"
+    safe_literal parquet_ref "${_ref}" 'A-Za-z0-9._/-'
+    case "${_ref}" in
+        /*) die "parquet_ref must NOT start with '/' — it is a bucket-relative prefix." ;;
+        */) die "parquet_ref must NOT end with '/'." \
+            "The prune gate is a string equality against this exact value, so 'staged/x/'" \
+            "and 'staged/x' would be two different runs. Only one spelling may be stamped." ;;
+        noorinalabs-pipeline/*)
+            die "parquet_ref must NOT include the bucket name." \
+                "Pass only the prefix under noorinalabs-pipeline (e.g. staged/narrator-resolve/<ver>)."
+            ;;
+    esac
+    case "${_ref}" in
+        ..|../*|*/../*|*/..) die "parquet_ref must not contain a '..' path segment." ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# token_value <line> <key>
+#
+# Whole-TOKEN extraction: split the line on spaces and match an exact `key=value`
+# token, so no key can be hijacked by a longer key ending in its name (da#419).
+#
+# The value charclass is `[!-~]` — every printable non-space character. That is
+# deliberately NOT an enumeration of what a parquet_ref may contain: enumerating a
+# charset for a value someone else writes is how a parser silently NARROWS when the
+# producer changes (deploy#589). Here the token is whatever sits between two spaces;
+# an unexpected character is still captured, still compared, and still refused on
+# mismatch. Fail-closed, not fail-blind.
+#
+# NO PIPE INTO AN EARLY-EXITING CONSUMER. `... | head -n1` would make the producer
+# take SIGPIPE, and `pipefail` promotes that 141 to the pipeline's rc EVEN WHEN THE
+# FINAL MATCH SUCCEEDED (deploy#591). sed reads its input to the end and the first
+# line is taken with a parameter expansion instead.
+# ---------------------------------------------------------------------------
+token_value() {
+    _tv_out="$(tr ' ' '\n' <<<"$1" | sed -n "s/^$2=\\([!-~][!-~]*\\)\$/\\1/p")"
+    printf '%s\n' "${_tv_out%%$'\n'*}"
+}
+
+# ---------------------------------------------------------------------------
+# MODE: stamp — the Cypher that records what this load loaded.
+# ---------------------------------------------------------------------------
+mode_stamp() {
+    PARQUET_REF="${PARQUET_REF:?PARQUET_REF must be set}"
+    LOAD_STATUS="${LOAD_STATUS:?LOAD_STATUS must be set}"
+    IMAGE="${IMAGE:?IMAGE must be set}"
+    LOAD_ARGS="${LOAD_ARGS:?LOAD_ARGS must be set}"
+
+    validate_parquet_ref "${PARQUET_REF}"
+
+    # A whitelist, not a charset: `complete` is the token the prune gate unlocks on, and
+    # a typo'd status must be a refusal here rather than an unrecognised value that the
+    # gate later reads as "not complete" for the wrong reason.
+    case "${LOAD_STATUS}" in
+        "${STATUS_IN_PROGRESS}" | "${STATUS_COMPLETE}") : ;;
+        *) die "LOAD_STATUS='${LOAD_STATUS}' is not one of: ${STATUS_IN_PROGRESS} ${STATUS_COMPLETE}." ;;
+    esac
+
+    # An OCI ref: registry/path:tag or @sha256:<digest>.
+    safe_literal image "${IMAGE}" 'A-Za-z0-9._/:@-'
+    # The loader subcommand — 'load' or 'load --nodes-only'. A space is legal HERE (it is
+    # stored, never projected into the space-delimited provenance line below).
+    safe_literal load_args "${LOAD_ARGS}" 'A-Za-z0-9 ._-'
+
+    # `scope` is the MERGE key: one provenance node per graph, upserted per load. Do not
+    # MERGE on parquet_ref — that would accumulate one node per ref and the read-back
+    # would have to pick a winner, which is precisely the ambiguity this gate exists to
+    # remove. The graph was loaded from exactly one ref, and it says which.
+    cat <<CYPHER
+MERGE (p:${NODE_LABEL} {scope: '${NODE_SCOPE}'})
+SET p.parquet_ref = '${PARQUET_REF}',
+    p.load_status = '${LOAD_STATUS}',
+    p.image = '${IMAGE}',
+    p.load_args = '${LOAD_ARGS}',
+    p.stamped_at = toString(datetime())
+CYPHER
+}
+
+# ---------------------------------------------------------------------------
+# MODE: read-query — project the stamp as ONE machine-readable line.
+#
+# The line is SPACE-DELIMITED, so every projected property must be space-free.
+# `load_args` ('load --nodes-only') is deliberately NOT projected: it is stored for
+# forensics, and projecting it would put a space inside a token and silently corrupt
+# the parse of everything after it.
+#
+# `coalesce(..., '<unset>')` rather than letting a null collapse the whole concatenation
+# to null: a node with a missing property must produce a line that FAILS the checks
+# below for a nameable reason, not vanish and read as "no stamp at all". Both refuse —
+# but only one of them tells the operator what is actually wrong.
+# ---------------------------------------------------------------------------
+mode_read_query() {
+    cat <<CYPHER
+MATCH (p:${NODE_LABEL} {scope: '${NODE_SCOPE}'})
+RETURN '${LINE_KEYWORD}'
+     + ' parquet_ref=' + coalesce(p.parquet_ref, '<unset>')
+     + ' load_status=' + coalesce(p.load_status, '<unset>')
+     + ' stamped_at=' + coalesce(p.stamped_at, '<unset>')
+     + ' image=' + coalesce(p.image, '<unset>') AS provenance
+CYPHER
+}
+
+# ---------------------------------------------------------------------------
+# MODE: verify — the refusal.
+# ---------------------------------------------------------------------------
+mode_verify() {
+    PRUNE_PARQUET_REF="${PRUNE_PARQUET_REF:?PRUNE_PARQUET_REF must be set (the ref being pruned against)}"
+    # May legitimately be empty (an unstamped graph). Empty is a REFUSAL, not a pass.
+    PROVENANCE_OUTPUT="${PROVENANCE_OUTPUT-}"
+
+    # First line carrying the keyword. `sed -n` exits 0 on no-match (unlike `grep`, which
+    # exits 1 and would CRASH this script under `set -e` on the very input it exists to
+    # reject — the no-stamp case). Look up the command's contract; do not generalise.
+    PROV_LINE="$(sed -n "/${LINE_KEYWORD} /{p;q;}" <<<"${PROVENANCE_OUTPUT}")"
+
+    # `cypher-shell --format plain` renders a string column QUOTED, so the row arrives as
+    #   "GRAPH_LOAD_PROVENANCE parquet_ref=… image=…"
+    # Strip that TRANSPORT ENVELOPE — one leading and one trailing double quote on the
+    # LINE — before tokenising. Doing it on the line, not on the extracted values, keeps
+    # this independent of WHICH field happens to sit first or last in the projection: a
+    # reorder in read-query must not silently start contaminating a value with a quote.
+    # No legal value can contain `"` (safe_literal excludes it at the stamp), and if the
+    # transport ever stops quoting, both strips are no-ops.
+    PROV_LINE="${PROV_LINE#\"}"
+    PROV_LINE="${PROV_LINE%\"}"
+
+    GRAPH_REF="$(token_value "${PROV_LINE}" parquet_ref)"
+    if [ -z "${PROV_LINE}" ] || [ -z "${GRAPH_REF}" ]; then
+        die "the graph carries NO load-provenance stamp." \
+            "Nothing in this graph says which resolve run it was loaded from, so there is no" \
+            "way to tell a correct keep-set from a genuine-but-older one — and an older run's" \
+            "keep-set passes EVERY other gate here (its record is valid, its md5 matches, its" \
+            "ids are a subset of the graph so 'missing' is 0) while the prune deletes every" \
+            "narrator loaded since. Run deploy-data-load.yml, which stamps the ref it loads." \
+            "  ref you asked to prune against: ${PRUNE_PARQUET_REF}"
+    fi
+
+    GRAPH_STATUS="$(token_value "${PROV_LINE}" load_status)"
+    GRAPH_STAMPED_AT="$(token_value "${PROV_LINE}" stamped_at)"
+
+    if [ "${GRAPH_STATUS}" != "${STATUS_COMPLETE}" ]; then
+        die "the last load of this graph did NOT complete (load_status=${GRAPH_STATUS:-<unreadable>})." \
+            "The graph therefore holds an unknown fraction of ${GRAPH_REF}, and NO keep-set" \
+            "names the narrators a half-finished load left behind — so a prune deletes exactly" \
+            "those, whatever ref you point it at. Re-run the load; it stamps 'complete' only" \
+            "after the loader commits." \
+            "  graph loaded from : ${GRAPH_REF} (stamped ${GRAPH_STAMPED_AT})" \
+            "  ref you asked to prune against: ${PRUNE_PARQUET_REF}"
+    fi
+
+    if [ "${GRAPH_REF}" != "${PRUNE_PARQUET_REF}" ]; then
+        die "WRONG REF — this graph was not loaded from the ref you are pruning against." \
+            "  graph was LOADED from        : ${GRAPH_REF}   (stamped ${GRAPH_STAMPED_AT})" \
+            "  you asked to PRUNE against   : ${PRUNE_PARQUET_REF}" \
+            "" \
+            "Every other gate in this workflow is derived from the keep-set and would go GREEN" \
+            "on a genuine but older, smaller run: its resolve record is valid, its md5 matches," \
+            "its ids are a SUBSET of what this graph holds so 'missing' is 0, and the" \
+            "completeness equality passes because the parquet really does hold what its run" \
+            "declared. The prune would then delete every narrator loaded since that run." \
+            "" \
+            "Either you meant the ref above, or the graph needs re-loading from the ref you" \
+            "typed. We do not get to guess which."
+    fi
+
+    echo "LOAD_PROVENANCE_OK parquet_ref=${GRAPH_REF} load_status=${GRAPH_STATUS} stamped_at=${GRAPH_STAMPED_AT}"
+}
+
+case "${1:-}" in
+    stamp) mode_stamp ;;
+    read-query) mode_read_query ;;
+    verify) mode_verify ;;
+    *)
+        echo "usage: $0 {stamp|read-query|verify}" >&2
+        echo "  stamp       env: PARQUET_REF LOAD_STATUS IMAGE LOAD_ARGS  -> Cypher MERGE" >&2
+        echo "  read-query                                                -> Cypher RETURN" >&2
+        echo "  verify      env: PRUNE_PARQUET_REF PROVENANCE_OUTPUT      -> rc 0 iff same ref" >&2
+        exit 2
+        ;;
+esac

--- a/scripts/tests/test_data_load_provenance_seam.py
+++ b/scripts/tests/test_data_load_provenance_seam.py
@@ -1,0 +1,258 @@
+"""BEHAVIOURAL tests for the LOAD↔STAMP seam — deploy-data-load's ssh block is EXECUTED.
+
+The prune gate (deploy#580) refuses unless the graph says which resolve run it was loaded
+from. That is worth exactly nothing unless the LOAD actually writes it. A stamp asserted by
+grepping the workflow's text is not a stamp — this repo has now shipped that mistake twice
+(a forged manifest inside the gate, then the identical forge relocated to the caller, both
+green). So the real ssh body runs here against stubs, and the assertions are on WHAT IT DID.
+
+The property under test is not merely "a stamp is written". It is the ORDER:
+
+    in_progress   BEFORE the loader touches the graph
+    complete      ONLY after the loader commits
+
+A load that dies mid-write therefore leaves the graph stamped `in_progress`, and the prune
+gate refuses it against ANY ref — including its own. That is the fail-closed direction and it
+matters: a half-loaded graph holds narrators that no keep-set names, so a prune deletes
+exactly those. rc=6 (REFUSED_ROWS) is precisely that shape — a partial graph — and it must
+NOT reach `complete`.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+REPO_ROOT = SCRIPTS_DIR.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "deploy-data-load.yml"
+
+REF = "staged/narrator-resolve/2026-07-11-4f2a1c9"
+IMAGE = "ghcr.io/noorinalabs/noorinalabs-data-acquisition-load:stg-latest"
+
+# da's exit-code contract (src/exit_codes.py), as classify_load_rc.sh reads it.
+RC_SUCCESS = 0
+RC_LOAD_FAILED = 1
+RC_VALIDATION_FINDINGS = 5  # the graph IS committed; findings are advisory
+RC_REFUSED_ROWS = 6  # a PARTIAL graph — the case the two-phase stamp exists for
+
+
+def _ssh_script() -> str:
+    doc = yaml.safe_load(WORKFLOW.read_text())
+    for step in doc["jobs"]["data-load"]["steps"]:
+        if step.get("id") == "load":
+            return str(step["with"]["script"])
+    raise AssertionError("no step id 'load' in deploy-data-load.yml")
+
+
+def _stub(bin_dir: Path, name: str, body: str) -> None:
+    p = bin_dir / name
+    p.write_text("#!/usr/bin/env bash\n" + body)
+    p.chmod(0o755)
+
+
+def _sandbox(tmp_path: Path, *, loader_rc: int = RC_SUCCESS) -> tuple[Path, Path]:
+    """A fake VPS. Returns (repo_root, audit_log).
+
+    The audit log is an ORDERED record of what the workflow asked docker to do, which is what
+    lets a test assert that the stamp preceded the load rather than merely accompanied it.
+    """
+    root = tmp_path / "repo"
+    (root / "scripts").mkdir(parents=True)
+    (root / "compose").mkdir()
+    # The REAL scripts — not stubs. The seam under test is workflow -> THESE.
+    for s in ("graph_load_provenance.sh", "classify_load_rc.sh"):
+        (root / "scripts" / s).write_bytes((SCRIPTS_DIR / s).read_bytes())
+    (root / "compose" / "docker-compose.prod.yml").write_text("services: {}\n")
+    (root / ".env").write_text("NEO4J_PASSWORD=x\n")
+
+    bins = tmp_path / "bin"
+    bins.mkdir()
+    audit = tmp_path / "audit.log"
+
+    _stub(bins, "git", "exit 0\n")
+    _stub(
+        bins,
+        "rclone",
+        """
+case "$1" in
+  lsf)  echo narrators_canonical.parquet
+        echo narrator_mentions_resolved.parquet
+        echo narrator_mentions_resolved_muhaddithat.parquet
+        echo hadiths_bukhari.parquet
+        echo collections_all.parquet
+        echo network_edges_a.parquet
+        echo parallel_links.parquet ;;
+  copy) mkdir -p "$3"; : > "$3/narrators_canonical.parquet" ;;
+esac
+exit 0
+""",
+    )
+    # Records every docker invocation IN ORDER. A stamp is a MERGE on :LoadProvenance; the
+    # loader is the only `run`. Both land in the same log, so ORDER is assertable.
+    _stub(
+        bins,
+        "docker",
+        f'''
+for a in "$@"; do
+  case "$a" in
+    *"MERGE (p:LoadProvenance"*)
+      status="$(printf '%s' "$a" | sed -n "s/.*p.load_status = '\\([a-z_]*\\)'.*/\\1/p")"
+      ref="$(printf '%s' "$a" | sed -n "s/.*p.parquet_ref = '\\([^']*\\)'.*/\\1/p")"
+      echo "STAMP status=${{status}} ref=${{ref}}" >> "{audit}"
+      exit 0 ;;
+    *"MATCH (h:Hadith)"*)
+      echo "source_corpus, hadiths"; echo '"bukhari", 7563'
+      exit 0 ;;
+  esac
+done
+for a in "$@"; do
+  if [ "$a" = "run" ]; then
+    echo "LOADER_RAN" >> "{audit}"
+    exit {loader_rc}
+  fi
+done
+exit 0
+''',
+    )
+    return root, audit
+
+
+def _run_ssh_block(root: Path, tmp_path: Path, **env: str) -> subprocess.CompletedProcess[str]:
+    # The ONLY edit to the real ssh body is the checkout path. Every guard runs exactly as it
+    # does on the VPS — a harness that rewrites the code under test proves things about the
+    # rewrite.
+    script = _ssh_script().replace("cd /opt/noorinalabs-deploy", f'cd "{root}"')
+    return subprocess.run(  # noqa: S603
+        ["bash", "-c", script],  # noqa: S607
+        env={
+            **os.environ,
+            "PATH": f"{tmp_path / 'bin'}:{os.environ['PATH']}",
+            "HOME": str(tmp_path),
+            "ENV_NAME": "stg",
+            "PARQUET_REF": REF,
+            "LOAD_ARGS": "load",
+            "DRY_RUN": "false",
+            "IMAGE": IMAGE,
+            "PIPELINE_B2_KEY_ID": "k",
+            "PIPELINE_B2_KEY": "s",
+            "GITHUB_TOKEN": "t",
+            "GITHUB_ACTOR": "a",
+            **env,
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _audit(audit: Path) -> list[str]:
+    return audit.read_text().splitlines() if audit.exists() else []
+
+
+# ---------------------------------------------------------------------------
+# THE POSITIVE CONTROL — and it arms every negative below it.
+# ---------------------------------------------------------------------------
+def test_a_committed_load_stamps_the_ref_it_loaded(tmp_path: Path) -> None:
+    """The whole of deploy#580 rests on this actually happening.
+
+    If the load does not stamp, the prune gate refuses forever and the feature is an outage;
+    if the stamp records the wrong ref, the gate is worse than useless. Assert the ref VALUE,
+    not merely that some stamp occurred.
+    """
+    root, audit = _sandbox(tmp_path, loader_rc=RC_SUCCESS)
+    r = _run_ssh_block(root, tmp_path)
+    log = _audit(audit)
+    assert r.returncode == 0, f"a clean load must succeed:\n{r.stdout}\n{r.stderr}"
+    assert f"STAMP status=complete ref={REF}" in log, (
+        f"the load did not stamp the ref it loaded — the prune gate will refuse forever.\n{log}"
+    )
+    assert "LOADER_RAN" in log, (
+        "the loader never ran, so this test's stamps prove nothing about a real load"
+    )
+
+
+def test_the_stamp_precedes_the_write_and_completes_after_it(tmp_path: Path) -> None:
+    """ORDER is the safety property, not the mere presence of a stamp.
+
+    `in_progress` must be on the graph BEFORE the loader can touch it, so that a load which
+    dies mid-write leaves a graph the prune gate will refuse. A stamp written only at the end
+    would leave a crashed load looking exactly like the previous good one.
+    """
+    root, audit = _sandbox(tmp_path, loader_rc=RC_SUCCESS)
+    _run_ssh_block(root, tmp_path)
+    log = _audit(audit)
+
+    assert f"STAMP status=in_progress ref={REF}" in log, "no pre-write stamp"
+    i_pre = log.index(f"STAMP status=in_progress ref={REF}")
+    i_load = log.index("LOADER_RAN")
+    i_post = log.index(f"STAMP status=complete ref={REF}")
+    assert i_pre < i_load, (
+        "the graph was written BEFORE it was stamped in_progress. A load that dies mid-write "
+        "would then leave the PREVIOUS run's stamp intact, and the prune gate would happily "
+        "prune a half-loaded graph against a keep-set that names none of what was half-loaded."
+    )
+    assert i_load < i_post, "'complete' was stamped before the loader committed"
+
+
+@pytest.mark.parametrize("rc", [RC_LOAD_FAILED, RC_REFUSED_ROWS])
+def test_a_failed_load_never_reaches_complete(tmp_path: Path, rc: int) -> None:
+    """rc=6 REFUSED_ROWS is the one that matters: it can leave a PARTIAL graph.
+
+    A partial graph holds narrators that no keep-set names, so a prune deletes exactly those —
+    whatever ref it is pointed at. The stamp must stay `in_progress`, which the prune gate
+    refuses against ANY ref, including its own. Re-running the load is what clears it.
+    """
+    root, audit = _sandbox(tmp_path, loader_rc=rc)
+    r = _run_ssh_block(root, tmp_path)
+    log = _audit(audit)
+    assert r.returncode != 0, f"loader rc={rc} must fail the job"
+    assert f"STAMP status=in_progress ref={REF}" in log, "the pre-write stamp must still be set"
+    assert not any("status=complete" in line for line in log), (
+        f"loader rc={rc} FAILED but the graph was stamped 'complete'. The prune gate would "
+        "then treat a failed/partial load as a trustworthy one."
+    )
+
+
+def test_findings_rc5_does_stamp_complete(tmp_path: Path) -> None:
+    """rc=5 VALIDATION_FINDINGS COMMITTED the graph — advisory findings, not a failed load.
+
+    Without this, `test_a_failed_load_never_reaches_complete` could be satisfied by a workflow
+    that simply never stamps `complete` at all. This is the control that separates 'refuses the
+    bad rc' from 'refuses every rc' (deploy#574 — an oracle that only ever says BLOCKED proves
+    every guard holds).
+    """
+    root, audit = _sandbox(tmp_path, loader_rc=RC_VALIDATION_FINDINGS)
+    r = _run_ssh_block(root, tmp_path)
+    log = _audit(audit)
+    assert r.returncode == 0, "rc=5 committed the graph; the job must not fail"
+    assert f"STAMP status=complete ref={REF}" in log, (
+        "rc=5 COMMITTED a graph but never stamped it complete — the prune gate would refuse a "
+        "perfectly good load forever"
+    )
+
+
+def test_a_dry_run_stamps_nothing(tmp_path: Path) -> None:
+    """A dry run writes nothing to the graph, so it must claim nothing about it."""
+    root, audit = _sandbox(tmp_path)
+    r = _run_ssh_block(root, tmp_path, DRY_RUN="true")
+    assert r.returncode == 0
+    assert not _audit(audit), f"a dry run touched the graph: {_audit(audit)}"
+
+
+def test_an_injecting_ref_is_refused_before_the_loader_runs(tmp_path: Path) -> None:
+    """`parquet_ref` is free text and is interpolated into a Cypher literal with write access.
+
+    The refusal must land BEFORE the loader — a load that runs and then fails to stamp leaves
+    a graph nobody can attribute to a ref. Asserted on behaviour: no stamp, and no loader.
+    """
+    root, audit = _sandbox(tmp_path)
+    r = _run_ssh_block(root, tmp_path, PARQUET_REF="staged/x'; MATCH (n) DETACH DELETE n; //")
+    log = _audit(audit)
+    assert r.returncode != 0, "a Cypher-injecting parquet_ref was accepted"
+    assert "LOADER_RAN" not in log, "the loader ran on a ref the graph could not be stamped with"
+    assert not any(line.startswith("STAMP") for line in log)

--- a/scripts/tests/test_load_provenance.py
+++ b/scripts/tests/test_load_provenance.py
@@ -1,0 +1,463 @@
+"""BEHAVIOURAL tests for the GRAPH-side load-provenance gate — it is RUN, not grepped.
+
+The hole (deploy#580): ``graph-prune-narrators.yml`` prunes the graph to the canonical set
+of whatever ``parquet_ref`` an operator types, and **every gate it has is derived from that
+parquet**. They prove the prune obeyed the keep-set. None of them can ask whether it was the
+**right** keep-set.
+
+The case they all miss is a **genuine but older, smaller run** — not corrupt, not foreign, a
+real earlier resolve run. Its resolve record is valid, its md5 matches, its ids are a *subset*
+of what the graph now holds so ``missing`` is 0, and the completeness equality passes because
+the parquet really does hold exactly what its producing run declared. Every automated check
+goes green and the prune deletes every narrator loaded since.
+
+``missing`` is **structurally blind** here and no fix to it can help: it bounds
+``canonical − graph``, none of which can be *deleted*. The over-deletion lives entirely in
+``graph − canonical`` — precisely the set the tool exists to delete.
+
+So the load stamps the ref it loaded onto the graph, and the prune refuses unless it is
+pruning against that same ref. It is the only check independent of **both** the parquet and
+the operator.
+
+THE TEST THAT IS THE DELIVERABLE
+--------------------------------
+``test_a_valid_but_wrong_ref_passes_every_parquet_gate_and_is_still_refused`` builds ref **B**
+as a *genuinely good artifact* — complete resolve record, correct md5, internally consistent —
+and **first proves that the pre-existing gate accepts it** by executing
+``verify_prune_provenance.sh`` against it and asserting rc 0. Only then does it assert that
+this gate refuses it.
+
+That ordering is the whole point. A fixture that cannot produce the failure the guard exists
+to catch makes the guard's assertion **vacuous** — an ``assert not id.startswith(BAD)`` where
+no fixture can produce ``BAD``, a mention-weighted A/B that structurally cannot see the class
+it is deleting. If B were corrupt or foreign it would be caught by gates that already exist,
+and this one would be **inert while appearing to work**. B must be a good artifact that is
+merely the WRONG ONE, and the existing gate saying "yes, this is fine" is what proves it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+GATE = SCRIPTS_DIR / "graph_load_provenance.sh"
+# The PRE-EXISTING, parquet-derived gate. Ref B must pass THIS for the critical test to mean
+# anything at all.
+PARQUET_GATE = SCRIPTS_DIR / "verify_prune_provenance.sh"
+
+PARQUET = "narrators_canonical.parquet"
+
+# A = the run the graph was actually loaded from (today's re-run from `parse`).
+REF_A = "staged/narrator-resolve/2026-07-11-4f2a1c9"
+COUNT_A = 129234
+# B = a REAL, EARLIER, SMALLER resolve run. Published correctly, complete, self-consistent.
+# It is not corrupt and it is not foreign. It is simply not the one the graph holds.
+REF_B = "staged/narrator-resolve/2026-06-28-9b1e7d3"
+COUNT_B = 120417
+
+IMAGE = "ghcr.io/noorinalabs/noorinalabs-data-acquisition-load:prod-latest"
+
+
+def _md5(data: bytes) -> str:
+    return hashlib.md5(data).hexdigest()  # noqa: S324 — matches the manifest's own digest
+
+
+def _run(mode: str, **env: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603
+        ["bash", str(GATE), mode],  # noqa: S607
+        env={**os.environ, **env},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _stamp(ref: str = REF_A, status: str = "complete", image: str = IMAGE, args: str = "load"):
+    return _run("stamp", PARQUET_REF=ref, LOAD_STATUS=status, IMAGE=image, LOAD_ARGS=args)
+
+
+def _graph_says(
+    ref: str = REF_A,
+    status: str = "complete",
+    *,
+    stamped_at: str = "2026-07-11T04:12:03Z",
+    quoted: bool = True,
+) -> str:
+    """Render what `cypher-shell --format plain` returns for the read-back query.
+
+    `quoted=True` is the real transport: cypher-shell renders a string column in double
+    quotes. The gate must be agnostic to that envelope, so both forms are exercised.
+    """
+    line = (
+        f"GRAPH_LOAD_PROVENANCE parquet_ref={ref} load_status={status} "
+        f"stamped_at={stamped_at} image={IMAGE}"
+    )
+    row = f'"{line}"' if quoted else line
+    return f"provenance\n{row}\n"
+
+
+def _verify(prune_ref: str, provenance: str, **env: str) -> subprocess.CompletedProcess[str]:
+    return _run("verify", PRUNE_PARQUET_REF=prune_ref, PROVENANCE_OUTPUT=provenance, **env)
+
+
+# ===========================================================================
+# THE CRITICAL TEST — the one the whole gate exists for.
+# ===========================================================================
+def _publish_run(tmp_path: Path, ref: str, count: int) -> Path:
+    """Publish a resolve run to a fake B2 prefix: a COMPLETE, HONEST, self-consistent artifact.
+
+    Nothing here is subtly wrong. The parquet is whole, the resolve record's tally is the
+    tally, the run completed, the md5 is the md5 of the bytes. This is what a good publish
+    looks like — and `verify_prune_provenance.sh` will say so.
+    """
+    d = tmp_path / ref.replace("/", "_") / "curated"
+    d.mkdir(parents=True)
+    payload = f"PAR1-{ref}-{count}".encode() + b"\x00" * 64
+    (d / PARQUET).write_bytes(payload)
+    (d / "_resolve_run.txt").write_text(
+        f"RESOLVE_RUN canonical_ids={count} run_status=complete git_sha=abc1234\n"
+    )
+    (d / "_manifest.txt").write_text(
+        f"CANONICAL_MANIFEST file={PARQUET} md5={_md5(payload)} bytes={len(payload)}\n"
+    )
+    return d
+
+
+def test_a_valid_but_wrong_ref_passes_every_parquet_gate_and_is_still_refused(
+    tmp_path: Path,
+) -> None:
+    """Load ref A. Prune against a VALID, record-bearing, internally-consistent ref B. REFUSE.
+
+    B is a real earlier resolve run — smaller, complete, correctly published. **Step 1 proves
+    it**: the pre-existing parquet-derived gate is executed against B and *accepts* it, rc 0,
+    emitting B's own tally. Every other gate in the prune workflow behaves the same way on B
+    (its ids are a subset of the graph, so ``missing`` is 0 and the completeness equality
+    holds), which is exactly why no parquet-derived gate can save us here.
+
+    If this test used a corrupt or foreign B, step 1 would fail and the refusal in step 2
+    would prove **nothing** — it would be caught by the gates that already exist, and this
+    gate would be inert while appearing to work.
+    """
+    # --- Step 1: B is a GOOD artifact. Not asserted — DEMONSTRATED, by the existing gate. ---
+    curated_b = _publish_run(tmp_path, REF_B, COUNT_B)
+    parquet_gate = subprocess.run(  # noqa: S603
+        ["bash", str(PARQUET_GATE)],  # noqa: S607
+        env={**os.environ, "CURATED_DIR": str(curated_b)},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert parquet_gate.returncode == 0, (
+        "the fixture for ref B is not a valid artifact, so this test proves NOTHING about the "
+        "load-provenance gate — a B that the pre-existing gates already reject would be caught "
+        "without this gate, and the guard under test would be vacuous.\n"
+        f"verify_prune_provenance.sh said:\n{parquet_gate.stderr}"
+    )
+    assert f"PRUNE_PROVENANCE canonical_ids={COUNT_B}" in parquet_gate.stdout, (
+        "the existing gate did not read B's tally — B must be a run that fully checks out"
+    )
+
+    # --- Step 2: and the graph-derived gate refuses it anyway. ---
+    r = _verify(REF_B, _graph_says(ref=REF_A))
+    assert r.returncode != 0, (
+        "the prune was allowed against a ref the graph was NOT loaded from. Every parquet-"
+        "derived gate green (step 1 just proved it), and the prune would delete every narrator "
+        "loaded since ref B."
+    )
+    # The diagnostic must name BOTH refs — an operator staring at an irreversible refusal needs
+    # to see what the graph holds and what they typed, side by side.
+    assert REF_A in r.stderr, "the diagnostic does not name the ref the graph was LOADED from"
+    assert REF_B in r.stderr, "the diagnostic does not name the ref the operator TYPED"
+    assert "WRONG REF" in r.stderr
+    assert "NO node was deleted." in r.stderr
+
+
+def test_the_stamped_ref_proceeds(tmp_path: Path) -> None:
+    """The positive control — and without it every refusal above is unfalsifiable.
+
+    A gate that refuses everything is not a gate, it is an outage. If this ever goes red while
+    the refusals stay green, the gate has become an unconditional 'no' and the refusals prove
+    nothing.
+    """
+    curated_a = _publish_run(tmp_path, REF_A, COUNT_A)
+    parquet_gate = subprocess.run(  # noqa: S603
+        ["bash", str(PARQUET_GATE)],  # noqa: S607
+        env={**os.environ, "CURATED_DIR": str(curated_a)},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert parquet_gate.returncode == 0, "ref A must also be a valid artifact"
+
+    r = _verify(REF_A, _graph_says(ref=REF_A))
+    assert r.returncode == 0, f"the gate refused the ref the graph WAS loaded from:\n{r.stderr}"
+    assert f"LOAD_PROVENANCE_OK parquet_ref={REF_A}" in r.stdout
+
+
+# ===========================================================================
+# Absence and incompleteness are refusals, never silent passes.
+# ===========================================================================
+def test_unstamped_graph_refuses() -> None:
+    """Every graph loaded before deploy#580 looks exactly like this: zero rows, header only.
+
+    An absent stamp must be a STOP. A gate whose instrument reads nothing has not measured
+    'fine' — it has not measured (feedback_silent_zero_is_not_a_measurement).
+    """
+    r = _verify(REF_A, "provenance\n")
+    assert r.returncode != 0, "an unstamped graph must not be prunable"
+    assert "NO load-provenance stamp" in r.stderr
+
+
+def test_empty_readback_refuses() -> None:
+    """Not even a header — the pathological case. Still a refusal, never a crash-into-pass."""
+    r = _verify(REF_A, "")
+    assert r.returncode != 0
+    assert "NO load-provenance stamp" in r.stderr
+
+
+def test_incomplete_load_refuses_even_against_its_own_ref() -> None:
+    """A load that died mid-write leaves `in_progress`. Refuse it against ANY ref — its own too.
+
+    This is the fail-closed direction and it is deliberate: a half-loaded graph holds narrators
+    that no keep-set names, so a prune deletes exactly those, whatever ref it is pointed at.
+    """
+    r = _verify(REF_A, _graph_says(ref=REF_A, status="in_progress"))
+    assert r.returncode != 0, "a graph whose last load did not complete must not be prunable"
+    assert "did NOT complete" in r.stderr
+
+
+def test_unset_properties_refuse() -> None:
+    """A node missing its properties projects `<unset>`, which must refuse — not read as fine."""
+    unset = (
+        "GRAPH_LOAD_PROVENANCE parquet_ref=<unset> load_status=<unset> "
+        "stamped_at=<unset> image=<unset>"
+    )
+    r = _verify(REF_A, f'provenance\n"{unset}"\n')
+    assert r.returncode != 0
+
+
+@pytest.mark.parametrize("quoted", [True, False])
+def test_verify_is_agnostic_to_the_transport_quoting(quoted: bool) -> None:
+    """`cypher-shell --format plain` quotes string columns. Parse the ROW, not the envelope.
+
+    Asserted in BOTH renderings so the gate cannot come to depend on a quoting detail of the
+    transport — and, more importantly, so a reorder of the projected fields can never start
+    contaminating a value with a stray quote.
+    """
+    ok = _verify(REF_A, _graph_says(ref=REF_A, quoted=quoted))
+    assert ok.returncode == 0, f"quoted={quoted} rendering was not parsed:\n{ok.stderr}"
+    bad = _verify(REF_B, _graph_says(ref=REF_A, quoted=quoted))
+    assert bad.returncode != 0, f"quoted={quoted}: a wrong ref slipped through"
+
+
+@pytest.mark.parametrize(
+    "bypass",
+    [
+        {"SKIP_PROVENANCE": "true"},
+        {"ALLOW_UNSTAMPED_GRAPH": "true"},
+        {"FORCE": "true"},
+        {"DRY_RUN": "true"},
+        {"GRAPH_PARQUET_REF": REF_B},
+        {"LOAD_STATUS": "complete"},
+        {"PARQUET_REF": REF_B},
+    ],
+)
+def test_no_environment_variable_can_unlock_an_unstamped_graph(bypass: dict[str, str]) -> None:
+    """The `env:` surface is a bypass channel an input allow-list cannot see (deploy#579).
+
+    `GRAPH_PARQUET_REF` and `LOAD_STATUS` are in this list on purpose: they are the names an
+    implementer would most plausibly reach for to "inject" the graph's side of the comparison.
+    The graph's answer must come from the GRAPH — via PROVENANCE_OUTPUT — and from nowhere else.
+    """
+    r = _verify(REF_A, "provenance\n", **bypass)
+    assert r.returncode != 0, (
+        f"env {bypass} unlocked a prune against an unstamped graph — the gate must have no "
+        "environment-variable escape hatch"
+    )
+
+
+# ===========================================================================
+# The stamp side — and the injection surface it closes.
+# ===========================================================================
+def test_stamp_records_the_ref_and_the_status() -> None:
+    r = _stamp(ref=REF_A, status="complete")
+    assert r.returncode == 0, r.stderr
+    assert "MERGE (p:LoadProvenance {scope: 'graph'})" in r.stdout
+    assert f"p.parquet_ref = '{REF_A}'" in r.stdout
+    assert "p.load_status = 'complete'" in r.stdout
+
+
+@pytest.mark.parametrize("status", ["in_progress", "complete"])
+def test_stamp_accepts_both_phases(status: str) -> None:
+    assert _stamp(status=status).returncode == 0
+
+
+@pytest.mark.parametrize("status", ["done", "COMPLETE", "true", "", "complete;DROP"])
+def test_stamp_refuses_an_unknown_status(status: str) -> None:
+    """`complete` is the token the prune unlocks on. A typo must refuse here, not be read as
+    'not complete' downstream for the wrong reason."""
+    assert _stamp(status=status).returncode != 0
+
+
+@pytest.mark.parametrize(
+    "ref",
+    [
+        "staged/x' SET p.load_status = 'complete",  # the injection
+        "staged/x'; MATCH (n) DETACH DELETE n; //",  # the one that matters
+        'staged/x" OR 1=1',
+        "staged/x\\",
+        "/staged/x",  # absolute
+        "staged/x/",  # trailing slash — two spellings of one prefix breaks a string equality
+        "noorinalabs-pipeline/staged/x",  # bucket name included
+        "staged/../../etc/passwd",
+        "",
+    ],
+)
+def test_stamp_refuses_an_unsafe_parquet_ref(ref: str) -> None:
+    """`parquet_ref` is free-text `workflow_dispatch` input interpolated into a single-quoted
+    Cypher literal, in a statement with write access to the graph.
+
+    "Only maintainers can dispatch" is exactly the reasoning that ships an injection bug. The
+    charset is whitelisted, not escaped: a `'` cannot reach the statement at all.
+    """
+    r = _stamp(ref=ref)
+    assert r.returncode != 0, f"unsafe parquet_ref {ref!r} was accepted into a Cypher literal"
+
+
+@pytest.mark.parametrize(
+    "image",
+    ["ghcr.io/x/y:tag' SET p.load_status='complete", "img\\", "img with space", ""],
+)
+def test_stamp_refuses_an_unsafe_image(image: str) -> None:
+    """`image` is a free-text input too, and it is stamped. The same injection surface."""
+    assert _stamp(image=image).returncode != 0
+
+
+def test_stamp_accepts_a_digest_pinned_image() -> None:
+    r = _stamp(image="ghcr.io/noorinalabs/x@sha256:" + "a" * 64)
+    assert r.returncode == 0, r.stderr
+
+
+def test_stamp_accepts_the_nodes_only_load_args() -> None:
+    """'load --nodes-only' has a SPACE. Legal in the stored property, and it must not be
+    projected into the space-delimited provenance line (see the round-trip test below)."""
+    r = _stamp(args="load --nodes-only")
+    assert r.returncode == 0, r.stderr
+    assert "p.load_args = 'load --nodes-only'" in r.stdout
+
+
+# ===========================================================================
+# DRIFT GUARD — the writer, the projector and the parser must agree.
+# ===========================================================================
+# A stamped property is either a QUOTED LITERAL we control (`p.x = 'v'`) or a Cypher
+# EXPRESSION the database computes (`p.stamped_at = toString(datetime())`). Both are stamped;
+# only the first has a value a test can know. Matching just the literal form is what an
+# earlier version of this file did — and the round-trip guard below immediately failed,
+# reporting that the stamp "never SETs p.stamped_at". It does. The guard was right and the
+# fixture's model of the producer was wrong, which is the correct way round for that to go.
+_SET_LITERAL = re.compile(r"p\.(\w+) = '([^']*)'")
+_SET_EXPR = re.compile(r"p\.(\w+) = ([A-Za-z][\w.]*\()")
+
+# What the DB computes for an expression-valued property. Space-free, because the provenance
+# line is space-delimited — and the round-trip below asserts exactly that of every field.
+DB_COMPUTED = {"stamped_at": "2026-07-11T04:12:03.000000000Z"}
+
+
+def _stamp_properties(status: str = "complete", ref: str = REF_A) -> dict[str, str]:
+    """The properties the STAMP actually SETs, read out of the stamp's own Cypher.
+
+    Expression-valued properties resolve to the value the DATABASE would compute, since the
+    test cannot know it — but they must still be present, or a rename of one goes unnoticed.
+    """
+    out = _stamp(ref=ref, status=status).stdout
+    props = dict(_SET_LITERAL.findall(out))
+    for prop, _expr in _SET_EXPR.findall(out):
+        assert prop in DB_COMPUTED, (
+            f"the stamp SETs p.{prop} to a Cypher expression this fixture cannot evaluate. "
+            "Teach it what the database computes (DB_COMPUTED) rather than dropping the field "
+            "— a field the fixture silently omits is a field the drift guard stops guarding."
+        )
+        props[prop] = DB_COMPUTED[prop]
+    return props
+
+
+def _projection() -> list[tuple[str, str]]:
+    """The (line-key, node-property) pairs the READ-QUERY actually projects, read out of it."""
+    q = _run("read-query").stdout
+    return re.findall(r"\+ ' (\w+)=' \+ coalesce\(p\.(\w+),", q)
+
+
+def test_stamp_write_read_query_and_verify_agree_on_every_field() -> None:
+    """Round-trip the three modes through each other — no hand-written provenance line.
+
+    This is the deploy#589 guard. A producer-side rename does not break a downstream parser,
+    it QUIETLY NARROWS it: the guard stops guarding and every test stays green. So the fixture
+    here is not written in the test's words. It is BUILT from the stamp's own SET clause and
+    the read-query's own projection, and then fed to verify.
+
+    It goes red if the stamp renames a property the read-query projects (the projection would
+    find no value), if the read-query projects a key verify cannot parse, or if verify starts
+    reading a field nobody writes.
+    """
+    props = _stamp_properties()
+    projection = _projection()
+    assert projection, "the read-query projects nothing — the parser has nothing to read"
+
+    rendered = []
+    for key, prop in projection:
+        assert prop in props, (
+            f"read-query projects p.{prop} as '{key}=', but the stamp never SETs p.{prop}. "
+            f"The stamp writes {sorted(props)}. A rename on one side silently narrows the "
+            "other — that is the whole failure mode this test exists for."
+        )
+        value = props[prop]
+        assert " " not in value, (
+            f"p.{prop}={value!r} contains a SPACE and is projected into the space-delimited "
+            "provenance line — it would split into two tokens and corrupt the parse of every "
+            "field after it. Store it, do not project it (this is why load_args is not here)."
+        )
+        rendered.append(f"{key}={value}")
+
+    line = "GRAPH_LOAD_PROVENANCE " + " ".join(rendered)
+    r = _verify(props["parquet_ref"], f'provenance\n"{line}"\n')
+    assert r.returncode == 0, (
+        f"verify could not read the line its own read-query projects from its own stamp:\n"
+        f"{line}\n{r.stderr}"
+    )
+    assert f"LOAD_PROVENANCE_OK parquet_ref={props['parquet_ref']}" in r.stdout
+
+
+def test_load_args_is_stored_but_never_projected() -> None:
+    """It is the one stamped field that can contain a space, and the line is space-delimited."""
+    assert "load_args" in _stamp_properties(), "load_args must be stored for forensics"
+    assert "load_args" not in dict(_projection()), (
+        "load_args ('load --nodes-only') is projected into the space-delimited provenance "
+        "line — its space splits the token and corrupts every field after it"
+    )
+
+
+def test_verify_reads_the_status_the_stamp_writes() -> None:
+    """Positive control on the status token: `in_progress` from the stamp must REFUSE at verify.
+
+    Without this, `test_incomplete_load_refuses_even_against_its_own_ref` could pass for the
+    wrong reason — an unparseable status refused as '<unreadable>' rather than as 'not
+    complete'. The refusal must be caused by the value the producer actually writes.
+    """
+    props = _stamp_properties(status="in_progress")
+    assert props["load_status"] == "in_progress", "the stamp does not write the status verbatim"
+    line = (
+        f"GRAPH_LOAD_PROVENANCE parquet_ref={props['parquet_ref']} "
+        f"load_status={props['load_status']} stamped_at=2026-07-11T04:12:03Z image={IMAGE}"
+    )
+    r = _verify(props["parquet_ref"], f'provenance\n"{line}"\n')
+    assert r.returncode != 0
+    assert "did NOT complete" in r.stderr, (
+        "the refusal did not come from the status VALUE — it may be refusing because the "
+        "status was unreadable, which would make the incompleteness check vacuous"
+    )

--- a/scripts/tests/test_prune_workflow_seam.py
+++ b/scripts/tests/test_prune_workflow_seam.py
@@ -47,6 +47,12 @@ GRAPH_TOTAL = 160614
 # da#426's measured short-parquet case: f=0.20 of the canonical rows retained.
 SHORT_COUNT = 25847
 
+# The ref the operator dispatches the prune against (the `parquet_ref` input).
+PRUNE_REF = "staged/narrator-resolve/test"
+# A DIFFERENT, GENUINE, EARLIER resolve run (deploy#580). Not corrupt. Not foreign. Correctly
+# published, complete, internally consistent — and simply not the one the graph holds.
+OTHER_REF = "staged/narrator-resolve/2026-06-28-9b1e7d3"
+
 
 def _ssh_script() -> str:
     doc = yaml.safe_load(WORKFLOW.read_text())
@@ -70,20 +76,24 @@ def _sandbox(
     run_status: str = "complete",
     publish_provenance: bool = True,
     manifest_md5_correct: bool = True,
+    stamped_ref: str | None = PRUNE_REF,
+    stamped_status: str = "complete",
 ) -> tuple[Path, Path]:
     """A fake VPS. Returns (repo_root, b2_dir).
 
     `canonical_in_parquet` is what the loader's dry-run REPORTS reading out of the parquet;
     `declared` is what resolve's record says it wrote. Making these differ is exactly the
     da#426 short-parquet case, and the completeness binding must catch it.
+
+    `stamped_ref` is what the GRAPH says it was loaded from (deploy#580) — `None` for a graph
+    that carries no load-provenance stamp at all, which is every graph loaded before #580.
     """
     root = tmp_path / "repo"
     (root / "scripts").mkdir(parents=True)
     (root / "compose").mkdir()
-    # The real gate — not a stub. The seam under test is workflow -> THIS.
-    (root / "scripts" / "verify_prune_provenance.sh").write_bytes(
-        (SCRIPTS_DIR / "verify_prune_provenance.sh").read_bytes()
-    )
+    # The real gates — not stubs. The seam under test is workflow -> THESE.
+    for gate in ("verify_prune_provenance.sh", "graph_load_provenance.sh"):
+        (root / "scripts" / gate).write_bytes((SCRIPTS_DIR / gate).read_bytes())
     (root / "compose" / "docker-compose.prod.yml").write_text("services: {}\n")
     (root / ".env").write_text("NEO4J_PASSWORD=x\n")
 
@@ -117,6 +127,20 @@ esac
 exit 0
 ''',
     )
+    # The graph's answer to the load-provenance read-back (deploy#580), rendered the way
+    # `cypher-shell --format plain` really renders a string column: header, then a QUOTED row.
+    # `stamped_ref=None` means the graph carries no stamp — the query matches nothing and
+    # returns the header alone, which is exactly what a pre-#580 graph does.
+    if stamped_ref is None:
+        provenance_rows = "echo provenance"
+    else:
+        provenance_rows = (
+            "echo provenance; "
+            f"echo '\"GRAPH_LOAD_PROVENANCE parquet_ref={stamped_ref} "
+            f"load_status={stamped_status} stamped_at=2026-07-11T04:12:03Z "
+            f"image=img:test\"'"
+        )
+
     # The loader. `prune-narrators --dry-run` reports what the PARQUET actually holds.
     _stub(
         bins,
@@ -125,6 +149,9 @@ exit 0
 echo "$@" >> "{audit}"
 for a in "$@"; do
   case "$a" in
+    *GRAPH_LOAD_PROVENANCE*)
+      {provenance_rows}
+      exit 0 ;;
     *"count(n)"*)
       echo "narrators"
       if grep -q REAL_PRUNE_ISSUED "{audit}" 2>/dev/null; then
@@ -174,7 +201,7 @@ def _run_ssh_block(root: Path, tmp_path: Path, **env: str) -> subprocess.Complet
             "PATH": path,
             "HOME": str(tmp_path),
             "ENV_NAME": "stg",
-            "PARQUET_REF": "staged/narrator-resolve/test",
+            "PARQUET_REF": PRUNE_REF,
             "EXPECTED_CANONICAL_IDS": "",
             "DRY_RUN": "true",
             "IMAGE": "img:test",
@@ -317,3 +344,93 @@ def test_bad_md5_blocked_at_the_seam(tmp_path: Path) -> None:
     r = _run_ssh_block(root, tmp_path, DRY_RUN="false")
     assert r.returncode != 0
     assert "REAL_PRUNE_ISSUED" not in (audit.read_text() if audit.exists() else "")
+
+
+# ---------------------------------------------------------------------------
+# LOAD PROVENANCE (deploy#580) — the wrong-ref prune, blocked END TO END.
+# ---------------------------------------------------------------------------
+def test_valid_but_wrong_ref_is_refused_end_to_end(tmp_path: Path) -> None:
+    """THE #580 CASE, through the real ssh block: a genuine but older, smaller run.
+
+    The keep-set in B2 here is the DEFAULT sandbox artifact — the same one
+    ``test_honest_artifact_reaches_the_real_prune`` drives all the way to a real prune. It is
+    complete, its resolve record is valid, its md5 matches, its tally agrees with its parquet.
+    **Every parquet-derived gate in this workflow passes it**, and that is not an assumption:
+    the honest-artifact test proves it by pruning with it.
+
+    The only thing changed is which ref the GRAPH was loaded from. That single fact must stop
+    the prune — because nothing else can. In production the operator's ref would name a real
+    earlier run whose ids are a subset of the graph, so ``missing`` is 0, the completeness
+    equality holds, and the prune deletes every narrator loaded since.
+    """
+    root, audit = _sandbox(tmp_path, stamped_ref=OTHER_REF)
+    r = _run_ssh_block(root, tmp_path, DRY_RUN="false", PARQUET_REF=PRUNE_REF)
+    out = r.stdout + r.stderr
+
+    assert r.returncode != 0, (
+        "the workflow pruned against a ref the graph was NOT loaded from. Every other gate "
+        f"went green — they are all derived from the keep-set.\n{out}"
+    )
+    assert "REAL_PRUNE_ISSUED" not in (audit.read_text() if audit.exists() else ""), (
+        "a DELETE was issued against a graph loaded from a different resolve run"
+    )
+    # The diagnostic must name BOTH refs. An operator halted on an irreversible op needs to see
+    # what the graph holds and what they typed, side by side — backups have never run.
+    assert OTHER_REF in out, "the diagnostic does not name the ref the graph was LOADED from"
+    assert PRUNE_REF in out, "the diagnostic does not name the ref the operator TYPED"
+    assert "WRONG REF" in out
+
+
+def test_wrong_ref_is_refused_on_a_dry_run_too(tmp_path: Path) -> None:
+    """A dry run against the wrong ref prints a confident "would delete N".
+
+    That is the most reassuring possible prelude to an operator setting dry_run=false, so the
+    gate refuses in both modes rather than quietly reporting a meaningless plan.
+    """
+    root, audit = _sandbox(tmp_path, stamped_ref=OTHER_REF)
+    r = _run_ssh_block(root, tmp_path, DRY_RUN="true", PARQUET_REF=PRUNE_REF)
+    assert r.returncode != 0, "a dry run against the wrong ref must refuse, not report a plan"
+    assert "would DETACH DELETE" not in r.stdout, (
+        "the workflow printed a would-delete count for a ref the graph was never loaded from"
+    )
+    assert "REAL_PRUNE_ISSUED" not in (audit.read_text() if audit.exists() else "")
+
+
+def test_unstamped_graph_issues_no_prune(tmp_path: Path) -> None:
+    """Every graph loaded before #580 carries no stamp. The prune must be inert against it."""
+    root, audit = _sandbox(tmp_path, stamped_ref=None)
+    r = _run_ssh_block(root, tmp_path, DRY_RUN="false")
+    assert r.returncode != 0, "an unstamped graph must not be prunable"
+    assert "NO load-provenance stamp" in r.stdout + r.stderr
+    assert "REAL_PRUNE_ISSUED" not in (audit.read_text() if audit.exists() else "")
+
+
+def test_half_loaded_graph_issues_no_prune_even_against_its_own_ref(tmp_path: Path) -> None:
+    """A load that died mid-write leaves `in_progress`. Refuse — against its OWN ref, too.
+
+    Note the ref here is the RIGHT one. The graph still must not be pruned: a half-loaded graph
+    holds narrators that no keep-set names, so the prune deletes exactly those.
+    """
+    root, audit = _sandbox(tmp_path, stamped_ref=PRUNE_REF, stamped_status="in_progress")
+    r = _run_ssh_block(root, tmp_path, DRY_RUN="false", PARQUET_REF=PRUNE_REF)
+    assert r.returncode != 0
+    assert "did NOT complete" in r.stdout + r.stderr
+    assert "REAL_PRUNE_ISSUED" not in (audit.read_text() if audit.exists() else "")
+
+
+def test_the_caller_does_not_forge_the_stamp(tmp_path: Path) -> None:
+    """The forge, one layer up — the shape that shipped green TWICE in this workflow.
+
+    Hardening ``graph_load_provenance.sh`` does nothing if the CALLER writes the stamp it is
+    about to check. So: with no stamp on the graph, the workflow must never issue a MERGE that
+    creates one. The audit log records every docker invocation, so a caller that stamps the
+    graph on the prune path is visible here — and nowhere else.
+    """
+    root, audit = _sandbox(tmp_path, stamped_ref=None)
+    _run_ssh_block(root, tmp_path, DRY_RUN="false")
+    log = audit.read_text() if audit.exists() else ""
+    assert "MERGE (p:LoadProvenance" not in log, (
+        "the PRUNE workflow wrote a load-provenance stamp. Only a LOAD may stamp the graph; a "
+        "prune that manufactures the evidence it then checks is not gated at all."
+    )
+    assert "REAL_PRUNE_ISSUED" not in log


### PR DESCRIPTION
## The hole

`graph-prune-narrators.yml` prunes the graph to the canonical set of whatever `parquet_ref` the operator types. Every gate in it is sound **relative to that ref**: the resolve record declares the count, the count binds the parquet, the md5 binds the bytes, `missing` rejects a foreign keep-set.

**None of them can ask whether it was the RIGHT ref.**

The residual case is a **genuine but older, smaller** run — not corrupt, not foreign, a real earlier resolve run:

- its `_resolve_run.txt` is valid and its tally agrees with its parquet (they were published together);
- its md5 matches;
- `missing ≈ 0`, because that run's ids are a **subset** of what the graph now holds;
- the completeness equality passes, because the parquet really does hold exactly what its run declared;
- `expected_canonical_ids`, if supplied, **agrees** — because it is that run's real count.

Every automated check goes green, and the prune deletes every narrator loaded since.

`missing` is **structurally blind** here and no fix to it can help: it bounds `canonical − graph`, **none of which can be deleted**. The over-deletion lives entirely in `graph − canonical` — exactly the set the tool exists to delete. **No gate derived from the parquet can see this**, because the parquet is internally perfect. The parquet cannot vouch for itself, and per the #574 review the operator has no independently-sourced number either (the pipeline's only count is a read-back of the artifact, `src/resolve/__init__.py:344`).

## The fix — the graph vouches for the ref

A gate derived from the **graph** can see it, and is the only thing that can:

1. **`deploy-data-load.yml` stamps** the `parquet_ref` it loaded onto the graph — `(:LoadProvenance {scope:'graph'})`.
2. **`graph-prune-narrators.yml` reads it back** and **refuses** unless the ref it is pruning against is the ref the graph was actually loaded from, printing a diagnostic that names **both** refs.

This is the only check independent of **both** the parquet and the operator — which is precisely what makes it worth having. It also turns the hazard the `parquet_ref` help text has been *naming and leaving unenforced* ("this MUST be the SAME parquet_ref that was loaded") from a doc comment into a gate.

**The stamp is two-phase, and the order is the safety property:** `in_progress` before the loader touches the graph, `complete` only after it commits (rc classified SUCCESS or FINDINGS). A load that dies mid-write therefore leaves the graph stamped `in_progress`, and the prune refuses it **against any ref, including its own**. That is fail-closed and deliberate: a half-loaded graph holds narrators no keep-set names, so a prune deletes exactly those. `rc=6 REFUSED_ROWS` is precisely that shape. Re-run the load to clear it.

The gate **also refuses on a dry run**. A dry run against the wrong ref prints a confident "would delete N" — the most reassuring possible prelude to an operator setting `dry_run=false`.

## Why a script, not ten lines of the ssh block

`scripts/graph_load_provenance.sh` owns the **stamp**, the **read-query** and the **parser** in one file, so a producer-side rename cannot quietly narrow the consumer (deploy#589) — a round-trip test builds the fixture *from the stamp's own SET clause and the read-query's own projection* rather than restating either in the test's words.

It is a script rather than ssh-block shell because a guard pinned by grepping workflow text **is not a guard**, and this repo has shipped that mistake twice (a forged manifest inside the gate; the identical forge relocated to the caller — both green). Under `scripts/` it is executed by tests and shellcheck-linted in CI, which an ssh `with: script:` body is not (deploy#555).

It **whitelists the charset** of `parquet_ref` and `image`: both are free-text `workflow_dispatch` inputs interpolated into a single-quoted Cypher literal in a statement with **write access to the graph**. "Only maintainers can dispatch" is the reasoning that ships an injection bug.

## The test IS the deliverable

`test_a_valid_but_wrong_ref_passes_every_parquet_gate_and_is_still_refused` builds ref **B** as a genuinely good artifact — complete record, correct md5, internally consistent — and **first proves the pre-existing gate accepts it** by executing `verify_prune_provenance.sh` against it and asserting rc 0. Only then does it assert this gate refuses it.

That ordering is the whole point. **A B that the existing gates already reject would make this guard vacuous while appearing to work** — it would be caught by gates that already exist, and the new one would be inert. B must be a good artifact that is merely the WRONG ONE.

The refusal, actually happening:

```
ERROR: [load-provenance] WRONG REF — this graph was not loaded from the ref you are pruning against.
    graph was LOADED from        : staged/narrator-resolve/2026-07-11-4f2a1c9   (stamped 2026-07-11T04:12:03Z)
    you asked to PRUNE against   : staged/narrator-resolve/2026-06-28-9b1e7d3

  Every other gate in this workflow is derived from the keep-set and would go GREEN
  on a genuine but older, smaller run: its resolve record is valid, its md5 matches,
  its ids are a SUBSET of what this graph holds so 'missing' is 0, and the
  completeness equality passes because the parquet really does hold what its run
  declared. The prune would then delete every narrator loaded since that run.

  Either you meant the ref above, or the graph needs re-loading from the ref you
  typed. We do not get to guess which.
  NO node was deleted.
```

**Both workflow seams execute the real ssh bodies** against stubs and assert on *behaviour*, not text: no `DELETE` issued, stamp order (`in_progress` before the loader ran), `complete` never reached on rc=1/rc=6, and the prune workflow never forges a stamp of its own.

## Instrument verification

A passing suite is not proof a gate can refuse. Every mutant below was confirmed **effective** (bytes differ from the pristine file — my first attempt used `git diff` on an untracked file and reported every mutant "inert" while they were in fact landing, so the effectiveness check itself was rebuilt) and then **killed** by its target test. Baseline green before, byte-identical restore after.

| Mutant | Killed by |
|---|---|
| ref-equality deleted (the #580 guard itself) | `test_a_valid_but_wrong_ref_..._is_still_refused` |
| `load_status` completeness deleted | `test_incomplete_load_refuses_even_against_its_own_ref` |
| unstamped-graph refusal deleted | `test_unstamped_graph_refuses` |
| ref charset whitelist deleted (injection reopened) | `test_stamp_refuses_an_unsafe_parquet_ref` |
| `verify` made unconditionally permissive | `test_a_valid_but_wrong_ref_..._is_still_refused` |
| LOAD: `complete` stamp deleted | `test_a_committed_load_stamps_the_ref_it_loaded` |
| LOAD: pre-write `in_progress` stamp deleted | `test_the_stamp_precedes_the_write_...` |
| PRUNE: gate call deleted | `test_valid_but_wrong_ref_is_refused_end_to_end` |
| PRUNE: gate softened to advisory (rc swallowed) | `test_valid_but_wrong_ref_is_refused_end_to_end` |

## Operational note

Every graph loaded before this PR carries **no stamp**, so the prune is **inert** against it until `deploy-data-load.yml` runs once and stamps it. That is the correct direction: an unstamped graph cannot say what it holds. The re-run from `parse` (main#928) will load and stamp in one go, and the prune becomes usable against exactly that ref and no other.

`local⇄CI parity`: `pre-commit run --all-files` green (terraform, gitleaks, actionlint, cspell, ruff-format, ruff-lint); pre-push green (mypy, all 3 pytest suites — **338 passed**); CI's shellcheck job run locally over the new script — clean. The `promtool` pre-push hooks fail locally only because the Docker daemon is down in this WSL distro; they are scoped to `^infra/prometheus/`, which this PR does not touch, so they do not fire on this push and run normally in CI.

TechDebt: none.

Closes #580
