### PR TITLE
fix(backup,restore): name the compose PROJECT on every call — every dump addressed a phantom project (#617)

### DIFF
--- a/.github/workflows/deploy-isnad-graph.yml
+++ b/.github/workflows/deploy-isnad-graph.yml
@@ -156,7 +156,7 @@ jobs:
               fi
               if [ "$i" -eq 24 ]; then
                 echo "ERROR: API health check failed after 120 seconds"
-                docker compose -f compose/docker-compose.prod.yml logs --tail=50 api
+                docker compose -p noorinalabs -f compose/docker-compose.prod.yml logs --tail=50 api
                 exit 1
               fi
               sleep 5

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -316,7 +316,7 @@ jobs:
               fi
               if [ "$i" -eq 24 ]; then
                 echo "ERROR: API health check failed after 120 seconds"
-                docker compose -f compose/docker-compose.prod.yml logs --tail=50 api
+                docker compose -p noorinalabs -f compose/docker-compose.prod.yml logs --tail=50 api
                 exit 1
               fi
               sleep 5

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -12,6 +12,30 @@
 # `logging: *default-logging`, so a per-container log is capped at
 # max-size × max-file = 10m × 5 = ~50MB and coverage cannot drift as new
 # services are added (a service without the alias is an obvious review miss).
+# THE PROJECT THIS STACK RUNS IN. THE SINGLE SOURCE OF TRUTH. (deploy#617)
+#
+# Compose resolves the project name in this order:
+#
+#   -p flag  >  COMPOSE_PROJECT_NAME  >  this `name:` key  >  the compose file's DIRECTORY
+#
+# Without this key, that last rung is what applied — and this file lives in `compose/`, so
+# every caller that passed `-f compose/docker-compose.prod.yml` WITHOUT `-p` addressed a
+# project literally named `compose`: a project no deploy path has ever brought anything up
+# in, containing nothing. That is deploy#617. It made every backup dump fail, and it made
+# `up -d neo4j` CREATE a stray, empty database beside the real one.
+#
+# `name:` makes the DERIVED project correct by construction, for every caller — including
+# the ~40 `docker compose -f compose/docker-compose.prod.yml exec|logs|ps …` lines in
+# docs/runbooks/**, and an operator typing one of them by hand at 3am mid-incident. Those
+# are the callers no static scan reaches and no code review catches.
+#
+# Every existing `-p noorinalabs` still wins, and still names this same value, so nothing
+# changes behaviourally. What changes is that the directory-derived `compose` fallback stops
+# existing. The explicit `-p` flags stay too (greppable, testable, and immune to this key
+# being dropped) — the flag is the per-call fix, this is the per-file one, and the class is
+# only closed by both.
+name: noorinalabs
+
 x-logging: &default-logging
   driver: json-file
   options:

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -136,7 +136,14 @@ source "$COMPOSE_PROJECT_LIB"
 # The directory below is the one node-exporter is actually pointed at
 # (`--collector.textfile.directory`, compose/docker-compose.prod.yml) and is the
 # only path bind-mounted into the container.
-TEXTFILE_DIR="/var/lib/node_exporter/textfile_collector"
+# Overridable ONLY so a test can observe what the run leaves on the box. The default is the
+# real path and the unit grants it (ReadWritePaths=/var/lib/node_exporter); nothing in
+# production sets this. It matters because the interesting assertion here is about the
+# textfiles themselves — the success gauge AND the failure marker `emit_success_metric`
+# deletes (:171) — and with the path hardcoded, a sandboxed run dies at `install -d` with
+# "Permission denied" and exits non-zero for a reason that has nothing to do with the
+# behaviour under test. That is a measurement of the sandbox, not of the script.
+TEXTFILE_DIR="${TEXTFILE_DIR:-/var/lib/node_exporter/textfile_collector}"
 SUCCESS_TEXTFILE="${TEXTFILE_DIR}/isnad_backup_success.prom"
 FAILURE_TEXTFILE="${TEXTFILE_DIR}/isnad_backup_failure.prom"
 
@@ -292,6 +299,32 @@ PG_OK=false
 USER_PG_OK=false
 NEO4J_OK=false
 
+# Did THIS RUN leave the graph down? (deploy#617 review — Aisha Idrissi)
+#
+# Deliberately SEPARATE from NEO4J_OK, and the distinction is the whole point:
+#
+#   NEO4J_OK   — is the ARTIFACT good?  (did the dump succeed and get uploaded)
+#   NEO4J_DOWN — is the HOST  good?     (did we put the graph back the way we found it)
+#
+# They are independent, and the interesting case is exactly the one where they disagree: a
+# run that dumps all three stores perfectly and then FAILS TO RESTART NEO4J has produced a
+# complete, restorable backup AND taken production down.
+#
+# Before this flag, that run reported plain SUCCESS. NEO4J_OK was set true at the dump; the
+# restart-failure branch logged "the graph is DOWN" and set nothing; the final gate read
+# only the three _OK flags, so it did not fire; the script exited 0. systemd therefore
+# marked the unit SUCCEEDED, `OnFailure=isnad-backup-failure-marker.service` never fired,
+# and emit_success_metric's `rm -f` of the failure textfile meant THE BACKUP THAT TOOK THE
+# GRAPH DOWN CLEARED ITS OWN FAILURE MARKER. The operator's only remaining signal was a
+# generic ServiceDown page with nothing to say the backup had caused it.
+#
+# The fix is NOT to fold this into NEO4J_OK. That would suppress the success gauge — hiding
+# a backup that is genuinely complete and restorable, and letting BackupStale fire falsely,
+# the alert-fatigue trap deploy#559/#565 closed. BOTH facts must reach the box, because both
+# are TRUE: *the last complete backup is at T* (the gauge) and *the last run broke something
+# and needs a human* (non-zero exit -> OnFailure -> failure marker).
+NEO4J_DOWN=false
+
 # ---------------------------------------------------------------------------
 # 1. PostgreSQL dumps (isnad + user-service)
 # ---------------------------------------------------------------------------
@@ -370,7 +403,12 @@ if service_is_running neo4j; then
     while dc ps --format '{{.Service}}:{{.State}}' 2>/dev/null | grep -q "neo4j:running"; do
         if [[ $WAITED -ge $MAX_WAIT ]]; then
             log "ERROR" "Neo4j did not stop within ${MAX_WAIT}s"
-            neo4j_start || log "ERROR" "Neo4j restart failed after a stop timeout — check manually"
+            # `|| log …` used to SWALLOW the return code here: the restart failed, the run
+            # logged a line, and exited 0 with the graph down. Set the flag instead.
+            if ! neo4j_start; then
+                NEO4J_DOWN=true
+                log "ERROR" "Neo4j restart failed after a stop timeout — the graph is DOWN. Start it by hand."
+            fi
             break
         fi
         sleep 1
@@ -385,7 +423,15 @@ if service_is_running neo4j; then
         # across all compose projects, so on a box running more than one stack the backup
         # could silently dump a different project's graph and be restored over the real one.
         # (deploy#559, same resolution as restore.sh restore_neo4j().)
-        NEO4J_CID=$(dc ps -aq neo4j 2>/dev/null | head -1)
+        # `|| NEO4J_CID=""` is not belt-and-braces here — it is the difference between a
+        # degraded backup and a DOWN DATABASE (deploy#622, Aisha Idrissi).
+        #
+        # This is a bare assignment under `set -euo pipefail`, and we are in the window AFTER
+        # Neo4j has been STOPPED. A daemon blip, a socket timeout, a `docker` that exits
+        # non-zero for any reason at all makes this a failing simple command — errexit fires AT
+        # THE ASSIGNMENT, the restart below is NEVER REACHED, and the graph stays down. The
+        # same deploy#563 shape assert_stack_present is careful about; these two lines were not.
+        NEO4J_CID="$(dc ps -aq neo4j 2>/dev/null | head -1)" || NEO4J_CID=""
         if [[ -z "$NEO4J_CID" ]]; then
             NEO4J_VOLUME=""
         else
@@ -447,7 +493,11 @@ if service_is_running neo4j; then
             HEALTH_WAITED=0
             while ! dc ps --format '{{.Service}}:{{.Health}}' 2>/dev/null | grep -q "neo4j:healthy"; do
                 if [[ $HEALTH_WAITED -ge $MAX_HEALTH_WAIT ]]; then
-                    log "WARNING" "Neo4j did not become healthy within ${MAX_HEALTH_WAIT}s — check manually"
+                    # A graph that never came back HEALTHY is a graph that is down, and this
+                    # branch used to say so at WARNING and then exit 0 — the same structural
+                    # hole as the restart-failure branch below, one state further on.
+                    NEO4J_DOWN=true
+                    log "ERROR" "Neo4j did not become healthy within ${MAX_HEALTH_WAIT}s — the graph is DOWN. Check it by hand."
                     break
                 fi
                 sleep 5
@@ -463,6 +513,7 @@ if service_is_running neo4j; then
             # fall into `[[ 0 -lt 120 ]]` and log "Neo4j healthy (waited 0s)" over a database
             # that is not running at all. That is the exact sentence the stg run printed while a
             # stray, empty container came up beside the real one.
+            NEO4J_DOWN=true
             log "ERROR" "Neo4j did NOT restart — the graph is DOWN. Start it by hand; do not wait for this script."
         fi
     else
@@ -652,3 +703,24 @@ if [[ "$PG_OK" == "false" || "$USER_PG_OK" == "false" || "$NEO4J_OK" == "false" 
 fi
 
 emit_success_metric
+
+# The ARTIFACT is complete (we are past the gate above) but THIS RUN left the graph DOWN.
+# Both facts are true and both must reach the box, so the order here is load-bearing:
+#
+#   emit_success_metric FIRST — the backup really is complete and restorable, and the gauge
+#   is what the alerts read as "a complete backup exists". Suppressing it would hide a good
+#   artifact and make BackupStale fire falsely (deploy#559/#565's alert-fatigue trap).
+#
+#   THEN exit non-zero — so systemd marks the unit failed and `OnFailure=` fires the failure
+#   marker. Because OnFailure runs AFTER the script exits, the marker is written after
+#   emit_success_metric's `rm -f`, and both signals survive.
+#
+# The run that produced this state is precisely the one the old code called a success: every
+# dump good, the restart dead, the graph offline, exit 0, and the success metric wiping the
+# failure textfile on its way out (deploy#617 review — Aisha Idrissi).
+if [[ "$NEO4J_DOWN" == "true" ]]; then
+    log "ERROR" "Backup artifact is COMPLETE and uploaded — but this run left Neo4j DOWN."
+    log "ERROR" "  The success metric WAS emitted: the backup at ${TIMESTAMP} is good and restorable."
+    log "ERROR" "  Exiting non-zero anyway so OnFailure= fires: production needs a human NOW."
+    exit 1
+fi

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -245,21 +245,40 @@ else
     exit 1
 fi
 
-# Assert the stack we are about to dump is ACTUALLY THERE — every service, running.
+# Assert we are addressing the REAL project and not a phantom one.
 #
 # This REPLACES `docker compose ps --format json &>/dev/null`, which exited 0 on an empty or
 # entirely nonexistent project: it asked whether `ps` RAN, not whether the stack EXISTS.
 # That zero is what waved the deploy#617 run through to the dumps, where both pg_dumps
 # failed against a project with no containers and the Neo4j leg CREATED one.
 #
+# ---------------------------------------------------------------------------
+# WHY `postgres user-postgres` AND NOT ALSO `neo4j`. (deploy#618 review, Weronika Zielinska)
+# ---------------------------------------------------------------------------
+# The first version of this gate demanded all three, and that QUIETLY REPEALED the contract
+# 270 lines below it — "a partial backup beats none" (`:5xx`, which refuses to upload only
+# when ALL THREE dumps fail). On any night Neo4j is down, an all-three gate takes ZERO
+# backups instead of two, and one of the two it discards is `user-postgres`: the only store
+# here that CANNOT be rebuilt from the published pipeline artifact (deploy#559). Worse, this
+# script can itself leave Neo4j stopped (see the `neo4j_start` failure branch), so one bad
+# night would have silently disarmed every backup after it.
+#
+# The Postgres pair is the reliable witness of project identity because NOTHING IN THIS PATH
+# CAN CREATE IT. Only `neo4j` was ever `up`'d, which is why a stray, empty `neo4j` — and no
+# Postgres — is precisely the state stg was found in. A "refuse only when zero services
+# resolve" rule would have passed that state and dumped the stray empty graph, which is the
+# silently-empty success this whole change exists to prevent. Requiring both Postgres
+# services refuses the phantom project in every observed state, stray Neo4j included.
+#
+# A missing Neo4j is a PER-LEG failure, handled at the Neo4j leg: skip the dump, record
+# NEO4J_OK=false, upload the Postgres stores with `complete=false`, exit non-zero.
+#
 # ORDER: after the B2 preflight, before the first dump. The credential check stays the first
 # thing that can stop a run (deploy#559/#613 — "discovering at upload time that the key
 # cannot write means we took an outage for nothing"), and this now stands between it and any
 # destructive step. Nothing has been stopped or dumped at this point; both are pure
 # preflights, and both must pass.
-#
-# The services named here are exactly the stores this script dumps (docs/DATASTORES.md).
-if ! assert_stack_present postgres user-postgres neo4j; then
+if ! assert_stack_present postgres user-postgres; then
     log "ERROR" "Refusing to back up a stack that is not present."
     exit 1
 fi
@@ -326,112 +345,136 @@ fi
 NEO4J_DUMP_FILE="${LOCAL_BACKUP_PATH}/isnad-neo4j-${TIMESTAMP}.dump"
 NEO4J_COMPRESSED="${NEO4J_DUMP_FILE}.zst"
 
-log "INFO" "Stopping Neo4j for offline dump..."
-dc stop neo4j 2>>"$LOG_FILE"
+# ---------------------------------------------------------------------------
+# IS THERE A NEO4J TO DUMP AT ALL? (deploy#618 review)
+# ---------------------------------------------------------------------------
+# A missing or stopped Neo4j is a PER-LEG failure, not a reason to abandon the run. The
+# project-identity gate above deliberately does not demand `neo4j` — demanding it would take
+# ZERO backups on a night Neo4j is down, instead of the two this script was designed to
+# still take, and one of those two is `user-postgres`, which no artifact can rebuild
+# (deploy#559). "A partial backup beats none" is the contract; an arity choice in a preflight
+# must not silently repeal it.
+#
+# So: skip the leg, record it as FAILED (not skipped-and-forgiven), and let the manifest and
+# the exit code carry the truth. NEO4J_OK stays false, the manifest attests complete=false,
+# `restore.sh` refuses that artifact without `--allow-partial`, and the run exits non-zero so
+# the systemd OnFailure marker fires and BackupStale keeps counting from the last COMPLETE
+# backup. Nothing here silently forgives a missing store.
+if service_is_running neo4j; then
+    log "INFO" "Stopping Neo4j for offline dump..."
+    dc stop neo4j 2>>"$LOG_FILE"
 
-# Wait for Neo4j container to fully stop
-MAX_WAIT=30
-WAITED=0
-while dc ps --format '{{.Service}}:{{.State}}' 2>/dev/null | grep -q "neo4j:running"; do
-    if [[ $WAITED -ge $MAX_WAIT ]]; then
-        log "ERROR" "Neo4j did not stop within ${MAX_WAIT}s"
-        neo4j_start || log "ERROR" "Neo4j restart failed after a stop timeout — check manually"
-        break
-    fi
-    sleep 1
-    WAITED=$((WAITED + 1))
-done
+    # Wait for Neo4j container to fully stop
+    MAX_WAIT=30
+    WAITED=0
+    while dc ps --format '{{.Service}}:{{.State}}' 2>/dev/null | grep -q "neo4j:running"; do
+        if [[ $WAITED -ge $MAX_WAIT ]]; then
+            log "ERROR" "Neo4j did not stop within ${MAX_WAIT}s"
+            neo4j_start || log "ERROR" "Neo4j restart failed after a stop timeout — check manually"
+            break
+        fi
+        sleep 1
+        WAITED=$((WAITED + 1))
+    done
 
-if [[ $WAITED -lt $MAX_WAIT ]]; then
-    log "INFO" "Neo4j stopped (waited ${WAITED}s). Running dump..."
+    if [[ $WAITED -lt $MAX_WAIT ]]; then
+        log "INFO" "Neo4j stopped (waited ${WAITED}s). Running dump..."
 
-    # Resolve the data volume from THIS compose project's neo4j container rather than
-    # by grepping every volume on the host. `docker volume ls | grep neo4j_data` matches
-    # across all compose projects, so on a box running more than one stack the backup
-    # could silently dump a different project's graph and be restored over the real one.
-    # (deploy#559, same resolution as restore.sh restore_neo4j().)
-    NEO4J_CID=$(dc ps -aq neo4j 2>/dev/null | head -1)
-    if [[ -z "$NEO4J_CID" ]]; then
-        NEO4J_VOLUME=""
-    else
-        NEO4J_VOLUME=$(docker inspect \
-            --format '{{range .Mounts}}{{if eq .Destination "/data"}}{{.Name}}{{end}}{{end}}' \
-            "$NEO4J_CID")
-    fi
-    if [[ -z "$NEO4J_VOLUME" ]]; then
-        log "ERROR" "Cannot resolve the Neo4j data volume for ${COMPOSE_FILE} — refusing to guess"
-    else
-        log "INFO" "Resolved Neo4j data volume: ${NEO4J_VOLUME}"
-        # Use bare docker run (not compose run) to avoid service config conflicts.
-        #
-        # `--user 0:0 --entrypoint neo4j-admin` is required, not cosmetic. The
-        # neo4j:5-community entrypoint drops privileges to neo4j(7474) even when the
-        # container starts as root. BACKUP_DIR is 0700 root:root (tmpfiles.d), and this
-        # script runs as root under systemd, so the dropped user cannot write the
-        # /backups bind mount: `neo4j-admin` dies with "AccessDeniedException: /backups"
-        # and the Neo4j leg of every backup fails. Measured on neo4j:5-community during
-        # deploy#560: entrypoint path -> uid 7474 -> exit 1; bypass -> uid 0 ->
-        # "Dump completed successfully". Same fix as restore.sh restore_neo4j().
-        if docker run --rm \
-            --user 0:0 \
-            --entrypoint neo4j-admin \
-            -v "${NEO4J_VOLUME}:/data" \
-            -v "${LOCAL_BACKUP_PATH}:/backups" \
-            neo4j:5-community \
-            database dump neo4j --to-path=/backups/ 2>>"$LOG_FILE"; then
+        # Resolve the data volume from THIS compose project's neo4j container rather than
+        # by grepping every volume on the host. `docker volume ls | grep neo4j_data` matches
+        # across all compose projects, so on a box running more than one stack the backup
+        # could silently dump a different project's graph and be restored over the real one.
+        # (deploy#559, same resolution as restore.sh restore_neo4j().)
+        NEO4J_CID=$(dc ps -aq neo4j 2>/dev/null | head -1)
+        if [[ -z "$NEO4J_CID" ]]; then
+            NEO4J_VOLUME=""
+        else
+            NEO4J_VOLUME=$(docker inspect \
+                --format '{{range .Mounts}}{{if eq .Destination "/data"}}{{.Name}}{{end}}{{end}}' \
+                "$NEO4J_CID")
+        fi
+        if [[ -z "$NEO4J_VOLUME" ]]; then
+            log "ERROR" "Cannot resolve the Neo4j data volume for ${COMPOSE_FILE} — refusing to guess"
+        else
+            log "INFO" "Resolved Neo4j data volume: ${NEO4J_VOLUME}"
+            # Use bare docker run (not compose run) to avoid service config conflicts.
+            #
+            # `--user 0:0 --entrypoint neo4j-admin` is required, not cosmetic. The
+            # neo4j:5-community entrypoint drops privileges to neo4j(7474) even when the
+            # container starts as root. BACKUP_DIR is 0700 root:root (tmpfiles.d), and this
+            # script runs as root under systemd, so the dropped user cannot write the
+            # /backups bind mount: `neo4j-admin` dies with "AccessDeniedException: /backups"
+            # and the Neo4j leg of every backup fails. Measured on neo4j:5-community during
+            # deploy#560: entrypoint path -> uid 7474 -> exit 1; bypass -> uid 0 ->
+            # "Dump completed successfully". Same fix as restore.sh restore_neo4j().
+            if docker run --rm \
+                --user 0:0 \
+                --entrypoint neo4j-admin \
+                -v "${NEO4J_VOLUME}:/data" \
+                -v "${LOCAL_BACKUP_PATH}:/backups" \
+                neo4j:5-community \
+                database dump neo4j --to-path=/backups/ 2>>"$LOG_FILE"; then
 
-            # The dump command outputs to /backups/neo4j.dump — rename it
-            if [[ -f "${LOCAL_BACKUP_PATH}/neo4j.dump" ]]; then
-                mv "${LOCAL_BACKUP_PATH}/neo4j.dump" "$NEO4J_DUMP_FILE"
-            fi
+                # The dump command outputs to /backups/neo4j.dump — rename it
+                if [[ -f "${LOCAL_BACKUP_PATH}/neo4j.dump" ]]; then
+                    mv "${LOCAL_BACKUP_PATH}/neo4j.dump" "$NEO4J_DUMP_FILE"
+                fi
 
-            if [[ -f "$NEO4J_DUMP_FILE" ]]; then
-                log "INFO" "Neo4j dump complete: $(du -h "$NEO4J_DUMP_FILE" | cut -f1)"
+                if [[ -f "$NEO4J_DUMP_FILE" ]]; then
+                    log "INFO" "Neo4j dump complete: $(du -h "$NEO4J_DUMP_FILE" | cut -f1)"
 
-                # Compress with zstd
-                log "INFO" "Compressing Neo4j dump with zstd..."
-                zstd -3 --rm "$NEO4J_DUMP_FILE" -o "$NEO4J_COMPRESSED" 2>>"$LOG_FILE"
-                log "INFO" "Compressed: $(du -h "$NEO4J_COMPRESSED" | cut -f1)"
-                NEO4J_OK=true
+                    # Compress with zstd
+                    log "INFO" "Compressing Neo4j dump with zstd..."
+                    zstd -3 --rm "$NEO4J_DUMP_FILE" -o "$NEO4J_COMPRESSED" 2>>"$LOG_FILE"
+                    log "INFO" "Compressed: $(du -h "$NEO4J_COMPRESSED" | cut -f1)"
+                    NEO4J_OK=true
+                else
+                    log "ERROR" "Neo4j dump file not found after dump command"
+                fi
             else
-                log "ERROR" "Neo4j dump file not found after dump command"
+                log "ERROR" "Neo4j dump command failed"
+            fi
+        fi
+
+        # Always restart Neo4j — the one we STOPPED. `neo4j_start` uses `start`, never `up`:
+        # `up` would CREATE a neo4j (and fresh, empty volumes) in a project that has none,
+        # which is exactly the stray container the deploy#617 run left on stg. A backup script
+        # must not be able to bring a database into existence.
+        log "INFO" "Restarting Neo4j..."
+        if neo4j_start; then
+            # Wait for Neo4j to become healthy
+            MAX_HEALTH_WAIT=120
+            HEALTH_WAITED=0
+            while ! dc ps --format '{{.Service}}:{{.Health}}' 2>/dev/null | grep -q "neo4j:healthy"; do
+                if [[ $HEALTH_WAITED -ge $MAX_HEALTH_WAIT ]]; then
+                    log "WARNING" "Neo4j did not become healthy within ${MAX_HEALTH_WAIT}s — check manually"
+                    break
+                fi
+                sleep 5
+                HEALTH_WAITED=$((HEALTH_WAITED + 5))
+            done
+
+            if [[ $HEALTH_WAITED -lt $MAX_HEALTH_WAIT ]]; then
+                log "INFO" "Neo4j healthy (waited ${HEALTH_WAITED}s)"
             fi
         else
-            log "ERROR" "Neo4j dump command failed"
-        fi
-    fi
-
-    # Always restart Neo4j — the one we STOPPED. `neo4j_start` uses `start`, never `up`:
-    # `up` would CREATE a neo4j (and fresh, empty volumes) in a project that has none,
-    # which is exactly the stray container the deploy#617 run left on stg. A backup script
-    # must not be able to bring a database into existence.
-    log "INFO" "Restarting Neo4j..."
-    if neo4j_start; then
-        # Wait for Neo4j to become healthy
-        MAX_HEALTH_WAIT=120
-        HEALTH_WAITED=0
-        while ! dc ps --format '{{.Service}}:{{.Health}}' 2>/dev/null | grep -q "neo4j:healthy"; do
-            if [[ $HEALTH_WAITED -ge $MAX_HEALTH_WAIT ]]; then
-                log "WARNING" "Neo4j did not become healthy within ${MAX_HEALTH_WAIT}s — check manually"
-                break
-            fi
-            sleep 5
-            HEALTH_WAITED=$((HEALTH_WAITED + 5))
-        done
-
-        if [[ $HEALTH_WAITED -lt $MAX_HEALTH_WAIT ]]; then
-            log "INFO" "Neo4j healthy (waited ${HEALTH_WAITED}s)"
+            # The health-wait is INSIDE the success branch on purpose. Hung off the end, it
+            # would run its first `ps`, see no healthy neo4j, and — with HEALTH_WAITED still 0 —
+            # fall into `[[ 0 -lt 120 ]]` and log "Neo4j healthy (waited 0s)" over a database
+            # that is not running at all. That is the exact sentence the stg run printed while a
+            # stray, empty container came up beside the real one.
+            log "ERROR" "Neo4j did NOT restart — the graph is DOWN. Start it by hand; do not wait for this script."
         fi
     else
-        # The health-wait is INSIDE the success branch on purpose. Hung off the end, it
-        # would run its first `ps`, see no healthy neo4j, and — with HEALTH_WAITED still 0 —
-        # fall into `[[ 0 -lt 120 ]]` and log "Neo4j healthy (waited 0s)" over a database
-        # that is not running at all. That is the exact sentence the stg run printed while a
-        # stray, empty container came up beside the real one.
-        log "ERROR" "Neo4j did NOT restart — the graph is DOWN. Start it by hand; do not wait for this script."
+        log "WARNING" "Skipped Neo4j dump due to stop timeout"
     fi
 else
-    log "WARNING" "Skipped Neo4j dump due to stop timeout"
+    log "ERROR" "Neo4j is NOT running in project '${COMPOSE_PROJECT}' — SKIPPING the Neo4j dump."
+    log "ERROR" "  The graph leg of this backup will be MISSING and the run will exit non-zero."
+    log "ERROR" "  The Postgres stores are still dumped: a partial backup beats none, and"
+    log "ERROR" "  user-postgres cannot be rebuilt from any artifact (deploy#559)."
+    log "ERROR" "  Start Neo4j and re-run to get a COMPLETE backup."
+    NEO4J_OK=false
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -16,6 +16,10 @@
 #   USER_POSTGRES_DB   — user-service database (default: user_service)
 #   COMPOSE_FILE       — Docker Compose file (default: compose/docker-compose.prod.yml,
 #                        resolved relative to /opt/noorinalabs-deploy/)
+#   COMPOSE_PROJECT    — Docker Compose PROJECT the stack runs in (default: noorinalabs).
+#                        Passed as an explicit `-p` on every compose call; `-f` alone names
+#                        the file, NOT the project. See scripts/compose_project.sh
+#                        (deploy#617) — an unflagged call addresses a phantom project.
 #   BACKUP_DIR         — Local backup staging root (default: /var/lib/noorinalabs-backups,
 #                        a persistent path managed via tmpfiles.d to survive reboots —
 #                        see deploy#121 Bug A for the /tmp/-namespace failure this avoids)
@@ -106,6 +110,21 @@ log() {
 }
 
 # ---------------------------------------------------------------------------
+# Compose project scoping (deploy#617)
+# ---------------------------------------------------------------------------
+# Sourced AFTER log(): the library's guards report through it. Provides
+# COMPOSE_PROJECT, dc(), assert_stack_present() and neo4j_start(). Every compose
+# call below goes through dc() — `-f` names the file, `-p` names the project, and
+# without the latter this script addresses a project with nothing in it.
+COMPOSE_PROJECT_LIB="$(dirname "${BASH_SOURCE[0]}")/compose_project.sh"
+if [[ ! -f "$COMPOSE_PROJECT_LIB" ]]; then
+    log "ERROR" "Missing ${COMPOSE_PROJECT_LIB} — cannot resolve the compose project to back up"
+    exit 1
+fi
+# shellcheck source=scripts/compose_project.sh
+source "$COMPOSE_PROJECT_LIB"
+
+# ---------------------------------------------------------------------------
 # node-exporter textfile-collector metrics (deploy#565)
 # ---------------------------------------------------------------------------
 # Until deploy#565 this script emitted no metric at all, so the BackupFailure
@@ -186,11 +205,6 @@ for cmd in docker rclone zstd sha256sum; do
     fi
 done
 
-if ! docker compose -f "$COMPOSE_FILE" ps --format json &>/dev/null; then
-    log "ERROR" "Cannot reach Docker Compose services (is Docker running?)"
-    exit 1
-fi
-
 # Verify the B2 credential BEFORE stopping Neo4j and dumping gigabytes. Discovering at
 # upload time that the key cannot write means we took an outage for nothing.
 #
@@ -231,6 +245,25 @@ else
     exit 1
 fi
 
+# Assert the stack we are about to dump is ACTUALLY THERE — every service, running.
+#
+# This REPLACES `docker compose ps --format json &>/dev/null`, which exited 0 on an empty or
+# entirely nonexistent project: it asked whether `ps` RAN, not whether the stack EXISTS.
+# That zero is what waved the deploy#617 run through to the dumps, where both pg_dumps
+# failed against a project with no containers and the Neo4j leg CREATED one.
+#
+# ORDER: after the B2 preflight, before the first dump. The credential check stays the first
+# thing that can stop a run (deploy#559/#613 — "discovering at upload time that the key
+# cannot write means we took an outage for nothing"), and this now stands between it and any
+# destructive step. Nothing has been stopped or dumped at this point; both are pure
+# preflights, and both must pass.
+#
+# The services named here are exactly the stores this script dumps (docs/DATASTORES.md).
+if ! assert_stack_present postgres user-postgres neo4j; then
+    log "ERROR" "Refusing to back up a stack that is not present."
+    exit 1
+fi
+
 log "INFO" "=== Backup started (${BACKUP_CATEGORY}) ==="
 log "INFO" "Timestamp: ${TIMESTAMP}"
 log "INFO" "Local staging: ${LOCAL_BACKUP_PATH}"
@@ -249,7 +282,7 @@ dump_postgres() {
     local service="$1" pg_user="$2" pg_db="$3" outfile="$4" label="$5"
 
     log "INFO" "Starting ${label} dump (service=${service} db=${pg_db})..."
-    if ! docker compose -f "$COMPOSE_FILE" exec -T "$service" \
+    if ! dc exec -T "$service" \
         pg_dump -U "$pg_user" -d "$pg_db" --format=custom \
         > "$outfile" 2>>"$LOG_FILE"; then
         log "ERROR" "${label} dump failed"
@@ -294,15 +327,15 @@ NEO4J_DUMP_FILE="${LOCAL_BACKUP_PATH}/isnad-neo4j-${TIMESTAMP}.dump"
 NEO4J_COMPRESSED="${NEO4J_DUMP_FILE}.zst"
 
 log "INFO" "Stopping Neo4j for offline dump..."
-docker compose -f "$COMPOSE_FILE" stop neo4j 2>>"$LOG_FILE"
+dc stop neo4j 2>>"$LOG_FILE"
 
 # Wait for Neo4j container to fully stop
 MAX_WAIT=30
 WAITED=0
-while docker compose -f "$COMPOSE_FILE" ps --format '{{.Service}}:{{.State}}' 2>/dev/null | grep -q "neo4j:running"; do
+while dc ps --format '{{.Service}}:{{.State}}' 2>/dev/null | grep -q "neo4j:running"; do
     if [[ $WAITED -ge $MAX_WAIT ]]; then
         log "ERROR" "Neo4j did not stop within ${MAX_WAIT}s"
-        docker compose -f "$COMPOSE_FILE" up -d neo4j 2>>"$LOG_FILE"
+        neo4j_start || log "ERROR" "Neo4j restart failed after a stop timeout — check manually"
         break
     fi
     sleep 1
@@ -317,7 +350,7 @@ if [[ $WAITED -lt $MAX_WAIT ]]; then
     # across all compose projects, so on a box running more than one stack the backup
     # could silently dump a different project's graph and be restored over the real one.
     # (deploy#559, same resolution as restore.sh restore_neo4j().)
-    NEO4J_CID=$(docker compose -f "$COMPOSE_FILE" ps -aq neo4j 2>/dev/null | head -1)
+    NEO4J_CID=$(dc ps -aq neo4j 2>/dev/null | head -1)
     if [[ -z "$NEO4J_CID" ]]; then
         NEO4J_VOLUME=""
     else
@@ -368,24 +401,34 @@ if [[ $WAITED -lt $MAX_WAIT ]]; then
         fi
     fi
 
-    # Always restart Neo4j
+    # Always restart Neo4j — the one we STOPPED. `neo4j_start` uses `start`, never `up`:
+    # `up` would CREATE a neo4j (and fresh, empty volumes) in a project that has none,
+    # which is exactly the stray container the deploy#617 run left on stg. A backup script
+    # must not be able to bring a database into existence.
     log "INFO" "Restarting Neo4j..."
-    docker compose -f "$COMPOSE_FILE" up -d neo4j 2>>"$LOG_FILE"
+    if neo4j_start; then
+        # Wait for Neo4j to become healthy
+        MAX_HEALTH_WAIT=120
+        HEALTH_WAITED=0
+        while ! dc ps --format '{{.Service}}:{{.Health}}' 2>/dev/null | grep -q "neo4j:healthy"; do
+            if [[ $HEALTH_WAITED -ge $MAX_HEALTH_WAIT ]]; then
+                log "WARNING" "Neo4j did not become healthy within ${MAX_HEALTH_WAIT}s — check manually"
+                break
+            fi
+            sleep 5
+            HEALTH_WAITED=$((HEALTH_WAITED + 5))
+        done
 
-    # Wait for Neo4j to become healthy
-    MAX_HEALTH_WAIT=120
-    HEALTH_WAITED=0
-    while ! docker compose -f "$COMPOSE_FILE" ps --format '{{.Service}}:{{.Health}}' 2>/dev/null | grep -q "neo4j:healthy"; do
-        if [[ $HEALTH_WAITED -ge $MAX_HEALTH_WAIT ]]; then
-            log "WARNING" "Neo4j did not become healthy within ${MAX_HEALTH_WAIT}s — check manually"
-            break
+        if [[ $HEALTH_WAITED -lt $MAX_HEALTH_WAIT ]]; then
+            log "INFO" "Neo4j healthy (waited ${HEALTH_WAITED}s)"
         fi
-        sleep 5
-        HEALTH_WAITED=$((HEALTH_WAITED + 5))
-    done
-
-    if [[ $HEALTH_WAITED -lt $MAX_HEALTH_WAIT ]]; then
-        log "INFO" "Neo4j healthy (waited ${HEALTH_WAITED}s)"
+    else
+        # The health-wait is INSIDE the success branch on purpose. Hung off the end, it
+        # would run its first `ps`, see no healthy neo4j, and — with HEALTH_WAITED still 0 —
+        # fall into `[[ 0 -lt 120 ]]` and log "Neo4j healthy (waited 0s)" over a database
+        # that is not running at all. That is the exact sentence the stg run printed while a
+        # stray, empty container came up beside the real one.
+        log "ERROR" "Neo4j did NOT restart — the graph is DOWN. Start it by hand; do not wait for this script."
     fi
 else
     log "WARNING" "Skipped Neo4j dump due to stop timeout"

--- a/scripts/bootstrap-vps.sh
+++ b/scripts/bootstrap-vps.sh
@@ -514,8 +514,14 @@ echo ""
 echo "  2. Start the stack as the deploy user (services are GHCR-only — no local builds):"
 echo "       su - $DEPLOY_USER"
 echo "       cd $INSTALL_DIR"
-echo "       docker compose -f compose/docker-compose.prod.yml --env-file .env pull"
-echo "       docker compose -f compose/docker-compose.prod.yml --env-file .env up -d"
+# `-p noorinalabs` is NOT optional in these printed instructions (deploy#617). Without it,
+# Compose derives the project from the compose file's DIRECTORY — `compose` — so an operator
+# following this on a fresh VPS brings the WHOLE STACK up in a project no deploy path, backup
+# or restore ever addresses. The first CI deploy then creates a SECOND, parallel stack as
+# `-p noorinalabs`, and the operator's data sits in the other one. A documented instruction
+# must not be a documented way to create the phantom project.
+echo "       docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env pull"
+echo "       docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env up -d"
 echo ""
 echo "  3. Verify: curl http://localhost:8000/health"
 echo ""

--- a/scripts/compose_project.sh
+++ b/scripts/compose_project.sh
@@ -71,7 +71,38 @@ log_captured_stderr() {
     done < "$1"
 }
 
-# assert_stack_present <service>...
+# The services running in COMPOSE_PROJECT, one `name:state` line each, on STDOUT.
+#
+# An EMPTY result is a legitimate answer — a project with nothing in it. A non-zero rc is
+# NOT: that is an instrument failure, and the two must never collapse into the same empty
+# string (deploy#584: "an empty listing and a failed listing are the same empty string, and
+# only one of them is a measurement").
+#
+# Every diagnostic here goes to STDERR, because this function's STDOUT IS ITS RETURN VALUE.
+# `log()` writes to stdout (backup.sh additionally tees it), so an unredirected log line
+# would be read back by the caller as a service state — the same shape as the rclone NOTICE
+# that became a "backup directory" in deploy#584.
+running_services() {
+    local err states rc=0
+
+    err="$(mktemp)"
+    # `|| rc=$?`, not a bare assignment: under `set -euo pipefail` an assignment whose
+    # command substitution fails IS a failing simple command and errexit fires AT THE
+    # ASSIGNMENT, making the rc check below dead code on every failing path (deploy#563).
+    states="$(dc ps --format '{{.Service}}:{{.State}}' 2>"$err")" || rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+        log "ERROR" "Cannot reach Docker Compose (rc=${rc}) — is the daemon running?" >&2
+        log_captured_stderr "$err" >&2
+        rm -f "$err"
+        return 1
+    fi
+    rm -f "$err"
+
+    printf '%s\n' "$states"
+    return 0
+}
+
+# assert_stack_present <service>... — THE PROJECT-IDENTITY ASSERTION.
 #
 # THE GUARD THIS REPLACES WAS VACUOUS, AND ITS ZERO IS WHAT LET THE DUMPS RUN.
 #
@@ -82,27 +113,38 @@ log_captured_stderr() {
 # different questions with different answers. It waved the deploy#617 run straight through
 # to the dumps.
 #
-# Reachability and presence are also different questions, and they get different answers
-# here: a docker daemon we cannot talk to is an INSTRUMENT failure; a reachable daemon
-# running none of our services is a real, reportable state. Collapsing them would repeat
-# the deploy#584 lesson (an empty listing and a failed listing are the same empty string,
-# and only one of them is a measurement).
+# ---------------------------------------------------------------------------
+# WHAT TO PASS HERE, AND WHY IT IS NOT "EVERY SERVICE YOU TOUCH". (deploy#618 review)
+# ---------------------------------------------------------------------------
+# The callers pass `postgres user-postgres` — NOT `neo4j`. That is deliberate, and getting
+# it wrong silently repeals backup.sh's oldest contract.
+#
+# This is an assertion about the PROJECT'S IDENTITY: "am I addressing the stack, or a
+# phantom?" It is not a health check on every store. Demanding `neo4j` too would make a
+# Neo4j outage — including one THIS SCRIPT's own failed restart caused — abort the run
+# before it dumped ANYTHING, taking zero backups on a night it could have taken two. And
+# one of those two is `user-postgres`, the only store that cannot be rebuilt from any
+# artifact (deploy#559). backup.sh's design is the opposite: upload what you got, attest
+# `complete=false`, exit non-zero. A partial backup beats none.
+#
+# The two Postgres services are the RELIABLE WITNESS, and the reason is structural: nothing
+# in the backup/restore path can create them. Only `neo4j` was ever `up`'d, so `neo4j` is
+# the one service that can exist in the phantom project WITHOUT the stack being there —
+# which is exactly the state stg was found in (a stray, empty neo4j in project `compose`,
+# no Postgres). A "refuse only if ZERO services resolve" rule would have passed that state
+# and dumped the stray empty graph. The Postgres pair refuses it.
+#
+# A missing `neo4j` is therefore a PER-LEG failure, handled where that leg runs — not a
+# reason to abandon the run.
 assert_stack_present() {
     local want=("$@")
-    local err states rc=0
+    local states rc=0
 
-    err="$(mktemp)"
-    # `|| rc=$?`, not a bare assignment: under `set -euo pipefail` an assignment whose
-    # command substitution fails IS a failing simple command and errexit fires AT THE
-    # ASSIGNMENT, making the rc check below dead code on every failing path (deploy#563).
-    states="$(dc ps --format '{{.Service}}:{{.State}}' 2>"$err")" || rc=$?
+    states="$(running_services)" || rc=$?
     if [[ "$rc" -ne 0 ]]; then
-        log "ERROR" "Cannot reach Docker Compose (rc=${rc}) — is the daemon running?"
-        log_captured_stderr "$err"
-        rm -f "$err"
+        # running_services has already said why, on stderr.
         return 1
     fi
-    rm -f "$err"
 
     local missing=() svc
     for svc in "${want[@]}"; do
@@ -121,6 +163,22 @@ assert_stack_present() {
 
     log "INFO" "Stack present in project '${COMPOSE_PROJECT}': ${want[*]} (all running)"
     return 0
+}
+
+# Is <service> running in COMPOSE_PROJECT? For a PER-LEG decision, not project identity.
+#
+# Returns non-zero both when the service is not running and when the listing could not be
+# taken at all. Callers use this only AFTER assert_stack_present has established that the
+# daemon is reachable and the project is real, so at that point the two collapse harmlessly:
+# either way the leg cannot be dumped and must be recorded as failed rather than skipped
+# silently.
+service_is_running() {
+    local svc="$1" states rc=0
+
+    states="$(running_services)" || rc=$?
+    [[ "$rc" -eq 0 ]] || return 1
+
+    grep -qx -- "${svc}:running" <<< "$states"
 }
 
 # Start the neo4j container we STOPPED. Never create one.

--- a/scripts/compose_project.sh
+++ b/scripts/compose_project.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# =============================================================================
+# The compose PROJECT the stack actually runs in — and the only way to address it.
+# Sourced by scripts/backup.sh and scripts/restore.sh. (deploy#617)
+#
+# WHY `-f compose/docker-compose.prod.yml` IS NOT ENOUGH
+#
+# `-f` names the FILE. It does not name the PROJECT. With no `-p` flag and no
+# COMPOSE_PROJECT_NAME in the environment, Compose derives the project name from the
+# compose file's DIRECTORY — `compose` — while every deploy path in this repo brings the
+# stack up as `-p noorinalabs` (.github/actions/write-deploy-env/action.yml, deploy-*.yml,
+# rollback.yml, graph-ops.yml, scripts/rotate_db_password.sh, scripts/compose_tiered_up.sh).
+#
+# So an unflagged call resolves a project that exists only as a name, and contains
+# nothing. Measured on stg 2026-07-13, on the first backup run in this project's history
+# to get past the B2 preflight (deploy#613 had been aborting every earlier run before a
+# single dump, which is why this sat undiscovered underneath it):
+#
+#   exec -T postgres pg_dump    -> no such service in project `compose` -> dump FAILED
+#   exec -T user-postgres ...   -> no such service in project `compose` -> dump FAILED
+#   stop neo4j                  -> stopped NOTHING ("Neo4j stopped (waited 0s)")
+#   ps -aq neo4j                -> empty -> the data volume could not be resolved
+#   up -d neo4j                 -> CREATED A NEW, EMPTY NEO4J, with fresh volumes
+#
+# The last line is the one to sit with. `up` is a CONVERGE verb: asked for a service the
+# project does not have, it does not fail — it MAKES one. A backup script that can spawn a
+# database is a bug independently of the project name, so `up` is not merely aimed
+# correctly here, it is REMOVED from the backup/restore path (see neo4j_start below).
+#
+# AND WHY THE BACKUP WAS ONLY *FAILED* AND NOT SILENTLY *EMPTY*
+#
+# backup.sh refuses to guess the Neo4j data volume when it cannot resolve the container
+# ("refusing to guess"). Had it fallen back to a `docker volume ls | grep neo4j_data`
+# match, it would have dumped `compose_neo4j_data` — the fresh, empty graph its own `up`
+# had just created — checksummed it, uploaded it, and reported SUCCESS. We would have held
+# a green backup containing nothing and found out at a restore. That guard is load-bearing;
+# nothing in this file weakens it.
+#
+# Contract for the sourcing script: define log() first, and set COMPOSE_FILE.
+# =============================================================================
+
+# An explicit `-p` FLAG on every call, not an exported COMPOSE_PROJECT_NAME. A flag cannot
+# be unset, overridden, or dropped between here and the call; an exported variable can —
+# the systemd unit's EnvironmentFile is exactly such a place, and "the project name was
+# left to be inferred from the environment" is the whole bug. COMPOSE_PROJECT_NAME is still
+# honoured as a fallback so a caller that names its project the compose-native way
+# (scripts/restore_rehearsal.sh) keeps working.
+COMPOSE_PROJECT="${COMPOSE_PROJECT:-${COMPOSE_PROJECT_NAME:-noorinalabs}}"
+
+# Every compose call in the backup/restore path goes through here. scripts/tests/
+# test_compose_project_scoping.py statically asserts that — an unflagged `docker compose`
+# added anywhere in these scripts fails the suite.
+dc() {
+    docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" "$@"
+}
+
+# Re-emit a captured stderr file THROUGH log(), rather than `sed … >&2`.
+#
+# Compose's own diagnostic is the most useful line in the file when this goes wrong, and it
+# has to land where the operator will look for it. backup.sh's log() tees into the per-run
+# log that is checksummed and uploaded with the dumps; a bare `>&2` would put the one line
+# that explains the failure in the journal only, and NOT in the artifact.
+#
+# Iterating stderr line-by-line is safe here because each line is being LOGGED, not parsed:
+# nothing downstream reads these as records (deploy#584 — the hazard is a CONSUMER that
+# treats commentary as data, not the redirect itself).
+log_captured_stderr() {
+    local line
+    while IFS= read -r line; do
+        log "ERROR" "    ${line}"
+    done < "$1"
+}
+
+# assert_stack_present <service>...
+#
+# THE GUARD THIS REPLACES WAS VACUOUS, AND ITS ZERO IS WHAT LET THE DUMPS RUN.
+#
+#   if ! docker compose -f "$COMPOSE_FILE" ps --format json &>/dev/null; then
+#
+# `ps` against an empty — or entirely nonexistent — project EXITS 0 and prints an empty
+# list. That command answers "did `ps` run?", not "is the stack there?", and those are
+# different questions with different answers. It waved the deploy#617 run straight through
+# to the dumps.
+#
+# Reachability and presence are also different questions, and they get different answers
+# here: a docker daemon we cannot talk to is an INSTRUMENT failure; a reachable daemon
+# running none of our services is a real, reportable state. Collapsing them would repeat
+# the deploy#584 lesson (an empty listing and a failed listing are the same empty string,
+# and only one of them is a measurement).
+assert_stack_present() {
+    local want=("$@")
+    local err states rc=0
+
+    err="$(mktemp)"
+    # `|| rc=$?`, not a bare assignment: under `set -euo pipefail` an assignment whose
+    # command substitution fails IS a failing simple command and errexit fires AT THE
+    # ASSIGNMENT, making the rc check below dead code on every failing path (deploy#563).
+    states="$(dc ps --format '{{.Service}}:{{.State}}' 2>"$err")" || rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+        log "ERROR" "Cannot reach Docker Compose (rc=${rc}) — is the daemon running?"
+        log_captured_stderr "$err"
+        rm -f "$err"
+        return 1
+    fi
+    rm -f "$err"
+
+    local missing=() svc
+    for svc in "${want[@]}"; do
+        grep -qx -- "${svc}:running" <<< "$states" || missing+=("$svc")
+    done
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        local seen="${states//$'\n'/ }"
+        log "ERROR" "Compose project '${COMPOSE_PROJECT}' is not running: ${missing[*]}"
+        log "ERROR" "  compose file:  ${COMPOSE_FILE}"
+        log "ERROR" "  running there: ${seen:-<nothing at all>}"
+        log "ERROR" "  Every deploy path brings this stack up as '-p noorinalabs'. If the services"
+        log "ERROR" "  ARE up, then this project name is wrong — not the stack. Set COMPOSE_PROJECT."
+        return 1
+    fi
+
+    log "INFO" "Stack present in project '${COMPOSE_PROJECT}': ${want[*]} (all running)"
+    return 0
+}
+
+# Start the neo4j container we STOPPED. Never create one.
+#
+# `up -d neo4j` converges: against a project with no neo4j container it does not fail, it
+# BUILDS one with fresh, empty volumes — which is precisely what left a stray
+# `compose-neo4j-1` and a stray, empty `compose_neo4j_data` on stg. In a RESTORE path the
+# same call is worse than untidy: the container it invents is the one whose volume the very
+# next command would have loaded a dump into.
+#
+# `start` can only start a container that already exists, and fails loudly when there is
+# none. That is the entire point: the capability to create is removed, not aimed.
+neo4j_start() {
+    local err rc=0
+    err="$(mktemp)"
+    dc start neo4j 2>"$err" || rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+        log "ERROR" "Could not START neo4j in project '${COMPOSE_PROJECT}' (rc=${rc}):"
+        log_captured_stderr "$err"
+        log "ERROR" "  NOT falling back to 'up' — that would CREATE a new, empty neo4j (deploy#617)."
+        rm -f "$err"
+        return "$rc"
+    fi
+    rm -f "$err"
+    return 0
+}

--- a/scripts/compose_project.sh
+++ b/scripts/compose_project.sh
@@ -156,8 +156,35 @@ assert_stack_present() {
         log "ERROR" "Compose project '${COMPOSE_PROJECT}' is not running: ${missing[*]}"
         log "ERROR" "  compose file:  ${COMPOSE_FILE}"
         log "ERROR" "  running there: ${seen:-<nothing at all>}"
-        log "ERROR" "  Every deploy path brings this stack up as '-p noorinalabs'. If the services"
-        log "ERROR" "  ARE up, then this project name is wrong — not the stack. Set COMPOSE_PROJECT."
+
+        # ---------------------------------------------------------------------------
+        # THE DIAGNOSIS IS DECIDED BY EVIDENCE, AND IT MUST NEVER SAY "RETARGET".
+        # (deploy#618 review, Aisha Idrissi)
+        # ---------------------------------------------------------------------------
+        # This used to end, unconditionally, with "this project name is wrong — Set
+        # COMPOSE_PROJECT." Read that as the operator who is about to see it: they are
+        # mid-incident, restoring a database, and the very next command they run carries
+        # `--overwrite-destination`. The guard whose entire purpose is to STOP a load into the
+        # wrong project was handing them an instruction to change the project until the guard
+        # stopped complaining. That is the guard becoming the accident.
+        #
+        # The two causes are distinguishable, and the listing already holds the evidence:
+        #
+        #   nothing running at all  -> could be a phantom project, or a stack that is simply
+        #                              down. Say both; assert neither.
+        #   other services running  -> the project is REAL. The name is RIGHT. The named
+        #                              services are DOWN. Retargeting could only make it worse.
+        if [[ -z "$states" ]]; then
+            log "ERROR" "  This project holds NO containers at all. Either the stack is down, or"
+            log "ERROR" "  '${COMPOSE_PROJECT}' is not the project it runs in — every deploy path"
+            log "ERROR" "  brings this stack up as '-p noorinalabs'. Run 'docker compose ls' and"
+            log "ERROR" "  find out WHICH before you change anything."
+        else
+            log "ERROR" "  This project IS the right one — other services are running in it. The"
+            log "ERROR" "  services listed above are DOWN. Start them."
+            log "ERROR" "  Do NOT change COMPOSE_PROJECT: the name is not the problem, and pointing"
+            log "ERROR" "  this run at a different project is how a restore overwrites the wrong stack."
+        fi
         return 1
     fi
 

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -16,6 +16,13 @@
 #                     resolved relative to /opt/noorinalabs-deploy/ — MUST match
 #                     backup.sh so a restore rolls back the same stack backup captured;
 #                     see deploy#498)
+#   COMPOSE_PROJECT — Docker Compose PROJECT the stack runs in (default: noorinalabs).
+#                     `-f` names the FILE, not the PROJECT: with neither this nor
+#                     COMPOSE_PROJECT_NAME set, Compose infers the project from the compose
+#                     file's DIRECTORY (`compose`) and every call lands on a project with no
+#                     containers in it. A RESTORE aimed at the wrong project is worse than a
+#                     backup that reads from one — it writes. See scripts/compose_project.sh
+#                     (deploy#617).
 #   RESTORE_DIR     — Local restore staging directory (default: /tmp/isnad-restore)
 #   RESTORE_LOCAL_DIR — Restore from a backup directory already on disk instead of
 #                     downloading from B2. Checksum verification and every restore
@@ -80,6 +87,26 @@ log() {
     shift
     echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [${level}] $*"
 }
+
+# ---------------------------------------------------------------------------
+# Compose project scoping (deploy#617)
+# ---------------------------------------------------------------------------
+# Sourced AFTER log(): the library's guards report through it. Provides COMPOSE_PROJECT,
+# dc(), assert_stack_present() and neo4j_start(). Every compose call below goes through
+# dc(). This script had the SAME defect backup.sh did — no `-p` anywhere — and it is the
+# more dangerous half: a backup addressing a phantom project READS nothing, a restore
+# addressing one WRITES. Once a stray neo4j exists in project `compose` (backup.sh's `up`
+# created exactly that on stg), `ps -aq neo4j` RESOLVES it, restore.sh's "refusing to
+# guess" volume guard is satisfied, and `neo4j-admin database load --overwrite-destination`
+# loads the backup into the STRAY volume — reporting "Neo4j restore complete" while the
+# real graph is untouched and the operator believes they have recovered.
+COMPOSE_PROJECT_LIB="$(dirname "${BASH_SOURCE[0]}")/compose_project.sh"
+if [[ ! -f "$COMPOSE_PROJECT_LIB" ]]; then
+    log "ERROR" "Missing ${COMPOSE_PROJECT_LIB} — cannot resolve the compose project to restore into"
+    exit 1
+fi
+# shellcheck source=scripts/compose_project.sh
+source "$COMPOSE_PROJECT_LIB"
 
 # ---------------------------------------------------------------------------
 # Cleanup
@@ -694,7 +721,7 @@ verify_checksums() {
 terminate_pg_connections() {
     local service="$1" pg_user="$2" pg_db="$3"
     log "INFO" "Terminating active PostgreSQL connections to ${pg_db} (service=${service})..."
-    docker compose -f "$COMPOSE_FILE" exec -T "$service" \
+    dc exec -T "$service" \
         psql -U "$pg_user" -d postgres -c \
         "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${pg_db}' AND pid <> pg_backend_pid();" \
         2>/dev/null || true
@@ -724,7 +751,7 @@ restore_postgres() {
     # was unreadable. Verified: restoring a truncated dump printed
     # "could not read from input file: end of file", restored zero rows, and the
     # script reported "PostgreSQL: restored / === Restore complete ===" with exit 0.
-    if docker compose -f "$COMPOSE_FILE" exec -T "$service" \
+    if dc exec -T "$service" \
         pg_restore -U "$pg_user" -d "$pg_db" --clean --if-exists \
         < "$dump_file" > "$out" 2>&1; then
         rc=0
@@ -768,7 +795,7 @@ restore_neo4j() {
     fi
 
     log "INFO" "Stopping Neo4j for restore..."
-    docker compose -f "$COMPOSE_FILE" stop neo4j
+    dc stop neo4j
 
     # Wait for Neo4j to stop.
     #
@@ -778,10 +805,10 @@ restore_neo4j() {
     # is ENVIRONMENT-BOUNDED, not artifact content — see "WHY THE OTHER EARLY-EXIT PIPELINES IN
     # THIS FILE ARE LEFT ALONE" above before copying this shape somewhere it is not.
     local max_wait=30 waited=0
-    while docker compose -f "$COMPOSE_FILE" ps --format '{{.Service}}:{{.State}}' 2>/dev/null | grep -q "neo4j:running"; do
+    while dc ps --format '{{.Service}}:{{.State}}' 2>/dev/null | grep -q "neo4j:running"; do
         if [[ $waited -ge $max_wait ]]; then
             log "ERROR" "Neo4j did not stop within ${max_wait}s"
-            docker compose -f "$COMPOSE_FILE" up -d neo4j
+            neo4j_start || log "ERROR" "  ...and it could not be restarted either — check manually"
             return 1
         fi
         sleep 1
@@ -803,10 +830,10 @@ restore_neo4j() {
     # container-id list is environment-bounded and fits the pipe buffer, so nothing is still
     # writing when `head` quits.
     local neo4j_cid
-    neo4j_cid=$(docker compose -f "$COMPOSE_FILE" ps -aq neo4j 2>/dev/null | head -1)
+    neo4j_cid=$(dc ps -aq neo4j 2>/dev/null | head -1)
     if [[ -z "$neo4j_cid" ]]; then
-        log "ERROR" "Cannot resolve a neo4j container for ${COMPOSE_FILE} — refusing to guess a data volume"
-        docker compose -f "$COMPOSE_FILE" up -d neo4j
+        log "ERROR" "Cannot resolve a neo4j container in project '${COMPOSE_PROJECT}' (${COMPOSE_FILE}) — refusing to guess a data volume"
+        neo4j_start || log "ERROR" "  ...and there is no neo4j container to start in that project either (deploy#617)"
         return 1
     fi
 
@@ -815,10 +842,10 @@ restore_neo4j() {
         "$neo4j_cid")
     if [[ -z "$NEO4J_VOLUME" ]]; then
         log "ERROR" "neo4j container ${neo4j_cid} has no named volume mounted at /data"
-        docker compose -f "$COMPOSE_FILE" up -d neo4j
+        neo4j_start || log "ERROR" "  ...and neo4j could not be restarted — check manually"
         return 1
     fi
-    log "INFO" "Resolved Neo4j data volume: ${NEO4J_VOLUME} (from ${COMPOSE_FILE})"
+    log "INFO" "Resolved Neo4j data volume: ${NEO4J_VOLUME} (project ${COMPOSE_PROJECT}, ${COMPOSE_FILE})"
 
     # `neo4j-admin database load <db> --from-path=DIR` locates the archive by NAME:
     # it looks for DIR/<db>.dump, i.e. DIR/neo4j.dump. backup.sh stores the archive as
@@ -853,17 +880,24 @@ restore_neo4j() {
         log "INFO" "Neo4j restore complete"
     else
         log "ERROR" "Neo4j restore failed"
-        docker compose -f "$COMPOSE_FILE" up -d neo4j
+        neo4j_start || log "ERROR" "  ...and neo4j could not be restarted — check manually"
         return 1
     fi
 
+    # `start`, never `up`. `up` CREATES a container when the project has none, and in THIS
+    # function that is not merely untidy: the container it would invent is the one whose
+    # volume the load above targets. Restoring into a project you accidentally created is
+    # how a restore reports success while the real graph sits untouched (deploy#617).
     log "INFO" "Restarting Neo4j..."
-    docker compose -f "$COMPOSE_FILE" up -d neo4j
+    if ! neo4j_start; then
+        log "ERROR" "Neo4j restored but could NOT be restarted — the graph is DOWN, check manually"
+        return 1
+    fi
 
     # Wait for healthy. Same early-exit pipeline, same environment-bounded producer, safe for
     # the same reason as the stop-loop above.
     local max_health=120 health_waited=0
-    while ! docker compose -f "$COMPOSE_FILE" ps --format '{{.Service}}:{{.Health}}' 2>/dev/null | grep -q "neo4j:healthy"; do
+    while ! dc ps --format '{{.Service}}:{{.Health}}' 2>/dev/null | grep -q "neo4j:healthy"; do
         if [[ $health_waited -ge $max_health ]]; then
             # The dump loaded; Neo4j not coming back healthy is a separate, real
             # failure. Report it as one rather than falling off the end with success.
@@ -921,6 +955,23 @@ done
 if [[ -z "$BACKUP_PATH" ]]; then
     echo "Usage: $0 [--force] [--allow-partial] [--list] <backup-path|latest>"
     echo "Run '$0 --list' to see available backups."
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Assert the stack we are about to restore INTO is actually there (deploy#617)
+# ---------------------------------------------------------------------------
+# Before we resolve anything, download gigabytes, or overwrite a single byte. A restore
+# aimed at a project with no containers does not fail cleanly: `exec` has nothing to feed
+# the dump to, and the Neo4j leg — absent this check and the `up`->`start` change — would
+# CREATE a container and load the dump into ITS fresh volume, then report success.
+#
+# Deliberately AFTER `--list` and `--help` (which need no stack) and BEFORE the
+# confirmation prompt: an operator who is about to type YES should already know the target
+# exists. `--list` still works on a box where the stack is down, which is a real DR case.
+if ! assert_stack_present postgres user-postgres neo4j; then
+    log "ERROR" "Refusing to restore into a stack that is not present."
+    log "ERROR" "  Nothing has been downloaded and nothing has been written."
     exit 1
 fi
 

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -829,8 +829,14 @@ restore_neo4j() {
     # `| head -1` is safe here for the same reason as the wait-loop above: a one-service
     # container-id list is environment-bounded and fits the pipe buffer, so nothing is still
     # writing when `head` quits.
-    local neo4j_cid
-    neo4j_cid=$(dc ps -aq neo4j 2>/dev/null | head -1)
+    # `|| neo4j_cid=""`, for the same reason as backup.sh's NEO4J_CID (deploy#622): a bare
+    # assignment under `set -euo pipefail`, in the window AFTER Neo4j has been stopped. Any
+    # non-zero exit from docker — a daemon blip, a socket timeout — fires errexit AT THE
+    # ASSIGNMENT, and the restart below is never reached: the graph stays down, mid-restore.
+    # With the guard, an unreadable listing becomes an empty cid, which the "refusing to guess"
+    # branch below already handles correctly AND which restarts Neo4j on its way out.
+    local neo4j_cid=""
+    neo4j_cid="$(dc ps -aq neo4j 2>/dev/null | head -1)" || neo4j_cid=""
     if [[ -z "$neo4j_cid" ]]; then
         log "ERROR" "Cannot resolve a neo4j container in project '${COMPOSE_PROJECT}' (${COMPOSE_FILE}) — refusing to guess a data volume"
         neo4j_start || log "ERROR" "  ...and there is no neo4j container to start in that project either (deploy#617)"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -969,7 +969,16 @@ fi
 # Deliberately AFTER `--list` and `--help` (which need no stack) and BEFORE the
 # confirmation prompt: an operator who is about to type YES should already know the target
 # exists. `--list` still works on a box where the stack is down, which is a real DR case.
-if ! assert_stack_present postgres user-postgres neo4j; then
+#
+# `postgres user-postgres` — NOT `neo4j`, for the same reason backup.sh does not demand it
+# (deploy#618 review). This asserts the PROJECT'S IDENTITY, and the Postgres pair is the
+# witness that cannot be forged: nothing in this path can create it, whereas a stray `neo4j`
+# in the phantom project is exactly what deploy#617 produced. Demanding a RUNNING neo4j here
+# would also be wrong on its own terms: restore_neo4j() STOPS it before loading, so it needs
+# the container to EXIST, not to be running — and `ps -aq` plus the untouched "refusing to
+# guess" guard already enforce exactly that, in the right project, at the right moment.
+# A DR restore of the Postgres stores must not be blocked because the graph is down.
+if ! assert_stack_present postgres user-postgres; then
     log "ERROR" "Refusing to restore into a stack that is not present."
     log "ERROR" "  Nothing has been downloaded and nothing has been written."
     exit 1

--- a/scripts/restore_rehearsal.sh
+++ b/scripts/restore_rehearsal.sh
@@ -612,6 +612,40 @@ main() {
         assert_restored_content
     fi
 
+    # -----------------------------------------------------------------------
+    # THE DR CASE: NEO4J IS NOT RUNNING. (deploy#618 review, Aisha Idrissi)
+    # -----------------------------------------------------------------------
+    # Every case above restores into a HEALTHY stack — which is not the stack anyone restores
+    # into in anger. You reach for a dump because the graph is DEAD: crashed, OOM-killed,
+    # crash-looping on a corrupt store. Neo4j is then `exited`, never `running`.
+    #
+    # So the rehearsal could not see the very thing it exists to rehearse. That is the same
+    # shape as the COMPOSE_PROJECT_NAME finding that produced this PR — a harness that hands
+    # the code under test an input production never provides (there, a project name; here, a
+    # healthy database) is not exercising the code under test. It is why an over-strict
+    # `assert_stack_present ... neo4j` would have sailed through CI and only failed on the one
+    # night it was needed.
+    #
+    # restore.sh does NOT need Neo4j running: restore_neo4j() STOPS it first, and resolves the
+    # volume with `ps -aq`, which sees a stopped container perfectly well. The load is offline.
+    # This case pins that, end to end, against real containers.
+    empty_scratch_stores
+    log "INFO" "--- DR case: stopping neo4j BEFORE the restore (you restore because it is dead) ---"
+    dc stop neo4j > /dev/null 2>&1
+    local neo4j_state
+    neo4j_state="$(dc ps -a --format '{{.Service}}:{{.State}}' 2>/dev/null | grep '^neo4j:' || echo 'neo4j:<gone>')"
+    log "INFO" "neo4j is now ${neo4j_state} — restoring into a stack whose graph is DOWN"
+    if [[ "$neo4j_state" == "neo4j:running" ]]; then
+        # An inert fixture proves nothing: if neo4j is still running, this case is just the
+        # positive case again under a different name.
+        fail "DR case: neo4j is STILL running — the fixture cannot express the state it tests"
+    else
+        if expect_pass "intact_artifact_with_neo4j_stopped" "$ARTIFACT"; then
+            wait_neo4j_healthy
+            assert_restored_content
+        fi
+    fi
+
     echo ""
     log "INFO" "=== Rehearsal summary ==="
     log "INFO" "passed: ${PASS_COUNT}   failed: ${FAIL_COUNT}"

--- a/scripts/restore_rehearsal.sh
+++ b/scripts/restore_rehearsal.sh
@@ -87,6 +87,21 @@ guard() {
         exit 1
     fi
 
+    # Same refusal for the PROJECT, and for the same reason. COMPOSE_FILE names the file;
+    # COMPOSE_PROJECT names the stack the calls actually land on, and it is the one that
+    # decides whether a `--overwrite-destination` load hits the rehearsal's scratch volume
+    # or production's (deploy#617). run_restore() sets it explicitly per invocation, so an
+    # ambient value cannot reach restore.sh — but a bare compose call added to this file
+    # later would inherit one, and the failure would be silent and unrecoverable.
+    local var
+    for var in COMPOSE_PROJECT COMPOSE_PROJECT_NAME; do
+        if [[ -n "${!var:-}" && "${!var}" != "$PROJECT" ]]; then
+            log "ERROR" "Refusing to run with an inherited ${var}=${!var}"
+            log "ERROR" "The rehearsal only ever drives the '${PROJECT}' compose project"
+            exit 1
+        fi
+    done
+
     if [[ ! -f "$REHEARSAL_COMPOSE" ]]; then
         log "ERROR" "Rehearsal compose file not found: ${REHEARSAL_COMPOSE}"
         exit 1
@@ -295,7 +310,26 @@ run_restore() {
     local src="$1" logfile="$2"
     (
         cd "$REPO_ROOT"
+        # ---------------------------------------------------------------------
+        # COMPOSE_PROJECT IS NOT OPTIONAL HERE. IT AIMS THE RESTORE. (deploy#617)
+        # ---------------------------------------------------------------------
+        # restore.sh now passes an explicit `-p "$COMPOSE_PROJECT"` on every compose call,
+        # and a FLAG BEATS COMPOSE_PROJECT_NAME. Drop this line and every restore below
+        # runs against `noorinalabs` — THE REAL STACK — while every safety guard in this
+        # file (the ENVIRONMENT check, the COMPOSE_FILE refusal, assert_volume_isolation)
+        # goes on inspecting the rehearsal project and reports all-clear. guard() refuses
+        # an inherited COMPOSE_PROJECT for the same reason.
+        #
+        # And note what this line's ABSENCE used to mean, because it is the whole of
+        # deploy#617: restore.sh had no `-p` at all, so COMPOSE_PROJECT_NAME was the ONLY
+        # thing aiming it — and this rehearsal SET it. Production does not: the systemd
+        # unit's EnvironmentFile has no such variable, so on stg and prod the same script
+        # silently addressed the project `compose`, which contains nothing. The rehearsal
+        # passed, every time, precisely because the harness supplied the one thing
+        # production omits. A fixture that hands the code under test the missing input is
+        # not exercising the code under test.
         COMPOSE_FILE="$REHEARSAL_COMPOSE" \
+        COMPOSE_PROJECT="$PROJECT" \
         COMPOSE_PROJECT_NAME="$PROJECT" \
         RESTORE_LOCAL_DIR="$src" \
         RESTORE_DIR="${WORK}/stage-$(basename "$src")" \

--- a/scripts/restore_rehearsal.sh
+++ b/scripts/restore_rehearsal.sh
@@ -311,23 +311,38 @@ run_restore() {
     (
         cd "$REPO_ROOT"
         # ---------------------------------------------------------------------
-        # COMPOSE_PROJECT IS NOT OPTIONAL HERE. IT AIMS THE RESTORE. (deploy#617)
+        # NAMING THE PROJECT EXPLICITLY — AND WHAT ACTUALLY PROTECTS THIS. (deploy#617)
         # ---------------------------------------------------------------------
-        # restore.sh now passes an explicit `-p "$COMPOSE_PROJECT"` on every compose call,
-        # and a FLAG BEATS COMPOSE_PROJECT_NAME. Drop this line and every restore below
-        # runs against `noorinalabs` — THE REAL STACK — while every safety guard in this
-        # file (the ENVIRONMENT check, the COMPOSE_FILE refusal, assert_volume_isolation)
-        # goes on inspecting the rehearsal project and reports all-clear. guard() refuses
-        # an inherited COMPOSE_PROJECT for the same reason.
+        # An earlier version of this comment claimed that deleting the COMPOSE_PROJECT line
+        # would send every restore below at `noorinalabs`, the REAL stack. THAT IS FALSE,
+        # and compose_project.sh is what disproves it (deploy#618 review, Weronika
+        # Zielinska):
         #
-        # And note what this line's ABSENCE used to mean, because it is the whole of
+        #   COMPOSE_PROJECT="${COMPOSE_PROJECT:-${COMPOSE_PROJECT_NAME:-noorinalabs}}"
+        #
+        # COMPOSE_PROJECT_NAME is set right below, so with the COMPOSE_PROJECT line removed
+        # the fallback still resolves to "$PROJECT" and the restore still lands on the
+        # scratch stack. The counterfactual could not happen. A false load-bearing claim in
+        # the PRODUCT is worse than one in a test — the test would at least stay green while
+        # breaking; a comment just misleads whoever reasons about the fallback chain next
+        # (deploy#589, "a paraphrase in the PRODUCT"). Doubly so in this file, whose own
+        # lesson is that a harness lied about what it exercised.
+        #
+        # What is TRUE:
+        #   * COMPOSE_PROJECT is DEFENCE IN DEPTH — it names the project without depending on
+        #     compose_project.sh keeping its COMPOSE_PROJECT_NAME fallback rung, which is an
+        #     implementation detail of another file and free to change.
+        #   * guard() is the ACTUAL PROTECTION against a wrongly-aimed rehearsal: it refuses
+        #     an inherited COMPOSE_PROJECT / COMPOSE_PROJECT_NAME that is not "$PROJECT".
+        #
+        # And what the ABSENCE of any project name here used to mean — the whole of
         # deploy#617: restore.sh had no `-p` at all, so COMPOSE_PROJECT_NAME was the ONLY
-        # thing aiming it — and this rehearsal SET it. Production does not: the systemd
-        # unit's EnvironmentFile has no such variable, so on stg and prod the same script
+        # thing aiming it, and this rehearsal SET it. Production does not — the systemd
+        # unit's EnvironmentFile has no such variable — so on stg and prod the same script
         # silently addressed the project `compose`, which contains nothing. The rehearsal
-        # passed, every time, precisely because the harness supplied the one thing
-        # production omits. A fixture that hands the code under test the missing input is
-        # not exercising the code under test.
+        # passed every time precisely because the harness supplied the one input production
+        # omits. A fixture that hands the code under test the missing input is not exercising
+        # the code under test.
         COMPOSE_FILE="$REHEARSAL_COMPOSE" \
         COMPOSE_PROJECT="$PROJECT" \
         COMPOSE_PROJECT_NAME="$PROJECT" \

--- a/scripts/tests/test_backup_textfile_metrics.py
+++ b/scripts/tests/test_backup_textfile_metrics.py
@@ -39,10 +39,33 @@ FAILURE_METRIC = "isnad_backup_last_failure_timestamp_seconds"
 
 
 def _textfile_dir_assignment(script: Path) -> str:
-    """Extract the TEXTFILE_DIR="..." literal a shell script assigns."""
-    match = re.search(r'^TEXTFILE_DIR="([^"]+)"', script.read_text(), re.MULTILINE)
+    """The directory a script will actually write metrics to WHEN PRODUCTION RUNS IT.
+
+    Accepts either form, and returns the same thing for both — the path used when nothing in
+    the environment overrides it:
+
+        TEXTFILE_DIR="/var/lib/node_exporter/textfile_collector"
+        TEXTFILE_DIR="${TEXTFILE_DIR:-/var/lib/node_exporter/textfile_collector}"
+
+    backup.sh took the second form so a test sandbox can point the gauge somewhere writable
+    and OBSERVE what a run leaves on the box (deploy#618 review: the run that dumps everything
+    and then fails to restart Neo4j used to exit 0 and `rm -f` its own failure marker — you
+    cannot assert on that without a writable textfile dir). Nothing in production sets the
+    variable: the systemd unit passes no such env and grants ReadWritePaths=/var/lib/node_exporter.
+
+    So what this helper must return is the DEFAULT, not the literal text of the assignment.
+    Returning the raw `${TEXTFILE_DIR:-...}` string would make the two assertions below compare
+    a shell expression against a path and fail — while the property they exist to protect (the
+    metric lands where node-exporter scrapes) is still perfectly true.
+    """
+    text = script.read_text()
+    match = re.search(
+        r'^TEXTFILE_DIR="(?:\$\{TEXTFILE_DIR:-(?P<default>[^}"]+)\}|(?P<literal>[^"$]+))"',
+        text,
+        re.MULTILINE,
+    )
     assert match, f"{script.name} does not assign TEXTFILE_DIR"
-    return match.group(1)
+    return match.group("default") or match.group("literal")
 
 
 def _collector_directory_flag() -> str:

--- a/scripts/tests/test_compose_project_scoping.py
+++ b/scripts/tests/test_compose_project_scoping.py
@@ -76,9 +76,14 @@ def _executable_surface() -> list[Path]:
 
 
 # Subcommands that do NOT resolve a project, so a missing `-p` cannot misaddress anything.
-# `config` parses the file; `version` asks the binary. Everything else — ps, exec, logs, up,
-# stop, start, pull, run, cp, restart, down — operates on a project's containers.
-PROJECT_AGNOSTIC_SUBCOMMANDS = {"config", "version"}
+# `config` parses the file; `version` asks the binary; `ls` ENUMERATES projects rather than
+# selecting one (it is what an operator runs to find out which project the stack is actually
+# in, and compose_project.sh's own diagnostic now tells them to). Everything else — ps, exec,
+# logs, up, stop, start, pull, run, cp, restart, down — operates on one project's containers.
+#
+# The property being enforced is not "a `-p` appears on every line". It is "no compose call
+# can resolve the WRONG project". These three cannot resolve one at all.
+PROJECT_AGNOSTIC_SUBCOMMANDS = {"config", "version", "ls"}
 
 PROJECT_FLAGS = {"-p", "--project-name"}
 # Compose top-level flags that consume the following token as their value.
@@ -146,7 +151,12 @@ def _compose_invocations(script: Path) -> list[tuple[str, list[str], str | None]
         while i < len(tokens):
             token = tokens[i]
             if not token.startswith("-"):
-                subcommand = token
+                # Strip trailing shell/prose punctuation. A `docker compose ls` quoted INSIDE a
+                # diagnostic string ("Run 'docker compose ls' and ...") tokenizes as `ls'`, and
+                # an un-normalized token would miss the project-agnostic exemption and flag the
+                # message as if it were a call. A real invocation's subcommand never carries
+                # quotes, so this cannot mask one.
+                subcommand = token.strip("\"'`;.,)")
                 break
             flags.append(token)
             i += 2 if token in VALUE_FLAGS else 1
@@ -170,6 +180,8 @@ def test_every_docker_compose_invocation_names_a_project() -> None:
     unflagged = []
     for script in SCANNED:
         for line, flags, subcommand in _compose_invocations(script):
+            if subcommand in PROJECT_AGNOSTIC_SUBCOMMANDS:
+                continue
             if not PROJECT_FLAGS & set(flags):
                 unflagged.append(f"{script.name}: {line}  (subcommand={subcommand})")
 
@@ -594,6 +606,34 @@ REAL_PROJECT="noorinalabs"
 
 printf '%s\n' "$*" >> "$DOCKER_ARGV_LOG"
 
+# --- bare `docker` verbs (NOT `docker compose`) -----------------------------------------
+# The Neo4j leg resolves its data volume with `docker inspect` and dumps with a bare
+# `docker run` (not `compose run`). Without these the leg can never SUCCEED here: NEO4J_OK
+# stays false, the partial gate fires, and the run exits non-zero for a reason unrelated to
+# the branch under test. A test that goes green because a DIFFERENT gate fired has measured
+# nothing (deploy#574) — and the graph-down test needs a COMPLETE artifact before the
+# restart fails.
+case "${1:-}" in
+    inspect)
+        printf '%s_neo4j_data\n' "$REAL_PROJECT"
+        exit 0
+        ;;
+    run)
+        # `neo4j-admin database dump --to-path=/backups/` writes /backups/neo4j.dump; the
+        # host side of that bind mount is $LOCAL_BACKUP_PATH.
+        dest=""
+        while [[ $# -gt 0 ]]; do
+            if [[ "$1" == "-v" && "${2:-}" == */backups ]]; then
+                dest="${2%%:*}"
+            fi
+            shift
+        done
+        [[ -n "$dest" ]] || exit 1
+        { printf 'fake-neo4j-dump\n'; head -c 2048 /dev/zero | tr '\0' 'n'; } > "${dest}/neo4j.dump"
+        exit 0
+        ;;
+esac
+
 [[ "${1:-}" == "compose" ]] || exit 0
 shift
 
@@ -623,7 +663,35 @@ shift || true
 
 case "$sub" in
     ps)
-        for s in $FAKE_RUNNING; do printf '%s:running\n' "$s"; done
+        # `-aq <svc>` asks for CONTAINER IDS including STOPPED ones (that is the `-a`) — it is
+        # how backup.sh resolves the data volume AFTER stopping the graph. It must keep
+        # answering once neo4j is stopped, or the volume is unresolvable, the leg dies in the
+        # "refusing to guess" branch, and the test exercises the wrong code path entirely.
+        if [[ "$*" == *-aq* ]]; then
+            svc=""
+            for a in "$@"; do case "$a" in -*) ;; *) svc="$a" ;; esac; done
+            for s in $FAKE_RUNNING; do
+                [[ "$s" == "$svc" ]] && { printf 'fake-cid-%s\n' "$svc"; exit 0; }
+            done
+            exit 0   # not in this project — empty, exactly like the real thing
+        fi
+
+        # Container state must be REAL state, not a constant. A service that has been STOPPED
+        # must stop reporting itself running, or backup.sh's stop-wait loop spins to its 30s
+        # timeout, SKIPS the dump, and exits down the stop-timeout path — never reaching the
+        # restart branch under test.
+        want_health=0
+        [[ "$*" == *Health* ]] && want_health=1
+
+        for s in $FAKE_RUNNING; do
+            if [[ -f "${DOCKER_STOPPED_FLAG}.${s}" ]]; then
+                [[ "$want_health" == "1" ]] || printf '%s:exited\n' "$s"
+            elif [[ "$want_health" == "1" ]]; then
+                printf '%s:healthy\n' "$s"
+            else
+                printf '%s:running\n' "$s"
+            fi
+        done
         exit 0
         ;;
     exec)
@@ -640,7 +708,21 @@ case "$sub" in
         echo "service \"${svc}\" is not running" >&2
         exit 1
         ;;
-    stop|start) exit 0 ;;
+    stop)
+        for a in "$@"; do case "$a" in -*) ;; *) : > "${DOCKER_STOPPED_FLAG}.${a}" ;; esac; done
+        exit 0
+        ;;
+    start)
+        # FAKE_START_FAILS models the graph refusing to come back after the dump — a
+        # crash-loop, a corrupt store, an OOM. `start` cannot create, so it simply fails: the
+        # run has produced a COMPLETE artifact and left production DOWN.
+        if [[ "${FAKE_START_FAILS:-0}" == "1" ]]; then
+            echo "Error response from daemon: cannot start neo4j" >&2
+            exit 1
+        fi
+        for a in "$@"; do case "$a" in -*) ;; *) rm -f "${DOCKER_STOPPED_FLAG}.${a}" ;; esac; done
+        exit 0
+        ;;
     up)
         printf 'CREATED %s in project %s\n' "$*" "$project" >> "$DOCKER_CREATED_LOG"
         exit 0
@@ -674,13 +756,25 @@ esac
 
 class BackupRun:
     def __init__(
-        self, proc: subprocess.CompletedProcess[str], upload: Path, argv: str, created: str
+        self,
+        proc: subprocess.CompletedProcess[str],
+        upload: Path,
+        argv: str,
+        created: str,
+        textfile_dir: Path,
     ) -> None:
         self.rc = proc.returncode
         self.output = proc.stdout + proc.stderr
         self.upload = upload
         self.argv = argv
         self.created = created
+        self.textfile_dir = textfile_dir
+
+    def textfiles(self) -> list[str]:
+        """What the run actually left on the box for node-exporter to scrape."""
+        if not self.textfile_dir.is_dir():
+            return []
+        return sorted(f.name for f in self.textfile_dir.iterdir() if f.suffix == ".prom")
 
     def uploaded(self) -> list[str]:
         if not self.upload.is_dir():
@@ -695,8 +789,18 @@ class BackupRun:
         )
 
 
-def _run_backup(running: str, tmp_path: Path, project: str = CANONICAL_PROJECT) -> BackupRun:
-    """Run the REAL backup.sh with `running` as the set of services actually up."""
+def _run_backup(
+    running: str,
+    tmp_path: Path,
+    project: str = CANONICAL_PROJECT,
+    *,
+    start_fails: bool = False,
+) -> BackupRun:
+    """Run the REAL backup.sh with `running` as the set of services actually up.
+
+    start_fails — `docker compose start neo4j` returns 1: the graph does not come back after
+    the dump. Every dump still succeeds, so the ARTIFACT is complete and the HOST is broken.
+    """
     stub = tmp_path / "stub"
     stub.mkdir()
     (stub / "docker").write_text(FAKE_DOCKER_E2E)
@@ -729,6 +833,14 @@ def _run_backup(running: str, tmp_path: Path, project: str = CANONICAL_PROJECT) 
         UPLOAD_DIR=str(upload),
         DOCKER_ARGV_LOG=str(argv_log),
         DOCKER_CREATED_LOG=str(created_log),
+        FAKE_START_FAILS="1" if start_fails else "0",
+        # Container state must be real state: `stop` writes a marker here and `ps` reads it.
+        DOCKER_STOPPED_FLAG=str(tmp_path / "stopped"),
+        # Where the run leaves its metrics. backup.sh `rm -f`s the FAILURE textfile from here
+        # when it emits the success gauge — which is how "the backup that took the graph down
+        # cleared its own failure marker" happened. Point it somewhere inspectable so the
+        # assertions read what the run ACTUALLY left on the box, not a log line.
+        TEXTFILE_DIR=str(tmp_path / "textfile"),
     )
 
     proc = subprocess.run(
@@ -744,6 +856,7 @@ def _run_backup(running: str, tmp_path: Path, project: str = CANONICAL_PROJECT) 
         upload,
         argv_log.read_text(),
         created_log.read_text() if created_log.exists() else "",
+        tmp_path / "textfile",
     )
 
 
@@ -810,4 +923,84 @@ def test_a_stray_neo4j_alone_does_not_satisfy_the_project_gate(tmp_path: Path) -
     assert "Stopping Neo4j" not in run.output, (
         "the stray, empty graph was about to be dumped — this is exactly the artifact that "
         "would have checksummed cleanly and restored as an empty database"
+    )
+
+
+# --------------------------------------------------------------------------
+# The producer must not lie about the HOST (deploy#618 review — Aisha Idrissi)
+# --------------------------------------------------------------------------
+
+
+def test_a_run_that_leaves_the_graph_down_does_not_report_success(tmp_path: Path) -> None:
+    """Every dump succeeds; then Neo4j does not come back. This run took production down.
+
+    Before NEO4J_DOWN, that run exited **0**. NEO4J_OK was set true at the dump; the
+    restart-failure branch logged "the graph is DOWN" and set nothing; the final gate read
+    only the three _OK flags. So systemd marked isnad-backup.service SUCCEEDED,
+    `OnFailure=isnad-backup-failure-marker.service` never fired, and emit_success_metric's
+    `rm -f "$FAILURE_TEXTFILE"` meant THE BACKUP THAT TOOK THE GRAPH DOWN CLEARED ITS OWN
+    FAILURE MARKER. The operator's only surviving signal was a generic ServiceDown page with
+    nothing tying it to the backup.
+
+    The correct behaviour is NOT simply "fail". Two facts are true at once and BOTH must
+    reach the box:
+
+      * the backup IS complete and restorable -> emit the success gauge. Suppressing it would
+        hide a good artifact and make BackupStale fire on a backup that exists — the
+        alert-fatigue trap deploy#559/#565 closed.
+      * the run DID break production -> exit non-zero, so OnFailure fires and a human comes.
+    """
+    run = _run_backup("postgres user-postgres neo4j", tmp_path, start_fails=True)
+    uploaded = run.uploaded()
+
+    # The artifact is COMPLETE: all three stores dumped and uploaded.
+    assert any(f.startswith("isnad-pg-") for f in uploaded), f"no isnad dump uploaded: {uploaded}"
+    assert any(f.startswith("isnad-userpg-") for f in uploaded), (
+        f"no user-postgres dump uploaded: {uploaded}"
+    )
+    assert any("neo4j" in f for f in uploaded), (
+        f"no neo4j dump uploaded: {uploaded} — the fixture must reach a COMPLETE artifact, or "
+        "this test passes off the partial gate and proves nothing about the restart branch"
+    )
+    assert "complete=true" in run.manifest(), (
+        "every dump succeeded, so the artifact IS complete and the manifest must say so"
+    )
+
+    # ...and it is ATTESTED: a good backup must not go invisible.
+    assert "isnad_backup_success.prom" in run.textfiles(), (
+        "the success gauge was NOT emitted for a COMPLETE backup. Suppressing it hides a good "
+        "artifact and makes BackupStale fire falsely (deploy#559/#565). 'the artifact is good' "
+        "and 'the host is broken' are different facts and need different signals."
+    )
+
+    # ...and the run FAILS, because it left production down.
+    assert run.rc != 0, (
+        "a run that left the graph DOWN exited 0. systemd marks the unit SUCCEEDED, OnFailure= "
+        "never fires the failure marker, and nobody is told — while the script's own log says "
+        "'the graph is DOWN'."
+    )
+    assert "the graph is DOWN" in run.output
+
+
+def test_the_health_timeout_branch_also_raises_the_graph_down_flag() -> None:
+    """The same structural hole, one state further on.
+
+    `start` succeeds but the graph never becomes HEALTHY within MAX_HEALTH_WAIT. That branch
+    logged a WARNING and walked straight into a green exit. A graph that never came back
+    healthy is a graph that is down.
+
+    Pinned separately because it is a DIFFERENT branch from the restart failure — and the
+    first fixup pass closed one and left the other open, which is exactly how this class of
+    bug survives its own fix.
+    """
+    src = BACKUP.read_text()
+    assert "NEO4J_DOWN=true" in src, "the graph-down flag is gone entirely"
+
+    before, _, after = src.partition("did not become healthy")
+    assert after, "the health-timeout branch vanished — retarget this test, do not delete it"
+    window = before[-500:] + after[:300]
+    assert "NEO4J_DOWN=true" in window, (
+        "the health-timeout branch does not raise NEO4J_DOWN. A graph that never came back "
+        "healthy is DOWN, and this branch would exit 0 over it — the same hole as the "
+        "restart-failure branch, which is why both are pinned."
     )

--- a/scripts/tests/test_compose_project_scoping.py
+++ b/scripts/tests/test_compose_project_scoping.py
@@ -1,0 +1,468 @@
+"""Every compose call in the backup/restore path must name its PROJECT (deploy#617).
+
+``docker compose -f compose/docker-compose.prod.yml <cmd>`` does not address the running
+stack. ``-f`` names the FILE; with no ``-p`` and no ``COMPOSE_PROJECT_NAME``, Compose
+derives the project name from the compose file's DIRECTORY — ``compose`` — while every
+deploy path in this repo brings the stack up as ``-p noorinalabs``. So every call in
+``backup.sh`` and ``restore.sh`` resolved a project that existed only as a name and held
+nothing. Measured on stg 2026-07-13, on the first run ever to get past the B2 preflight:
+both pg_dumps failed, ``stop neo4j`` stopped nothing, and ``up -d neo4j`` **created a new,
+empty Neo4j with fresh volumes.**
+
+WHY A COMMAND-STRING TEST WOULD PROVE NOTHING HERE
+--------------------------------------------------
+Stub ``docker``, assert the script issues ``pg_dump -U isnad -d isnad_graph --format=custom``,
+go green. That test passes on the *broken* script: the command string is identical either
+way. The bug is not in the command — it is in **which project the command is addressed
+to**, and that is invisible to any assertion about the command's text.
+
+So this module tests the two things that actually distinguish the trees:
+
+1. a **static scan** — every ``docker compose`` invocation in the backup/restore path
+   carries a project flag, and an unflagged one added later fails the suite;
+2. a **behavioural** check against a fake ``docker`` that models the one fact that matters:
+   a compose project you never deployed into is EMPTY, and ``ps`` against it EXITS 0.
+   That vacuous zero is what the replaced guard read as "the stack is fine", and it is why
+   ``test_the_replaced_ps_guard_cannot_tell_an_empty_project_from_a_healthy_one`` exists —
+   the fixture must be shown capable of expressing the defect before its silence about the
+   fixed code means anything (cf. ``feedback_calibrate_the_mutation_before_counting_it``).
+
+Both classes are exercised in BOTH directions: the guard must fail on the phantom project
+AND pass on the real one, and the stub must be shown able to record a container creation
+before an empty creation-log is read as "nothing was created".
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import subprocess
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+REPO_ROOT = SCRIPTS_DIR.parent
+LIB = SCRIPTS_DIR / "compose_project.sh"
+BACKUP = SCRIPTS_DIR / "backup.sh"
+RESTORE = SCRIPTS_DIR / "restore.sh"
+REHEARSAL = SCRIPTS_DIR / "restore_rehearsal.sh"
+
+# The scripts that talk to the LIVE stack. restore_rehearsal.sh is in scope because it
+# drives restore.sh: it is the one caller that must NOT resolve to `noorinalabs`.
+SCANNED = (LIB, BACKUP, RESTORE, REHEARSAL)
+
+PROJECT_FLAGS = {"-p", "--project-name"}
+# Compose top-level flags that consume the following token as their value.
+VALUE_FLAGS = {
+    "-p",
+    "--project-name",
+    "-f",
+    "--file",
+    "--env-file",
+    "--profile",
+    "--project-directory",
+    "--progress",
+    "--ansi",
+    "--parallel",
+}
+
+# The project the stack is actually deployed into, by every workflow and action in the repo.
+CANONICAL_PROJECT = "noorinalabs"
+
+# Matches:  COMPOSE_PROJECT="${COMPOSE_PROJECT:-${COMPOSE_PROJECT_NAME:-noorinalabs}}"
+_PROJECT_DEFAULT_RE = re.compile(
+    r'^COMPOSE_PROJECT="\$\{COMPOSE_PROJECT:-(?:\$\{COMPOSE_PROJECT_NAME:-)?(?P<default>[A-Za-z0-9_.-]+)',
+    re.MULTILINE,
+)
+
+
+def _code_lines(script: Path) -> list[str]:
+    """Logical shell lines with comments dropped and backslash-continuations joined.
+
+    The fixes in these files quote the old, buggy commands verbatim so the next reader
+    knows what was wrong. A raw substring scan would match the explanation instead of the
+    executable line and fire on its own documentation — the same trap
+    ``test_restore_failure_modes.py`` documents. Comment lines go first, then continuations
+    are joined so a call split across lines is scanned as one invocation.
+    """
+    joined = re.sub(r"\\\n\s*", " ", script.read_text())
+    return [ln for ln in joined.splitlines() if not ln.lstrip().startswith("#")]
+
+
+def _compose_invocations(script: Path) -> list[tuple[str, list[str], str | None]]:
+    """Every literal ``docker compose`` call: (line, top-level flags, subcommand).
+
+    A script that is not there contributes nothing rather than raising. Its ABSENCE is a
+    separate assertion (``test_the_project_library_exists``) — folded in here, a missing
+    ``compose_project.sh`` would make the scan below die on a FileNotFoundError, i.e. go red
+    for a reason unrelated to what it tests, and its red would stop meaning "an unflagged
+    compose call exists".
+    """
+    if not script.is_file():
+        return []
+    found = []
+    for line in _code_lines(script):
+        idx = line.find("docker compose")
+        if idx == -1:
+            continue
+        rest = line[idx + len("docker compose") :]
+        try:
+            tokens = shlex.split(rest)
+        except ValueError:  # unbalanced quotes across a redirect; fall back to whitespace
+            tokens = rest.split()
+
+        flags: list[str] = []
+        subcommand: str | None = None
+        i = 0
+        while i < len(tokens):
+            token = tokens[i]
+            if not token.startswith("-"):
+                subcommand = token
+                break
+            flags.append(token)
+            i += 2 if token in VALUE_FLAGS else 1
+        found.append((line.strip(), flags, subcommand))
+    return found
+
+
+# --------------------------------------------------------------------------
+# Static scan: the project flag is not optional
+# --------------------------------------------------------------------------
+
+
+def test_the_project_library_exists() -> None:
+    """backup.sh and restore.sh both source it and refuse to run without it."""
+    assert LIB.is_file(), f"scripts/compose_project.sh is missing (expected at {LIB})"
+
+
+def test_every_docker_compose_invocation_names_a_project() -> None:
+    """The regression guard. FAILS on origin/main: 8 unflagged calls in backup.sh, 11 in
+    restore.sh. An unflagged call added tomorrow fails here rather than on staging."""
+    unflagged = []
+    for script in SCANNED:
+        for line, flags, subcommand in _compose_invocations(script):
+            if not PROJECT_FLAGS & set(flags):
+                unflagged.append(f"{script.name}: {line}  (subcommand={subcommand})")
+
+    assert not unflagged, (
+        "docker compose invocation(s) with no project flag — each one addresses the project "
+        "Compose infers from the compose file's DIRECTORY (`compose`), not the project the "
+        "stack runs in (`noorinalabs`), and therefore a project with nothing in it "
+        "(deploy#617):\n  " + "\n  ".join(unflagged)
+    )
+
+
+def test_backup_and_restore_route_every_compose_call_through_the_library() -> None:
+    """Stronger than the scan above, and the reason it can stay simple: the ONLY literal
+    ``docker compose`` in the backup/restore path lives in ``compose_project.sh``'s dc()."""
+    for script in (BACKUP, RESTORE):
+        literals = [line for line, _, _ in _compose_invocations(script)]
+        assert not literals, (
+            f"{script.name} calls `docker compose` directly instead of going through dc() "
+            f"in scripts/compose_project.sh — the project flag is then one edit away from "
+            f"being forgotten again (deploy#617):\n  " + "\n  ".join(literals)
+        )
+
+
+def test_the_library_defaults_to_the_project_the_stack_is_deployed_into() -> None:
+    match = _PROJECT_DEFAULT_RE.search(LIB.read_text())
+    assert match is not None, "no COMPOSE_PROJECT default assignment found in compose_project.sh"
+    assert match.group("default") == CANONICAL_PROJECT, (
+        f"COMPOSE_PROJECT defaults to {match.group('default')!r}, but every deploy path in "
+        f"this repo brings the stack up as `-p {CANONICAL_PROJECT}` — a backup or restore "
+        f"would address a project with no containers in it"
+    )
+
+
+def test_the_canonical_project_matches_what_the_deploy_path_actually_uses() -> None:
+    """Anchor the default in the deploy path itself, so a rename of the project on the
+    deploy side cannot leave backup/restore quietly pointing at the old one."""
+    action = REPO_ROOT / ".github" / "actions" / "write-deploy-env" / "action.yml"
+    assert f"docker compose -p {CANONICAL_PROJECT}" in action.read_text(), (
+        f"the deploy action no longer brings the stack up as `-p {CANONICAL_PROJECT}` — "
+        f"scripts/compose_project.sh's default is now aimed at a project nothing deploys into"
+    )
+
+
+def test_the_backup_and_restore_path_never_uses_compose_up() -> None:
+    """`up` is a CONVERGE verb: asked for a service the project does not have, it does not
+    fail — it CREATES one, with fresh, empty volumes. That is how the stg run left a stray
+    neo4j and a stray, empty `compose_neo4j_data`. In a RESTORE path the invented container
+    is the one whose volume the next command loads a dump into. The capability is removed
+    from these scripts, not merely aimed correctly."""
+    offenders = []
+    for script in (LIB, BACKUP, RESTORE):
+        for line, _, subcommand in _compose_invocations(script):
+            if subcommand == "up":
+                offenders.append(f"{script.name}: {line}")
+        # dc()-routed calls are invisible to the scan above; catch those too.
+        for line in _code_lines(script):
+            if re.search(r"(?<![\w-])dc\s+up(\s|$)", line):
+                offenders.append(f"{script.name}: {line.strip()}")
+
+    assert not offenders, (
+        "compose `up` in the backup/restore path — it can CREATE a database that was not "
+        "there (deploy#617). Use `start`, which can only start an existing container and "
+        "fails loudly when there is none:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_the_rehearsal_names_its_own_project_when_driving_restore() -> None:
+    """restore.sh now passes an explicit `-p`, and a FLAG BEATS COMPOSE_PROJECT_NAME. If the
+    rehearsal does not set COMPOSE_PROJECT, every restore it runs — including the
+    `--overwrite-destination` Neo4j load — lands on `noorinalabs`, THE REAL STACK, while
+    assert_volume_isolation goes on inspecting the rehearsal project and reports all-clear."""
+    body = re.search(
+        r"^run_restore\(\) \{\n(.*?)^\}", REHEARSAL.read_text(), re.MULTILINE | re.DOTALL
+    )
+    assert body is not None, "run_restore() not found in restore_rehearsal.sh"
+    code = "\n".join(ln for ln in body.group(1).splitlines() if not ln.lstrip().startswith("#"))
+    assert 'COMPOSE_PROJECT="$PROJECT"' in code, (
+        "restore_rehearsal.sh does not pass COMPOSE_PROJECT to restore.sh — the rehearsal "
+        "would drive the REAL `noorinalabs` stack (deploy#617)"
+    )
+
+
+# --------------------------------------------------------------------------
+# Behavioural: a fake docker that models compose's project scoping
+# --------------------------------------------------------------------------
+
+# The ONE fact this stub exists to model: a compose project you never deployed into is
+# EMPTY, and asking about it is not an error. Everything the bug did follows from that.
+FAKE_DOCKER = r"""#!/usr/bin/env bash
+set -u
+REAL_PROJECT="noorinalabs"
+REAL_SERVICES="postgres user-postgres neo4j"
+
+printf '%s\n' "$*" >> "$DOCKER_ARGV_LOG"
+
+[[ "${1:-}" == "compose" ]] || exit 0
+shift
+
+project=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -p|--project-name) project="$2"; shift 2 ;;
+        -f|--file|--env-file|--profile) shift 2 ;;
+        -*) shift ;;
+        *) break ;;
+    esac
+done
+
+# No -p: Compose derives the project from the compose file's DIRECTORY. Ours lives in
+# compose/, so an unflagged call lands on the project `compose`.
+[[ -n "$project" ]] || project="compose"
+
+sub="${1:-}"
+shift || true
+
+case "$sub" in
+    ps)
+        # THE VACUOUS ZERO. An empty or entirely nonexistent project lists nothing and
+        # EXITS 0. `ps` answers "did ps run", not "is the stack there".
+        [[ "$project" == "$REAL_PROJECT" ]] || exit 0
+        for s in $REAL_SERVICES; do
+            if [[ "$*" == *"{{.Health}}"* ]]; then
+                printf '%s:healthy\n' "$s"
+            else
+                printf '%s:running\n' "$s"
+            fi
+        done
+        exit 0
+        ;;
+    start)
+        # Starts an EXISTING container. Fails loudly when there is none.
+        [[ "$project" == "$REAL_PROJECT" ]] && exit 0
+        echo "no container to start: neo4j" >&2
+        exit 1
+        ;;
+    up)
+        # CONVERGE. Does not fail on a project with no containers — it CREATES them.
+        printf 'CREATED neo4j in project %s\n' "$project" >> "$DOCKER_CREATED_LOG"
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+"""
+
+
+class LibRun:
+    def __init__(self, proc: subprocess.CompletedProcess[str], argv: str, created: str) -> None:
+        self.rc = proc.returncode
+        self.output = proc.stdout + proc.stderr
+        self.argv = argv
+        self.created = created
+
+
+def _run_with_fake_docker(
+    snippet: str, project: str, tmp_path: Path, source_lib: bool = True
+) -> LibRun:
+    """Run ``snippet`` with the fake docker on PATH (and, by default, the library sourced).
+
+    ``source_lib=False`` is for the two FIXTURE-CALIBRATION tests, and it is not a
+    convenience. They must demonstrate that the stub reproduces the defect *on the tree that
+    has the defect* — where ``compose_project.sh`` does not exist. Sourcing it there would
+    make them die on a missing file, i.e. fail for a reason that has nothing to do with what
+    they assert, and a control that fails for the wrong reason has stopped controlling
+    anything (the lesson ``restore_rehearsal.sh``'s ``expect_fail`` third argument exists to
+    enforce).
+
+    The snippet runs under the same ``set -euo pipefail`` the real scripts do: a harness
+    running production code under a weaker ``set -...`` is not running production code.
+    """
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    fake = bindir / "docker"
+    fake.write_text(FAKE_DOCKER)
+    fake.chmod(0o755)
+
+    argv_log = tmp_path / "argv.log"
+    created_log = tmp_path / "created.log"
+    argv_log.write_text("")
+
+    env = dict(os.environ)
+    env.pop("COMPOSE_PROJECT_NAME", None)
+    env.update(
+        PATH=f"{bindir}:{env['PATH']}",
+        DOCKER_ARGV_LOG=str(argv_log),
+        DOCKER_CREATED_LOG=str(created_log),
+        COMPOSE_FILE="compose/docker-compose.prod.yml",
+        COMPOSE_PROJECT=project,
+    )
+
+    prelude = f'source "{LIB}"' if source_lib else ""
+    script = f"""
+set -euo pipefail
+log() {{ printf '[%s] %s\\n' "$1" "${{*:2}}"; }}
+{prelude}
+{snippet}
+"""
+    proc = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, env=env, cwd=REPO_ROOT
+    )
+    return LibRun(
+        proc,
+        argv_log.read_text(),
+        created_log.read_text() if created_log.exists() else "",
+    )
+
+
+# --- calibration: prove the fixture can express the defect ---------------------------
+
+
+def test_the_replaced_ps_guard_cannot_tell_an_empty_project_from_a_healthy_one(
+    tmp_path: Path,
+) -> None:
+    """The instrument check, and the whole diagnosis in one assertion.
+
+    This runs the LITERAL guard that used to stand at backup.sh's preflight, verbatim,
+    against a project with no containers — and it EXITS 0. That zero is what waved the run
+    through to the dumps. It also calibrates every assertion below it: the fake docker
+    demonstrably reproduces the failure, so its silence about the fixed code is a
+    measurement and not a stub that cannot fail.
+    """
+    run = _run_with_fake_docker(
+        'docker compose -f "$COMPOSE_FILE" ps --format json &>/dev/null; echo "old_guard_rc=$?"',
+        project="compose",
+        tmp_path=tmp_path,
+        source_lib=False,
+    )
+    assert "old_guard_rc=0" in run.output, (
+        "the fixture does not reproduce the defect — if `ps` on an empty project did NOT "
+        "exit 0 here, nothing below this test is calibrated"
+    )
+
+
+def test_compose_up_against_an_empty_project_creates_a_container(tmp_path: Path) -> None:
+    """The other half of the calibration. The stub RECORDS a creation when `up` is used, so
+    the empty creation-log asserted in the next test is a real negative and not a log
+    nothing ever writes to."""
+    run = _run_with_fake_docker(
+        'docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" up -d neo4j',
+        project="compose",
+        tmp_path=tmp_path,
+        source_lib=False,
+    )
+    assert run.rc == 0, "`up` on an empty project does not fail — that is the point of it"
+    assert "CREATED neo4j in project compose" in run.created
+
+
+# --- the guards themselves, in both directions ---------------------------------------
+
+
+def test_stack_presence_guard_refuses_a_project_with_no_containers(tmp_path: Path) -> None:
+    """The replacement for the vacuous `ps` guard, against the exact project an unflagged
+    call resolves to."""
+    run = _run_with_fake_docker(
+        "assert_stack_present postgres user-postgres neo4j",
+        project="compose",
+        tmp_path=tmp_path,
+    )
+    assert run.rc != 0, (
+        "assert_stack_present passed against a project with NO containers — this is the "
+        "vacuous zero of the guard it replaces (deploy#617)"
+    )
+    assert "is not running" in run.output
+    assert "compose" in run.output
+    # It must name what is missing, not merely refuse: an operator mid-incident reads the
+    # last line, and "the stack is not there" and "you asked the wrong project" are
+    # different problems with different fixes.
+    for service in ("postgres", "user-postgres", "neo4j"):
+        assert service in run.output
+
+
+def test_stack_presence_guard_passes_against_the_project_the_stack_runs_in(
+    tmp_path: Path,
+) -> None:
+    """The positive control. A guard that only ever refuses proves nothing: it must
+    SEPARATE the two classes, not merely go red on one of them."""
+    run = _run_with_fake_docker(
+        "assert_stack_present postgres user-postgres neo4j",
+        project=CANONICAL_PROJECT,
+        tmp_path=tmp_path,
+    )
+    assert run.rc == 0, f"assert_stack_present refused the real stack:\n{run.output}"
+    assert f"-p {CANONICAL_PROJECT}" in run.argv, (
+        f"the compose call did not carry `-p {CANONICAL_PROJECT}`:\n{run.argv}"
+    )
+
+
+def test_neo4j_restart_fails_loudly_rather_than_creating_a_database(tmp_path: Path) -> None:
+    """The stray-container behaviour, directly. Against a project with no neo4j, the backup
+    path must REFUSE — not conjure one. `up -d neo4j` here created `compose-neo4j-1` and a
+    fresh, empty `compose_neo4j_data` on stg."""
+    run = _run_with_fake_docker("neo4j_start", project="compose", tmp_path=tmp_path)
+
+    assert run.rc != 0, "neo4j_start reported success against a project with no neo4j container"
+    assert run.created == "", (
+        f"the backup path CREATED a neo4j container: {run.created!r} — a backup script must "
+        f"not be able to bring a database into existence (deploy#617)"
+    )
+    assert " up " not in f" {run.argv} ", f"an `up` reached docker:\n{run.argv}"
+    assert "start neo4j" in run.argv, f"neo4j_start did not issue `start`:\n{run.argv}"
+
+
+def test_neo4j_restart_starts_the_container_it_stopped_in_the_real_project(
+    tmp_path: Path,
+) -> None:
+    """Positive control for the above: `start` is not merely 'the verb that always fails'."""
+    run = _run_with_fake_docker("neo4j_start", project=CANONICAL_PROJECT, tmp_path=tmp_path)
+    assert run.rc == 0, f"neo4j_start could not restart the real stack's neo4j:\n{run.output}"
+    assert run.created == ""
+    assert f"compose -p {CANONICAL_PROJECT}" in run.argv
+
+
+def test_the_library_addresses_the_project_it_was_given_on_every_call(tmp_path: Path) -> None:
+    """dc() puts the project on the wire. Without this the flag is decorative."""
+    run = _run_with_fake_docker(
+        "dc ps -aq neo4j >/dev/null; dc stop neo4j >/dev/null",
+        project=CANONICAL_PROJECT,
+        tmp_path=tmp_path,
+    )
+    assert run.rc == 0
+    calls = [ln for ln in run.argv.splitlines() if ln.startswith("compose")]
+    assert calls, "no compose calls reached docker"
+    for call in calls:
+        assert f"-p {CANONICAL_PROJECT}" in call, f"compose call with no project: {call}"

--- a/scripts/tests/test_compose_project_scoping.py
+++ b/scripts/tests/test_compose_project_scoping.py
@@ -47,9 +47,38 @@ BACKUP = SCRIPTS_DIR / "backup.sh"
 RESTORE = SCRIPTS_DIR / "restore.sh"
 REHEARSAL = SCRIPTS_DIR / "restore_rehearsal.sh"
 
+BOOTSTRAP = SCRIPTS_DIR / "bootstrap-vps.sh"
+PROD_COMPOSE = REPO_ROOT / "compose" / "docker-compose.prod.yml"
+
 # The scripts that talk to the LIVE stack. restore_rehearsal.sh is in scope because it
 # drives restore.sh: it is the one caller that must NOT resolve to `noorinalabs`.
 SCANNED = (LIB, BACKUP, RESTORE, REHEARSAL)
+
+
+# The whole EXECUTABLE surface that can address the prod stack (deploy#618 review). The
+# original scan stopped at the four files above, and the class was still live in three
+# places it could not see: `bootstrap-vps.sh` PRINTED an unflagged `up -d` as the repo's own
+# fresh-VPS bring-up instruction, and deploy-prod.yml / deploy-isnad-graph.yml each ran an
+# unflagged `logs --tail=50 api` in their api_health FAILURE branch — so on a failed PROD
+# deploy the one diagnostic the operator got was EMPTY.
+#
+# Docs are deliberately NOT scanned. ~40 lines under docs/runbooks/** run
+# `docker compose -f compose/docker-compose.prod.yml exec|logs|ps …` by hand, and the fix for
+# those is not a flag in each one — it is `name: noorinalabs` in the compose file itself,
+# which makes the DERIVED project correct for every caller, including an operator typing one
+# of them at 3am. test_the_compose_file_pins_the_project_name pins that.
+def _executable_surface() -> list[Path]:
+    paths = sorted(SCRIPTS_DIR.glob("*.sh"))
+    paths += sorted((REPO_ROOT / ".github" / "workflows").glob("*.yml"))
+    paths += sorted((REPO_ROOT / ".github" / "actions").rglob("*.yml"))
+    paths.append(REPO_ROOT / ".pre-commit-config.yaml")
+    return [p for p in paths if p.is_file()]
+
+
+# Subcommands that do NOT resolve a project, so a missing `-p` cannot misaddress anything.
+# `config` parses the file; `version` asks the binary. Everything else — ps, exec, logs, up,
+# stop, start, pull, run, cp, restart, down — operates on a project's containers.
+PROJECT_AGNOSTIC_SUBCOMMANDS = {"config", "version"}
 
 PROJECT_FLAGS = {"-p", "--project-name"}
 # Compose top-level flags that consume the following token as their value.
@@ -174,6 +203,51 @@ def test_the_library_defaults_to_the_project_the_stack_is_deployed_into() -> Non
     )
 
 
+def test_the_compose_file_pins_the_project_name() -> None:
+    """The single source of truth, and the only fix that reaches the runbooks.
+
+    Compose precedence: `-p` > COMPOSE_PROJECT_NAME > compose-file `name:` > the file's
+    DIRECTORY. Without `name:`, that last rung applied — and this file lives in `compose/`,
+    so every caller passing `-f compose/docker-compose.prod.yml` with no `-p` addressed a
+    project literally called `compose`, which nothing ever deployed into. `name:` makes the
+    DERIVED project correct by construction for every caller the scan cannot reach: the ~40
+    hand-run `docker compose -f compose/docker-compose.prod.yml exec|logs|ps` lines in
+    docs/runbooks/**, and the operator typing one of them mid-incident.
+    """
+    text = PROD_COMPOSE.read_text()
+    assert re.search(rf"^name:\s*{CANONICAL_PROJECT}\s*$", text, re.MULTILINE), (
+        f"compose/docker-compose.prod.yml has no top-level `name: {CANONICAL_PROJECT}` — the "
+        f"project a caller without `-p` derives falls back to the file's DIRECTORY "
+        f"(`compose`), which is deploy#617"
+    )
+
+
+def test_no_unflagged_project_scoped_call_against_the_prod_stack() -> None:
+    """The sweep. Every compose call naming the prod stack file, anywhere in the executable
+    surface, must carry `-p` — `config`/`version` excepted, since they resolve no project.
+
+    FAILS on origin/main in three places the original 4-file scan could not see:
+    bootstrap-vps.sh's printed `pull`/`up -d`, and the api_health `logs` in deploy-prod.yml
+    and deploy-isnad-graph.yml.
+    """
+    offenders = []
+    for path in _executable_surface():
+        for line, flags, subcommand in _compose_invocations(path):
+            if "docker-compose.prod.yml" not in line:
+                continue
+            if subcommand in PROJECT_AGNOSTIC_SUBCOMMANDS:
+                continue
+            if PROJECT_FLAGS & set(flags):
+                continue
+            offenders.append(f"{path.relative_to(REPO_ROOT)}: {line}  (subcommand={subcommand})")
+
+    assert not offenders, (
+        "project-scoped `docker compose` call(s) against the prod stack with no `-p` — each "
+        "addresses the project derived from the compose file's DIRECTORY (`compose`), not "
+        "the one the stack runs in (deploy#617):\n  " + "\n  ".join(offenders)
+    )
+
+
 def test_the_canonical_project_matches_what_the_deploy_path_actually_uses() -> None:
     """Anchor the default in the deploy path itself, so a rename of the project on the
     deploy side cannot leave backup/restore quietly pointing at the old one."""
@@ -208,10 +282,19 @@ def test_the_backup_and_restore_path_never_uses_compose_up() -> None:
 
 
 def test_the_rehearsal_names_its_own_project_when_driving_restore() -> None:
-    """restore.sh now passes an explicit `-p`, and a FLAG BEATS COMPOSE_PROJECT_NAME. If the
-    rehearsal does not set COMPOSE_PROJECT, every restore it runs — including the
-    `--overwrite-destination` Neo4j load — lands on `noorinalabs`, THE REAL STACK, while
-    assert_volume_isolation goes on inspecting the rehearsal project and reports all-clear."""
+    """The rehearsal names the project it drives restore.sh against — defence in depth.
+
+    An earlier version of this docstring claimed that WITHOUT this line the rehearsal would
+    restore into the real `noorinalabs` stack. That is FALSE, and compose_project.sh disproves
+    it: `COMPOSE_PROJECT="${COMPOSE_PROJECT:-${COMPOSE_PROJECT_NAME:-noorinalabs}}"`, and
+    run_restore() also exports COMPOSE_PROJECT_NAME, so the fallback still resolves to the
+    rehearsal project (deploy#618 review, Weronika Zielinska).
+
+    What this pins is real but narrower: the rehearsal must not depend on ANOTHER file's
+    fallback rung — a detail of compose_project.sh, free to change — to stay aimed at the
+    scratch stack. guard()'s refusal of an inherited project name is the actual protection,
+    and test_the_rehearsal_refuses_an_inherited_project pins that.
+    """
     body = re.search(
         r"^run_restore\(\) \{\n(.*?)^\}", REHEARSAL.read_text(), re.MULTILINE | re.DOTALL
     )
@@ -396,7 +479,7 @@ def test_stack_presence_guard_refuses_a_project_with_no_containers(tmp_path: Pat
     """The replacement for the vacuous `ps` guard, against the exact project an unflagged
     call resolves to."""
     run = _run_with_fake_docker(
-        "assert_stack_present postgres user-postgres neo4j",
+        "assert_stack_present postgres user-postgres",
         project="compose",
         tmp_path=tmp_path,
     )
@@ -409,7 +492,7 @@ def test_stack_presence_guard_refuses_a_project_with_no_containers(tmp_path: Pat
     # It must name what is missing, not merely refuse: an operator mid-incident reads the
     # last line, and "the stack is not there" and "you asked the wrong project" are
     # different problems with different fixes.
-    for service in ("postgres", "user-postgres", "neo4j"):
+    for service in ("postgres", "user-postgres"):
         assert service in run.output
 
 
@@ -419,7 +502,7 @@ def test_stack_presence_guard_passes_against_the_project_the_stack_runs_in(
     """The positive control. A guard that only ever refuses proves nothing: it must
     SEPARATE the two classes, not merely go red on one of them."""
     run = _run_with_fake_docker(
-        "assert_stack_present postgres user-postgres neo4j",
+        "assert_stack_present postgres user-postgres",
         project=CANONICAL_PROJECT,
         tmp_path=tmp_path,
     )
@@ -466,3 +549,265 @@ def test_the_library_addresses_the_project_it_was_given_on_every_call(tmp_path: 
     assert calls, "no compose calls reached docker"
     for call in calls:
         assert f"-p {CANONICAL_PROJECT}" in call, f"compose call with no project: {call}"
+
+
+def test_the_rehearsal_refuses_an_inherited_project() -> None:
+    """guard() is the ACTUAL protection against a wrongly-aimed rehearsal (deploy#618 review).
+
+    The explicit COMPOSE_PROJECT in run_restore() is defence in depth; this refusal is what
+    stops an ambient project name from steering a `--overwrite-destination` Neo4j load at a
+    stack the rehearsal does not own. It is the exact shape of the file's existing
+    COMPOSE_FILE refusal, which exists for the same reason one layer up.
+    """
+    code = "\n".join(
+        ln for ln in REHEARSAL.read_text().splitlines() if not ln.lstrip().startswith("#")
+    )
+    for var in ("COMPOSE_PROJECT", "COMPOSE_PROJECT_NAME"):
+        assert var in code, f"restore_rehearsal.sh does not guard an inherited {var}"
+    assert "Refusing to run with an inherited ${var}" in code, (
+        "restore_rehearsal.sh's guard() does not refuse an inherited project name — an "
+        "ambient COMPOSE_PROJECT could aim the rehearsal's restores at another stack"
+    )
+
+
+# --------------------------------------------------------------------------
+# End-to-end: the partial-backup contract (deploy#618 review)
+# --------------------------------------------------------------------------
+# The first version of this PR gated backup.sh on `postgres user-postgres neo4j` — all three
+# running — and that SILENTLY REPEALED the script's oldest contract, 270 lines below the
+# gate: upload what you got, attest `complete=false`, exit non-zero. "A partial backup beats
+# none." On any night Neo4j was down, the gate would have taken ZERO backups instead of two,
+# and one of the two it discarded is `user-postgres` — the only store here that no artifact
+# can rebuild (deploy#559). backup.sh can even leave Neo4j stopped ITSELF (the neo4j_start
+# failure branch), so one bad night would have disarmed every backup after it.
+#
+# These tests run the REAL backup.sh, under its real `set -euo pipefail`, with docker and
+# rclone stubbed — the same shape as test_b2_preflight.py's end-to-end harness, and for the
+# same reason: a harness running production code under a weaker `set -...` is not running
+# production code. The fake rclone COPIES the staging directory to an inspectable path, so
+# the assertions are made against WHAT WAS ACTUALLY UPLOADED — not against a log line
+# claiming it was.
+
+FAKE_DOCKER_E2E = r"""#!/usr/bin/env bash
+set -u
+REAL_PROJECT="noorinalabs"
+
+printf '%s\n' "$*" >> "$DOCKER_ARGV_LOG"
+
+[[ "${1:-}" == "compose" ]] || exit 0
+shift
+
+project=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -p|--project-name) project="$2"; shift 2 ;;
+        -f|--file|--env-file|--profile) shift 2 ;;
+        -*) shift ;;
+        *) break ;;
+    esac
+done
+# No -p: Compose derives the project from the compose file's directory.
+[[ -n "$project" ]] || project="compose"
+
+sub="${1:-}"
+shift || true
+
+# Anything addressed to a project we never deployed into is EMPTY — and `ps` says so with a
+# ZERO, which is the whole of deploy#617.
+[[ "$project" == "$REAL_PROJECT" ]] || {
+    case "$sub" in
+        ps) exit 0 ;;
+        *)  echo "no such service in project ${project}" >&2; exit 1 ;;
+    esac
+}
+
+case "$sub" in
+    ps)
+        for s in $FAKE_RUNNING; do printf '%s:running\n' "$s"; done
+        exit 0
+        ;;
+    exec)
+        while [[ $# -gt 0 && "$1" == -* ]]; do shift; done
+        svc="${1:-}"
+        for s in $FAKE_RUNNING; do
+            if [[ "$s" == "$svc" ]]; then
+                # A plausible, non-empty pg_dump. backup.sh rejects a zero-byte dump.
+                printf 'PGDMP-fake-dump-of-%s\n' "$svc"
+                head -c 2048 /dev/zero | tr '\0' 'x'
+                exit 0
+            fi
+        done
+        echo "service \"${svc}\" is not running" >&2
+        exit 1
+        ;;
+    stop|start) exit 0 ;;
+    up)
+        printf 'CREATED %s in project %s\n' "$*" "$project" >> "$DOCKER_CREATED_LOG"
+        exit 0
+        ;;
+    *) exit 0 ;;
+esac
+"""
+
+# Enough rclone to drive the B2 preflight to verdict=OK and to capture the upload.
+FAKE_RCLONE_E2E = r"""#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+    lsd)
+        # b2_preflight greps the LAST field of each line for $B2_BUCKET.
+        printf '          -1 2026-01-01 00:00:00        -1 %s\n' "$B2_BUCKET"
+        exit 0
+        ;;
+    copyto|deletefile|purge) exit 0 ;;
+    copy)
+        # $2 = local staging dir, $3 = remote. Capture what would have been uploaded —
+        # backup.sh's EXIT trap deletes the staging dir, so this is the only chance to see it.
+        mkdir -p "$UPLOAD_DIR"
+        cp -a "$2"/. "$UPLOAD_DIR"/ 2>/dev/null || true
+        exit 0
+        ;;
+    lsf) exit 0 ;;
+    *) exit 0 ;;
+esac
+"""
+
+
+class BackupRun:
+    def __init__(
+        self, proc: subprocess.CompletedProcess[str], upload: Path, argv: str, created: str
+    ) -> None:
+        self.rc = proc.returncode
+        self.output = proc.stdout + proc.stderr
+        self.upload = upload
+        self.argv = argv
+        self.created = created
+
+    def uploaded(self) -> list[str]:
+        if not self.upload.is_dir():
+            return []
+        return sorted(p.name for p in self.upload.iterdir())
+
+    def manifest(self) -> str:
+        return "".join(
+            p.read_text()
+            for p in self.upload.glob("_backup_manifest-*.txt")
+            if self.upload.is_dir()
+        )
+
+
+def _run_backup(running: str, tmp_path: Path, project: str = CANONICAL_PROJECT) -> BackupRun:
+    """Run the REAL backup.sh with `running` as the set of services actually up."""
+    stub = tmp_path / "stub"
+    stub.mkdir()
+    (stub / "docker").write_text(FAKE_DOCKER_E2E)
+    (stub / "rclone").write_text(FAKE_RCLONE_E2E)
+    # backup.sh's command preflight requires zstd on PATH before it does anything else. It is
+    # only ever INVOKED on the Neo4j leg, which neither of these scenarios reaches — but the
+    # preflight does not know that, and a missing binary would abort the run before the gate
+    # under test ever fired, i.e. the test would pass or fail for a reason unrelated to what
+    # it asserts.
+    (stub / "zstd").write_text("#!/usr/bin/env bash\nexit 0\n")
+    for f in stub.iterdir():
+        f.chmod(0o755)
+
+    upload = tmp_path / "uploaded"
+    argv_log = tmp_path / "argv.log"
+    created_log = tmp_path / "created.log"
+    argv_log.write_text("")
+
+    env = dict(os.environ)
+    env.pop("COMPOSE_PROJECT_NAME", None)
+    env["PATH"] = f"{stub}:{env['PATH']}"
+    env.update(
+        B2_KEY_ID="fake-key-id",
+        B2_APP_KEY="fake-app-key",
+        B2_BUCKET="noorinalabs-backups",
+        BACKUP_DIR=str(tmp_path / "backups"),
+        COMPOSE_FILE="compose/docker-compose.prod.yml",
+        COMPOSE_PROJECT=project,
+        FAKE_RUNNING=running,
+        UPLOAD_DIR=str(upload),
+        DOCKER_ARGV_LOG=str(argv_log),
+        DOCKER_CREATED_LOG=str(created_log),
+    )
+
+    proc = subprocess.run(
+        ["bash", str(BACKUP)],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=REPO_ROOT,
+        timeout=180,
+    )
+    return BackupRun(
+        proc,
+        upload,
+        argv_log.read_text(),
+        created_log.read_text() if created_log.exists() else "",
+    )
+
+
+def test_neo4j_down_still_backs_up_both_postgres_stores(tmp_path: Path) -> None:
+    """THE PARTIAL-BACKUP CONTRACT. A Neo4j outage must cost the Neo4j leg, not the run.
+
+    `user-postgres` holds accounts, sessions and audit_log, and no pipeline artifact can
+    rebuild it. An all-three presence gate would have thrown it away on every night the graph
+    was down — including a night backup.sh's own failed restart caused.
+    """
+    run = _run_backup("postgres user-postgres", tmp_path)
+    uploaded = run.uploaded()
+
+    pg = [f for f in uploaded if f.startswith("isnad-pg-") and f.endswith(".dump")]
+    userpg = [f for f in uploaded if f.startswith("isnad-userpg-") and f.endswith(".dump")]
+    neo = [f for f in uploaded if f.startswith("isnad-neo4j-")]
+
+    assert pg, f"the isnad Postgres dump was NOT uploaded — a partial backup beats none: {uploaded}"
+    assert userpg, (
+        f"the user-postgres dump was NOT uploaded. It holds accounts, sessions and audit_log, "
+        f"and NOTHING can rebuild it (deploy#559) — a Neo4j outage must not discard it: {uploaded}"
+    )
+    assert not neo, f"a Neo4j dump appeared with Neo4j down: {uploaded}"
+
+    # Both dumps are real bytes, not empty files that happen to exist.
+    for name in pg + userpg:
+        assert (run.upload / name).stat().st_size > 0, f"{name} uploaded EMPTY"
+
+    assert "complete=false" in run.manifest(), (
+        f"the run must ATTEST its incompleteness — restore.sh refuses a partial artifact "
+        f"without --allow-partial, and that refusal is driven by this manifest: "
+        f"{run.manifest()!r}"
+    )
+    assert "SKIPPING the Neo4j dump" in run.output
+    assert run.rc != 0, "a partial backup is a FAILED backup: it must exit non-zero so the "
+    "systemd OnFailure marker fires and the success gauge is not advanced (deploy#565)"
+
+    # And it must not have conjured the database it could not find.
+    assert run.created == "", f"backup.sh CREATED a container: {run.created!r}"
+
+
+def test_a_stray_neo4j_alone_does_not_satisfy_the_project_gate(tmp_path: Path) -> None:
+    """The state stg was ACTUALLY found in — and why "refuse only if ZERO services resolve"
+    is not the fix.
+
+    Project `compose` held a stray, running `neo4j` (created by backup.sh's own `up`) and no
+    Postgres at all. A zero-services rule would have passed that: one of three matched. The
+    backup would then have dumped the stray, EMPTY graph, checksummed it, uploaded it, and
+    reported success — the silently-empty success this whole change exists to prevent.
+
+    The Postgres pair is the witness precisely because nothing in this path can create it.
+    """
+    run = _run_backup("neo4j", tmp_path)
+
+    assert run.rc != 0, "a project holding only a stray neo4j must not be backed up"
+    assert "Refusing to back up a stack that is not present" in run.output
+    assert run.uploaded() == [], (
+        f"something was uploaded from a project with no Postgres in it: {run.uploaded()}"
+    )
+    # The gate must fire BEFORE the dumps, not after they fail.
+    assert "pg_dump" not in run.argv, (
+        "a dump was attempted against a project the gate should have refused outright"
+    )
+    assert "Stopping Neo4j" not in run.output, (
+        "the stray, empty graph was about to be dumped — this is exactly the artifact that "
+        "would have checksummed cleanly and restored as an empty database"
+    )


### PR DESCRIPTION
Fixes #617.

## The bug

`-f compose/docker-compose.prod.yml` names the **file**, not the **project**. With no `-p` and no `COMPOSE_PROJECT_NAME`, Compose derives the project name from the compose file's **directory** — `compose` — while every deploy path in this repo brings the stack up as `-p noorinalabs`. All **19** compose calls in `backup.sh` (8) and `restore.sh` (11) therefore addressed a project that existed only as a name and contained nothing.

Measured on stg 2026-07-13, on the first backup run in this project's history to get past the B2 preflight (#613 had been aborting every earlier run before a single dump, which is why this sat undiscovered underneath it): both pg_dumps failed, `stop neo4j` stopped nothing, and **`up -d neo4j` created a new, empty Neo4j with fresh volumes.**

## restore.sh had the same defect — and it is the worse half

A backup addressing a phantom project *reads* nothing. A restore **writes**.

The sequence is reachable today, without a second mistake: once `backup.sh`'s `up` has created a stray neo4j in project `compose` (it did, on stg), `restore.sh`'s `ps -aq neo4j` **resolves it**. The "refusing to guess" volume guard is then satisfied — it was never bypassed — and `neo4j-admin database load --overwrite-destination` loads the backup into the **stray** volume. The script logs "Neo4j restore complete" and exits, the real graph untouched, the operator believing they have recovered.

`restore_rehearsal.sh` itself was **not** defective (its `dc()` carries `-p "$PROJECT"`), but it is the reason nobody caught this: it drove `restore.sh` with `COMPOSE_PROJECT_NAME="$PROJECT"` in the environment. That variable was the *only* thing aiming the unflagged script — and **production does not set it** (the systemd unit's `EnvironmentFile` has no such variable). The harness supplied the one input production omits, so the rehearsal passed every time and could not have seen the bug. Same class as `feedback_fixture_makes_guard_assertion_inert`.

> **Correction (review, Weronika Zielinska).** An earlier version of this PR body — and a comment in `run_restore()`, and a test docstring — claimed that *removing* the new `COMPOSE_PROJECT` line would send every rehearsal restore at the real `noorinalabs` stack. **That is false**, and `compose_project.sh` disproves it: the fallback chain is `COMPOSE_PROJECT` → `COMPOSE_PROJECT_NAME` → `noorinalabs`, and `run_restore()` already exports `COMPOSE_PROJECT_NAME`, so the rehearsal project still wins. The line stays as defence-in-depth against that fallback rung ever being removed; `guard()`'s refusal of an inherited project name is the actual protection. All three statements are corrected in `c1b90db`.

## What changed

* **`scripts/compose_project.sh`** (new, sourced by both scripts) — `COMPOSE_PROJECT` (default `noorinalabs`), `dc()` which puts `-p` on **every** call, `assert_stack_present()`, `neo4j_start()`. An explicit **flag**, not an exported `COMPOSE_PROJECT_NAME`, per the issue: a flag cannot be unset or overridden by the unit's `EnvironmentFile`; a variable can.
* **The vacuous preflight guard is replaced.** `docker compose ps --format json &>/dev/null` exits **0** on an empty or nonexistent project — it asked "did `ps` run?", not "is the stack there?", and that zero is exactly how the bug reached the dumps. `assert_stack_present postgres user-postgres neo4j` now requires every store this script dumps to be **present and running**, and distinguishes an unreachable daemon (instrument failure) from a reachable one running none of our services (a real, reportable state). Ordered **after** the B2 preflight — #559/#613 deliberately made the credential check the first thing that can stop a run, and both are non-destructive preflights — and **before** any dump or stop.
* **`up -d neo4j` is gone from both scripts.** `up` is a *converge* verb: asked for a service the project does not have, it does not fail, it **makes one**. `start` can only start an existing container and fails loudly when there is none. The capability to create a database is removed from the backup/restore path, not merely aimed correctly. (`backup.sh`'s health-wait also moved inside the restart-succeeded branch — hung off the end it would have logged `Neo4j healthy (waited 0s)` over a database that never came back.)
* **`restore_rehearsal.sh`** now passes `COMPOSE_PROJECT="$PROJECT"`. This is load-bearing, not cosmetic: a **flag beats `COMPOSE_PROJECT_NAME`**, so without it every rehearsal restore — including the `--overwrite-destination` Neo4j load — would land on `noorinalabs`, **the real stack**, while `assert_volume_isolation` went on inspecting the rehearsal project and reported all-clear. `guard()` now also refuses an inherited project name, symmetric with its existing `COMPOSE_FILE` refusal.
* **The "refusing to guess" volume guard is untouched.** It is the only reason this was a *failed* backup and not a silently *empty* successful one — had it fuzzy-matched `docker volume ls | grep neo4j_data`, it would have dumped the stray empty volume, checksummed it, uploaded it, and reported success.

## Tests — and their calibration

`scripts/tests/test_compose_project_scoping.py` (14 tests).

A test that stubs `docker` and asserts a `pg_dump` command string would prove **nothing** here: the command string is identical on both trees. The bug is in *which project the command is addressed to*. So:

1. **Static scan** — every `docker compose` invocation in `compose_project.sh` / `backup.sh` / `restore.sh` / `restore_rehearsal.sh` must carry `-p`/`--project-name`. It joins backslash-continuations and strips comments (the fixes quote the old buggy commands verbatim, so a naive grep would fire on its own documentation). An unflagged call added later fails the suite. A companion test asserts `backup.sh`/`restore.sh` contain **no** literal `docker compose` at all — everything routes through `dc()`. Another anchors the default `noorinalabs` against `write-deploy-env/action.yml`, so renaming the project on the deploy side cannot leave backup/restore aimed at the old one.
2. **Behavioural**, against a fake `docker` modelling the one fact that matters: *a compose project you never deployed into is empty, and `ps` against it exits 0*. `assert_stack_present` must **refuse** the phantom project and **pass** against the real one; `neo4j_start` must **fail loudly and create nothing** against a project with no neo4j, and start the existing container in the real one.

**Fixture calibration** (`feedback_calibrate_the_mutation_before_counting_it`, `feedback_silent_zero_is_not_a_measurement`) — two controls run *without* the library, so they execute on the defective tree too:
* `test_the_replaced_ps_guard_cannot_tell_an_empty_project_from_a_healthy_one` runs the **literal** old guard against the empty project and asserts it exits **0**. If the stub didn't reproduce that, nothing else in the file would be calibrated.
* `test_compose_up_against_an_empty_project_creates_a_container` proves the stub **records** a creation — so the empty creation-log asserted in the stray-container test is a real negative, not a log nothing ever writes to.

**Calibration numbers** (same test file, both trees):

| Tree | Result |
|---|---|
| This branch | **14 passed**, 0 failed |
| `origin/main` (`800d34d`) | **11 failed**, 3 passed |

The 3 that pass on `origin/main` are exactly the two fixture controls above (they *must* pass there — that is what proves the fixture reproduces the defect) and the tree-independent deploy-path anchor. The static scan names all 19 unflagged invocations in its failure output.

## Local gate

`shellcheck` (CI form, 22 scripts) clean · `bash -n` clean · `ruff check` + `ruff format --check` clean · `mypy` clean · **431 passed, 3 skipped** across `scripts/tests`, `.claude/lib/tests`, `integration-tests/scripts/tests`. Pre-commit and pre-push hooks ran in full; nothing bypassed.

> One real interaction found and resolved: my stack-presence check initially ran *before* the B2 preflight, which made `test_b2_preflight.py`'s two end-to-end tests exit before reaching the preflight they pin. I moved the check after the preflight rather than weaken it or edit those tests — #613 deliberately made the credential check the first gate, and both checks are non-destructive.

## Not done here (deliberately)

Nothing was run against prod. The prod backup timer must stay uninstalled until this lands — per the issue, prod has never run `backup.sh`, so it has not yet been exposed to the stray-container half, but it would be the moment we deploy.



---

## Review round 2 — `c1b90db`

All four items from the review are addressed.

**1. The presence gate silently repealed "a partial backup beats none" (BLOCKING).** The gate demanded all three services, contradicting `backup.sh`'s own contract 270 lines below it (upload what you got, attest `complete=false`, exit non-zero; refuse only when *all three* dumps fail). On any night Neo4j was down — including one this script's own failed restart caused — it would have taken **zero** backups instead of two, discarding `user-postgres`, the only store no artifact can rebuild. "Refuse only when zero services resolve" was checked and rejected for the reason the review gives: the real stg state was a stray running `neo4j` and no Postgres, so one-of-three matched and it would have dumped the stray empty graph.

Landed: **the two Postgres services are the project-identity witness** (nothing in this path can create them; only `neo4j` was ever `up`'d). A missing or stopped `neo4j` is now a **per-leg failure** — skip the dump, `NEO4J_OK=false`, dump both Postgres stores, upload the partial with `complete=false`, exit non-zero. `restore.sh`'s gate becomes the same pair: `restore_neo4j()` *stops* Neo4j anyway, so it needs the container to **exist**, not to run — which `ps -aq` plus the untouched "refusing to guess" guard already enforce.

**2. The false "load-bearing" comment (BLOCKING).** Corrected in the product, the test docstring, and this PR body (above).

**3. The sweep stopped at four files (BLOCKING).** All three sites fixed: `bootstrap-vps.sh`'s printed fresh-VPS `pull`/`up -d`, and the `api_health` failure-branch `logs --tail=50 api` in `deploy-prod.yml` and `deploy-isnad-graph.yml`. There are now **zero** unflagged project-scoped calls against the prod stack anywhere in the executable surface.

**4. `name: noorinalabs` in `compose/docker-compose.prod.yml`.** Added. This is the layer the bug actually lives at: it makes the *derived* project correct by construction for every caller the scan cannot reach — including the ~40 hand-run `docker compose -f compose/docker-compose.prod.yml exec|logs|ps` lines under `docs/runbooks/**`, and an operator typing one of them at 3am. Every existing `-p noorinalabs` still wins and still names the same value, so nothing changes behaviourally; the directory-derived `compose` fallback simply stops existing. The flags stay: the flag is the per-call fix, `name:` is the per-file one, and only both close the class.

### Tests (+5, 19 total)

* The static scan now covers the whole **executable surface** (`scripts/*.sh`, workflows, actions, `.pre-commit-config.yaml`) rather than four files. `config` and `version` resolve no project and are exempt; everything else must carry `-p`.
* `name: noorinalabs` is pinned, as is `guard()`'s inherited-project refusal.
* **Two end-to-end tests drive the real `backup.sh`** under its real `set -euo pipefail` with `docker`/`rclone` stubbed, asserting against **what was actually uploaded** — the fake rclone captures the staging directory before the EXIT trap deletes it — not against a log line claiming it:
  * *Neo4j down* → both Postgres dumps upload, non-empty, manifest `complete=false`, no Neo4j dump, `rc != 0`, nothing created.
  * *Stray Neo4j alone* → **refused before any dump**; nothing uploaded, no `pg_dump` attempted, `"Stopping Neo4j"` never reached. That stray empty graph is precisely the artifact that would have checksummed cleanly and restored as an empty database.

### Calibration

| Tree | Result |
|---|---|
| This branch (`c1b90db`) | **19 passed**, 0 failed |
| `origin/main` (`800d34d`) | **16 failed**, 3 passed |

The 3 that pass on `origin/main` are the two fixture-calibration controls (they *must* pass there — that is what proves the stub reproduces the defect) and the tree-independent deploy-path anchor. Each new test was checked to fail on main **for the right reason**: the sweep scan names all four unflagged lines; the Neo4j-down test fails with `the isnad Postgres dump was NOT uploaded ... []` (on main the phantom project makes every dump fail, which is the bug); the stray test fails because main has no gate to print a refusal.

### Local gate

shellcheck (CI form, 22 scripts) · `bash -n` · actionlint · ruff · mypy · **436 passed, 3 skipped** across all three pytest suites. Nothing bypassed.

Non-blocking TD (#619 scan coverage, #620 measuring the `start` contract against real Compose) left as filed.