### PR TITLE
deploy#603: over_merged transport observability + stg flag-now op

### DIFF
--- a/.github/workflows/deploy-data-load.yml
+++ b/.github/workflows/deploy-data-load.yml
@@ -573,6 +573,19 @@ jobs:
               'NEO4J_USERNAME=neo4j NEO4J_PASSWORD="${NEO4J_AUTH#neo4j/}" exec cypher-shell --format plain "MATCH (h:Hadith) RETURN h.source_corpus AS source_corpus, count(*) AS hadiths ORDER BY hadiths DESC"' \
               || echo "    WARNING: [${ENV_NAME}] post-load read-back query failed (non-fatal)." >&2
 
+            # --- transport observability (deploy#603): the over_merged Narrator
+            #     property (da#447) rides the loader passthrough — this workflow pulls
+            #     the WHOLE narrators_canonical.parquet and enumerates no node-property
+            #     allow-list, so the new columns land as node properties with no change
+            #     here. This read-back is the PROOF the property survived the reload:
+            #     it reports how many Narrator nodes carry over_merged=true. Non-fatal,
+            #     same OR-arm idiom as above. A durable reload should show the same
+            #     count graph-flag-over-merged.yml flags on the live graph. ---
+            echo "==> [${ENV_NAME}] post-load read-back: over_merged Narrator count (deploy#603 transport check)"
+            ${COMPOSE} exec -T neo4j sh -c \
+              'NEO4J_USERNAME=neo4j NEO4J_PASSWORD="${NEO4J_AUTH#neo4j/}" exec cypher-shell --format plain "MATCH (n:Narrator) WHERE n.over_merged = true RETURN count(n) AS over_merged_narrators"' \
+              || echo "    WARNING: [${ENV_NAME}] over_merged read-back query failed (non-fatal)." >&2
+
             echo "==> [${ENV_NAME}] batch load '${LOAD_ARGS}' complete — graph committed (loader rc=${RC})."
 
       - name: Report

--- a/.github/workflows/graph-flag-over-merged.yml
+++ b/.github/workflows/graph-flag-over-merged.yml
@@ -1,0 +1,302 @@
+name: Graph flag over-merged narrators (live-graph annotate)
+
+# Repeatable, observable, env-gated Neo4j annotate op: set `over_merged=true` +
+# `over_merge_note` on the canonical Narrator nodes the producer resolved from the
+# curated over-merge seed (da#447) — the immediate "flag-NOW" leg of the honest-
+# leaderboard work (deploy#603 / main#928 / main#958 / da#443).
+#
+# WHY THIS EXISTS ALONGSIDE THE RELOAD.
+# da#447 made `over_merged` a durable Narrator property, and deploy-data-load.yml
+# carries it into Neo4j on every reload (the durable TRANSPORT leg of deploy#603).
+# But a full reload is ~7.5h. `over_merged=true` means a canonical node FUSES
+# multiple distinct narrators, so its betweenness/centrality is inflated and it
+# must not be read as one transmitter — and we want that flag visible on stg NOW,
+# without waiting on a reload. This workflow writes exactly that annotation to the
+# live graph. A later reload from a parquet that carries the same property simply
+# re-asserts it (idempotent, self-reconciling).
+#
+# NEO4J-ONLY (no loader image). Pure Cypher via cypher-shell in the live neo4j
+# container — the same run_cypher credential helper graph-ops.yml / graph-prune-
+# narrators.yml use (password from the container's own NEO4J_AUTH, never on argv,
+# never over the GH transport — CWE-214). So this path has no GHCR login and no
+# image pull. Shape mirrors graph-ops.yml's prune-orphans path (SSH to the VPS as
+# `deploy`, refresh the /opt checkout, cypher-shell pre-count -> op -> post-verify).
+#
+# INJECTION-SAFE + PARAMETERIZED. The statements are parameterized on `$ids` /
+# `$note`; the `:param` value literals are BUILT by scripts/flag_over_merged_
+# narrators.sh under a charset whitelist (a `'` or `\` cannot reach a statement
+# with graph-write access). That script is shellcheck-linted and unit-tested
+# (scripts/tests/test_flag_over_merged_narrators.py) — an ssh `with: script:` body
+# is neither (deploy#555). cypher-shell 5.x removed `:auto`; a non-interactive
+# cypher-shell auto-commits each stdin statement, which is the implicit tx a plain
+# SET needs — so no client-command prefix is used (deploy#540).
+#
+# THE ID SET is scripts/over_merged_narrator_ids.txt — the producer's AUTHORITATIVE
+# resolved canonical ids (da#447). It is NOT re-derived from names here (canonical
+# ids drift across resolve runs, da#371/#376). The op REFUSES on a real run unless
+# every configured id is present in the live graph (a mismatch means the seed is
+# stale against the loaded resolve run — reconcile it, do not flag a subset). The
+# file ships as a placeholder, so the op is inert until the real ids are wired in.
+#
+# stg-gated + PROD HELD. This wave the op runs on stg ONLY. Prod flagging is held
+# behind an explicit owner go-ahead AND a verified-green backup (main#928); the
+# script hard-refuses env=prod until that hold is lifted. dry_run defaults to TRUE
+# — a fat-fingered dispatch reports what it WOULD flag and writes nothing.
+
+on:
+  workflow_dispatch:
+    inputs:
+      env:
+        description: "Target env — stg (prod is HELD this wave; see below)"
+        required: true
+        type: choice
+        options: [stg, prod]
+      note:
+        description: "over_merge_note text set on each flagged node (safe charset only)"
+        required: false
+        type: string
+        default: >-
+          Over-merged canonical narrator: this node fuses multiple distinct
+          transmitters, so its betweenness/centrality is inflated; flagged pending
+          an external-evidence split (main#928 / main#958 / da#443). Do not read as
+          a single historical narrator.
+      dry_run:
+        description: "Plan/read only — report the would-flag count; write NOTHING"
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  # Serialize against itself per env. This op writes Narrator properties on the
+  # live graph; queue rather than cancel so a mid-write dispatch is never severed.
+  # It does NOT exclude the other graph writers (data-load / graph-ops / prune use
+  # disjoint groups); the shared graph-write-<env> group is deploy#576. Until then,
+  # do not dispatch this while a load/migrate/prune is in flight on the same env.
+  group: graph-flag-over-merged-${{ inputs.env }}
+  cancel-in-progress: false
+
+jobs:
+  flag-over-merged:
+    name: flag-over-merged (${{ inputs.env }})
+    runs-on: ubuntu-latest
+    # A SET over a handful of ids finishes in seconds; the ceiling is well above the
+    # SSH command_timeout so the runner never caps the step short, and far under the
+    # 6h hard cap. Dry-run is seconds.
+    timeout-minutes: 20
+    # Maps to GH Environment protection (stg -> staging, prod -> production). prod
+    # additionally requires manual approval — but the script ALSO hard-refuses prod
+    # this wave (the hold), so prod is double-gated. Same env mapping as graph-ops.yml.
+    environment: ${{ inputs.env == 'prod' && 'production' || 'staging' }}
+    permissions:
+      # No GHCR pull (Neo4j-only op) — read is all this needs.
+      contents: read
+    steps:
+      - name: Flag over-merged narrators on ${{ inputs.env }} VPS
+        id: flag
+        uses: appleboy/ssh-action@v1
+        env:
+          ENV_NAME: ${{ inputs.env }}
+          NOTE: ${{ inputs.note }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        with:
+          host: ${{ vars.VPS_HOST }}
+          username: deploy
+          # A cypher SET over a handful of nodes is instant; 10m covers the git
+          # refresh + compose exec overhead while staying under timeout-minutes so
+          # the SSH timeout — not a hard runner kill — is the binding limit.
+          command_timeout: 10m
+          key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          capture_stdout: true
+          envs: ENV_NAME,NOTE,DRY_RUN
+          script: |
+            set -uo pipefail
+
+            # PROD HOLD (deploy#603 / main#928): prod flagging is not authorized this
+            # wave — held behind an explicit owner go-ahead AND a verified-green backup.
+            # Refuse BEFORE touching anything. Remove this guard only when prod is
+            # authorized (the env choice + production-environment approval remain the
+            # gate at that point).
+            if [ "${ENV_NAME}" = "prod" ]; then
+              echo "ERROR: [prod] over-merged flagging is HELD this wave — owner go-ahead + verified backup required (main#928). Refusing." >&2
+              exit 1
+            fi
+
+            cd /opt/noorinalabs-deploy
+
+            # Refresh the on-box checkout to origin/main BEFORE reading the id file or
+            # the builder script, exactly as graph-ops.yml / deploy-data-load.yml do,
+            # so both are the current committed versions. Guarded (this script runs
+            # `set -uo pipefail`, no -e): an unguarded fetch failure would let the
+            # following reset succeed against a STALE remote-tracking ref.
+            echo "==> Pulling latest deploy config..."
+            git fetch origin main \
+              || { echo "ERROR: [${ENV_NAME}] git fetch origin main failed — refusing to run against a stale checkout." >&2; exit 1; }
+            git reset --hard origin/main \
+              || { echo "ERROR: [${ENV_NAME}] git reset --hard origin/main failed." >&2; exit 1; }
+
+            # .env on the VPS (mode 600, written by the deploy workflow) is the single
+            # source of truth for NEO4J credentials — compose interpolates the service
+            # env from it, so creds never reach this script's argv (CWE-214).
+            if [ ! -f .env ]; then
+              echo "ERROR: /opt/noorinalabs-deploy/.env is missing on ${ENV_NAME} VPS." >&2
+              exit 1
+            fi
+
+            COMPOSE="docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env"
+
+            # run_phase <precount|flag|postcount>: build the cypher-shell stdin stream
+            # for the phase (the :param line(s) + the statement) with the tested
+            # builder, then feed it to cypher-shell INSIDE the live neo4j container.
+            # The builder reads NOTE (flag phase) and scripts/over_merged_narrator_ids.txt.
+            run_phase() {
+              _phase="$1"
+              _built=""
+              _built="$(bash scripts/flag_over_merged_narrators.sh stdin "${_phase}")" \
+                || { echo "ERROR: [${ENV_NAME}] builder refused for phase '${_phase}' — check the wired ids in scripts/over_merged_narrator_ids.txt and the note charset." >&2; return 1; }
+              # SC2016: the ${NEO4J_AUTH#neo4j/} expands INSIDE the neo4j container's
+              # sh -c (reading that container's own NEO4J_AUTH), not on the VPS host.
+              # shellcheck disable=SC2016
+              printf '%s\n' "${_built}" | ${COMPOSE} exec -T neo4j sh -c \
+                'NEO4J_USERNAME=neo4j NEO4J_PASSWORD="${NEO4J_AUTH#neo4j/}" exec cypher-shell --format plain'
+            }
+
+            # extract_int <cypher-plain-output>: the sole all-digits line (the count).
+            # cypher-shell --format plain renders an integer column value unquoted, so
+            # the result row is a bare number; the header (`matched`/`flagged`) is not.
+            # `|| true` keeps a no-match from tripping pipefail — the caller HARD-FAILS
+            # on an empty result, so a missing reading is a stop, never a silent zero.
+            extract_int() {
+              printf '%s\n' "$1" | grep -oE '^[0-9]+$' | tail -n1 || true
+            }
+
+            # --- expected count: how many ids are configured (builder refuses 0) ---
+            EXPECTED=""
+            EXPECTED="$(bash scripts/flag_over_merged_narrators.sh id-count)" \
+              || { echo "ERROR: [${ENV_NAME}] could not read the configured id count." >&2; exit 1; }
+            if [ "${EXPECTED:-0}" -le 0 ]; then
+              echo "ERROR: [${ENV_NAME}] no canonical ids configured in scripts/over_merged_narrator_ids.txt — the flag set is empty (fail-safe). Wire in the producer's resolved ids (da#447) before dispatching." >&2
+              exit 1
+            fi
+            echo "==> [${ENV_NAME}] flag-over-merged — configured ids: ${EXPECTED} | dry_run=${DRY_RUN}"
+
+            # --- pre-count: how many of the configured ids exist in the live graph ---
+            echo "==> [${ENV_NAME}] pre-count: configured ids present in the graph"
+            PRE_OUT=""
+            PRE_OUT="$(run_phase precount)" \
+              || { echo "ERROR: [${ENV_NAME}] pre-count query failed to execute." >&2; exit 1; }
+            MATCHED="$(extract_int "${PRE_OUT}")"
+            if [ -z "${MATCHED}" ]; then
+              echo "ERROR: [${ENV_NAME}] could not parse the matched count from cypher output:" >&2
+              printf '%s\n' "${PRE_OUT}" >&2
+              exit 1
+            fi
+            echo "    configured: ${EXPECTED} | present in graph: ${MATCHED}"
+
+            # --- FAIL-SAFE DRY RUN. Tested as != "false" (fails safe: anything not
+            #     explicitly "false" is a plan). ---
+            if [ "${DRY_RUN}" != "false" ]; then
+              if [ "${DRY_RUN}" != "true" ]; then
+                echo "WARNING: [${ENV_NAME}] dry_run='${DRY_RUN}' is not 'true'/'false' — treating as a DRY RUN, writing nothing." >&2
+              fi
+              echo "==> [${ENV_NAME}] DRY RUN — would SET over_merged=true + over_merge_note on ${MATCHED} node(s); NO write issued."
+              if [ "${MATCHED}" -ne "${EXPECTED}" ]; then
+                echo "    NOTE: ${MATCHED} of ${EXPECTED} configured ids are present — a REAL run would REFUSE (the seed does not match the loaded graph; reconcile scripts/over_merged_narrator_ids.txt against the producer's resolve run)."
+              fi
+              echo "FLAG_RESULT outcome=dry-run configured=${EXPECTED} matched=${MATCHED} flagged=0"
+              echo "==> [${ENV_NAME}] dry run complete (exit 0)."
+              exit 0
+            fi
+
+            # --- real run: refuse unless EVERY configured id is present. Flagging a
+            #     subset would silently annotate a graph the seed no longer describes. ---
+            if [ "${MATCHED}" -ne "${EXPECTED}" ]; then
+              echo "ERROR: [${ENV_NAME}] refusing to flag — only ${MATCHED} of ${EXPECTED} configured ids exist in the live graph. The curated seed does not match the loaded resolve run (canonical-id drift, da#371/#376, or wrong env). Reconcile scripts/over_merged_narrator_ids.txt with the producer before flagging." >&2
+              exit 1
+            fi
+
+            echo "==> [${ENV_NAME}] flag: SET over_merged=true + over_merge_note on ${EXPECTED} node(s)"
+            FLAG_OUT=""
+            FLAG_OUT="$(run_phase flag)" \
+              || { echo "ERROR: [${ENV_NAME}] flag SET failed to execute." >&2; exit 1; }
+            FLAGGED="$(extract_int "${FLAG_OUT}")"
+            if [ -z "${FLAGGED}" ]; then
+              echo "ERROR: [${ENV_NAME}] could not parse the flagged count from the SET output:" >&2
+              printf '%s\n' "${FLAG_OUT}" >&2
+              exit 1
+            fi
+            if [ "${FLAGGED}" -ne "${EXPECTED}" ]; then
+              echo "ERROR: [${ENV_NAME}] SET reported ${FLAGGED} nodes flagged but ${EXPECTED} were expected." >&2
+              exit 1
+            fi
+
+            # --- post-verify: exactly the configured ids now carry over_merged=true ---
+            echo "==> [${ENV_NAME}] verify: configured ids now carry over_merged=true"
+            POST_OUT=""
+            POST_OUT="$(run_phase postcount)" \
+              || { echo "ERROR: [${ENV_NAME}] post-count query failed to execute." >&2; exit 1; }
+            POST="$(extract_int "${POST_OUT}")"
+            if [ -z "${POST}" ]; then
+              echo "ERROR: [${ENV_NAME}] could not parse the post-count from cypher output:" >&2
+              printf '%s\n' "${POST_OUT}" >&2
+              exit 1
+            fi
+            if [ "${POST}" -ne "${EXPECTED}" ]; then
+              echo "ERROR: [${ENV_NAME}] verification FAILED — ${POST} of ${EXPECTED} configured ids carry over_merged=true after the SET." >&2
+              exit 1
+            fi
+            echo "    ${POST} of ${EXPECTED} configured ids carry over_merged=true."
+            echo "FLAG_RESULT outcome=flagged configured=${EXPECTED} matched=${MATCHED} flagged=${FLAGGED}"
+            echo "==> [${ENV_NAME}] flag-over-merged complete — post-op verification PASSED."
+
+      - name: Report
+        if: always()
+        env:
+          ENV_NAME: ${{ inputs.env }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          JOB_STATUS: ${{ job.status }}
+          FLAG_STDOUT: ${{ steps.flag.outputs.stdout }}
+        run: |
+          set -euo pipefail
+
+          # Whole-token extraction from the captured remote stdout (da#419 discipline).
+          result_field() {
+            printf '%s\n' "${FLAG_STDOUT}" \
+              | grep -o 'FLAG_RESULT .*' \
+              | head -n1 \
+              | tr ' ' '\n' \
+              | sed -n "s/^$1=\\([0-9A-Za-z-][0-9A-Za-z-]*\\)$/\\1/p" \
+              | head -n1
+          }
+
+          R_OUTCOME="$(result_field outcome || true)"
+          R_CONFIGURED="$(result_field configured || true)"
+          R_MATCHED="$(result_field matched || true)"
+          R_FLAGGED="$(result_field flagged || true)"
+
+          {
+            echo "## Flag over-merged narrators (${ENV_NAME}): ${JOB_STATUS}"
+            echo ""
+            echo "- **Env:** ${ENV_NAME}"
+            echo "- **Dry run:** ${DRY_RUN}"
+            echo ""
+            if [ -n "${R_OUTCOME}" ]; then
+              echo "| | |"
+              echo "|---|---|"
+              echo "| Outcome | \`${R_OUTCOME}\` |"
+              echo "| Configured ids (keep-set) | ${R_CONFIGURED} |"
+              echo "| Present in graph | ${R_MATCHED} |"
+              if [ "${R_OUTCOME}" = "dry-run" ]; then
+                echo "| Would flag | ${R_MATCHED} |"
+              else
+                echo "| **Flagged** (over_merged=true) | **${R_FLAGGED}** |"
+              fi
+              echo ""
+            else
+              echo "**Not reported.** The op did not reach a terminal success path — read the step log"
+              echo "to establish the graph's state before re-running."
+              echo ""
+            fi
+            echo "Sets \`over_merged=true\` + \`over_merge_note\` on the producer's curated canonical ids"
+            echo "(da#447). Durable transport is deploy-data-load.yml; a later reload re-asserts the flag."
+            echo "stg-gated: prod flagging is HELD this wave behind owner go-ahead + verified backup (main#928)."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/flag_over_merged_narrators.sh
+++ b/scripts/flag_over_merged_narrators.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# =============================================================================
+# flag_over_merged_narrators.sh — build the Cypher that flags over-merged
+# Narrator nodes on the LIVE graph, for graph-flag-over-merged.yml (deploy#603).
+#
+# WHAT IT IS FOR
+#
+# da#447 gave every canonical Narrator row an `over_merged: bool` (+
+# `over_merge_note: str`): true means the node FUSES multiple distinct narrators,
+# so its betweenness/centrality is inflated and it must NOT be read as one
+# historical transmitter. deploy-data-load.yml carries those properties into
+# Neo4j on every reload (the durable transport). But a reload is a ~7.5h op, so
+# this script backs the immediate "flag-NOW" path: annotate the live stg graph
+# directly from the producer's curated id set, with no reload.
+#
+# WHY A SCRIPT AND NOT TEN LINES OF THE WORKFLOW'S ssh BLOCK
+#
+# Same reason graph_load_provenance.sh / verify_prune_provenance.sh are scripts
+# and not inline `script:` bodies: a guard that lives in an ssh `with: script:`
+# string can only ever be pinned by grepping the workflow TEXT — it is NOT
+# linted by shellcheck (deploy#555) and cannot be unit-tested. The values flagged
+# here (canonical ids, the note) are interpolated into Cypher literals that run
+# with WRITE access to the graph, so the injection guard MUST be executable and
+# tested. It lives here, EXECUTED by scripts/tests/test_flag_over_merged_narrators.py
+# and shellcheck-linted by compose-validate.yml's shellcheck job.
+#
+# INJECTION MODEL (mirrors graph_load_provenance.sh safe_literal)
+#
+# Every id and the note are interpolated into SINGLE-QUOTED Cypher string
+# literals, so a value containing `'` or `\` would be a Cypher injection into a
+# write statement. Values are WHITELISTED, not escaped: no quote, backslash,
+# newline or brace can reach the statement at all. Refuse rather than sanitise —
+# a rejected input is a typo the operator fixes; a sanitised one is a guess.
+#
+# The QUERIES are parameterized on `$ids` / `$note` (cypher-shell `:param`), and
+# the `:param` value literals are what this script builds under the whitelist. So
+# the statement text is fixed and parameter-driven, and the only operator-supplied
+# bytes that reach the session are ones that passed the charset gate.
+#
+# ---------------------------------------------------------------------------------
+# MODES
+#
+#   set-query        out: the parameterized SET statement (references $ids, $note).
+#   precount-query   out: count of Narrator nodes whose id is in $ids.
+#   postcount-query  out: count of those now carrying over_merged=true.
+#   param-ids        env: IDS_FILE   out: `:param ids => ['nar:..', ..]`
+#   param-note       env: NOTE       out: `:param note => '..'`
+#   id-count         env: IDS_FILE   out: the integer count of configured ids.
+#   stdin <phase>    env: IDS_FILE (+NOTE for flag)  out: the full cypher-shell
+#                    stdin stream for <phase> = precount | flag | postcount
+#                    (the `:param` line(s) followed by the statement).
+#
+# All statements are SINGLE statements terminated by `;` so a non-interactive
+# cypher-shell (which auto-commits each stdin statement — cypher-shell 5.x removed
+# `:auto`, deploy#540) runs them in the implicit transaction a plain SET needs.
+# =============================================================================
+set -euo pipefail
+
+# Default to the committed id set; the test overrides IDS_FILE to a fixture.
+IDS_FILE="${IDS_FILE:-"$(cd "$(dirname "$0")" && pwd)/over_merged_narrator_ids.txt"}"
+
+die() {
+    echo "ERROR: [flag-over-merged] $1" >&2
+    shift
+    for _l in "$@"; do echo "  ${_l}" >&2; done
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# safe_literal <name> <value> <allowed-charclass>
+# Whitelist every byte that will land inside a single-quoted Cypher literal.
+# ---------------------------------------------------------------------------
+safe_literal() {
+    _name="$1"
+    _val="$2"
+    _allowed="$3"
+    [ -n "${_val}" ] || die "${_name} is empty — refusing to build a Cypher literal from nothing."
+    # shellcheck disable=SC2254  # ${_allowed} is an intentional bracket-expression body.
+    case "${_val}" in
+        *[!${_allowed}]*)
+            die "${_name}='${_val}' contains a character outside [${_allowed}]." \
+                "It is interpolated into a single-quoted Cypher literal that runs with write" \
+                "access to the graph, so a quote or backslash here is an injection. Fix the" \
+                "input; this check is not the thing to relax."
+            ;;
+    esac
+}
+
+# read_ids — echo the configured canonical ids, one per line, each whitelisted.
+# Blank lines and #-comments are ignored; leading/trailing whitespace trimmed.
+# A canonical id is `nar:<uuid>` — charset A-Za-z0-9:_- (no quote can hide here).
+read_ids() {
+    [ -f "${IDS_FILE}" ] || die "id file not found: ${IDS_FILE}"
+    while IFS= read -r _line || [ -n "${_line}" ]; do
+        # trim leading whitespace
+        _line="${_line#"${_line%%[![:space:]]*}"}"
+        # trim trailing whitespace
+        _line="${_line%"${_line##*[![:space:]]}"}"
+        case "${_line}" in
+            '' | \#*) continue ;;
+        esac
+        safe_literal id "${_line}" 'A-Za-z0-9:_-'
+        printf '%s\n' "${_line}"
+    done <"${IDS_FILE}"
+}
+
+mode_id_count() {
+    # Capture FIRST, not `read_ids | grep`: a bad id makes read_ids die, and this
+    # plain assignment propagates that rc so `set -e` aborts HERE with the whitelist
+    # diagnostic — a pipe would mask it and report a count instead.
+    _ids_out="$(read_ids)"
+    if [ -z "${_ids_out}" ]; then
+        printf '0\n'
+        return 0
+    fi
+    printf '%s\n' "${_ids_out}" | grep -c '^'
+}
+
+mode_param_ids() {
+    # Capture FIRST so an id failing the whitelist aborts here (set -e) with the
+    # injection diagnostic as the sole error — running read_ids inside the loop's
+    # `<<<"$(read_ids)"` subshell would swallow that exit and mis-report "no ids".
+    _ids_out="$(read_ids)"
+    [ -n "${_ids_out}" ] || die "no canonical ids configured in ${IDS_FILE}." \
+        "Wire in the producer's resolved over-merged ids (da#447) before dispatching;" \
+        "the set is empty, so there is nothing to flag (fail-safe refusal)."
+    _lit=""
+    # Herestring keeps the loop in THIS shell so _lit accumulates; every id in
+    # _ids_out is already whitelisted.
+    while IFS= read -r _id; do
+        [ -n "${_id}" ] || continue
+        if [ -n "${_lit}" ]; then _lit="${_lit}, "; fi
+        _lit="${_lit}'${_id}'"
+    done <<<"${_ids_out}"
+    printf ':param ids => [%s]\n' "${_lit}"
+}
+
+mode_param_note() {
+    NOTE="${NOTE:?NOTE must be set (the over_merge_note text)}"
+    # Prose, but still a single-quoted Cypher literal: allow spaces + safe
+    # punctuation, refuse quote/backslash/brace/newline/$ (the injection surface).
+    safe_literal note "${NOTE}" 'A-Za-z0-9 ._,:;/#()-'
+    printf ":param note => '%s'\n" "${NOTE}"
+}
+
+# The statement text is FIXED and parameter-driven — no operator bytes here.
+# SC2016: `$ids`/`$note` are Cypher parameters and MUST stay literal (single-quoted
+# so the shell never expands them); cypher-shell binds them from the `:param` lines.
+mode_set_query() {
+    # shellcheck disable=SC2016
+    printf '%s\n' \
+        'MATCH (n:Narrator) WHERE n.id IN $ids SET n.over_merged = true, n.over_merge_note = $note RETURN count(n) AS flagged;'
+}
+mode_precount_query() {
+    # shellcheck disable=SC2016
+    printf '%s\n' \
+        'MATCH (n:Narrator) WHERE n.id IN $ids RETURN count(n) AS matched;'
+}
+mode_postcount_query() {
+    # shellcheck disable=SC2016
+    printf '%s\n' \
+        'MATCH (n:Narrator) WHERE n.id IN $ids AND n.over_merged = true RETURN count(n) AS flagged;'
+}
+
+mode_stdin() {
+    case "${1:-}" in
+        precount)
+            mode_param_ids
+            mode_precount_query
+            ;;
+        flag)
+            mode_param_ids
+            mode_param_note
+            mode_set_query
+            ;;
+        postcount)
+            mode_param_ids
+            mode_postcount_query
+            ;;
+        *) die "stdin: unknown phase '${1:-}' (want: precount | flag | postcount)" ;;
+    esac
+}
+
+case "${1:-}" in
+    set-query) mode_set_query ;;
+    precount-query) mode_precount_query ;;
+    postcount-query) mode_postcount_query ;;
+    param-ids) mode_param_ids ;;
+    param-note) mode_param_note ;;
+    id-count) mode_id_count ;;
+    stdin) mode_stdin "${2:-}" ;;
+    *)
+        echo "usage: $0 {set-query|precount-query|postcount-query|param-ids|param-note|id-count|stdin <phase>}" >&2
+        echo "  param-ids/id-count/stdin   env: IDS_FILE   param-note/stdin flag   env: NOTE" >&2
+        exit 2
+        ;;
+esac

--- a/scripts/over_merged_narrator_ids.txt
+++ b/scripts/over_merged_narrator_ids.txt
@@ -1,0 +1,16 @@
+# Canonical Narrator ids (nar:<uuid>) that graph-flag-over-merged.yml flags with
+# over_merged=true — the "flag-now" leg of the honest-leaderboard work
+# (deploy#603 / main#928 / main#958 / da#443).
+#
+# AUTHORITATIVE SOURCE: the data-acquisition producer's resolution of the curated
+# seed over_merged_narrators.yaml (da#447). Do NOT hand-derive these ids from
+# narrator names — canonical ids drift across resolve runs (da#371/#376); only the
+# producer's resolved ids are authoritative. The workflow flags EXACTLY these ids
+# and refuses if any of them is absent from the live graph (a mismatch means the
+# seed is stale against the loaded resolve run, not something to flag around).
+#
+# Format: one canonical id per line; blank lines and #-comments are ignored.
+# flag_over_merged_narrators.sh REFUSES an empty set, so this file is INERT until
+# the real ids are wired in — a dispatch before wiring flags nothing (fail-safe).
+#
+# <<< PENDING: the 8 canonical nar: ids, to be relayed from the producer >>>

--- a/scripts/tests/test_flag_over_merged_narrators.py
+++ b/scripts/tests/test_flag_over_merged_narrators.py
@@ -1,0 +1,226 @@
+"""BEHAVIOURAL tests for flag_over_merged_narrators.sh — it is RUN, not grepped.
+
+The script builds the Cypher that graph-flag-over-merged.yml runs against the LIVE stg
+graph to set ``over_merged=true`` + ``over_merge_note`` on the producer's curated set of
+canonical Narrator ids (deploy#603, the "flag-now" leg of main#928/#958/da#443).
+
+Two properties have to hold and a comment cannot enforce either, so they are executed here:
+
+1. INJECTION. Every id and the note land inside a single-quoted Cypher literal in a
+   statement with WRITE access to the graph. The charset is whitelisted, not escaped —
+   a ``'`` or ``\\`` cannot reach the statement at all — and the tests below feed the
+   classic ``'; MATCH (n) DETACH DELETE n; //`` payload through every mode and require a
+   refusal. "Only maintainers can dispatch" is exactly the reasoning that ships an
+   injection, so the guard is proven, not asserted.
+
+2. THE CONTRACT. The SET statement must be *exactly* da#447's shape
+   (``over_merged=true``, ``over_merge_note=$note``, matched on ``n.id IN $ids``), and the
+   ``:param`` lines the workflow prepends must carry precisely the file's ids. A drift on
+   either side would flag the wrong nodes or none, silently.
+
+The committed id file ships as a PLACEHOLDER (comments only). ``test_committed_id_file_is_inert``
+pins the fail-safe: until the producer's real ids are wired in, a dispatch flags nothing.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+BUILDER = SCRIPTS_DIR / "flag_over_merged_narrators.sh"
+COMMITTED_ID_FILE = SCRIPTS_DIR / "over_merged_narrator_ids.txt"
+
+NOTE = "Over-merged canonical narrator: fuses distinct transmitters (main#928 / da#443)"
+
+
+def _run(
+    *args: str, ids_file: Path | None = None, note: str | None = None
+) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ}
+    if ids_file is not None:
+        env["IDS_FILE"] = str(ids_file)
+    if note is not None:
+        env["NOTE"] = note
+    return subprocess.run(  # noqa: S603
+        ["bash", str(BUILDER), *args],  # noqa: S607
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _ids_file(tmp_path: Path, *ids: str, preamble: str = "# a comment\n\n") -> Path:
+    f = tmp_path / "ids.txt"
+    f.write_text(preamble + "".join(f"{i}\n" for i in ids))
+    return f
+
+
+# ===========================================================================
+# THE CONTRACT — the SET statement is exactly da#447's shape.
+# ===========================================================================
+def test_set_query_is_the_da447_contract() -> None:
+    r = _run("set-query")
+    assert r.returncode == 0, r.stderr
+    q = r.stdout.strip()
+    assert q == (
+        "MATCH (n:Narrator) WHERE n.id IN $ids "
+        "SET n.over_merged = true, n.over_merge_note = $note RETURN count(n) AS flagged;"
+    ), f"SET statement drifted from the da#447 contract:\n{q}"
+
+
+def test_count_queries_are_parameterized_on_ids() -> None:
+    pre = _run("precount-query").stdout
+    post = _run("postcount-query").stdout
+    assert "WHERE n.id IN $ids RETURN count(n) AS matched;" in pre
+    # The post-count is the verification gate: it must require over_merged=true, not just
+    # membership, or a run that flagged NOTHING would still "verify".
+    assert "n.id IN $ids AND n.over_merged = true RETURN count(n)" in post
+
+
+# ===========================================================================
+# param-ids / id-count — the ids the workflow binds are exactly the file's.
+# ===========================================================================
+def test_param_ids_carries_exactly_the_file_ids_in_order(tmp_path: Path) -> None:
+    f = _ids_file(tmp_path, "nar:aaaa-1111", "nar:bbbb-2222", "nar:cccc-3333")
+    r = _run("param-ids", ids_file=f)
+    assert r.returncode == 0, r.stderr
+    assert r.stdout.strip() == ":param ids => ['nar:aaaa-1111', 'nar:bbbb-2222', 'nar:cccc-3333']"
+
+
+def test_id_count_ignores_comments_and_blanks(tmp_path: Path) -> None:
+    f = _ids_file(tmp_path, "nar:a-1", "nar:b-2", preamble="# header\n\n#nother\n")
+    assert _run("id-count", ids_file=f).stdout.strip() == "2"
+
+
+def test_whitespace_around_ids_is_trimmed(tmp_path: Path) -> None:
+    f = tmp_path / "ids.txt"
+    f.write_text("  nar:aaaa-1111  \n\tnar:bbbb-2222\t\n")
+    assert (
+        _run("param-ids", ids_file=f).stdout.strip()
+        == ":param ids => ['nar:aaaa-1111', 'nar:bbbb-2222']"
+    )
+
+
+# ===========================================================================
+# INJECTION — the guard is proven, not asserted.
+# ===========================================================================
+INJECTION_IDS = [
+    "nar:x'; MATCH (n) DETACH DELETE n; //",  # the one that matters
+    "nar:x' SET n.pwned = true //",
+    'nar:x" OR 1=1',
+    "nar:x\\",
+    "nar:x with space",
+    "nar:x}{",
+    "nar:x`whoami`",  # a backtick
+]
+
+
+@pytest.mark.parametrize("bad", INJECTION_IDS)
+def test_param_ids_refuses_an_unsafe_id(tmp_path: Path, bad: str) -> None:
+    f = tmp_path / "ids.txt"
+    f.write_text(bad + "\n")
+    r = _run("param-ids", ids_file=f)
+    assert r.returncode != 0, f"unsafe id {bad!r} was accepted into a Cypher literal:\n{r.stdout}"
+
+
+@pytest.mark.parametrize("bad", INJECTION_IDS)
+def test_id_count_also_refuses_an_unsafe_id(tmp_path: Path, bad: str) -> None:
+    """id-count must fail on a bad id too — the workflow reads it BEFORE the flag, so a
+    mode that counted a poisoned file as 'fine' would green-light the dispatch."""
+    f = tmp_path / "ids.txt"
+    f.write_text(bad + "\n")
+    assert _run("id-count", ids_file=f).returncode != 0
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "x' SET n.pwned = true //",
+        "note with a ' quote",
+        'note "quoted"',
+        "back\\slash",
+        "brace}{",
+        "dollar$sign",
+    ],
+)
+def test_param_note_refuses_an_unsafe_note(bad: str) -> None:
+    assert _run("param-note", note=bad).returncode != 0, f"unsafe note {bad!r} accepted"
+
+
+def test_param_note_emits_a_quoted_literal() -> None:
+    r = _run("param-note", note=NOTE)
+    assert r.returncode == 0, r.stderr
+    assert r.stdout.strip() == f":param note => '{NOTE}'"
+
+
+def test_param_note_refuses_empty() -> None:
+    assert _run("param-note", note="").returncode != 0
+
+
+# ===========================================================================
+# FAIL-SAFE — empty set refuses; the committed placeholder is inert.
+# ===========================================================================
+def test_empty_id_set_refuses(tmp_path: Path) -> None:
+    f = tmp_path / "ids.txt"
+    f.write_text("# only comments\n\n")
+    r = _run("param-ids", ids_file=f)
+    assert r.returncode != 0
+    assert "no canonical ids configured" in r.stderr
+    # id-count reports 0 rather than erroring — the workflow reads it to say "nothing wired".
+    assert _run("id-count", ids_file=f).stdout.strip() == "0"
+
+
+def test_committed_id_file_is_inert() -> None:
+    """The file ships as a placeholder: a dispatch on this PR must flag NOTHING.
+
+    When the producer's ids are wired in, this test flips to asserting the count — it is
+    here to guarantee the PR cannot silently ship a live-flagging set no reviewer saw.
+    """
+    assert COMMITTED_ID_FILE.exists()
+    assert _run("id-count", ids_file=COMMITTED_ID_FILE).stdout.strip() == "0", (
+        "the committed id file is no longer empty — if the real ids were wired in, update "
+        "this test to assert their exact count so the flagged set stays reviewed"
+    )
+    assert _run("param-ids", ids_file=COMMITTED_ID_FILE).returncode != 0
+
+
+# ===========================================================================
+# stdin composition — the exact stream the workflow pipes to cypher-shell.
+# ===========================================================================
+def test_stdin_flag_is_params_then_set(tmp_path: Path) -> None:
+    """The positive control: the flag phase is the two :param lines then the SET, in order."""
+    f = _ids_file(tmp_path, "nar:aaaa-1111", "nar:bbbb-2222")
+    r = _run("stdin", "flag", ids_file=f, note=NOTE)
+    assert r.returncode == 0, r.stderr
+    lines = r.stdout.strip().splitlines()
+    assert lines[0] == ":param ids => ['nar:aaaa-1111', 'nar:bbbb-2222']"
+    assert lines[1] == f":param note => '{NOTE}'"
+    assert lines[2].startswith("MATCH (n:Narrator) WHERE n.id IN $ids SET n.over_merged = true")
+    assert lines[2].endswith("RETURN count(n) AS flagged;")
+
+
+@pytest.mark.parametrize("phase", ["precount", "postcount"])
+def test_stdin_count_phases_bind_ids_but_not_note(tmp_path: Path, phase: str) -> None:
+    f = _ids_file(tmp_path, "nar:aaaa-1111")
+    r = _run("stdin", phase, ids_file=f)  # no NOTE: count phases must not need it
+    assert r.returncode == 0, r.stderr
+    lines = r.stdout.strip().splitlines()
+    assert lines[0] == ":param ids => ['nar:aaaa-1111']"
+    assert "note" not in r.stdout, "a count phase bound $note it does not use"
+    assert lines[1].startswith("MATCH (n:Narrator) WHERE n.id IN $ids")
+
+
+def test_stdin_flag_refuses_an_unsafe_id(tmp_path: Path) -> None:
+    f = tmp_path / "ids.txt"
+    f.write_text("nar:x'; MATCH (n) DETACH DELETE n; //\n")
+    assert _run("stdin", "flag", ids_file=f, note=NOTE).returncode != 0
+
+
+def test_unknown_mode_and_phase_refuse(tmp_path: Path) -> None:
+    assert _run("bogus-mode").returncode != 0
+    assert _run("stdin", "bogus-phase", ids_file=_ids_file(tmp_path, "nar:a-1")).returncode != 0


### PR DESCRIPTION
## What

The **transport** leg of the cross-repo honest-leaderboard "flag-now" work — carries da#447's `over_merged` / `over_merge_note` Narrator properties end-to-end into Neo4j, and gives stg an immediate live-graph flag without a ~7.5h reload.

Closes #603
Part of main#928 / main#958

## Piece 1 — durable transport (survives every reload)

The property rides the loader **passthrough unchanged**: `deploy-data-load.yml` pulls the *whole* `narrators_canonical.parquet` and enumerates **no** node-property allow-list anywhere in this repo, so the two new columns land as node properties with **zero code change** to the load path. (The loader image, da#447, writes them from the parquet columns.)

Added: a **non-fatal post-load read-back** that reports the `over_merged` Narrator count on every committed load, so each reload *proves* the property survived transport (same OR-arm idiom as the existing `source_corpus` read-back).

## Piece 2 — immediate flag on stg (`graph-flag-over-merged.yml`)

A cypher-shell dispatch op (**no loader image**), modeled on `graph-ops.yml`'s `prune-orphans` path: SSH to the VPS, refresh the `/opt` checkout, `cypher-shell` pre-count → SET → post-verify. It sets `over_merged=true` + `over_merge_note` on the producer's curated canonical ids directly on the live graph.

- **Parameterized + injection-safe.** Statements are parameterized on `$ids` / `$note`; the `:param` value literals are **built by `scripts/flag_over_merged_narrators.sh` under a charset whitelist** (a `'` or `\` cannot reach a graph-write statement — same `safe_literal` discipline as `graph_load_provenance.sh`). That builder is shellcheck-linted and **behaviourally unit-tested** by `scripts/tests/test_flag_over_merged_narrators.py` (34 tests: contract, injection payloads through every mode, fail-safe, stdin composition) — an ssh `script:` body is neither (deploy#555).
- **Match key** is `n.id` (the `nar:` canonical id), confirmed against `graph-ops.yml`'s enrich read-back.
- **Ids are authoritative, not derived.** From the committed `scripts/over_merged_narrator_ids.txt` — the producer's resolved ids (da#447), never re-derived from names (canonical-id drift, da#371/#376). **Ships as a placeholder → the op is INERT until the real ids are wired in** (fail-safe; `test_committed_id_file_is_inert` pins this).
- **Gates.** Pre/post refuse unless *every* configured id is present in the live graph (a subset means the seed is stale against the loaded run — reconcile, don't flag a partial set).
- **cypher-shell 5.x**: no `:auto`; non-interactive stdin auto-commits the plain SET (deploy#540).

## Safety / scope

- **stg-only this wave.** The script **hard-refuses `env=prod`** — prod flagging is HELD behind an explicit owner go-ahead **and** a verified-green backup (main#928). The env choice + `production` environment approval remain wired for when the hold lifts.
- **Delivers the workflow only** — I do **not** dispatch it here. The stg dispatch is a follow-on step after merge + the id list is confirmed.

## Pending (not a blocker to reviewing the mechanism)

The real 8 canonical `nar:` ids from the producer are **not yet wired** — `over_merged_narrator_ids.txt` is a placeholder, so the op flags nothing until they land. The mechanism (transport + workflow + guards + tests) is the reviewable deliverable; the ids get committed when relayed.

## Verification

`actionlint`, `shellcheck` + `bash -n`, `ruff` (check + format), `mypy`, and the full `scripts/tests` suite (416 passed / 3 skipped) all green locally; all pre-commit + pre-push hooks passed on commit and push.
