### PR TITLE
fix(backup): a check that could not run must not testify about the system (#623)

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -160,7 +160,14 @@ emit_success_metric() {
     # Atomic write: temp + rename, so Prometheus never scrapes a half-written
     # file. The mktemp suffix means the temp name does NOT end in `.prom`, so
     # the collector ignores it until the rename lands.
-    tmp="$(mktemp "${SUCCESS_TEXTFILE}.XXXXXX")"
+    #
+    # The parent is named EXPLICITLY (`-p`), not implied by a template that
+    # happens to carry a path. Both land in the same directory, but only one of
+    # them is checkable: in a hardened script every mktemp names its parent, so
+    # the guard in test_scratch_under_hardening.py needs no escape hatch to let
+    # this line through — and an escape hatch is exactly what let deploy#613
+    # back in (#624 review, Nino Kavtaradze).
+    tmp="$(mktemp -p "$(dirname "$SUCCESS_TEXTFILE")" "$(basename "$SUCCESS_TEXTFILE").XXXXXX")"
     cat > "$tmp" <<EOF
 # HELP isnad_backup_last_success_timestamp_seconds Unix timestamp of the most recent fully-successful isnad-backup run.
 # TYPE isnad_backup_last_success_timestamp_seconds gauge

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -393,7 +393,38 @@ NEO4J_COMPRESSED="${NEO4J_DUMP_FILE}.zst"
 # `restore.sh` refuses that artifact without `--allow-partial`, and the run exits non-zero so
 # the systemd OnFailure marker fires and BackupStale keeps counting from the last COMPLETE
 # backup. Nothing here silently forgives a missing store.
-if service_is_running neo4j; then
+# `|| NEO4J_PROBE_RC=$?`, never a bare `if service_is_running neo4j`: we need to tell rc=1
+# (the graph is genuinely down) from rc=2 (we could not find out) — see compose_project.sh.
+# The `||` also keeps errexit off our backs; a bare assignment from a failing command would
+# abort the run here (deploy#563).
+NEO4J_PROBE_RC=0
+service_is_running neo4j || NEO4J_PROBE_RC=$?
+
+if [[ "$NEO4J_PROBE_RC" -eq 2 ]]; then
+    # THE INSTRUMENT FAILED — WE KNOW NOTHING ABOUT THE GRAPH. (deploy#624 review)
+    #
+    # running_services() has already printed the honest diagnostic (no writable scratch;
+    # check ProtectSystem=strict and free disk). Do NOT talk over it with a claim about
+    # Neo4j. The old code did exactly that — it said "Neo4j is NOT running — Start Neo4j and
+    # re-run", while the graph was UP and the disk was FULL, which makes re-running the one
+    # action that makes things worse.
+    #
+    # This is reachable precisely BECAUSE the scratch now lives on BACKUP_DIR: the gate above
+    # runs before the Postgres dumps, this runs after them, and the volume they just filled is
+    # the volume the scratch needs.
+    NEO4J_OK=false
+    log "ERROR" "Could not determine whether Neo4j is running — the check itself failed (see above)."
+    log "ERROR" "  This says NOTHING about the graph: do not start, stop, or re-run on the"
+    log "ERROR" "  strength of it. Fix the scratch problem named above (free disk first)."
+    log "ERROR" "  The Neo4j leg is SKIPPED; the Postgres stores are still dumped."
+elif [[ "$NEO4J_PROBE_RC" -ne 0 ]]; then
+    log "ERROR" "Neo4j is NOT running in project '${COMPOSE_PROJECT}' — SKIPPING the Neo4j dump."
+    log "ERROR" "  The graph leg of this backup will be MISSING and the run will exit non-zero."
+    log "ERROR" "  The Postgres stores are still dumped: a partial backup beats none, and"
+    log "ERROR" "  user-postgres cannot be rebuilt from any artifact (deploy#559)."
+    log "ERROR" "  Start Neo4j and re-run to get a COMPLETE backup."
+    NEO4J_OK=false
+else
     log "INFO" "Stopping Neo4j for offline dump..."
     dc stop neo4j 2>>"$LOG_FILE"
 
@@ -519,13 +550,6 @@ if service_is_running neo4j; then
     else
         log "WARNING" "Skipped Neo4j dump due to stop timeout"
     fi
-else
-    log "ERROR" "Neo4j is NOT running in project '${COMPOSE_PROJECT}' — SKIPPING the Neo4j dump."
-    log "ERROR" "  The graph leg of this backup will be MISSING and the run will exit non-zero."
-    log "ERROR" "  The Postgres stores are still dumped: a partial backup beats none, and"
-    log "ERROR" "  user-postgres cannot be rebuilt from any artifact (deploy#559)."
-    log "ERROR" "  Start Neo4j and re-run to get a COMPLETE backup."
-    NEO4J_OK=false
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/compose_project.sh
+++ b/scripts/compose_project.sh
@@ -82,10 +82,76 @@ log_captured_stderr() {
 # `log()` writes to stdout (backup.sh additionally tees it), so an unredirected log line
 # would be read back by the caller as a service state — the same shape as the rclone NOTICE
 # that became a "backup directory" in deploy#584.
+# scratch_file — a capture file that EXISTS UNDER THE BACKUP UNIT'S HARDENING. (deploy#623)
+#
+# THIS IS deploy#613, AND WE SHIPPED IT TWICE.
+#
+# A bare `mktemp` defaults to /tmp. Under systemd/isnad-backup.service, /tmp is READ-ONLY:
+# the unit runs ProtectSystem=strict with PrivateTmp deliberately unset (deploy#121 Bug A)
+# and grants only BACKUP_DIR, /opt/noorinalabs-deploy and /var/lib/node_exporter. So the
+# allocation failed, $err was empty, the `2>"$err"` redirect died, and running_services()
+# announced:
+#
+#     [ERROR] Cannot reach Docker Compose (rc=1) — is the daemon running?
+#
+# The daemon was running. The SCRATCH WRITE failed. That sentence is the same lie
+# b2_preflight.sh used to tell about the B2 key — a check that could not run, reporting its
+# own breakage as a fact about the system it was supposed to be checking, and pointing the
+# operator at the wrong subsystem entirely. Measured on stg 2026-07-14T01:23:30Z, on the
+# first backup run after the deploy#617 fix merged.
+#
+# Every capture file in this library now comes from here, so there is ONE place to get this
+# right rather than one per call site. Failure to allocate is FATAL and says so in its own
+# words — it must never be rendered as a claim about Docker, the project, or the stack.
+#
+# NOTE FOR ANYONE ADDING A THIRD CALLER: CI cannot catch this. GitHub Actions runners and
+# the rehearsal containers all have a writable /tmp, so the entire test surface — including
+# the e2e tests that drive the real backup.sh — runs where this bug is UNREACHABLE. Only the
+# on-host systemd path is affected, and nothing in CI executes it. That blind spot, not the
+# mktemp, is why this shipped twice. test_scratch_under_hardening.py exists to close it.
+scratch_file() {
+    local parent tmp
+    parent="${BACKUP_DIR:-${TMPDIR:-/tmp}}"
+    mkdir -p "$parent" 2>/dev/null
+
+    if ! tmp="$(mktemp -p "$parent" compose-project-XXXXXX 2>/dev/null)" \
+        || [[ -z "$tmp" || ! -f "$tmp" ]]; then
+        return 1
+    fi
+    # EXISTS is not WRITABLE. Under ENOSPC the creat() succeeds and the write fails, leaving
+    # a 0-byte file — so the -s check, not the redirect's exit status, is what catches a full
+    # disk. Same lesson as deploy#614: prove the scratch is usable, never infer it.
+    if ! printf 'x\n' > "$tmp" 2>/dev/null || [[ ! -s "$tmp" ]]; then
+        rm -f "$tmp"
+        return 1
+    fi
+    : > "$tmp"
+    printf '%s\n' "$tmp"
+    return 0
+}
+
+# The diagnostic for a scratch failure. Deliberately says what it does NOT know.
+scratch_failed() {
+    log "ERROR" "The compose check could not RUN: no writable scratch file." >&2
+    log "ERROR" "  It therefore has NO evidence about Docker, the project, or the stack —" >&2
+    log "ERROR" "  do not go looking at the daemon on the strength of this message." >&2
+    log "ERROR" "  Scratch parent tried: ${BACKUP_DIR:-${TMPDIR:-/tmp}}" >&2
+    log "ERROR" "  Under systemd, isnad-backup.service runs ProtectSystem=strict with no" >&2
+    log "ERROR" "  PrivateTmp (deploy#121 Bug A), so /tmp is READ-ONLY and scratch must live" >&2
+    log "ERROR" "  under BACKUP_DIR, which the unit grants via ReadWritePaths (deploy#613/#623)." >&2
+    log "ERROR" "  Also check free space: BACKUP_DIR is the volume the dumps themselves fill." >&2
+}
+
 running_services() {
     local err states rc=0
 
-    err="$(mktemp)"
+    # A capture file we could not create is a CHECK THAT DID NOT RUN. It says nothing about
+    # the daemon, and it must not pretend otherwise (deploy#623).
+    if ! err="$(scratch_file)"; then
+        scratch_failed
+        return 1
+    fi
+
     # `|| rc=$?`, not a bare assignment: under `set -euo pipefail` an assignment whose
     # command substitution fails IS a failing simple command and errexit fires AT THE
     # ASSIGNMENT, making the rc check below dead code on every failing path (deploy#563).
@@ -220,7 +286,16 @@ service_is_running() {
 # none. That is the entire point: the capability to create is removed, not aimed.
 neo4j_start() {
     local err rc=0
-    err="$(mktemp)"
+
+    # Same trap as running_services (deploy#623). Here it is worse: a scratch failure
+    # rendered as "could not START neo4j" would tell the operator the graph is broken when
+    # in fact the graph was never touched — and this runs in the window where backup.sh has
+    # already STOPPED it.
+    if ! err="$(scratch_file)"; then
+        scratch_failed
+        return 1
+    fi
+
     dc start neo4j 2>"$err" || rc=$?
     if [[ "$rc" -ne 0 ]]; then
         log "ERROR" "Could not START neo4j in project '${COMPOSE_PROJECT}' (rc=${rc}):"

--- a/scripts/compose_project.sh
+++ b/scripts/compose_project.sh
@@ -125,7 +125,19 @@ scratch_file() {
         rm -f "$tmp"
         return 1
     fi
-    : > "$tmp"
+
+    # The truncation is checked too, and that is not paranoia (deploy#624 review — Nino
+    # Kavtaradze). An UNCHECKED redirect here — inside the one function whose entire purpose
+    # is that there are no unchecked redirects — would hand the caller back a path it had
+    # just failed to write to. The caller's `2>"$err"` then dies and running_services prints
+    # "Cannot reach Docker Compose — is the daemon running?": deploy#623, verbatim,
+    # resurrected inside its own fix.
+    #
+    # ENOSPC does not get you here (truncating FREES space). The way in is the filesystem
+    # going read-only BETWEEN the check above and this line — an ext4 `remount-ro` on I/O
+    # error, which is precisely the failure a backup script exists to survive. Narrow. Real.
+    : > "$tmp" || { rm -f "$tmp"; return 1; }
+
     printf '%s\n' "$tmp"
     return 0
 }

--- a/scripts/compose_project.sh
+++ b/scripts/compose_project.sh
@@ -277,13 +277,43 @@ assert_stack_present() {
 # daemon is reachable and the project is real, so at that point the two collapse harmlessly:
 # either way the leg cannot be dumped and must be recorded as failed rather than skipped
 # silently.
+# service_is_running <svc>
+#
+#   0 — the service IS running
+#   1 — the service is NOT running          (a fact about the stack)
+#   2 — WE COULD NOT FIND OUT               (a fact about us)
+#
+# THE THIRD CALL SITE, AND deploy#624 IS WHAT MADE IT REACHABLE. (review — Lucas Ferreira)
+#
+# This used to collapse 1 and 2 into a single `return 1`, and the comment justifying that
+# said the two "collapse harmlessly" because callers only reach here after
+# assert_stack_present has already established the project. That was true while scratch lived
+# on /tmp — **because /tmp never fills.**
+#
+# deploy#623's fix moves scratch onto BACKUP_DIR: the volume the dumps themselves fill. It
+# knows this — the ENOSPC `-s` check in scratch_file() exists for exactly that reason. And the
+# ordering is against us: backup.sh calls assert_stack_present BEFORE the Postgres dumps and
+# `service_is_running neo4j` AFTER them, so the disk that was fine at the gate can be full by
+# the time we ask this question.
+#
+# Collapsed, the outcome is a lie with a dangerous remedy attached: scratch fails, this
+# returns 1, and backup.sh prints "Neo4j is NOT running — Start Neo4j and re-run." The graph
+# is UP. The disk is FULL. Re-running is the single action that makes it worse. Reproduced on
+# the head tree with a healthy docker reporting neo4j:running.
+#
+# So the instrument failure gets its own code. A caller that cannot tell "the thing is broken"
+# from "I am broken" will always eventually blame the thing.
 service_is_running() {
     local svc="$1" states rc=0
 
     states="$(running_services)" || rc=$?
-    [[ "$rc" -eq 0 ]] || return 1
+    # running_services has already printed the honest scratch diagnostic. Do NOT overwrite it
+    # with a claim about the service — return the "I could not find out" code and let the
+    # caller stay silent about the stack.
+    [[ "$rc" -eq 0 ]] || return 2
 
-    grep -qx -- "${svc}:running" <<< "$states"
+    grep -qx -- "${svc}:running" <<< "$states" || return 1
+    return 0
 }
 
 # Start the neo4j container we STOPPED. Never create one.

--- a/scripts/emit-backup-failure-marker.sh
+++ b/scripts/emit-backup-failure-marker.sh
@@ -42,9 +42,11 @@ echo "BACKUP_FAILURE: unit=${FAILED_UNIT} exited non-zero at ${NOW_ISO}" \
     | systemd-cat -t BACKUP_FAILURE -p err
 
 # Textfile-collector metric — atomic write via mktemp + mv so prometheus
-# never observes a half-written file mid-scrape.
+# never observes a half-written file mid-scrape. The parent is named explicitly
+# (`-p`) rather than implied by the template: see the note at backup.sh's
+# emit_success_metric — in a hardened script, every mktemp names its parent.
 install -d -m 0755 "$TEXTFILE_DIR"
-TMP="$(mktemp "${TEXTFILE_DIR}/isnad_backup_failure.prom.XXXXXX")"
+TMP="$(mktemp -p "$TEXTFILE_DIR" isnad_backup_failure.prom.XXXXXX)"
 cat > "$TMP" <<EOF
 # HELP isnad_backup_last_failure_timestamp_seconds Unix timestamp of the most recent isnad-backup failure.
 # TYPE isnad_backup_last_failure_timestamp_seconds gauge

--- a/scripts/tests/test_backup_textfile_metrics.py
+++ b/scripts/tests/test_backup_textfile_metrics.py
@@ -133,7 +133,15 @@ def test_success_metric_written_atomically() -> None:
     """
     body = BACKUP_SH.read_text()
 
-    m = re.search(r'tmp="\$\(mktemp\b([^\n]*)\)"', body)
+    # Scope to emit_success_metric's own body. A whole-file search would take the FIRST
+    # `mktemp` in backup.sh, which today happens to be this one and tomorrow may not — and
+    # then this test would be vouching for a call in some other function while the one it
+    # names goes unchecked (Lucas Ferreira, #624 review 3).
+    fn = re.search(r"\nemit_success_metric\(\)\s*\{(.*?)\n\}", body, re.DOTALL)
+    assert fn, "emit_success_metric() not found in backup.sh — this test is checking nothing"
+    fn_body = fn.group(1)
+
+    m = re.search(r'tmp="\$\(mktemp\b([^\n]*)\)"', fn_body)
     assert m, "emit_success_metric no longer allocates its temp file with mktemp"
     call = m.group(1)
 

--- a/scripts/tests/test_backup_textfile_metrics.py
+++ b/scripts/tests/test_backup_textfile_metrics.py
@@ -121,10 +121,34 @@ def test_success_metric_is_world_readable() -> None:
 
 
 def test_success_metric_written_atomically() -> None:
-    """temp + rename, and the temp name must not end in .prom or the collector
-    will scrape a half-written file."""
+    """temp + rename, the temp lands beside the target, and its name must not end in .prom
+    or the collector will scrape a half-written file.
+
+    Pinned on the PROPERTY, not on the spelling. The previous cut asserted the literal
+    `mktemp "${SUCCESS_TEXTFILE}.XXXXXX"` and went red when deploy#624 converted the call to
+    the explicit-parent form — same directory, same non-.prom suffix, same atomicity, and the
+    test failed anyway. A test that pins the source text instead of the behaviour blocks
+    correct changes and trains people to "fix" it by editing the assertion, which is how an
+    assertion quietly stops meaning anything (cf. `feedback_paraphrase_in_the_product`).
+    """
     body = BACKUP_SH.read_text()
-    assert 'mktemp "${SUCCESS_TEXTFILE}.XXXXXX"' in body
+
+    m = re.search(r'tmp="\$\(mktemp\b([^\n]*)\)"', body)
+    assert m, "emit_success_metric no longer allocates its temp file with mktemp"
+    call = m.group(1)
+
+    # It must land beside the target — NOT in /tmp, which is read-only under
+    # ProtectSystem=strict (deploy#613/#623). Naming SUCCESS_TEXTFILE is how it says so.
+    assert "SUCCESS_TEXTFILE" in call, (
+        f"the success-metric temp no longer names its parent via SUCCESS_TEXTFILE, so it may "
+        f"be defaulting to /tmp — read-only under the backup unit. Call: mktemp{call}"
+    )
+    # The random suffix must come LAST, so the temp name does not match the collector's
+    # *.prom glob until the rename lands.
+    assert call.rstrip('" ').endswith(".XXXXXX"), (
+        f"the temp name must end in .XXXXXX, not .prom, or node-exporter scrapes it "
+        f"half-written. Call: mktemp{call}"
+    )
     assert 'mv "$tmp" "$SUCCESS_TEXTFILE"' in body
 
 

--- a/scripts/tests/test_scratch_under_hardening.py
+++ b/scripts/tests/test_scratch_under_hardening.py
@@ -45,6 +45,7 @@ quietly turn this whole class green; procfs does not care who you are. Same reas
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -112,6 +113,40 @@ def unit_reachable_scripts() -> set[Path]:
             if sibling != script and sibling.name in body and sibling not in seen:
                 pending.append(sibling)
     return seen
+
+
+# The ANCHOR IS THE INVOCATION, NOT THE LINE. (deploy#624 review — Lucas Ferreira)
+#
+# The first cut asked `"-p " not in ln`, i.e. it judged the whole LINE. Any unrelated `-p `
+# elsewhere on the line — a `grep -p`, a comment fragment, a second command — vouched for a
+# bare `mktemp` sitting next to it. Lucas mutated a bare `mktemp` back in on such a line and
+# the pin stayed GREEN. A guard whose anchor is bigger than the thing it guards is not a
+# guard; it is a coincidence detector (cf. feedback_lint_gate_cover_all_syntactic_forms).
+#
+# So: find each `mktemp` occurrence and read only ITS OWN arguments, up to the next shell
+# separator.
+_MKTEMP_CALL = re.compile(r"\bmktemp\b([^|;&)`\n]*)")
+
+
+def _mktemp_invocations(line: str) -> list[str]:
+    """The argument text of every `mktemp` call on this line, each judged on its own."""
+    return [m.group(1) for m in _MKTEMP_CALL.finditer(line)]
+
+
+def _names_its_parent(args: str) -> bool:
+    """Did THIS mktemp call choose where its file lands, rather than defaulting to /tmp?
+
+    Accepts an explicit parent (`-p DIR`, `--tmpdir=DIR`) or a template carrying a directory
+    (`mktemp "${SUCCESS_TEXTFILE}.XXXXXX"` — lands wherever that variable points, which is the
+    author's choice and is checked elsewhere). A bare `mktemp` / `mktemp -d` chooses /tmp for
+    you, and /tmp is read-only under the unit.
+    """
+    tokens = args.split()
+    if any(t == "-p" or t.startswith("-p") or t.startswith("--tmpdir") for t in tokens):
+        return True
+    # A template argument (non-flag) that contains a path separator or a variable expansion
+    # names its own directory.
+    return any(not t.startswith("-") and ("/" in t or "$" in t) for t in tokens)
 
 
 # A directory that EXISTS and into which no file can be created — for root too.
@@ -320,10 +355,9 @@ def test_no_bare_mktemp_survives_in_the_library() -> None:
             stripped = ln.lstrip()
             if stripped.startswith("#") or "mktemp" not in ln:
                 continue
-            # An explicit parent (-p / --tmpdir) or a template with a directory in it means
-            # the author chose where it lands. A bare `mktemp` chooses /tmp for them.
-            if "-p " not in ln and '-p"' not in ln and "--tmpdir" not in ln and "${" not in ln:
-                offenders.append(f"{script.name}: {ln.strip()}")
+            for args in _mktemp_invocations(ln):
+                if not _names_its_parent(args):
+                    offenders.append(f"{script.name}: {ln.strip()}")
 
     assert not offenders, (
         "bare mktemp in a script the hardened units EXECUTE — it defaults to /tmp, which is "
@@ -331,4 +365,57 @@ def test_no_bare_mktemp_survives_in_the_library() -> None:
         "TWICE (#613 in b2_preflight.sh, #623 in compose_project.sh). Allocate under a path "
         "the unit grants — scratch_file() in compose_project.sh does this.\n  "
         + "\n  ".join(offenders)
+    )
+
+
+def test_service_is_running_separates_not_running_from_could_not_find_out(tmp_path: Path) -> None:
+    """THE THIRD CALL SITE — and deploy#624 is what made it reachable. (Lucas Ferreira)
+
+    `service_is_running` used to collapse "the service is not running" and "I could not take
+    the listing" into a single `return 1`. The comment justifying that said the two "collapse
+    harmlessly", and while scratch lived on /tmp it was true — **because /tmp never fills.**
+
+    deploy#623's fix moves scratch onto BACKUP_DIR: the volume the dumps themselves fill. And
+    the ordering is against us — backup.sh gates on assert_stack_present BEFORE the Postgres
+    dumps and asks `service_is_running neo4j` AFTER them, so the disk that was fine at the
+    gate can be full by the time we ask.
+
+    Collapsed, that produces a lie with a dangerous remedy attached: scratch fails, this
+    returns 1, and backup.sh prints "Neo4j is NOT running — Start Neo4j and re-run." The graph
+    is UP. The disk is FULL. Re-running is the one action that makes it worse.
+
+    So: rc=1 is a fact about the STACK; rc=2 is a fact about US.
+    """
+    # Docker is healthy and reports neo4j:running. Only the scratch is broken.
+    proc = _run(
+        # `|| rc=$?` — the exact form backup.sh uses. A bare call under `set -e` would abort
+        # the driver before the echo, and the test would be measuring errexit, not the code.
+        "rc=0; service_is_running neo4j || rc=$?; echo RC=$rc",
+        backup_dir=UNWRITABLE_PARENT,
+        with_docker=True,
+        tmp_path=tmp_path,
+    )
+    combined = proc.stdout + proc.stderr
+
+    assert "RC=2" in combined, (
+        "a scratch failure returned the NOT-RUNNING code. The graph is up and the docker stub "
+        "says so; the only thing that failed is a temp file. Collapsing 'I could not find out' "
+        f"into 'it is not running' is what tells an operator with a FULL DISK to re-run the "
+        f"backup — the single action that makes it worse.\n\n{combined}"
+    )
+    assert "RC=1" not in combined
+
+    # Positive control: with a writable scratch, the SAME function must still be able to say
+    # "not running" — otherwise rc=2 is just the new constant and nothing is distinguished.
+    good = tmp_path / "backups"
+    good.mkdir()
+    proc_ok = _run(
+        "rc=0; service_is_running redis || rc=$?; echo RC=$rc",  # stub lists only pg/user-pg/neo4j
+        backup_dir=str(good),
+        with_docker=True,
+        tmp_path=tmp_path,
+    )
+    assert "RC=1" in (proc_ok.stdout + proc_ok.stderr), (
+        "with a WORKING scratch, a genuinely absent service must still return 1. If it does "
+        "not, the fix has simply replaced one constant with another and distinguishes nothing."
     )

--- a/scripts/tests/test_scratch_under_hardening.py
+++ b/scripts/tests/test_scratch_under_hardening.py
@@ -1,0 +1,241 @@
+"""Scratch allocation must survive the backup unit's hardening — and never lie when it can't.
+
+THE BLIND SPOT THIS MODULE EXISTS TO CLOSE
+------------------------------------------
+``systemd/isnad-backup.service`` runs ``ProtectSystem=strict`` with ``PrivateTmp``
+deliberately unset (deploy#121 Bug A) and grants only ``BACKUP_DIR``,
+``/opt/noorinalabs-deploy`` and ``/var/lib/node_exporter``. **``/tmp`` is READ-ONLY there.**
+
+A bare ``mktemp`` defaults to ``/tmp``. So a script that captures stderr into a temp file
+cannot run under the unit at all — and, worse, the *way* it fails is silent: the allocation
+returns empty, the ``2>"$err"`` redirect dies, and the caller reports the resulting non-zero
+as a fact about whatever it was checking.
+
+This has now shipped **twice**:
+
+* **deploy#613** — ``b2_preflight.sh`` reported ``verdict=KEY_INVALID``. The B2 key was
+  perfectly good. Every backup this project ever attempted died there, blaming a credential.
+* **deploy#623** — ``compose_project.sh`` reported ``Cannot reach Docker Compose — is the
+  daemon running?``. The daemon was running. This shipped *in the fix for deploy#617*, past
+  23 CI checks and four reviewers.
+
+Both are the same bug: **a check that could not run, reporting its own breakage as a fact
+about the system it was supposed to be checking**, and pointing the operator at the wrong
+subsystem.
+
+WHY THE REST OF THE SUITE CANNOT CATCH IT
+-----------------------------------------
+GitHub Actions runners have a writable ``/tmp``. So do the rehearsal containers. So does the
+dev box. **The entire test surface — including the e2e tests that drive the real
+``backup.sh`` — runs in an environment where this bug is unreachable.** Only the on-host
+systemd path is affected, and nothing in CI executes that path. The tests were never weak;
+they were *structurally incapable* of failing, which is why a green suite meant nothing here
+twice over (cf. ``feedback_silent_zero_is_not_a_measurement``,
+``feedback_fixture_makes_guard_assertion_inert``).
+
+So this module does the one thing the others cannot: it makes the scratch parent
+**unusable** and asserts on what the script then says.
+
+The unusable parent is ``/proc/self`` — a real directory that exists and refuses ``creat()``
+**for uid 0 as well**. ``chmod`` would be a no-op against root, so a root CI runner would
+quietly turn this whole class green; procfs does not care who you are. Same reasoning as the
+``ENOTDIR`` fixture in ``test_b2_preflight.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+LIB = SCRIPTS_DIR / "compose_project.sh"
+
+# A directory that EXISTS and into which no file can be created — for root too.
+UNWRITABLE_PARENT = "/proc/self"
+
+# Words that constitute a claim about a subsystem the check never actually reached. If a
+# scratch failure produces any of these, it is doing the deploy#613/#623 thing: converting
+# "I could not run" into "the thing you asked me about is broken".
+FALSE_CLAIMS = (
+    "is the daemon running",
+    "Cannot reach Docker Compose",
+    "is not running:",
+    "Could not START neo4j",
+)
+
+_DRIVER = """
+set -euo pipefail
+log() {{ printf '%s %s\\n' "$1" "$2"; }}
+COMPOSE_FILE="compose/docker-compose.prod.yml"
+source "{lib}"
+{call}
+"""
+
+
+def _run(
+    call: str, *, backup_dir: str, with_docker: bool, tmp_path: Path
+) -> subprocess.CompletedProcess[str]:
+    """Drive the library with BACKUP_DIR pointed at `backup_dir`."""
+    env = dict(os.environ)
+    env["BACKUP_DIR"] = backup_dir
+    env["COMPOSE_PROJECT"] = "noorinalabs"
+    # TMPDIR must not rescue the fallback chain: under the real unit /tmp is read-only and
+    # TMPDIR is unset, so the ONLY writable path is BACKUP_DIR. A test that let TMPDIR stand
+    # in would silently restore the very escape hatch production does not have.
+    env["TMPDIR"] = UNWRITABLE_PARENT
+    env.pop("COMPOSE_PROJECT_NAME", None)
+
+    stub = tmp_path / "stub"
+    stub.mkdir(exist_ok=True)
+    if with_docker:
+        # A perfectly healthy docker. If the script still blames the daemon, that accusation
+        # is coming from the scratch failure, not from docker — which is the entire point.
+        (stub / "docker").write_text(
+            "#!/usr/bin/env bash\n"
+            "if [[ \"$*\" == *'{{.Service}}:{{.State}}'* ]]; then\n"
+            "  printf 'postgres:running\\nuser-postgres:running\\nneo4j:running\\n'\n"
+            "fi\n"
+            "exit 0\n"
+        )
+        (stub / "docker").chmod(0o755)
+        env["PATH"] = f"{stub}:{env['PATH']}"
+
+    script = _DRIVER.format(lib=LIB, call=call)
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=SCRIPTS_DIR.parent,
+        timeout=60,
+    )
+
+
+# --------------------------------------------------------------------------
+# Calibration: the fixture must be able to express the defect
+# --------------------------------------------------------------------------
+
+
+def test_the_unwritable_parent_really_is_unwritable_even_for_root() -> None:
+    """The instrument, before the reading.
+
+    If `/proc/self` were writable in this environment, every assertion below would pass
+    vacuously against ANY code, fixed or broken. A root runner defeats `chmod`; it does not
+    defeat procfs. Prove that here, or the rest of this file is theatre.
+    """
+    probe = subprocess.run(
+        ["bash", "-c", f'mktemp -p "{UNWRITABLE_PARENT}" probe-XXXXXX'],
+        capture_output=True,
+        text=True,
+    )
+    assert probe.returncode != 0, (
+        f"{UNWRITABLE_PARENT} accepted a file — this fixture cannot express the deploy#623 "
+        f"defect, so every test in this module is inert. Pick a parent that refuses creat() "
+        f"for uid 0 as well (chmod does NOT, which is why it is not used here)."
+    )
+
+
+def test_the_library_works_when_the_scratch_parent_is_writable(tmp_path: Path) -> None:
+    """Positive control: the guard is not simply 'the function that always fails'.
+
+    Without this, a `scratch_file` that returned 1 unconditionally would satisfy every
+    negative assertion below and look like a perfect fix.
+    """
+    good = tmp_path / "backups"
+    good.mkdir()
+    proc = _run(
+        "running_services > /dev/null && echo REACHED_DOCKER",
+        backup_dir=str(good),
+        with_docker=True,
+        tmp_path=tmp_path,
+    )
+    assert proc.returncode == 0, (
+        f"the library failed with a WRITABLE scratch parent:\n{proc.stderr}"
+    )
+    assert "REACHED_DOCKER" in proc.stdout
+
+
+# --------------------------------------------------------------------------
+# The defect: a check that could not run must not speak about the system
+# --------------------------------------------------------------------------
+
+
+def test_running_services_does_not_blame_docker_when_scratch_is_unwritable(tmp_path: Path) -> None:
+    """deploy#623, exactly. Docker is HEALTHY; only the scratch write fails.
+
+    Before the fix this printed "Cannot reach Docker Compose (rc=1) — is the daemon running?"
+    and sent the operator to inspect a daemon that was fine, while the real cause — a
+    read-only /tmp under ProtectSystem=strict — went unmentioned.
+    """
+    proc = _run(
+        "running_services || true",
+        backup_dir=UNWRITABLE_PARENT,
+        with_docker=True,
+        tmp_path=tmp_path,
+    )
+    combined = proc.stdout + proc.stderr
+
+    for claim in FALSE_CLAIMS:
+        assert claim not in combined, (
+            f"a failed SCRATCH WRITE was reported as {claim!r} — docker is healthy in this "
+            f"fixture and was never even reached. This is deploy#613/#623: a check that could "
+            f"not run, testifying about the system it never checked.\n\n{combined}"
+        )
+
+    assert "could not RUN" in combined, (
+        "the diagnostic must say the check could not run, in its own words"
+    )
+    assert "NO evidence" in combined, (
+        "it must explicitly disown any conclusion about docker/the project/the stack — "
+        "otherwise the next operator debugs the daemon, as they would have on stg"
+    )
+    assert "ProtectSystem=strict" in combined and "BACKUP_DIR" in combined, (
+        "the diagnostic must name the actual cause and the actual remedy"
+    )
+
+
+def test_neo4j_start_does_not_claim_the_graph_failed_when_scratch_is_unwritable(
+    tmp_path: Path,
+) -> None:
+    """The same trap, in the more dangerous place.
+
+    `neo4j_start` runs in the window where backup.sh has ALREADY STOPPED the graph. A scratch
+    failure rendered as "Could not START neo4j" would tell the operator the database is
+    broken — when in truth it was never touched, and the only thing that failed was a temp
+    file.
+    """
+    proc = _run(
+        "neo4j_start || true",
+        backup_dir=UNWRITABLE_PARENT,
+        with_docker=True,
+        tmp_path=tmp_path,
+    )
+    combined = proc.stdout + proc.stderr
+
+    assert "Could not START neo4j" not in combined, (
+        "a failed scratch write was reported as a failure to start Neo4j. The graph was never "
+        "touched. Telling an operator their database would not start — in the window where "
+        f"the backup has just stopped it — is the worst possible false claim here.\n\n{combined}"
+    )
+    assert "could not RUN" in combined and "NO evidence" in combined
+
+
+def test_no_bare_mktemp_survives_in_the_library() -> None:
+    """Structural backstop: the next caller must not have to remember any of this.
+
+    A bare `mktemp` (no `-p`, no explicit parent) resolves to /tmp and is unusable under the
+    unit. Every capture file in this library goes through `scratch_file`; this pins that, so
+    a third instance of deploy#613 cannot be added by hand.
+    """
+    code = [
+        ln
+        for ln in LIB.read_text().splitlines()
+        if not ln.lstrip().startswith("#") and "mktemp" in ln
+    ]
+    offenders = [ln.strip() for ln in code if "-p " not in ln]
+    assert not offenders, (
+        "bare mktemp in compose_project.sh — it defaults to /tmp, which is READ-ONLY under "
+        "isnad-backup.service (ProtectSystem=strict). This is deploy#613, which has now "
+        "shipped twice. Use scratch_file().\n  " + "\n  ".join(offenders)
+    )

--- a/scripts/tests/test_scratch_under_hardening.py
+++ b/scripts/tests/test_scratch_under_hardening.py
@@ -40,6 +40,28 @@ The unusable parent is ``/proc/self`` — a real directory that exists and refus
 **for uid 0 as well**. ``chmod`` would be a no-op against root, so a root CI runner would
 quietly turn this whole class green; procfs does not care who you are. Same reasoning as the
 ``ENOTDIR`` fixture in ``test_b2_preflight.py``.
+
+WHAT A GREEN RUN MEANS — AND WHAT IT DOES NOT
+---------------------------------------------
+Say it in the narrow words, because the wide words are how deploy#613 shipped inside the fix
+for deploy#617, past a green suite: **a green run of this module means the scripts behave
+honestly when a scratch allocation fails, and no ``mktemp`` in them defaults to /tmp.** It
+does **not** mean the backup path is safe under hardening.
+
+The property that actually matters is *"writes nothing outside ``ReadWritePaths=``"*, and that
+is a runtime property of a process under a namespace. It is not decidable by reading source
+text, and ``mktemp`` is merely where it has bitten us twice. ``> /tmp/foo``, a ``cd /tmp``, a
+config read under ``ProtectHome=yes``, a ``python -c`` calling ``tempfile.mkstemp()`` — each
+fails identically under the unit and none of them is a ``mktemp`` line. (``rclone`` escapes
+``ProtectHome=yes`` today only because ``backup.sh`` configures it entirely through
+``RCLONE_CONFIG_ISNAD_*`` env vars rather than a config file. Nothing tests that, and it is one
+refactor away from being the next defect. — Nino Kavtaradze, #624 review.)
+
+The real gate is **deploy#626**: run the entry points under the hardening *read out of the unit
+file itself*, so the test cannot disagree with production about what production permits. A
+hand-written "read-only /tmp" job would just be a third place to encode the same assumption,
+stale the moment someone edits ``ReadWritePaths=``. This module is the cheap, deterministic
+stopgap that closes the known proxy and buys the time to build that. It is not the answer.
 """
 
 from __future__ import annotations
@@ -95,9 +117,14 @@ def unit_reachable_scripts() -> set[Path]:
     #
     # So this DELIBERATELY OVER-APPROXIMATES: any sibling *.sh whose basename is mentioned
     # anywhere in a unit-reachable script is treated as reachable. Over-inclusion only WIDENS
-    # the scan — it can produce a false red (someone merely names a script in a comment-free
-    # string), never a false green. For a guard against a bug that has shipped twice, that is
-    # the correct direction to be wrong in.
+    # the set of files scanned, so THE RESOLVER can produce a false red (someone merely names
+    # a script in a comment-free string) but not a false green. For a guard against a bug that
+    # has shipped twice, that is the correct direction to be wrong in.
+    #
+    # Read that claim narrowly: it is a property of the RESOLVER, not of the module. Scanning
+    # the right files says nothing about whether the pattern applied to them is sound, and it
+    # says nothing about the writes that are not `mktemp` calls at all. See the module
+    # docstring, "WHAT A GREEN RUN MEANS".
     seen: set[Path] = set()
     pending = list(entry)
     siblings = sorted(SCRIPTS_DIR.glob("*.sh"))
@@ -127,6 +154,27 @@ def unit_reachable_scripts() -> set[Path]:
 # separator.
 _MKTEMP_CALL = re.compile(r"\bmktemp\b([^|;&)`\n]*)")
 
+# ONE rule, no exemptions: in a hardened script, every `mktemp` NAMES ITS PARENT.
+#
+# The first cut accepted a template carrying a `$` or a `/` as proof the call had chosen its
+# own directory. It is not proof, and Nino Kavtaradze broke it three ways (#624 review):
+#
+#   mktemp -t "${X}.XXXXXX"    `-t` puts it in $TMPDIR-or-/tmp. The `${` vouched for it.
+#   mktemp --tmpdir            No `=DIR` means $TMPDIR-or-/tmp. The prefix-match vouched for it.
+#   MUT="$(mktemp)"  # ${BACKUP_DIR}   ...and the bare call passes if a `$` shares the line.
+#
+# The third is the one that matters: this PR's own convention is to write `${BACKUP_DIR}`, so
+# the codebase actively selects for the line that disarms the guard. An escape hatch inside a
+# guard against a bug that has now shipped twice is not a convenience, it is the hole.
+#
+# So the hatch is REMOVED, not narrowed. A call is exempt only if it says where the file goes:
+# `-p <val>` or `--tmpdir=<val>`. Bare `--tmpdir` and `-t` both resolve to $TMPDIR-or-/tmp, so
+# neither is an exemption; `${` is never one. The two legitimate sites in the closure
+# (backup.sh, emit-backup-failure-marker.sh) were converted to `-p` to meet it — same landing
+# directory, now checkable. Cost: `mktemp "$dir/x.XXXXXX"` is a false RED. That is the correct
+# direction to be wrong in, and it is one flag to fix.
+_HAS_PARENT = re.compile(r'(-p\s*["$\w/]|--tmpdir=)')
+
 
 def _mktemp_invocations(line: str) -> list[str]:
     """The argument text of every `mktemp` call on this line, each judged on its own."""
@@ -134,19 +182,8 @@ def _mktemp_invocations(line: str) -> list[str]:
 
 
 def _names_its_parent(args: str) -> bool:
-    """Did THIS mktemp call choose where its file lands, rather than defaulting to /tmp?
-
-    Accepts an explicit parent (`-p DIR`, `--tmpdir=DIR`) or a template carrying a directory
-    (`mktemp "${SUCCESS_TEXTFILE}.XXXXXX"` — lands wherever that variable points, which is the
-    author's choice and is checked elsewhere). A bare `mktemp` / `mktemp -d` chooses /tmp for
-    you, and /tmp is read-only under the unit.
-    """
-    tokens = args.split()
-    if any(t == "-p" or t.startswith("-p") or t.startswith("--tmpdir") for t in tokens):
-        return True
-    # A template argument (non-flag) that contains a path separator or a variable expansion
-    # names its own directory.
-    return any(not t.startswith("-") and ("/" in t or "$" in t) for t in tokens)
+    """Did THIS mktemp call say where its file lands, rather than defaulting to /tmp?"""
+    return _HAS_PARENT.search(args) is not None
 
 
 # A directory that EXISTS and into which no file can be created — for root too.
@@ -317,6 +354,59 @@ def test_neo4j_start_does_not_claim_the_graph_failed_when_scratch_is_unwritable(
         f"the backup has just stopped it — is the worst possible false claim here.\n\n{combined}"
     )
     assert "could not RUN" in combined and "NO evidence" in combined
+
+
+def test_the_offender_filter_itself_separates_tmp_from_not_tmp() -> None:
+    """Calibrate the guard before trusting the guard.
+
+    `test_no_bare_mktemp_survives_in_the_library` reports "0 offenders" over the closure. That
+    number is worth exactly what the filter behind it is worth — and the previous filter was
+    worth nothing against three spellings that all land in /tmp (Nino Kavtaradze, #624 review).
+    An oracle that only ever says CLEAN proves every line clean
+    (cf. `feedback_calibrate_the_mutation_before_counting_it`).
+
+    So: run the filter over both classes and require it to SEPARATE them. Every LANDS_IN_TMP
+    line must be flagged, every NAMES_ITS_PARENT line must not. Anyone who loosens the pattern
+    to wave a line through fails here first, with the reason spelled out.
+    """
+    # Each of these resolves to $TMPDIR-or-/tmp, which is READ-ONLY under the unit.
+    lands_in_tmp = [
+        'tmp="$(mktemp)"',
+        'tmp="$(mktemp -d)"',
+        'tmp="$(mktemp -t probe.XXXXXX)"',
+        'tmp="$(mktemp --tmpdir probe.XXXXXX)"',
+        # `-t` with an expansion in the template: the `${` used to vouch for it.
+        'tmp="$(mktemp -t "${PREFIX}.XXXXXX")"',
+        # A bare call with an unrelated expansion elsewhere on the line. This PR's own
+        # convention is to write ${BACKUP_DIR}, so the codebase SELECTS for this line.
+        'mkdir -p "${BACKUP_DIR}" && tmp="$(mktemp)"',
+        # An unrelated `-p` belonging to some other command on the line.
+        'grep -p foo bar || true; tmp="$(mktemp)"',
+    ]
+    # Each of these says where the file goes. These are the real forms in the closure.
+    names_its_parent = [
+        'tmp="$(mktemp -p "$parent" compose-project-XXXXXX)"',
+        'tmp="$(mktemp -d -p "$scratch_parent" b2-preflight-XXXXXX)"',
+        'TMP="$(mktemp -p "$TEXTFILE_DIR" isnad_backup_failure.prom.XXXXXX)"',
+        'tmp="$(mktemp --tmpdir=/var/lib/x probe.XXXXXX)"',
+    ]
+
+    for line in lands_in_tmp:
+        calls = _mktemp_invocations(line)
+        assert calls, f"the filter did not even SEE a mktemp call in: {line}"
+        assert not all(_names_its_parent(a) for a in calls), (
+            f"FALSE GREEN: this lands in /tmp and the filter waves it through:\n    {line}\n"
+            "Under ProtectSystem=strict /tmp is read-only, so this is deploy#613 again. Only "
+            "an explicit `-p <val>` / `--tmpdir=<val>` is an exemption — not `-t`, not a bare "
+            "`--tmpdir`, and never a `${...}` sharing the line."
+        )
+
+    for line in names_its_parent:
+        calls = _mktemp_invocations(line)
+        assert calls, f"the filter did not even SEE a mktemp call in: {line}"
+        assert all(_names_its_parent(a) for a in calls), (
+            f"FALSE RED: this names its parent and the filter flags it anyway:\n    {line}"
+        )
 
 
 def test_no_bare_mktemp_survives_in_the_library() -> None:

--- a/scripts/tests/test_scratch_under_hardening.py
+++ b/scripts/tests/test_scratch_under_hardening.py
@@ -49,7 +49,70 @@ import subprocess
 from pathlib import Path
 
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+REPO_ROOT = SCRIPTS_DIR.parent
+SYSTEMD_DIR = REPO_ROOT / "systemd"
 LIB = SCRIPTS_DIR / "compose_project.sh"
+
+
+def unit_reachable_scripts() -> set[Path]:
+    """Every script a HARDENED systemd unit can execute, resolved from the units themselves.
+
+    `ExecStart=` gives the entry points; the transitive `source`/`.` graph gives the rest. A
+    hand-typed list would drift the moment someone adds a unit or sources a new helper — and
+    drift in THIS list means a script runs under `ProtectSystem=strict` with nobody checking
+    where its scratch lands, which is the whole of deploy#613/#623.
+
+    Scoped to units that are actually hardened: an unhardened unit has a writable /tmp and a
+    bare `mktemp` in it is not a bug.
+    """
+    entry: set[Path] = set()
+    for unit in sorted(SYSTEMD_DIR.glob("*.service")):
+        text = unit.read_text()
+        if "ProtectSystem=strict" not in text:
+            continue
+        for line in text.splitlines():
+            if not line.startswith("ExecStart="):
+                continue
+            for token in line[len("ExecStart=") :].split():
+                name = Path(token.lstrip("-@+!")).name
+                candidate = SCRIPTS_DIR / name
+                if candidate.is_file() and candidate.suffix == ".sh":
+                    entry.add(candidate)
+
+    # Transitive closure over the `source` graph — but matched on BASENAME ANYWHERE in the
+    # script, not on the `source` line itself.
+    #
+    # The obvious implementation (look only at lines starting with `source`/`.`) finds
+    # NOTHING here, and I know because I wrote it and this module's own closure assertion
+    # caught it. backup.sh sources indirectly:
+    #
+    #     COMPOSE_PROJECT_LIB="$(dirname "${BASH_SOURCE[0]}")/compose_project.sh"
+    #     source "$COMPOSE_PROJECT_LIB"
+    #
+    # The filename is on the ASSIGNMENT line; the `source` line carries only a variable. A
+    # resolver that evaluated the path expression would be guessing at runtime semantics.
+    #
+    # So this DELIBERATELY OVER-APPROXIMATES: any sibling *.sh whose basename is mentioned
+    # anywhere in a unit-reachable script is treated as reachable. Over-inclusion only WIDENS
+    # the scan — it can produce a false red (someone merely names a script in a comment-free
+    # string), never a false green. For a guard against a bug that has shipped twice, that is
+    # the correct direction to be wrong in.
+    seen: set[Path] = set()
+    pending = list(entry)
+    siblings = sorted(SCRIPTS_DIR.glob("*.sh"))
+    while pending:
+        script = pending.pop()
+        if script in seen:
+            continue
+        seen.add(script)
+        body = "\n".join(
+            ln for ln in script.read_text().splitlines() if not ln.lstrip().startswith("#")
+        )
+        for sibling in siblings:
+            if sibling != script and sibling.name in body and sibling not in seen:
+                pending.append(sibling)
+    return seen
+
 
 # A directory that EXISTS and into which no file can be created — for root too.
 UNWRITABLE_PARENT = "/proc/self"
@@ -222,20 +285,50 @@ def test_neo4j_start_does_not_claim_the_graph_failed_when_scratch_is_unwritable(
 
 
 def test_no_bare_mktemp_survives_in_the_library() -> None:
-    """Structural backstop: the next caller must not have to remember any of this.
+    """Structural backstop over EVERY script the hardened units can execute.
 
-    A bare `mktemp` (no `-p`, no explicit parent) resolves to /tmp and is unusable under the
-    unit. Every capture file in this library goes through `scratch_file`; this pins that, so
-    a third instance of deploy#613 cannot be added by hand.
+    The first cut of this test read `compose_project.sh` and nothing else — and
+    `isnad-backup.service` does not ExecStart `compose_project.sh`. It ExecStarts
+    **`backup.sh`**, which *sources* `b2_preflight.sh` and `compose_project.sh`. So a bare
+    `mktemp` added to `backup.sh` tomorrow would be deploy#613 for the THIRD time, under
+    `ProtectSystem=strict`, and this suite would not have said a word. A guard written
+    against "the next caller" that covers one of the three files in the closure is not a
+    guard (deploy#624 review — Nino Kavtaradze).
+
+    The reachable set is RESOLVED FROM THE UNITS — `ExecStart=` plus the transitive `source`
+    graph — never a hand-typed list, so it cannot drift away from what systemd actually runs.
+    Add a script to a unit, or source one from a script a unit runs, and it is scanned from
+    that moment on without anyone remembering to add it here.
     """
-    code = [
-        ln
-        for ln in LIB.read_text().splitlines()
-        if not ln.lstrip().startswith("#") and "mktemp" in ln
-    ]
-    offenders = [ln.strip() for ln in code if "-p " not in ln]
+    reachable = unit_reachable_scripts()
+
+    # The closure must be non-empty AND contain the entry points, or the scan is inert and
+    # every assertion below passes vacuously (cf. calibrate_the_mutation_before_counting_it).
+    names = {p.name for p in reachable}
+    assert "backup.sh" in names, (
+        f"the unit-reachable closure does not contain backup.sh — the resolver is broken and "
+        f"this guard is inert. Found: {sorted(names)}"
+    )
+    assert {"compose_project.sh", "b2_preflight.sh"} <= names, (
+        f"the closure did not follow `source` — backup.sh sources both of these, and both "
+        f"allocate scratch. Found: {sorted(names)}"
+    )
+
+    offenders: list[str] = []
+    for script in sorted(reachable):
+        for ln in script.read_text().splitlines():
+            stripped = ln.lstrip()
+            if stripped.startswith("#") or "mktemp" not in ln:
+                continue
+            # An explicit parent (-p / --tmpdir) or a template with a directory in it means
+            # the author chose where it lands. A bare `mktemp` chooses /tmp for them.
+            if "-p " not in ln and '-p"' not in ln and "--tmpdir" not in ln and "${" not in ln:
+                offenders.append(f"{script.name}: {ln.strip()}")
+
     assert not offenders, (
-        "bare mktemp in compose_project.sh — it defaults to /tmp, which is READ-ONLY under "
-        "isnad-backup.service (ProtectSystem=strict). This is deploy#613, which has now "
-        "shipped twice. Use scratch_file().\n  " + "\n  ".join(offenders)
+        "bare mktemp in a script the hardened units EXECUTE — it defaults to /tmp, which is "
+        "READ-ONLY under ProtectSystem=strict. This is deploy#613, which has now shipped "
+        "TWICE (#613 in b2_preflight.sh, #623 in compose_project.sh). Allocate under a path "
+        "the unit grants — scratch_file() in compose_project.sh does this.\n  "
+        + "\n  ".join(offenders)
     )

--- a/scripts/tests/test_scratch_under_hardening.py
+++ b/scripts/tests/test_scratch_under_hardening.py
@@ -173,7 +173,27 @@ _MKTEMP_CALL = re.compile(r"\bmktemp\b([^|;&)`\n]*)")
 # (backup.sh, emit-backup-failure-marker.sh) were converted to `-p` to meet it — same landing
 # directory, now checkable. Cost: `mktemp "$dir/x.XXXXXX"` is a false RED. That is the correct
 # direction to be wrong in, and it is one flag to fix.
-_HAS_PARENT = re.compile(r'(-p\s*["$\w/]|--tmpdir=)')
+#
+# THE OPTION MUST BE AN OPTION, NOT A SUBSTRING. (#624 review 3 — Lucas Ferreira)
+#
+# The first cut of this regex was `-p\s*["$\w/]`, unanchored — so a `-p` ANYWHERE in the
+# argument text exempted the call, INCLUDING inside a template NAME. The library's own scratch
+# template is `compose-project-XXXXXX`. It contains `-p`. So:
+#
+#     err2="$(mktemp -t compose-project-XXXXXX)"     <-- allocates in the READ-ONLY /tmp
+#
+# passed GREEN, and that is deploy#613 verbatim, in the file the unit executes. `mktemp
+# --tmpdir backup-pg.XXXXXX` evades identically (`-pg`). Worse, the calibration fixtures I
+# wrote to PROVE this filter worked used template names — `probe.XXXXXX`, `${PREFIX}.XXXXXX` —
+# that happen to contain no `-p`, so the very test meant to catch this could not see it. A
+# guard and its calibration sharing the same blind spot is not a guard
+# (cf. `feedback_fixture_makes_guard_assertion_inert`).
+#
+# So the option is anchored: it must START a token (preceded by whitespace or the string
+# start). `-\w*p` admits clustered short flags (`-dp DIR`) while still requiring the `p` to
+# live in a token that begins with `-`. The fixtures below now carry `-p` INSIDE the template
+# name in both classes, so this cannot silently reopen.
+_HAS_PARENT = re.compile(r'(?:\s|^)(?:-\w*p\s*["$\w/]|--tmpdir=)')
 
 
 def _mktemp_invocations(line: str) -> list[str]:
@@ -382,6 +402,12 @@ def test_the_offender_filter_itself_separates_tmp_from_not_tmp() -> None:
         'mkdir -p "${BACKUP_DIR}" && tmp="$(mktemp)"',
         # An unrelated `-p` belonging to some other command on the line.
         'grep -p foo bar || true; tmp="$(mktemp)"',
+        # THE TEMPLATE NAME CONTAINS `-p`. (Lucas Ferreira, #624 review 3.) These are the two
+        # that shipped past the unanchored regex — and note the first uses the library's OWN
+        # scratch template, so the codebase supplies the evasion for free. Both allocate in the
+        # read-only /tmp. If either of these ever goes green again, deploy#613 is back.
+        'err2="$(mktemp -t compose-project-XXXXXX)"',
+        'tmp="$(mktemp --tmpdir backup-pg.XXXXXX)"',
     ]
     # Each of these says where the file goes. These are the real forms in the closure.
     names_its_parent = [
@@ -389,6 +415,11 @@ def test_the_offender_filter_itself_separates_tmp_from_not_tmp() -> None:
         'tmp="$(mktemp -d -p "$scratch_parent" b2-preflight-XXXXXX)"',
         'TMP="$(mktemp -p "$TEXTFILE_DIR" isnad_backup_failure.prom.XXXXXX)"',
         'tmp="$(mktemp --tmpdir=/var/lib/x probe.XXXXXX)"',
+        # The positive-control half of Lucas's finding: a REAL `-p` whose template ALSO carries
+        # a `-p`. Anchoring the option must not cost us the legitimate call it looks like.
+        'tmp="$(mktemp -p "$parent" compose-project-XXXXXX)"',
+        # Clustered short flags — `-d` and `-p` in one token. Still names its parent.
+        'tmp="$(mktemp -dp "$parent" compose-project-XXXXXX)"',
     ]
 
     for line in lands_in_tmp:


### PR DESCRIPTION
Closes #623.

## deploy#613, shipped a second time — inside the fix for #617

`compose_project.sh` captured stderr into a **bare `mktemp`**, which defaults to `/tmp`. Under `isnad-backup.service`, `/tmp` is **read-only**: `ProtectSystem=strict`, `PrivateTmp` deliberately unset (deploy#121 Bug A), and only `BACKUP_DIR`, `/opt/noorinalabs-deploy` and `/var/lib/node_exporter` are granted. The allocation failed, `$err` was empty, the `2>"$err"` redirect died, and the helper announced:

```
[ERROR] Cannot reach Docker Compose (rc=1) — is the daemon running?
```

**The daemon was running. The scratch write failed.**

That is the same lie `b2_preflight.sh` used to tell about the B2 key: *a check that could not run, reporting its own breakage as a fact about the system it was meant to check* — and sending the operator to the wrong subsystem. Measured on stg `2026-07-14T01:23:30Z`, on the first backup run after #617 merged.

## The fix

- **One `scratch_file()`** for every capture file in the library, allocating under `BACKUP_DIR` (which the unit grants), falling back to `TMPDIR` then `/tmp` so standalone and CI invocation keep working.
- It proves the scratch is **writable, not merely allocated**: under `ENOSPC` the `creat()` succeeds and the write fails, leaving a 0-byte file — so `-s`, not the redirect's exit status, is what catches a full disk (deploy#614's lesson).
- **Allocation failure is fatal and self-describing.** `scratch_failed()` says the check could not run, disowns any conclusion about Docker / the project / the stack *in the imperative*, and names `ProtectSystem=strict`, `BACKUP_DIR`, and a full disk as the things to actually go look at.
- **`neo4j_start()` gets the same guard**, where the false claim is worse: it runs in the window where `backup.sh` has **already stopped the graph**, so `"Could not START neo4j"` would tell an operator their database is broken when it was never touched.

## Why CI could not catch this — and why *that* is the real bug

**GitHub Actions runners have a writable `/tmp`.** So do the rehearsal containers. So does the dev box. The entire test surface — *including* the new e2e tests that drive the real `backup.sh` — runs in an environment where this defect is **unreachable**. Only the on-host systemd path is affected, and nothing in CI executes it.

The tests were never weak. They were **structurally incapable of failing**. That is how the same root cause shipped twice, past 23 CI checks and four adversarial reviewers.

`scripts/tests/test_scratch_under_hardening.py` closes the blind spot by doing the one thing the rest of the suite cannot: it makes the scratch parent **unusable** and asserts on what the script then says.

- The unusable parent is **`/proc/self`** — a real directory that refuses `creat()` **for uid 0 as well**. `chmod` is a no-op against root, so a root CI runner would quietly turn this whole class green; procfs does not care who you are. (Same reasoning as the `ENOTDIR` fixture in `test_b2_preflight.py`.)
- **The fixture is calibrated first** — `test_the_unwritable_parent_really_is_unwritable_even_for_root` proves the instrument can express the defect before anything is read from it.
- **A positive control** keeps a `scratch_file` that always failed from passing every negative assertion and looking like a perfect fix.
- The diagnostic is asserted to contain **no claim about Docker**, and a structural test pins that **no bare `mktemp` can be added to the library again**.

## Calibration (measured, both directions)

- **5 pass** on this branch.
- **4 fail** against `origin/main` — printing the exact production lie (`'is the daemon running'`) while the stubbed docker is healthy and was never reached.
- The positive control also fails on `main`, which is its own evidence: the old library ignores `BACKUP_DIR` entirely.

Full gate: shellcheck (CI form, 22 scripts), `bash -n`, ruff, mypy, **443 passed / 3 skipped**. Nothing bypassed.

## Sequencing

This is the **third** distinct defect in this path (#613 → #617 → #623), each hidden behind the last. Zero backups still exist. Prod's timer is still not installed — do not install it until this lands.
