### PR TITLE
load-provenance gate: token_value matches [[:graph:]], not the locale-collated [!-~] (#601)

### DIFF
--- a/scripts/graph_load_provenance.sh
+++ b/scripts/graph_load_provenance.sh
@@ -163,12 +163,20 @@ validate_parquet_ref() {
 # Whole-TOKEN extraction: split the line on spaces and match an exact `key=value`
 # token, so no key can be hijacked by a longer key ending in its name (da#419).
 #
-# The value charclass is `[!-~]` — every printable non-space character. That is
+# The value charclass is `[[:graph:]]` — the POSIX "printable non-space" class. That is
 # deliberately NOT an enumeration of what a parquet_ref may contain: enumerating a
 # charset for a value someone else writes is how a parser silently NARROWS when the
-# producer changes (deploy#589). Here the token is whatever sits between two spaces;
-# an unexpected character is still captured, still compared, and still refused on
-# mismatch. Fail-closed, not fail-blind.
+# producer changes (deploy#589). `[[:graph:]]` is the WIDEST printable class, so the token
+# is effectively whatever sits between two spaces; an unexpected character is still
+# captured, still compared, and still refused on mismatch. Fail-closed, not fail-blind.
+#
+# It must be the POSIX CLASS, not the byte RANGE `[!-~]`. GNU sed evaluates a range by the
+# locale's COLLATION order, and under a glibc language locale such as en_US.UTF-8 — the
+# locale on every deploy VPS — the collated span `!`..`~` excludes ordinary ref bytes
+# (`/`, `-`, `.`), so `parquet_ref=staged/narrator-resolve/<date>-<sha>` extracted to EMPTY
+# and `verify` false-refused a correctly-stamped graph with "NO stamp" (deploy#601). C /
+# C.UTF-8 use codepoint order and hid it — same locale trap as the sibling `verify_prune_
+# provenance.sh` matcher (deploy#599).
 #
 # NO PIPE INTO AN EARLY-EXITING CONSUMER. `... | head -n1` would make the producer
 # take SIGPIPE, and `pipefail` promotes that 141 to the pipeline's rc EVEN WHEN THE
@@ -176,7 +184,7 @@ validate_parquet_ref() {
 # line is taken with a parameter expansion instead.
 # ---------------------------------------------------------------------------
 token_value() {
-    _tv_out="$(tr ' ' '\n' <<<"$1" | sed -n "s/^$2=\\([!-~][!-~]*\\)\$/\\1/p")"
+    _tv_out="$(tr ' ' '\n' <<<"$1" | sed -n "s/^$2=\\([[:graph:]][[:graph:]]*\\)\$/\\1/p")"
     printf '%s\n' "${_tv_out%%$'\n'*}"
 }
 

--- a/scripts/tests/test_load_provenance.py
+++ b/scripts/tests/test_load_provenance.py
@@ -461,3 +461,81 @@ def test_verify_reads_the_status_the_stamp_writes() -> None:
         "the refusal did not come from the status VALUE — it may be refusing because the "
         "status was unreadable, which would make the incompleteness check vacuous"
     )
+
+
+# ===========================================================================
+# Locale robustness — `token_value` must not depend on collation order (deploy#601).
+# ===========================================================================
+# `token_value` extracted `key=value` with the bracket RANGE `[!-~]`. GNU sed evaluates a
+# range by the locale's COLLATION order, not codepoint order: under a glibc language locale
+# such as en_US.UTF-8 (the locale on every deploy VPS) the collated span `!`..`~` excludes
+# ordinary ref bytes (`/`, `-`, `.`), so `parquet_ref=staged/narrator-resolve/<date>-<sha>`
+# extracted to EMPTY and `verify` false-refused a correctly-stamped graph with "NO stamp".
+# Every test above runs under C / C.UTF-8 (codepoint order), which does NOT reproduce it —
+# the same test-vs-prod gap as the sibling verify_prune_provenance.sh matcher (deploy#599).
+# The fix is the POSIX class `[[:graph:]]`, which is locale-independent.
+_QUIRK_LOCALE_CANDIDATES = (
+    "en_US.UTF-8",
+    "en_US.utf8",
+    "en_GB.UTF-8",
+    "de_DE.UTF-8",
+    "fr_FR.UTF-8",
+    "es_ES.UTF-8",
+)
+
+
+def _locale_reproducing_the_range_quirk() -> str | None:
+    """First installed locale under which sed's ``[!-~]`` FAILS to match a ref-like token.
+
+    An INSTRUMENT CHECK, not a formality: a green assertion under a locale that does not
+    reproduce the quirk (C / C.UTF-8) proves nothing about the fix, so the test below refuses
+    to run under one. An *uninstalled* locale makes glibc fall back to C — where ``[!-~]``
+    matches — so the probe rejects it too.
+    """
+    probe = "staged/narrator-resolve/2026-07-12-bd133e6\n"  # the '/','-','.' bytes at issue
+    for loc in _QUIRK_LOCALE_CANDIDATES:
+        env = {**os.environ, "LC_ALL": loc, "LC_COLLATE": loc, "LANG": loc}
+        try:
+            r = subprocess.run(  # noqa: S603
+                ["sed", "-n", r"s/^\([!-~][!-~]*\)$/HIT/p"],  # noqa: S607
+                input=probe,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except OSError:
+            continue
+        if r.returncode == 0 and "HIT" not in r.stdout:
+            return loc
+    return None
+
+
+@pytest.mark.parametrize("quoted", [True, False])
+def test_verify_parses_the_ref_under_a_collation_quirk_locale(quoted: bool) -> None:
+    """`verify` must accept a correctly-stamped graph regardless of the VPS's locale (deploy#601).
+
+    Runs the real `verify` under a locale proven above to break the old ``[!-~]`` range, in
+    both transport renderings. Before the ``[[:graph:]]`` fix this refuses with "NO stamp"
+    (the ref token extracts empty); after it, rc=0.
+    """
+    loc = _locale_reproducing_the_range_quirk()
+    if loc is None:
+        pytest.skip(
+            "no installed locale reproduces the [!-~] collation quirk "
+            "(C / C.UTF-8 use codepoint order); cannot exercise deploy#601 here"
+        )
+    assert loc is not None  # narrow for mypy --ignore-missing-imports (pytest.skip untyped)
+    ok = _verify(
+        REF_A,
+        _graph_says(ref=REF_A, quoted=quoted),
+        LC_ALL=loc,
+        LC_COLLATE=loc,
+        LANG=loc,
+        LC_CTYPE=loc,
+    )
+    assert ok.returncode == 0, (
+        f"verify refused a correctly-stamped graph under {loc} (quoted={quoted}): the "
+        f"parquet_ref token matcher is locale-collation-sensitive (deploy#601).\n{ok.stderr}"
+    )
+    assert f"LOAD_PROVENANCE_OK parquet_ref={REF_A}" in ok.stdout


### PR DESCRIPTION
## What

The prune's **load-provenance gate** (`scripts/graph_load_provenance.sh`, mode `verify`)
false-refuses a **correctly-stamped** graph on any deploy VPS running `en_US.UTF-8`,
reporting `the graph carries NO load-provenance stamp` and deleting nothing.

This is the **same `[!-~]` locale bug as #599 / PR #600**, in a sibling file that #600 did
not fix. Closes #601.

## Root cause

`token_value()` extracted `key=value` with the bracket **range** `[!-~]`:

```sh
# scripts/graph_load_provenance.sh
_tv_out="$(tr ' ' '\n' <<<"$1" | sed -n "s/^$2=\([!-~][!-~]*\)$/\1/p")"
```

GNU sed evaluates a range by locale **collation**. Under `en_US.UTF-8` the collated span
`!`..`~` excludes `/`, `-`, `.`, so `parquet_ref=staged/narrator-resolve/<date>-<sha>`
extracts to empty → `GRAPH_REF` empty → "NO stamp". `C` / `C.UTF-8` (codepoint order) hide
it — same test-vs-prod gap as #599.

Found when the stg prune dry-run (run 29204292249) cleared the now-fixed provenance gate and
hit this one. The `(:LoadProvenance {scope:'graph'})` node on stg is present and correct
(`parquet_ref=staged/narrator-resolve/2026-07-12-bd133e6 load_status=complete`) — only the
shell parser was locale-fragile.

## Fix

`[!-~]` → POSIX class `[[:graph:]]` (locale-independent, widest printable class — no
narrowing, deploy#589). The `token_value` block comment, which argued *for* `[!-~]`, is
corrected.

## Test

The existing round-trip tests exercise the cypher-shell quote envelope and a `/`-and-`-`
ref, but only under C/C.UTF-8 where `[!-~]` works — which is why they stayed green while the
VPS refused. Added a locale-parametrized `verify` test that runs under a locale it first
**proves** breaks the old range (instrument check; skips only if none installed), in both
transport renderings. Verified **RED** on `[!-~]`, **GREEN** on `[[:graph:]]` via a
`localedef`-built `en_US.UTF-8`.

## Sweep

The rest of the prune's gate chain was checked: `run_count` (`tr -dc '0-9'`) and
`summary_field` (`[0-9]`) are digit-only and locale-safe; the load-provenance `parquet_ref`
string was the only locale-fragile parse. `[!-~]` now appears nowhere in the repo.

## Checks

Local (mirrors CI): ruff format+lint, mypy (`--ignore-missing-imports`), shellcheck, and the
load-provenance + prune-provenance + workflow suites (75 passed) all green.

## Safety

False-refusal only, no data loss — the gate failed closed. The fix restores the ability to
verify a correctly-stamped graph; no refusal (wrong-ref, incomplete-load, unstamped,
env-bypass) is weakened — all those tests still pass.
