### PR TITLE
fix(backup): a preflight that could not run must not condemn the key (#613)

### DIFF
--- a/scripts/b2_preflight.sh
+++ b/scripts/b2_preflight.sh
@@ -32,6 +32,24 @@
 # Each probe's outcome is a fact. The error text is used only to enrich the human-facing
 # diagnosis, never to decide it.
 #
+# A PROBE THAT COULD NOT RUN IS NOT EVIDENCE ABOUT THE KEY (deploy#613)
+#
+# The probes need somewhere to capture rclone's output. `mktemp -d` defaults to /tmp, and
+# /tmp is READ-ONLY inside systemd/isnad-backup.service: it runs ProtectSystem=strict with
+# PrivateTmp deliberately unset (deploy#121 Bug A), and /tmp is not in ReadWritePaths. The
+# scratch allocation therefore failed on every scheduled run, its status went unchecked,
+# the redirect to `${tmp}/lsd.out` degraded to `/lsd.out` on the read-only root, lsd_rc
+# came back 1 -- and lsd_rc != 0 was read as "the key cannot list buckets", i.e.
+# KEY_INVALID. That verdict is key-INDEPENDENT: the same freshly-provisioned,
+# write-capable key that produced KEY_INVALID under the unit produced OK when run by hand
+# with a writable /tmp (stg, 2026-07-13). Every backup this project has ever attempted
+# died there, blaming a credential that was fine.
+#
+# So: scratch lives under BACKUP_DIR (which the unit DOES grant, and which the unit's own
+# comment already assumed backup.sh would use), a failure to allocate it is FATAL, and
+# "the probe never ran" is its own verdict -- PROBE_FAILED -- which can never be mistaken
+# for a statement about the credential.
+#
 # NEVER set RCLONE_DUMP (or any equivalent). An ambient `RCLONE_DUMP=auth` once leaked
 # base64 credentials past GitHub's log masking in a PUBLIC repo. This script prints no
 # credential material: it reports presence and length only.
@@ -48,18 +66,32 @@ RCLONE_REMOTE="${RCLONE_REMOTE:-isnad}"
 # Pure classifier. No I/O, no network -- takes probe outcomes, returns a verdict code.
 # Kept side-effect free so it can be unit-tested against the real captured outcomes.
 #
-#   $1 lsd_rc          exit status of `rclone lsd <remote>:`
+#   $1 lsd_rc          exit status of `rclone lsd <remote>:` ("skip" if it never ran)
 #   $2 bucket_visible  "yes" | "no"  -- was B2_BUCKET in the lsd listing
 #   $3 write_rc        exit status of the canary write ("skip" if not attempted)
 #   $4 delete_rc       exit status of the canary delete ("skip" if not attempted)
 #
 # Echoes one of:
-#   OK | KEY_INVALID | BUCKET_UNREACHABLE | KEY_READ_ONLY | KEY_CANNOT_DELETE
+#   OK | PROBE_FAILED | KEY_INVALID | BUCKET_UNREACHABLE | KEY_READ_ONLY | KEY_CANNOT_DELETE
 # ---------------------------------------------------------------------------
 classify_b2_state() {
     local lsd_rc="$1" bucket_visible="$2" write_rc="$3" delete_rc="$4"
 
-    # The key cannot even enumerate buckets: it is invalid, revoked, or lacks
+    # The probe never ran, so we hold no evidence about the key. `lsd_rc` is an exit
+    # status; anything that is not a number is not one. "skip" is the sentinel preflight_b2
+    # passes when it could not allocate the scratch directory the probes write into -- the
+    # same "skip" vocabulary write_rc/delete_rc already use for "not attempted".
+    #
+    # This branch MUST precede the KEY_INVALID one. Until deploy#613 it did not exist: a
+    # preflight that could not run at all fell straight through into "lsd_rc != 0" and
+    # condemned the credential. Absence of evidence was rendered as evidence of absence,
+    # and it was wrong every single time -- see the header.
+    if [[ ! "$lsd_rc" =~ ^[0-9]+$ ]]; then
+        echo "PROBE_FAILED"
+        return
+    fi
+
+    # The probe RAN and the key cannot enumerate buckets: it is invalid, revoked, or lacks
     # listBuckets. Nothing downstream is meaningful.
     if [[ "$lsd_rc" != "0" ]]; then
         echo "KEY_INVALID"
@@ -100,6 +132,14 @@ explain_b2_state() {
         OK)
             echo "B2 credentials verified: bucket reachable, writable, and prunable."
             ;;
+        PROBE_FAILED)
+            echo "The B2 preflight could not RUN its capability probes. It therefore has NO evidence about the credential."
+            echo "This is NOT a verdict on the key: do not rotate, revoke, or re-provision anything on the strength of it."
+            echo "Cause: no writable scratch directory (BACKUP_DIR=${BACKUP_DIR:-<unset>}). The probes need one to capture rclone's output."
+            echo "Under systemd, isnad-backup.service runs ProtectSystem=strict with no PrivateTmp (deploy#121 Bug A), so /tmp is READ-ONLY;"
+            echo "the scratch dir must therefore live under BACKUP_DIR, which the unit grants via ReadWritePaths."
+            echo "Remediation: ensure BACKUP_DIR is set, exists, is writable by the unit, and is listed in the unit's ReadWritePaths; then check for a full disk."
+            ;;
         KEY_INVALID)
             echo "B2 key cannot list buckets. It is invalid, revoked, or lacks the listBuckets capability."
             ;;
@@ -132,7 +172,7 @@ explain_b2_state() {
 # ---------------------------------------------------------------------------
 preflight_b2() {
     local remote="${RCLONE_REMOTE}"
-    local tmp lsd_out lsd_rc bucket_visible write_rc delete_rc verdict canary
+    local tmp scratch_parent lsd_out lsd_rc bucket_visible write_rc delete_rc verdict canary
 
     # Every probe below is EXPECTED to fail sometimes -- that is the entire point, and a
     # probe's non-zero exit is data, not an error. A caller running under `set -e` with
@@ -150,7 +190,29 @@ preflight_b2() {
         return 1
     fi
 
-    tmp="$(mktemp -d)"
+    # Scratch space for the probes' output. NOT /tmp: read-only under the backup unit's
+    # ProtectSystem=strict (deploy#613, see header). BACKUP_DIR is what the unit grants in
+    # ReadWritePaths and what backup.sh already stages its dumps into, so a scratch dir we
+    # can allocate there is a scratch dir the probes can actually use. Falling back to
+    # TMPDIR, then /tmp, keeps standalone and CI invocation (no BACKUP_DIR) working.
+    scratch_parent="${BACKUP_DIR:-${TMPDIR:-/tmp}}"
+    tmp=""
+    mkdir -p "$scratch_parent" 2>/dev/null
+
+    # FATAL, and never a credential verdict. An unchecked mktemp is what turned a read-only
+    # /tmp into "your B2 key is invalid" on every backup this project ever ran. mktemp's
+    # own diagnostic goes to stderr, which backup.sh captures and tees to the journal.
+    if ! tmp="$(mktemp -d -p "$scratch_parent" b2-preflight-XXXXXX)" \
+        || [[ -z "$tmp" || ! -d "$tmp" ]]; then
+        tmp=""
+        verdict="$(classify_b2_state skip unknown skip skip)"
+        echo "[preflight] scratch_parent=${scratch_parent} scratch_dir=FAILED"
+        echo "[preflight] lsd_rc=skip bucket_visible=unknown write_rc=skip delete_rc=skip"
+        echo "[preflight] verdict=${verdict}"
+        explain_b2_state "$verdict"
+        return 1
+    fi
+
     # shellcheck disable=SC2064  # expand tmp now, on purpose
     trap "rm -rf '$tmp'" RETURN
 

--- a/scripts/b2_preflight.sh
+++ b/scripts/b2_preflight.sh
@@ -135,10 +135,15 @@ explain_b2_state() {
         PROBE_FAILED)
             echo "The B2 preflight could not RUN its capability probes. It therefore has NO evidence about the credential."
             echo "This is NOT a verdict on the key: do not rotate, revoke, or re-provision anything on the strength of it."
-            echo "Cause: no writable scratch directory (BACKUP_DIR=${BACKUP_DIR:-<unset>}). The probes need one to capture rclone's output."
-            echo "Under systemd, isnad-backup.service runs ProtectSystem=strict with no PrivateTmp (deploy#121 Bug A), so /tmp is READ-ONLY;"
-            echo "the scratch dir must therefore live under BACKUP_DIR, which the unit grants via ReadWritePaths."
-            echo "Remediation: ensure BACKUP_DIR is set, exists, is writable by the unit, and is listed in the unit's ReadWritePaths; then check for a full disk."
+            echo "Cause: ${PROBE_FAILED_CAUSE:-the probes could not be executed}."
+            echo "Scratch parent actually used: ${SCRATCH_PARENT_USED:-<none>} (BACKUP_DIR=${BACKUP_DIR:-<unset>}, TMPDIR=${TMPDIR:-<unset>})."
+            echo "Two things commonly do this. (1) A read-only scratch parent: under systemd, isnad-backup.service runs"
+            echo "ProtectSystem=strict with no PrivateTmp (deploy#121 Bug A), so /tmp is READ-ONLY and the scratch dir must live"
+            echo "under BACKUP_DIR, which the unit grants via ReadWritePaths. (2) A FULL DISK: BACKUP_DIR is the volume the dumps"
+            echo "themselves fill, so ENOSPC there is an expected fault -- and it can let a directory be created while a file"
+            echo "written into it stays empty."
+            echo "Remediation: check free space on the scratch parent first (df), then confirm BACKUP_DIR is set, exists, is"
+            echo "writable by the unit, and is listed in the unit's ReadWritePaths."
             ;;
         KEY_INVALID)
             echo "B2 key cannot list buckets. It is invalid, revoked, or lacks the listBuckets capability."
@@ -190,34 +195,76 @@ preflight_b2() {
         return 1
     fi
 
+    # A probe that could not run yields NO evidence about the key. Every such route -- and
+    # there are four -- funnels through here, so none of them can drift back into a
+    # credential verdict the way the unchecked mktemp did (deploy#613, Lucas/Nino review).
+    probe_failed() {
+        PROBE_FAILED_CAUSE="$1"
+        SCRATCH_PARENT_USED="$scratch_parent"
+        verdict="$(classify_b2_state skip unknown skip skip)"
+        echo "[preflight] scratch_parent=${scratch_parent} probe_failed=${1}"
+        echo "[preflight] lsd_rc=skip bucket_visible=unknown write_rc=skip delete_rc=skip"
+        echo "[preflight] verdict=${verdict}"
+        explain_b2_state "$verdict"
+    }
+
+    # rclone absent is a probe that cannot run, not a bad key: `rclone lsd` would exit 127
+    # and 127 is a number, so it would sail past PROBE_FAILED into KEY_INVALID. backup.sh
+    # pre-checks rclone, but the standalone and `source` invocations this file documents do
+    # not -- and standalone is precisely what an operator reaches for to double-check a
+    # KEY_INVALID they do not believe.
+    if ! command -v rclone > /dev/null 2>&1; then
+        scratch_parent="${BACKUP_DIR:-${TMPDIR:-/tmp}}"
+        probe_failed "rclone is not installed or not executable on PATH"
+        return 1
+    fi
+
     # Scratch space for the probes' output. NOT /tmp: read-only under the backup unit's
     # ProtectSystem=strict (deploy#613, see header). BACKUP_DIR is what the unit grants in
-    # ReadWritePaths and what backup.sh already stages its dumps into, so a scratch dir we
-    # can allocate there is a scratch dir the probes can actually use. Falling back to
+    # ReadWritePaths and what backup.sh already stages its dumps into. Falling back to
     # TMPDIR, then /tmp, keeps standalone and CI invocation (no BACKUP_DIR) working.
     scratch_parent="${BACKUP_DIR:-${TMPDIR:-/tmp}}"
     tmp=""
     mkdir -p "$scratch_parent" 2>/dev/null
 
     # FATAL, and never a credential verdict. An unchecked mktemp is what turned a read-only
-    # /tmp into "your B2 key is invalid" on every backup this project ever ran. mktemp's
-    # own diagnostic goes to stderr, which backup.sh captures and tees to the journal.
+    # /tmp into "your B2 key is invalid" on every backup this project ever ran.
     if ! tmp="$(mktemp -d -p "$scratch_parent" b2-preflight-XXXXXX)" \
         || [[ -z "$tmp" || ! -d "$tmp" ]]; then
         tmp=""
-        verdict="$(classify_b2_state skip unknown skip skip)"
-        echo "[preflight] scratch_parent=${scratch_parent} scratch_dir=FAILED"
-        echo "[preflight] lsd_rc=skip bucket_visible=unknown write_rc=skip delete_rc=skip"
-        echo "[preflight] verdict=${verdict}"
-        explain_b2_state "$verdict"
+        probe_failed "the scratch directory could not be created under ${scratch_parent}"
         return 1
     fi
 
-    # shellcheck disable=SC2064  # expand tmp now, on purpose
-    trap "rm -rf '$tmp'" RETURN
+    # Single-quoted so $tmp expands when the trap FIRES, not when it is set. The previous
+    # form interpolated the path into a string that bash re-parses at return time, so a
+    # single quote anywhere in BACKUP_DIR broke the quoting of an `rm -rf` in a ROOT-run
+    # unit. `rm -rf ''` stays unreachable either way -- the trap is installed only after the
+    # [[ -z "$tmp" || ! -d "$tmp" ]] guard above has already returned.
+    trap 'rm -rf -- "$tmp"' RETURN
+
+    # The directory EXISTS. That is not the same as being able to put a file in it, and the
+    # difference is the whole bug one layer down: if the redirect below cannot create its
+    # target, bash never execs rclone, $? is 1, and 1 is a number -- so it would sail past
+    # PROBE_FAILED straight into KEY_INVALID, condemning a key that was never consulted.
+    #
+    # This is not a theoretical fault, and moving scratch onto BACKUP_DIR RAISES it: that is
+    # the one volume that fills with multi-GB dumps under a 7-daily/4-weekly retention, so
+    # ENOSPC is its single most expected failure. Under ENOSPC the creat() can succeed while
+    # the write fails, leaving a 0-byte file -- so testing the redirect's exit status alone
+    # is not enough. -s (non-empty) is what actually catches it.
+    if ! printf 'preflight-writable\n' > "${tmp}/.rw" 2>/dev/null || [[ ! -s "${tmp}/.rw" ]]; then
+        probe_failed "the scratch directory ${tmp} exists but cannot hold a file (full disk, quota, or read-only filesystem)"
+        return 1
+    fi
+    rm -f -- "${tmp}/.rw"
 
     # 1. Can the key enumerate buckets, and is ours among them?
     lsd_out="${tmp}/lsd.out"
+    if ! : > "$lsd_out" 2>/dev/null; then
+        probe_failed "the scratch directory ${tmp} would not accept the probe's output file"
+        return 1
+    fi
     rclone lsd "${remote}:" > "$lsd_out" 2>&1
     lsd_rc=$?
 
@@ -233,7 +280,18 @@ preflight_b2() {
     delete_rc="skip"
     if [[ "$bucket_visible" == "yes" ]]; then
         canary=".backup-preflight/canary-$(date -u +%Y%m%d-%H%M%S)-$$"
-        printf 'noorinalabs backup preflight canary\n' > "${tmp}/canary"
+
+        # An unchecked local write here is the WORST of this family, because its downstream
+        # verdict is actively harmful. A failed/empty canary makes `rclone copyto` fail,
+        # which classifies as KEY_READ_ONLY -- whose remediation text says "rotate
+        # BACKUP_B2_APP_KEY to the write-capable key". So a FULL DISK would hand the
+        # operator a written instruction to re-provision a perfectly good credential with
+        # MORE capability than it needs. That is the exact door PROBE_FAILED exists to shut.
+        if ! printf 'noorinalabs backup preflight canary\n' > "${tmp}/canary" 2>/dev/null \
+            || [[ ! -s "${tmp}/canary" ]]; then
+            probe_failed "the canary file could not be written to ${tmp} (full disk, quota, or read-only filesystem)"
+            return 1
+        fi
 
         rclone copyto "${tmp}/canary" "${remote}:${B2_BUCKET}/${canary}" > "${tmp}/write.out" 2>&1
         write_rc=$?

--- a/scripts/tests/test_b2_preflight.py
+++ b/scripts/tests/test_b2_preflight.py
@@ -335,23 +335,56 @@ exit "$rc"
 """
 
 
+# The three states the probes' scratch space can be in. "unwritable" is the one that
+# reopened this bug in review (deploy#614, Lucas Ferreira + Nino Kavtaradze, independently):
+# the original fix keyed on `mktemp`'s exit status and `[[ -d "$tmp" ]]`, both of which say
+# the directory EXISTS — neither of which says a file can be created in it. A scratch dir
+# that allocates and then refuses a write made the redirect fail, so bash never exec'd
+# rclone, `$?` was 1, and 1 is a NUMBER: it sailed straight past PROBE_FAILED into
+# KEY_INVALID. Same conflation as #613, one layer down.
+#
+# This is not exotic. The fix deliberately moves scratch onto BACKUP_DIR — the one volume
+# that fills with multi-GB dumps under a 7-daily/4-weekly retention — so ENOSPC there is the
+# single most expected fault on a backup host.
+SCRATCH_USABLE = "usable"
+SCRATCH_UNALLOCATABLE = "unallocatable"  # mktemp -d itself fails (read-only /tmp: #613)
+SCRATCH_UNWRITABLE = "unwritable"  # mkdir succeeds, file creation does not (ENOSPC: #614)
+SCRATCH_STATES = (SCRATCH_USABLE, SCRATCH_UNALLOCATABLE, SCRATCH_UNWRITABLE)
+
+# A directory that demonstrably exists and into which no file can be created — for uid 0
+# as well, which is the point: a root CI runner must not be able to turn this class green.
+# procfs refuses creat() outright, so it models "allocated but unwritable" without needing
+# a loopback mount or a real full disk. Same reasoning as the ENOTDIR choice above.
+_MKTEMP_STUB_RETURNING_UNWRITABLE_DIR = """#!/bin/sh
+# Ignore the args; hand back a real directory that cannot hold a file.
+echo /proc/self
+"""
+
+
 def _run_preflight(
     tmp_path: Path,
     *,
     key_is_good: bool,
-    scratch_usable: bool,
+    scratch: str,
 ) -> subprocess.CompletedProcess[str]:
     """Drive the real preflight, exactly as backup.sh drives it.
 
-    Two independent factors, so the four cells can be compared:
-      key_is_good     — whether the stubbed rclone behaves like a valid, write-capable key
-      scratch_usable  — whether the preflight can allocate its scratch directory at all
+    Two independent factors, so the six cells can be compared:
+      key_is_good  — whether the stubbed rclone behaves like a valid, write-capable key
+      scratch      — one of SCRATCH_STATES; how the probes' scratch space misbehaves
     """
+    assert scratch in SCRATCH_STATES, f"unknown scratch state {scratch!r}"
+
     tmp_path.mkdir(parents=True, exist_ok=True)  # each matrix cell gets its own sandbox
     stub = tmp_path / "stub"
     stub.mkdir()
     (stub / "rclone").write_text(GOOD_RCLONE if key_is_good else BAD_RCLONE)
     (stub / "rclone").chmod(0o755)
+
+    if scratch == SCRATCH_UNWRITABLE:
+        # Intercept mktemp so it "succeeds" and returns a dir that refuses file creation.
+        (stub / "mktemp").write_text(_MKTEMP_STUB_RETURNING_UNWRITABLE_DIR)
+        (stub / "mktemp").chmod(0o755)
 
     # An ENOTDIR parent: `not-a-dir` is a regular file, so both `mkdir -p` and
     # `mktemp -d -p` fail on any path beneath it — for root as well as for us.
@@ -368,7 +401,9 @@ def _run_preflight(
         B2_KEY_ID="fake-key-id",
         B2_APP_KEY="fake-app-key",
         B2_BUCKET="noorinalabs-backups",
-        BACKUP_DIR=str(usable) if scratch_usable else unusable,
+        # UNWRITABLE keeps a perfectly good parent: the fault is inside the scratch dir the
+        # mktemp stub hands back, which is exactly the case existence-checks cannot see.
+        BACKUP_DIR=unusable if scratch == SCRATCH_UNALLOCATABLE else str(usable),
     )
     env.pop("RCLONE_DUMP", None)
 
@@ -388,46 +423,64 @@ def _verdict_of(proc: subprocess.CompletedProcess[str]) -> str:
 def test_the_preflight_separates_its_own_breakage_from_a_bad_key(tmp_path: Path) -> None:
     """THE test. One instrument, two failure classes, and it must not conflate them.
 
-    Read the matrix as a 2x2: the verdict has to move with BOTH factors. If the preflight
-    answered KEY_INVALID down the whole `scratch_usable=False` column — which is precisely
-    what it did before deploy#613 — the key column would be doing no work at all, and the
+    Read it as a 2x3: the verdict has to move with BOTH factors. If the preflight answered
+    KEY_INVALID down a whole broken-scratch column — which is precisely what it did before
+    deploy#613, and what it STILL did for the `unwritable` column at the first cut of the
+    fix (deploy#614 review) — the key column would be doing no work at all, and the
     "detector" would just be a constant wearing a credential's name.
+
+    The `unwritable` column is the one that matters most now: `mktemp` succeeding proves the
+    scratch dir EXISTS, never that a file can be put in it, and the fix moved scratch onto
+    the very volume that fills with dumps. A full disk must not be able to speak as a
+    credential.
     """
     verdicts = {
-        (key_is_good, scratch_usable): _verdict_of(
+        (key_is_good, scratch): _verdict_of(
             _run_preflight(
-                tmp_path / f"k{int(key_is_good)}s{int(scratch_usable)}",
+                tmp_path / f"k{int(key_is_good)}-{scratch}",
                 key_is_good=key_is_good,
-                scratch_usable=scratch_usable,
+                scratch=scratch,
             )
         )
         for key_is_good in (True, False)
-        for scratch_usable in (True, False)
+        for scratch in SCRATCH_STATES
     }
 
     # Calibration first: with a working scratch dir the instrument demonstrably WORKS —
     # it tells a good key from a bad one. Without this cell, PROBE_FAILED below could be
     # an artefact of the stub rather than a real discrimination.
-    assert verdicts[(True, True)] == "OK", "a good key with usable scratch must verify"
-    assert verdicts[(False, True)] == "KEY_INVALID", (
+    assert verdicts[(True, SCRATCH_USABLE)] == "OK", "a good key with usable scratch must verify"
+    assert verdicts[(False, SCRATCH_USABLE)] == "KEY_INVALID", (
         "a key that genuinely cannot list buckets is still KEY_INVALID — the fix must not "
         "have blunted the real diagnosis"
     )
 
-    # And now the bug: a broken scratch dir is the PROBE's failure, never the key's.
-    assert verdicts[(True, False)] == "PROBE_FAILED", (
-        "a good key + unusable scratch was reported as KEY_INVALID before deploy#613. "
-        "The probe never ran; it holds no evidence about the credential and must say so."
-    )
-    assert verdicts[(False, False)] == "PROBE_FAILED", (
-        "even when the key IS bad, a preflight that could not run has not LEARNED that. "
-        "Reporting KEY_INVALID here would be right by accident — and it is the same "
-        "accident that condemned a good key on every scheduled run."
-    )
+    # And now the bug, in both of its shapes. A scratch dir that cannot be ALLOCATED (#613,
+    # read-only /tmp) and one that allocates but cannot be WRITTEN TO (#614, ENOSPC on
+    # BACKUP_DIR) are both a probe that did not run. Neither is evidence about the key.
+    for scratch in (SCRATCH_UNALLOCATABLE, SCRATCH_UNWRITABLE):
+        assert verdicts[(True, scratch)] == "PROBE_FAILED", (
+            f"a GOOD key + {scratch} scratch must be PROBE_FAILED. Before the fix this was "
+            "KEY_INVALID: the probe never ran, held no evidence about the credential, and "
+            "condemned it anyway."
+        )
+        assert verdicts[(False, scratch)] == "PROBE_FAILED", (
+            f"even when the key IS bad, a {scratch} preflight has not LEARNED that. "
+            "Reporting KEY_INVALID here would be right by accident — and it is the same "
+            "accident that condemned a good key on every scheduled run."
+        )
 
-    # The separation, stated as the property rather than as four literals: the verdict
-    # under a broken scratch dir must not be a credential verdict at all.
-    broken = {verdicts[(True, False)], verdicts[(False, False)]}
+    # The separation, stated as the property rather than as literals: under ANY broken
+    # scratch state the verdict must not be a credential verdict at all. KEY_READ_ONLY is in
+    # this set deliberately — its remediation text says "rotate BACKUP_B2_APP_KEY to the
+    # write-capable key", so a full disk reaching it would hand the operator a written
+    # instruction to re-provision a key that was never at fault, with MORE capability than
+    # it needs.
+    broken = {
+        verdicts[(key_is_good, scratch)]
+        for key_is_good in (True, False)
+        for scratch in (SCRATCH_UNALLOCATABLE, SCRATCH_UNWRITABLE)
+    }
     assert broken.isdisjoint({"OK", "KEY_INVALID", "BUCKET_UNREACHABLE", "KEY_READ_ONLY"}), (
         f"a probe that could not run emitted a verdict about the credential: {broken}"
     )
@@ -484,13 +537,55 @@ def test_a_good_key_verifies_when_tmp_is_unusable_but_backup_dir_is_writable(
     assert "KEY_INVALID" not in combined
 
 
+def test_a_full_disk_never_tells_the_operator_to_rotate_the_key(tmp_path: Path) -> None:
+    """The most harmful cell in the matrix, called out on its own (deploy#614 review).
+
+    An unchecked local canary write does not merely produce a wrong verdict — it produces
+    an ACTIVELY DANGEROUS one. A scratch dir that cannot hold a file leaves the canary
+    absent or empty, `rclone copyto` fails, and that classifies as KEY_READ_ONLY, whose
+    remediation reads "rotate BACKUP_B2_APP_KEY to the write-capable key (writeFiles +
+    deleteFiles)". So a FULL DISK would hand the operator a written instruction to
+    re-provision a perfectly good credential with MORE capability than it needs — the
+    over-privileging door that PROBE_FAILED exists to shut.
+
+    A good key + a disk that cannot take a byte must never emit a credential verdict, and
+    must never print the word "rotate".
+    """
+    proc = _run_preflight(tmp_path, key_is_good=True, scratch=SCRATCH_UNWRITABLE)
+    combined = proc.stdout + proc.stderr
+
+    assert _verdict_of(proc) == "PROBE_FAILED"
+    assert proc.returncode != 0
+
+    for credential_verdict in ("KEY_READ_ONLY", "KEY_INVALID", "BUCKET_UNREACHABLE"):
+        assert credential_verdict not in combined, (
+            f"a full disk was reported as {credential_verdict} — the probe could not write a "
+            "single byte locally, so it learned NOTHING about the key's capabilities"
+        )
+    # Ban the INSTRUCTION, not the word. A bare `"rotate" not in ...` is the wrong
+    # assertion and fails against correct code: PROBE_FAILED's own text contains "do not
+    # rotate, revoke, or re-provision anything on the strength of it" — the sentence that
+    # FORBIDS the action. What must never appear is the KEY_READ_ONLY remediation that
+    # PRESCRIBES it.
+    assert "rotate BACKUP_B2_APP_KEY" not in combined, (
+        "a local disk fault instructed the operator to rotate the key — that is how a good "
+        "credential gets churned and re-provisioned with more capability than it needs"
+    )
+    assert "do not rotate, revoke, or re-provision" in combined, (
+        "the diagnosis must explicitly disown the credential, not merely decline to accuse it"
+    )
+    assert "full disk" in combined.lower(), (
+        "the diagnosis must name the actual cause so the operator checks df, not Backblaze"
+    )
+
+
 def test_scratch_failure_is_fatal_and_leaves_no_scratch_behind(tmp_path: Path) -> None:
     """A scratch failure must abort — never fall through into a credential verdict."""
-    proc = _run_preflight(tmp_path, key_is_good=True, scratch_usable=False)
+    proc = _run_preflight(tmp_path, key_is_good=True, scratch=SCRATCH_UNALLOCATABLE)
     combined = proc.stdout + proc.stderr
 
     assert proc.returncode != 0, "an unrunnable preflight must fail, not pass by default"
-    assert "scratch_dir=FAILED" in combined, "the operator must be told WHICH thing broke"
+    assert "probe_failed=" in combined, "the operator must be told WHICH thing broke"
     assert "NOT a verdict on the key" in combined, (
         "the diagnosis must explicitly disown the credential, or the next operator rotates "
         "a perfectly good key — which is exactly what deploy#612 nearly did"

--- a/scripts/tests/test_b2_preflight.py
+++ b/scripts/tests/test_b2_preflight.py
@@ -96,7 +96,14 @@ def test_fully_capable_key_passes() -> None:
 
 
 def test_every_verdict_has_a_distinct_explanation() -> None:
-    verdicts = ["OK", "KEY_INVALID", "BUCKET_UNREACHABLE", "KEY_READ_ONLY", "KEY_CANNOT_DELETE"]
+    verdicts = [
+        "OK",
+        "PROBE_FAILED",
+        "KEY_INVALID",
+        "BUCKET_UNREACHABLE",
+        "KEY_READ_ONLY",
+        "KEY_CANNOT_DELETE",
+    ]
     texts = {v: explain(v).strip() for v in verdicts}
     assert len(set(texts.values())) == len(verdicts), "verdicts must not share a diagnosis"
     for v, t in texts.items():
@@ -271,3 +278,330 @@ def test_failing_preflight_stops_before_any_dump(tmp_path: Path) -> None:
     assert "refusing to dump databases we cannot upload" in combined
     # backup.sh logs this immediately before it stops Neo4j.
     assert "Stopping Neo4j" not in combined, "the preflight must abort before Neo4j is stopped"
+
+
+# --------------------------------------------------------------------------
+# deploy#613 — the probe must not blame the key for its OWN breakage
+# --------------------------------------------------------------------------
+#
+# `mktemp -d` defaults to /tmp, and /tmp is READ-ONLY under the backup unit
+# (ProtectSystem=strict, PrivateTmp deliberately unset — deploy#121 Bug A). The scratch
+# allocation failed, its status went unchecked, the redirect to `${tmp}/lsd.out` degraded
+# to `/lsd.out` on the read-only root, `lsd_rc` came back 1 — and `lsd_rc != 0` meant
+# KEY_INVALID. Every backup this project ever ran died there, blaming a key that was fine:
+# the SAME freshly-provisioned write-capable key yielded KEY_INVALID under systemd and OK
+# by hand with a writable /tmp (stg, 2026-07-13).
+#
+# WHY THE OBVIOUS TEST IS WORTHLESS HERE
+#
+# `assert classify("1", "no", "skip", "skip") == "KEY_INVALID"` passed throughout. It
+# still does. It cannot fail, because it asserts the very conflation that IS the bug: it
+# is handed the *symptom* (lsd_rc=1) and asked whether the code draws the conclusion the
+# code draws. An instrument that returns KEY_INVALID for both a bad key and a broken probe
+# has not measured anything, and a test that only ever feeds it one class cannot tell.
+# So these tests run the preflight on BOTH classes and require it to SEPARATE them —
+# same harness, same stub, one factor varied at a time. Cf. the org memory
+# `feedback_silent_zero_is_not_a_measurement`.
+#
+# Unusable scratch is simulated with an ENOTDIR parent (a *file* standing where a
+# directory must be), not with chmod: chmod is a no-op against uid 0, so a root CI runner
+# would quietly turn the whole class into a passing OK. ENOTDIR fails for root too.
+
+GOOD_RCLONE = """#!/usr/bin/env bash
+# A write-capable, correctly-scoped key: lists the bucket, writes, deletes.
+case "$1" in
+    lsd) echo "         -1 2026-07-13 00:00:00        -1 ${B2_BUCKET}" ;;
+esac
+exit 0
+"""
+
+BAD_RCLONE = """#!/usr/bin/env bash
+# A revoked / wrongly-scoped key: cannot even enumerate buckets.
+echo 'CRITICAL: you must use bucket(s) [...] with this application key' >&2
+exit 1
+"""
+
+# backup.sh's own invocation form, verbatim (scripts/backup.sh § Preflight checks):
+# `set -euo pipefail` + the `|| RC=$?` condition-context guard. A harness under a weaker
+# `set -…` is not running production's code — deploy#563/#584 were both found this way.
+_PRODUCTION_INVOCATION = """
+set -euo pipefail
+shopt -s inherit_errexit
+source "{preflight}"
+rc=0
+out="$(set +e; preflight_b2 2>&1)" || rc=$?
+printf '%s\\n' "$out"
+exit "$rc"
+"""
+
+
+def _run_preflight(
+    tmp_path: Path,
+    *,
+    key_is_good: bool,
+    scratch_usable: bool,
+) -> subprocess.CompletedProcess[str]:
+    """Drive the real preflight, exactly as backup.sh drives it.
+
+    Two independent factors, so the four cells can be compared:
+      key_is_good     — whether the stubbed rclone behaves like a valid, write-capable key
+      scratch_usable  — whether the preflight can allocate its scratch directory at all
+    """
+    tmp_path.mkdir(parents=True, exist_ok=True)  # each matrix cell gets its own sandbox
+    stub = tmp_path / "stub"
+    stub.mkdir()
+    (stub / "rclone").write_text(GOOD_RCLONE if key_is_good else BAD_RCLONE)
+    (stub / "rclone").chmod(0o755)
+
+    # An ENOTDIR parent: `not-a-dir` is a regular file, so both `mkdir -p` and
+    # `mktemp -d -p` fail on any path beneath it — for root as well as for us.
+    blocker = tmp_path / "not-a-dir"
+    blocker.write_text("")
+    unusable = str(blocker / "scratch")
+
+    usable = tmp_path / "backups"
+    usable.mkdir()
+
+    env = dict(os.environ)
+    env["PATH"] = f"{stub}:{env['PATH']}"
+    env.update(
+        B2_KEY_ID="fake-key-id",
+        B2_APP_KEY="fake-app-key",
+        B2_BUCKET="noorinalabs-backups",
+        BACKUP_DIR=str(usable) if scratch_usable else unusable,
+    )
+    env.pop("RCLONE_DUMP", None)
+
+    script = _PRODUCTION_INVOCATION.format(preflight=PREFLIGHT)
+    return subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, env=env, timeout=120
+    )
+
+
+def _verdict_of(proc: subprocess.CompletedProcess[str]) -> str:
+    for line in (proc.stdout + proc.stderr).splitlines():
+        if line.startswith("[preflight] verdict="):
+            return line.split("=", 1)[1].strip()
+    raise AssertionError(f"the preflight printed no verdict at all:\n{proc.stdout}{proc.stderr}")
+
+
+def test_the_preflight_separates_its_own_breakage_from_a_bad_key(tmp_path: Path) -> None:
+    """THE test. One instrument, two failure classes, and it must not conflate them.
+
+    Read the matrix as a 2x2: the verdict has to move with BOTH factors. If the preflight
+    answered KEY_INVALID down the whole `scratch_usable=False` column — which is precisely
+    what it did before deploy#613 — the key column would be doing no work at all, and the
+    "detector" would just be a constant wearing a credential's name.
+    """
+    verdicts = {
+        (key_is_good, scratch_usable): _verdict_of(
+            _run_preflight(
+                tmp_path / f"k{int(key_is_good)}s{int(scratch_usable)}",
+                key_is_good=key_is_good,
+                scratch_usable=scratch_usable,
+            )
+        )
+        for key_is_good in (True, False)
+        for scratch_usable in (True, False)
+    }
+
+    # Calibration first: with a working scratch dir the instrument demonstrably WORKS —
+    # it tells a good key from a bad one. Without this cell, PROBE_FAILED below could be
+    # an artefact of the stub rather than a real discrimination.
+    assert verdicts[(True, True)] == "OK", "a good key with usable scratch must verify"
+    assert verdicts[(False, True)] == "KEY_INVALID", (
+        "a key that genuinely cannot list buckets is still KEY_INVALID — the fix must not "
+        "have blunted the real diagnosis"
+    )
+
+    # And now the bug: a broken scratch dir is the PROBE's failure, never the key's.
+    assert verdicts[(True, False)] == "PROBE_FAILED", (
+        "a good key + unusable scratch was reported as KEY_INVALID before deploy#613. "
+        "The probe never ran; it holds no evidence about the credential and must say so."
+    )
+    assert verdicts[(False, False)] == "PROBE_FAILED", (
+        "even when the key IS bad, a preflight that could not run has not LEARNED that. "
+        "Reporting KEY_INVALID here would be right by accident — and it is the same "
+        "accident that condemned a good key on every scheduled run."
+    )
+
+    # The separation, stated as the property rather than as four literals: the verdict
+    # under a broken scratch dir must not be a credential verdict at all.
+    broken = {verdicts[(True, False)], verdicts[(False, False)]}
+    assert broken.isdisjoint({"OK", "KEY_INVALID", "BUCKET_UNREACHABLE", "KEY_READ_ONLY"}), (
+        f"a probe that could not run emitted a verdict about the credential: {broken}"
+    )
+
+
+def test_a_good_key_verifies_when_tmp_is_unusable_but_backup_dir_is_writable(
+    tmp_path: Path,
+) -> None:
+    """The regression test: production's exact namespace, reproduced without systemd.
+
+    Under the unit, /tmp is read-only and BACKUP_DIR (/var/lib/noorinalabs-backups) is
+    writable via ReadWritePaths. `mktemp -d` honours TMPDIR, so pointing TMPDIR at an
+    ENOTDIR path reproduces the read-only /tmp the unit imposes, exactly, in CI.
+
+    Against the pre-fix tree this run yields KEY_INVALID — the stg failure, reproduced.
+    After the fix the scratch dir comes from BACKUP_DIR and the same key verifies OK.
+    """
+    stub = tmp_path / "stub"
+    stub.mkdir()
+    (stub / "rclone").write_text(GOOD_RCLONE)
+    (stub / "rclone").chmod(0o755)
+
+    blocker = tmp_path / "not-a-dir"
+    blocker.write_text("")
+    backup_dir = tmp_path / "backups"
+    backup_dir.mkdir()
+
+    env = dict(os.environ)
+    env["PATH"] = f"{stub}:{env['PATH']}"
+    env.update(
+        B2_KEY_ID="fake-key-id",
+        B2_APP_KEY="fake-app-key",
+        B2_BUCKET="noorinalabs-backups",
+        BACKUP_DIR=str(backup_dir),
+        TMPDIR=str(blocker / "tmp"),  # stands in for the unit's read-only /tmp
+    )
+    env.pop("RCLONE_DUMP", None)
+
+    proc = subprocess.run(
+        ["bash", "-c", _PRODUCTION_INVOCATION.format(preflight=PREFLIGHT)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+    )
+    combined = proc.stdout + proc.stderr
+
+    assert _verdict_of(proc) == "OK", (
+        "a valid key must verify with an unusable /tmp, because the scratch dir belongs "
+        "under BACKUP_DIR — which the unit grants in ReadWritePaths. This is the stg "
+        "failure of deploy#613: same key, KEY_INVALID under systemd, OK by hand."
+    )
+    assert proc.returncode == 0
+    assert "KEY_INVALID" not in combined
+
+
+def test_scratch_failure_is_fatal_and_leaves_no_scratch_behind(tmp_path: Path) -> None:
+    """A scratch failure must abort — never fall through into a credential verdict."""
+    proc = _run_preflight(tmp_path, key_is_good=True, scratch_usable=False)
+    combined = proc.stdout + proc.stderr
+
+    assert proc.returncode != 0, "an unrunnable preflight must fail, not pass by default"
+    assert "scratch_dir=FAILED" in combined, "the operator must be told WHICH thing broke"
+    assert "NOT a verdict on the key" in combined, (
+        "the diagnosis must explicitly disown the credential, or the next operator rotates "
+        "a perfectly good key — which is exactly what deploy#612 nearly did"
+    )
+    assert "ReadWritePaths" in combined and "BACKUP_DIR" in combined, (
+        "the remediation must name the systemd knob that actually governs this"
+    )
+
+
+def test_standalone_invocation_also_refuses_rather_than_blaming_the_key(tmp_path: Path) -> None:
+    """`./scripts/b2_preflight.sh` is the form an operator runs on the host by hand."""
+    stub = tmp_path / "stub"
+    stub.mkdir()
+    (stub / "rclone").write_text(GOOD_RCLONE)
+    (stub / "rclone").chmod(0o755)
+
+    blocker = tmp_path / "not-a-dir"
+    blocker.write_text("")
+
+    env = dict(os.environ)
+    env["PATH"] = f"{stub}:{env['PATH']}"
+    env.update(
+        B2_KEY_ID="fake-key-id",
+        B2_APP_KEY="fake-app-key",
+        B2_BUCKET="noorinalabs-backups",
+        TMPDIR=str(blocker / "tmp"),  # BACKUP_DIR unset: the fallback must break safely too
+    )
+    env.pop("BACKUP_DIR", None)
+    env.pop("RCLONE_DUMP", None)
+
+    proc = subprocess.run(
+        ["bash", str(PREFLIGHT)], capture_output=True, text=True, env=env, timeout=120
+    )
+    combined = proc.stdout + proc.stderr
+
+    assert proc.returncode != 0
+    assert _verdict_of(proc) == "PROBE_FAILED"
+    assert "KEY_INVALID" not in combined
+
+
+def test_backup_never_blames_the_key_when_its_staging_dir_is_unwritable(tmp_path: Path) -> None:
+    """End-to-end through backup.sh, which stages into BACKUP_DIR before it ever probes.
+
+    If BACKUP_DIR is unusable, backup.sh now cannot reach the preflight at all (it dies at
+    its own `mkdir -p`). That is fine — what must NEVER happen, by any path, is that an
+    infrastructure fault at the host presents itself to the operator as a bad credential.
+    """
+    blocker = tmp_path / "not-a-dir"
+    blocker.write_text("")
+
+    stub = tmp_path / "stub"
+    stub.mkdir()
+    for name in ("docker", "zstd"):
+        (stub / name).write_text("#!/usr/bin/env bash\nexit 0\n")
+    (stub / "rclone").write_text(GOOD_RCLONE)
+    for f in stub.iterdir():
+        f.chmod(0o755)
+
+    env = dict(os.environ)
+    env["PATH"] = f"{stub}:{env['PATH']}"
+    env.update(
+        B2_KEY_ID="fake-key-id",
+        B2_APP_KEY="fake-app-key",
+        B2_BUCKET="noorinalabs-backups",
+        BACKUP_DIR=str(blocker / "scratch"),
+        COMPOSE_FILE="/dev/null",
+    )
+    env.pop("RCLONE_DUMP", None)
+
+    proc = subprocess.run(
+        ["bash", str(BACKUP)], capture_output=True, text=True, env=env, timeout=120
+    )
+    combined = proc.stdout + proc.stderr
+
+    assert proc.returncode != 0
+    assert "KEY_INVALID" not in combined, (
+        "a host-side storage fault must not be rendered as a credential verdict"
+    )
+    assert "Stopping Neo4j" not in combined, "and it must not take an outage on the way"
+
+
+# --------------------------------------------------------------------------
+# The classifier's own contract for a probe that never ran
+# --------------------------------------------------------------------------
+
+
+def test_a_probe_that_never_ran_is_not_an_invalid_key() -> None:
+    """`lsd_rc` is an exit status. "skip" is not one — it means the probe never ran."""
+    assert classify("skip", "unknown", "skip", "skip") == "PROBE_FAILED"
+    # It stays PROBE_FAILED whatever the other probes claim: they cannot have run either.
+    assert classify("skip", "yes", "0", "0") == "PROBE_FAILED"
+
+
+def test_a_missing_exit_status_is_never_read_as_evidence() -> None:
+    """The original defect in one line: `tmp=""` → no probe → a status that isn't one.
+
+    Anything non-numeric reaching `lsd_rc` means no probe produced it, so it can carry no
+    information about the key. Guarding only the literal "skip" would re-open the hole for
+    the next caller that passes an empty string, exactly as `tmp=""` once did.
+    """
+    for not_a_status in ("", "unknown", "null", "skip"):
+        assert classify(f"'{not_a_status}'", "no", "skip", "skip") == "PROBE_FAILED", (
+            f"lsd_rc={not_a_status!r} is not an exit status; it must not condemn the key"
+        )
+
+
+def test_probe_failed_diagnosis_disowns_the_credential() -> None:
+    text = explain("PROBE_FAILED")
+    assert "NOT a verdict on the key" in text
+    assert "do not rotate" in text.lower()
+    assert "ProtectSystem=strict" in text and "ReadWritePaths" in text, (
+        "name the systemd hardening that causes this, or the next operator spends the "
+        "afternoon on the key instead of on /tmp"
+    )


### PR DESCRIPTION
Closes #613.

## The bug

`b2_preflight.sh` allocated its scratch dir with a bare `mktemp -d` — into `/tmp`. Under `systemd/isnad-backup.service`, `/tmp` is **read-only**: the unit runs `ProtectSystem=strict` with `PrivateTmp` deliberately unset (deploy#121 Bug A) and `/tmp` is not in `ReadWritePaths`. The allocation failed, **its exit status was never checked**, `lsd_out="${tmp}/lsd.out"` degraded to `/lsd.out`, the redirect died on the read-only root, `lsd_rc=1` — and `classify_b2_state` mapped `lsd_rc != 0` straight to **`KEY_INVALID`**.

That verdict is **key-independent**. Proven on stg (2026-07-13) with a freshly-provisioned, write-capable key:

| Context | `/tmp` | Verdict |
|---|---|---|
| under `isnad-backup.service` | read-only | `lsd_rc=1` → **KEY_INVALID** |
| same key, by hand | writable | `lsd_rc=0 bucket_visible=yes write_rc=0 delete_rc=0` → **OK** |

Every backup this project has ever attempted died there, blaming a credential that was fine — the reason **zero backups have ever succeeded** on either host. CI never caught it because Actions runners have a writable `/tmp`; only the on-host systemd path is affected.

## The fix

- Scratch now lives under **`BACKUP_DIR`** — what the unit actually grants via `ReadWritePaths`, and what `backup.sh` already stages dumps into (the unit's own comment assumed exactly this). Falls back to `TMPDIR` then `/tmp` so standalone/CI invocation is unchanged.
- **A scratch-allocation failure is now fatal**, with its own diagnostic. It can no longer fall through into a credential verdict.
- **New `PROBE_FAILED` verdict.** "The probe never ran" is now inexpressible as a statement about the key. Its operator message says so out loud: *do not rotate, revoke, or re-provision anything on the strength of it.*

## Why the tests are shaped this way

The pre-existing assertion `classify("1","no","skip","skip") == "KEY_INVALID"` **passed throughout the entire life of this bug, and still does.** It cannot fail — it asserts the very conflation that *is* the bug. A detector that returns `KEY_INVALID` for both a bad key and a broken probe has not measured anything, and a test that only ever feeds it one class cannot tell.

So the new test is a **2×2 over {key good, key bad} × {scratch usable, unusable}**:

- The `scratch_usable=True` column **calibrates the instrument** — it must still separate a good key (`OK`) from a genuinely bad one (`KEY_INVALID`). Without that cell, `PROBE_FAILED` in the broken column could be a detector that has simply stopped discriminating at all.
- The `scratch_usable=False` column then asserts `PROBE_FAILED` for **both** key classes — including the good-key cell that used to read `KEY_INVALID`. Reporting `KEY_INVALID` for a bad key with broken scratch would be *right by accident*, and it is the same conflation.

Unusable scratch is simulated with an **`ENOTDIR` parent** (a file where a directory must be), **not `chmod`** — `chmod` is a no-op against uid 0, so a root CI runner would have quietly turned the whole class into a passing `OK`.

## Verification

- **8 of the new tests fail against the pre-fix script** and pass against this one — the test can detect the bug it guards.
- Full suite: **416 passed, 3 skipped.** shellcheck clean, ruff/gitleaks clean, mypy clean.
- `restore.sh` was checked: it does not invoke the preflight, so it is unaffected.

## Not in scope

This unblocks #612 (zero backups) and therefore #609 (backup go/no-go). Production still needs a deploy to populate its empty `.env` and install `isnad-backup.timer` via `converge_host.sh` — tracked in #612.
