### PR TITLE
prune gate: match file= with [[:graph:]], not the locale-collated [!-~] range (#599)

### DIFF
--- a/scripts/tests/test_prune_provenance.py
+++ b/scripts/tests/test_prune_provenance.py
@@ -286,3 +286,78 @@ def test_no_environment_variable_can_unlock_a_provenance_less_artifact(
         f"env {bypass} unlocked a keep-set with no provenance — the gate must have no "
         "environment-variable escape hatch"
     )
+
+
+# ---------------------------------------------------------------------------
+# Locale robustness — the file= matcher must not depend on collation order.
+# ---------------------------------------------------------------------------
+# The manifest line for OUR parquet is found by extracting the `file=` token and
+# comparing it to the parquet name. That extraction was written with the bracket
+# RANGE `[!-~]`. GNU sed evaluates a range by the locale's COLLATION order, not by
+# codepoint order: under a glibc language locale such as en_US.UTF-8 — the locale
+# on every deploy VPS — the collated span `!`..`~` excludes ordinary filename bytes
+# (`.`, `_`), the match returns empty, `manifest_line` finds nothing, and the gate
+# false-refuses a valid keep-set with "has no md5". No node is deleted (it fails
+# closed), but the prune silently never runs (deploy#599). C / C.UTF-8 use codepoint
+# order and do NOT reproduce it — which is exactly why CI and local runs stayed green
+# while the VPS refused. The fix uses the POSIX class `[[:graph:]]`, which is
+# locale-independent.
+_QUIRK_LOCALE_CANDIDATES = (
+    "en_US.UTF-8",
+    "en_US.utf8",
+    "en_GB.UTF-8",
+    "de_DE.UTF-8",
+    "fr_FR.UTF-8",
+    "es_ES.UTF-8",
+)
+
+
+def _locale_reproducing_the_range_quirk() -> str | None:
+    """First installed locale under which sed's ``[!-~]`` FAILS to match a filename.
+
+    This is an INSTRUMENT CHECK, not a formality. A green assertion under a locale that
+    does not reproduce the quirk (C / C.UTF-8) would prove nothing about the fix, so the
+    test below refuses to run under one. An *uninstalled* locale makes glibc fall back to
+    C — where ``[!-~]`` matches — so the probe rejects it too. The locale we accept is one
+    demonstrated, right here, to break the old range on ordinary filename bytes.
+    """
+    probe = "a.b_c\n"  # letters plus '.' and '_' — the bytes the collated range drops
+    for loc in _QUIRK_LOCALE_CANDIDATES:
+        env = {**os.environ, "LC_ALL": loc, "LC_COLLATE": loc, "LANG": loc}
+        try:
+            r = subprocess.run(  # noqa: S603
+                ["sed", "-n", r"s/^\([!-~][!-~]*\)$/HIT/p"],  # noqa: S607
+                input=probe,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except OSError:
+            continue
+        if r.returncode == 0 and "HIT" not in r.stdout:
+            return loc
+    return None
+
+
+def test_honest_artifact_is_accepted_under_a_collation_quirk_locale(tmp_path: Path) -> None:
+    """The gate must accept a valid keep-set regardless of the VPS's locale (deploy#599).
+
+    Runs the real gate under a locale proven above to break the old ``[!-~]`` range.
+    Before the ``[[:graph:]]`` fix this returns rc=1 "has no md5"; after it, rc=0.
+    """
+    loc = _locale_reproducing_the_range_quirk()
+    if loc is None:
+        pytest.skip(
+            "no installed locale reproduces the [!-~] collation quirk "
+            "(C / C.UTF-8 use codepoint order); cannot exercise deploy#599 here"
+        )
+    # pytest.skip() is NoReturn, but CI runs mypy with --ignore-missing-imports, under
+    # which pytest is untyped and mypy cannot see that — so narrow loc to str explicitly.
+    assert loc is not None
+    r = _run(_curated(tmp_path), LC_ALL=loc, LC_COLLATE=loc, LANG=loc, LC_CTYPE=loc)
+    assert r.returncode == 0, (
+        f"the gate rejected an honest artifact under {loc}: the file= matcher is "
+        f"locale-collation-sensitive (deploy#599).\n{r.stderr}"
+    )
+    assert f"PRUNE_PROVENANCE canonical_ids={GOOD_COUNT}" in r.stdout

--- a/scripts/verify_prune_provenance.sh
+++ b/scripts/verify_prune_provenance.sh
@@ -94,9 +94,19 @@ token_value() {
 
 # The CANONICAL_MANIFEST line for OUR parquet. A manifest may describe several
 # objects; match the `file=` token exactly, never a substring.
+#
+# The `file` value is a PRODUCER-CHOSEN identifier (a filename), so its charclass is
+# [[:graph:]] — the POSIX "printable non-space" class — NOT a range. A range like
+# `[!-~]` is a byte-order assumption that GNU sed evaluates by LOCALE COLLATION: under
+# a language locale such as en_US.UTF-8 (every deploy VPS) the collated range excludes
+# ordinary filename bytes (`.`, `_`), the whole match returns empty, and the gate
+# false-refuses a valid keep-set with "has no md5" — with no deletion, but also no
+# prune (deploy#599). [[:graph:]] is locale-safe and is the WIDEST printable class, so
+# it does not "quietly narrow" the way an enumerated subset would (deploy#589); a
+# filename byte that somehow fell outside it would fail CLOSED, never silently through.
 manifest_line() {
     grep '^CANONICAL_MANIFEST ' "${MANIFEST}" 2>/dev/null | while IFS= read -r _l; do
-        if [ "$(token_value "${_l}" file '[!-~]')" = "${PARQUET_NAME}" ]; then
+        if [ "$(token_value "${_l}" file '[[:graph:]]')" = "${PARQUET_NAME}" ]; then
             printf '%s\n' "${_l}"
             return 0
         fi


### PR DESCRIPTION
## What

The `graph-prune-narrators` provenance gate (`scripts/verify_prune_provenance.sh`)
false-refuses a **valid** keep-set on any deploy VPS running a glibc language UTF-8
locale (`en_US.UTF-8`). It reports `curated/_manifest.txt has no md5 for
narrators_canonical.parquet` and issues no deletion — blocking the stg prune today and
the prod prune identically.

Closes #599.

## Root cause

The `file=` token matcher extracts the value with the bracket **range** `[!-~]`. GNU sed
evaluates a range by the locale's **collation** order, not codepoint order. Under
`en_US.UTF-8` the collated span `!`..`~` excludes ordinary filename bytes (`.`, `_`), so
the match returns empty, `manifest_line` finds no line for the parquet, `MF_MD5` is empty,
and the gate dies at the byte-integrity step. `C` / `C.UTF-8` use codepoint order and do
**not** reproduce it — which is why the suite and every local/CI run stayed green while the
stg VPS refused (deploy run 29202264098).

Confirmed on the box: `[!-~]` → empty, `[[:graph:]]` → `narrators_canonical.parquet`.

## Fix

One token: the `file` field now uses the POSIX class `[[:graph:]]` (locale-independent,
"printable non-space"). It is the **widest** printable class, so it does not "quietly
narrow" the way an enumerated subset would (deploy#589), and a filename byte outside it
would fail **closed**. The other charclasses (`[0-9]`, `[0-9a-f]`, `[a-z_]`) are
collation-safe and unchanged.

## Test

`test_prune_provenance.py` gains a behavioural case that runs the real gate under a locale
it first **proves** breaks the old range (an instrument check — it skips only if no such
locale is installed; `C`/`C.UTF-8` cannot trigger it), then asserts acceptance of an honest
artifact. Verified **RED** on `[!-~]` (`has no md5`) and **GREEN** on `[[:graph:]]` using a
`localedef`-built `en_US.UTF-8`.

## Checks

Local (mirrors CI): ruff format+lint, gitleaks, mypy, shellcheck, and the full prune test
suite (45 passed) all green. Pre-push mypy + pytest + pytest-scripts + integration-scripts
passed.

## Safety note

The bug is a false-refusal, not data loss: the gate failed **closed** and deleted nothing.
This fix restores the ability to prune a legitimately-provenanced keep-set; it does not
weaken any of the gate's refusals (all inertness / forged-manifest / incomplete-run /
byte-integrity / env-bypass tests still pass).
