### PR TITLE
feat(backup): codify the real-artifact restore rehearsal as IaC (#640)

### DIFF
--- a/.github/workflows/restore-verify.yml
+++ b/.github/workflows/restore-verify.yml
@@ -1,0 +1,184 @@
+# Restore the REAL B2 artifact and prove it reproduces the live database (deploy#640)
+#
+# WHY THIS EXISTS WHEN restore-rehearsal.yml ALREADY DOES
+#
+# `restore-rehearsal.yml` drives restore.sh against SYNTHETIC seed data and a
+# LOCALLY-FABRICATED artifact. It proves the restore CODE PATH works and that restore.sh
+# rejects broken artifacts. It stays.
+#
+# It cannot prove THIS artifact loads, and the difference is not academic: the real backup
+# only became restorable after #613/#617/#623/#632, and the synthetic rehearsal was GREEN
+# through every one of those. It supplies COMPOSE_PROJECT_NAME — the one input production
+# omits — so it could never have caught #617.
+#
+# On 2026-07-14 the real thing was done twice, BY HAND (stg, then prod): an ad-hoc compose
+# file scp'd to /var/tmp, driven by shell written in the moment. That is the evidence
+# deploy#612 was closed on, and it lived nowhere. "Can we restore prod?" was answered by a
+# transcript rather than a green check. This workflow is that procedure, as IaC.
+#
+# THE TWO JOBS ARE DIFFERENT KINDS OF CHECK
+#
+#   self-test  — runs on a plain runner. No B2, no VPS, no secrets, nothing live reachable.
+#                It stands up two REAL Neo4j instances and proves the comparator SEPARATES:
+#                MATCH on identical content, DIFFER on a missing narrator, DIFFER on a
+#                same-count content corruption, and it reproduces the `n.name` trap that
+#                made the first hand-run's checksum read 0 on both sides and "agree".
+#
+#                It runs on PRs because a comparator is a thing that BREAKS, and a unit test
+#                over the query STRING would not notice: the n.name Cypher is perfectly
+#                valid, it just measures nothing (cf. deploy#606/#607 — an invalid-Cypher
+#                precheck passed 32 tests and two reviewers; only a real engine caught it).
+#
+#   verify     — runs ON the host, against the real artifact in B2. Scheduled, because a
+#                restore path rots silently. Never on a PR: it needs the live stack and the
+#                bucket, and a job that cannot see them must not report on them.
+name: Restore verify (real B2 artifact)
+
+on:
+  schedule:
+    # Weekly, Tuesdays 04:40 UTC. Offset off the hour, and off restore-rehearsal.yml's
+    # Monday 04:17 — the two are independent checks and a shared failure window would
+    # make them look like one.
+    - cron: "40 4 * * 2"
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Which environment's backup to restore and verify"
+        required: true
+        type: choice
+        options: [stg, prod]
+        default: stg
+  pull_request:
+    paths:
+      - "scripts/restore_verify.sh"
+      - "scripts/restore.sh"
+      - "scripts/tests/test_restore_verify.py"
+      - "compose/docker-compose.restore-verify.yml"
+      - ".github/workflows/restore-verify.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # The comparator must be shown able to go RED before any green run is believed.
+  # ---------------------------------------------------------------------------
+  self-test:
+    name: Comparator self-test (real engine, no B2)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Assert prerequisites are really present
+        run: |
+          set -euo pipefail
+          # A missing tool must fail loudly rather than let the self-test skip a leg and
+          # report a green it did not earn.
+          command -v docker >/dev/null || { echo "::error::missing required command: docker"; exit 1; }
+          docker compose version
+
+      - name: The comparator must separate MATCH from DIFFER
+        run: |
+          set -euo pipefail
+          chmod +x scripts/restore_verify.sh
+          ./scripts/restore_verify.sh --self-test 2>&1 | tee "${RUNNER_TEMP}/self-test.txt"
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## Comparator self-test — ${{ job.status }}"
+            echo ""
+            echo "Two REAL Neo4j instances, seeded identically, then perturbed. The comparator"
+            echo "must MATCH on identical content and DIFFER on both a missing narrator and a"
+            echo "same-count content corruption — and it must reproduce the \`n.name\` trap, where"
+            echo "a fingerprint over a property that does not exist reads **0 on both sides** and"
+            echo "\"agrees\" perfectly."
+            echo ""
+            echo "> A both-sides-zero is not a match. It is the instrument reading nothing, twice."
+            echo ""
+            if [ -f "${RUNNER_TEMP}/self-test.txt" ]; then
+              echo "### Verdicts"
+              echo ""
+              echo '```'
+              grep -E '\[PASS\]|\[FAIL\]' "${RUNNER_TEMP}/self-test.txt" || echo "(no verdicts recorded — the self-test did not reach its assertions)"
+              echo '```'
+            else
+              echo "_No self-test output captured._"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------------
+  # The real thing: restore the actual artifact on the actual host.
+  # ---------------------------------------------------------------------------
+  verify:
+    # Not on PRs. The environment secrets do not resolve there and the live stack is not
+    # reachable — and a check that cannot look must not testify about what it did not see.
+    if: github.event_name != 'pull_request'
+    name: ${{ matrix.env }} — does the REAL B2 artifact restore?
+    needs: self-test
+    runs-on: ubuntu-latest
+    # 7.9 GiB store: download, decompress, neo4j-admin load, two pg_restores, then the
+    # content comparison. The hand-run took well under this; the ceiling is deliberate.
+    timeout-minutes: 90
+    environment: ${{ matrix.env == 'prod' && 'production' || 'staging' }}
+    strategy:
+      fail-fast: false # stg being broken must not hide prod being broken
+      matrix:
+        # A dispatch verifies the one environment it was asked for; the schedule does both.
+        env: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.environment)) || fromJSON('["stg","prod"]') }}
+    concurrency:
+      # Two of these on one host would fight over the same compose project and the same
+      # scratch volumes. Queue rather than cancel: a half-torn-down run leaks volumes
+      # holding a full copy of the database.
+      group: restore-verify-${{ matrix.env }}
+      cancel-in-progress: false
+    steps:
+      - name: Restore the real artifact into a throwaway stack and compare it to live
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ vars.VPS_HOST }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          # The restore of a 7.9 GiB store, plus the comparison.
+          command_timeout: 80m
+          # EXPECT_PREFIX is the scoping guard (deploy#632/#633). The matrix leg says which
+          # environment it BELIEVES it is checking; the host's .env says which one it IS. If
+          # they disagree the script refuses, rather than restore one environment's backup
+          # and compare it against the other's live database. Before #632 the backup watchdog
+          # had exactly this defect: both legs scanned the same objects, so the prod leg would
+          # have reported `fresh` on the strength of STAGING's backup.
+          envs: EXPECT_PREFIX
+          script: |
+            set -euo pipefail
+            cd /opt/noorinalabs-deploy
+            export EXPECT_PREFIX='${{ matrix.env }}'
+            ./scripts/restore_verify.sh
+        env:
+          EXPECT_PREFIX: ${{ matrix.env }}
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## Restore verify — ${{ matrix.env }}: ${{ job.status }}"
+            echo ""
+            echo "Restored the **real** \`${{ matrix.env }}\` artifact out of B2 into a throwaway"
+            echo "stack on the host, and asserted the restored **content** matches the live"
+            echo "database — row counts, full-table checksums, \`count(n)\`, label and"
+            echo "relationship-type histograms."
+            echo ""
+            echo "The verdict is **never** the restore's exit code: \`pg_restore --clean\` can"
+            echo "warn-and-succeed while restoring nothing."
+            echo ""
+            echo "| exit | meaning | what to do |"
+            echo "|---|---|---|"
+            echo "| 0 | **VERIFIED** — the artifact reproduces live, and the comparator was proven able to go red first. | Nothing. This is the evidence deploy#609 asks for. |"
+            echo "| 1 | **FAILED** — a real negative. The artifact did not reproduce the live database. | The backup is not restorable. Treat as an incident: the nightly is producing something that does not load. |"
+            echo "| 2 | **INSTRUMENT FAILURE** — the check could not run (credentials, disk/memory, an inert comparator, a dirty scratch stack). | **Not** a claim about the backup. Fix the instrument and re-run. Do **not** read it as \"backups are fine\", and do **not** read it as \"backups are broken\". |"
+            echo ""
+            echo "\`restore-rehearsal.yml\` is a different check and does not substitute for this"
+            echo "one: it restores a **fabricated** artifact, and it was green throughout the"
+            echo "entire period the real artifact was unrestorable (#613/#617/#623/#632)."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/restore-verify.yml
+++ b/.github/workflows/restore-verify.yml
@@ -84,6 +84,37 @@ jobs:
           chmod +x scripts/restore_verify.sh
           ./scripts/restore_verify.sh --self-test 2>&1 | tee "${RUNNER_TEMP}/self-test.txt"
 
+      # AN ORTHOGONAL WITNESS. The script prints its own "no stray objects remain" verdict —
+      # and a verification script must not be the only witness to its own cleanliness
+      # (deploy#632/#641: three instrument failures in one night, every one of them a script
+      # testifying about itself). This step asks DOCKER, not the script.
+      #
+      # `if: always()` is the entire point: it must run when the self-test FAILED, because a
+      # failing run is exactly when a teardown gets skipped and a stack is left behind. A
+      # leaked scratch volume on the real host holds a full copy of production.
+      - name: Independently verify the self-test left nothing behind
+        if: always()
+        run: |
+          set -uo pipefail
+          STRAY=0
+          for p in isnad-rv-selftest-ref isnad-rv-selftest-sub; do
+            for kind in "ps -a" "volume ls" "network ls"; do
+              # shellcheck disable=SC2086
+              OUT="$(docker $kind --filter "label=com.docker.compose.project=${p}" -q)"
+              if [ -n "${OUT}" ]; then
+                echo "::error::STRAY ${kind} in project ${p} — the teardown leaked:"
+                echo "${OUT}"
+                STRAY=1
+              fi
+            done
+          done
+          if [ "${STRAY}" -ne 0 ]; then
+            echo "::error::The self-test left objects behind. On the real host these hold a full"
+            echo "  copy of the production database. This fails the job even if the comparator passed."
+            exit 1
+          fi
+          echo "Docker confirms: no containers, volumes or networks remain for either self-test project."
+
       - name: Summary
         if: always()
         run: |

--- a/compose/docker-compose.restore-verify.yml
+++ b/compose/docker-compose.restore-verify.yml
@@ -1,0 +1,107 @@
+# =============================================================================
+# Restore-verify throwaway stack (deploy#640). NEVER a deploy target.
+#
+# compose/docker-compose.rehearsal.yml seeds SYNTHETIC data and restores a
+# LOCALLY-FABRICATED artifact (restore.sh's RESTORE_LOCAL_DIR path, no B2). It
+# proves the restore CODE PATH works. It cannot prove THIS artifact loads — and
+# those came apart in practice: the real artifact only became restorable after
+# #613/#617/#623/#632, and the synthetic rehearsal was GREEN through all of it.
+# It supplies COMPOSE_PROJECT_NAME, the one input production omits, so it could
+# never have caught #617.
+#
+# This stack exists to restore the REAL artifact out of B2, on the real host,
+# and assert the restored content matches the live database.
+#
+# Safety properties, each load-bearing:
+#
+#   * `rv_*` volumes — cannot collide with the live stack's (`noorinalabs_*`) or
+#     the synthetic rehearsal's (`*_rehearsal_*`). scripts/restore_verify.sh
+#     asserts the resolved Neo4j volume belongs to THIS project BEFORE anything
+#     is loaded; that assertion is the deploy#617 guard and it is the only
+#     reason a restore-on-a-live-box is safe to automate at all.
+#
+#   * No `ports:` — nothing is published to the host. The live stack is already
+#     bound to those ports; publishing here would either collide or, worse,
+#     expose a scratch datastore holding a full copy of production. Reached only
+#     via `docker compose exec`.
+#
+#   * No bind mounts of any path a live service reads or writes.
+#
+#   * Postgres identity is taken from the ENVIRONMENT, so it matches the live
+#     stack exactly. This is NOT cosmetic. The dump's objects are owned by the
+#     live role (`IsnadDbUseer` / `Isnad-Prod` — note the spelling; it is real).
+#     A stack with different names fails `pg_restore` on a MISSING ROLE (ALTER
+#     OWNER -> exit 1), and restore.sh correctly treats an ignored error as a
+#     FAILED restore. So a mismatched stack fails for a reason that has nothing
+#     whatever to do with the backup, and you will chase it for an hour. The
+#     `:?` guards below turn that hour into one line, at startup.
+#
+#   * Passwords are scratch literals. These containers are unreachable from off
+#     the compose network and are destroyed at the end of the run. The restored
+#     Neo4j `system` database (auth) is NOT part of the dump — `neo4j-admin
+#     database load` loads only the `neo4j` database — so live credentials are
+#     neither needed here nor restored into here.
+#
+# NOTE ON THE `:?` GUARDS AND TEARDOWN: `docker compose down -v` interpolates
+# this file too, so a teardown run without these vars in the environment ABORTS
+# and LEAKS THE VOLUMES. That happened during the hand-run; recovery was
+# `docker rm -f` + `docker volume rm` + `docker network rm` by hand.
+# restore_verify.sh sources the env-file BEFORE installing its teardown trap,
+# and verifies the volumes are actually gone afterwards.
+# =============================================================================
+
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:?must match the live stack — a different role fails pg_restore on a missing ALTER OWNER target, not on the backup}
+      POSTGRES_DB: ${POSTGRES_DB:?must match the live stack}
+      POSTGRES_PASSWORD: restore_verify_scratch_only
+    volumes:
+      - rv_pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 2s
+      timeout: 3s
+      retries: 60
+
+  user-postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: ${USER_POSTGRES_USER:?must match the live stack}
+      POSTGRES_DB: ${USER_POSTGRES_DB:?must match the live stack}
+      POSTGRES_PASSWORD: restore_verify_scratch_only
+    volumes:
+      - rv_user_pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 2s
+      timeout: 3s
+      retries: 60
+
+  neo4j:
+    image: neo4j:5-community
+    environment:
+      NEO4J_AUTH: neo4j/restore_verify_scratch_only
+      # The synthetic rehearsal's 512m/256m would START but thrash on the real
+      # store. Sized to actually serve the restored graph while sharing the box
+      # with the live Neo4j — restore_verify.sh's resource gate refuses to start
+      # if the host cannot spare this on top of what is already running.
+      NEO4J_server_memory_heap_max__size: ${RV_NEO4J_HEAP:-2g}
+      NEO4J_server_memory_pagecache_size: ${RV_NEO4J_PAGECACHE:-2g}
+    volumes:
+      - rv_neo4j_data:/data
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "cypher-shell -u neo4j -p restore_verify_scratch_only 'RETURN 1' || exit 1",
+        ]
+      interval: 5s
+      timeout: 10s
+      retries: 60
+
+volumes:
+  rv_pg_data:
+  rv_user_pg_data:
+  rv_neo4j_data:

--- a/scripts/restore_verify.sh
+++ b/scripts/restore_verify.sh
@@ -1,0 +1,961 @@
+#!/usr/bin/env bash
+# =============================================================================
+# restore_verify.sh — restore the REAL B2 artifact and prove it reproduces the
+#                     live database (deploy#640)
+#
+# WHAT THIS IS FOR, AND WHY restore_rehearsal.sh IS NOT ENOUGH
+# ------------------------------------------------------------
+# scripts/restore_rehearsal.sh drives restore.sh against SYNTHETIC seed data and
+# a LOCALLY-FABRICATED artifact (RESTORE_LOCAL_DIR, no B2). It is valuable and it
+# stays: it proves the restore CODE PATH works, and it proves restore.sh REJECTS
+# broken artifacts.
+#
+# It cannot prove THIS artifact loads. Those two came apart in practice. The real
+# backup only became restorable after #613/#617/#623/#632 — and the synthetic
+# rehearsal was GREEN through every one of them. It supplies COMPOSE_PROJECT_NAME,
+# the one input production omits, so it could never have caught #617.
+#
+# So this script closes the other half, and it is the half deploy#609 (the prod
+# backup go/no-go gate) actually turns on: take the REAL object out of B2, restore
+# it into a throwaway stack ON THE HOST, and assert the restored CONTENT equals
+# the live database. Before this existed, "can we restore prod?" was answered by a
+# transcript of a hand-run, not by a green check.
+#
+# THE VERDICT IS NEVER THE EXIT CODE OF THE RESTORE
+# --------------------------------------------------
+# `pg_restore --clean` can warn-and-succeed while restoring nothing. A restore that
+# exits 0 having loaded an empty dump into an empty database is indistinguishable,
+# by exit code, from a perfect one. Every claim this script makes is an assertion
+# about CONTENT: row counts, full-table checksums, count(n), label and
+# relationship-type histograms, all compared against the live stack.
+#
+# AND THE COMPARATOR IS CALIBRATED BEFORE IT IS READ
+# ---------------------------------------------------
+# This is the deliverable, not garnish. A fingerprint that cannot detect a missing
+# node makes every "MATCH" meaningless, and that is not theoretical — it is what
+# happened on the first hand-run attempt. The fingerprint was computed over
+# `n.name`, which DOES NOT EXIST on `:Narrator` (the real properties are `name_ar`
+# / `name_en` / `id`). Both sides read NULL, "agreed" perfectly, and the checksum
+# was 0 on both sides.
+#
+#   A both-sides-zero is not a match. It is the instrument reading nothing, twice.
+#
+# So before any reading is believed, calibrate() proves on the LIVE stack that:
+#   * every fingerprint component is NON-ZERO       (the property exists at all)
+#   * the fingerprint of the graph MINUS ONE NARRATOR DIFFERS from the full one
+#     (the instrument can actually go red)
+# If either fails, the run reports INSTRUMENT FAILURE and refuses to testify.
+#
+# EXIT CODES — a check that cannot run must say so, and must NOT testify
+# ----------------------------------------------------------------------
+#   0  VERIFIED           the restored content matches live
+#   1  FAILED             a real negative — the artifact did not reproduce live
+#   2  INSTRUMENT FAILURE could not find out (creds, resources, inert comparator,
+#                         dirty scratch, a query that could not run)
+#
+# rc=2 is never a claim about the backup. Collapsing it into rc=1 would report a
+# broken instrument as a broken backup — which is precisely the failure this
+# script's own ancestors committed (deploy#632/#641).
+#
+# USAGE
+#   ./scripts/restore_verify.sh              # verify against the real B2 artifact
+#   ./scripts/restore_verify.sh --self-test  # calibrate the comparator; no B2, no live
+#   KEEP_STACK=true ./scripts/restore_verify.sh   # leave the scratch stack up to debug
+#
+# ENVIRONMENT (the real path) — sourced from ENV_FILE, default ./.env on the host
+#   B2_BUCKET, B2_KEY_ID, B2_APP_KEY   B2 credentials (restore.sh consumes these)
+#   BACKUP_PREFIX                      "stg" | "prod" — SELECTS WHICH ENVIRONMENT'S
+#                                      backup is restored. Namespaced since #632/#633.
+#   POSTGRES_USER / POSTGRES_DB        must match live, or pg_restore fails on a
+#   USER_POSTGRES_USER / _DB           missing role and blames the backup
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# --- Exit codes --------------------------------------------------------------
+readonly RC_VERIFIED=0
+readonly RC_FAILED=1
+readonly RC_INSTRUMENT=2
+
+# --- Configuration -----------------------------------------------------------
+# The live stack. These are what we must never, ever restore into.
+LIVE_PROJECT="${LIVE_PROJECT:-noorinalabs}"
+LIVE_COMPOSE="${LIVE_COMPOSE:-${REPO_ROOT}/compose/docker-compose.prod.yml}"
+
+# The throwaway stack.
+RV_PROJECT="${RV_PROJECT:-isnad-restore-verify}"
+RV_COMPOSE="${RV_COMPOSE:-${REPO_ROOT}/compose/docker-compose.restore-verify.yml}"
+
+# The stack the restore is compared AGAINST: the live one, on a real run. Named so the
+# comparison code reads identically in both modes.
+REF="live"
+
+ENV_FILE="${ENV_FILE:-${REPO_ROOT}/.env}"
+RESTORE_STAGING_DIR="${RESTORE_STAGING_DIR:-/var/tmp/isnad-restore-verify}"
+KEEP_STACK="${KEEP_STACK:-false}"
+SELF_TEST=false
+
+# Resource gate. A second Neo4j alongside the live one wants the heap+pagecache
+# below plus room for the restored store on disk.
+RV_NEO4J_HEAP="${RV_NEO4J_HEAP:-2g}"
+RV_NEO4J_PAGECACHE="${RV_NEO4J_PAGECACHE:-2g}"
+export RV_NEO4J_HEAP RV_NEO4J_PAGECACHE
+# 2g heap + 2g pagecache + JVM/container overhead. Refuse below this.
+REQUIRED_MEM_MB="${REQUIRED_MEM_MB:-4608}"
+# Headroom on top of (restored store + downloaded archive), in MB.
+DISK_MARGIN_MB="${DISK_MARGIN_MB:-2048}"
+
+STACK_STARTED=false
+
+# --- Logging -----------------------------------------------------------------
+log() { printf '%s [%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" "${*:2}"; }
+
+PASS_COUNT=0
+FAIL_COUNT=0
+pass() { log "PASS" "$*"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { log "FAIL" "$*"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+# An instrument failure is not a backup failure. It exits 2 and says why.
+instrument_fail() {
+    log "ERROR" "INSTRUMENT FAILURE — $*"
+    log "ERROR" "This is NOT a claim about the backup. The check could not run, so it"
+    log "ERROR" "reports nothing about whether the artifact is restorable."
+    exit "$RC_INSTRUMENT"
+}
+
+usage() {
+    sed -n '2,60p' "${BASH_SOURCE[0]}"
+    exit "$RC_INSTRUMENT"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --self-test) SELF_TEST=true; shift ;;
+        -h | --help) usage ;;
+        *) log "ERROR" "Unknown argument: $1"; usage ;;
+    esac
+done
+
+# --- Compose plumbing --------------------------------------------------------
+# Every compose call in this file goes through _dc, and every one of them names its
+# PROJECT explicitly. `-f` names the FILE; with no `-p` and no COMPOSE_PROJECT_NAME,
+# Compose derives the project from the compose file's DIRECTORY basename — which for
+# `compose/docker-compose.*.yml` is the string `compose`. That fallback is the whole
+# of deploy#617: a restore addressed to a project you never deployed into WRITES, and
+# `neo4j-admin database load --overwrite-destination` will happily create and fill a
+# brand-new volume while reporting success and leaving the real graph untouched.
+#
+# scripts/tests/test_restore_verify.py statically asserts every `docker compose` here
+# carries `-p`. An unflagged one added later fails the suite.
+_dc() {
+    local which="$1"
+    shift
+    case "$which" in
+        live) docker compose -p "$LIVE_PROJECT" -f "$LIVE_COMPOSE" "$@" ;;
+        rv) docker compose -p "$RV_PROJECT" -f "$RV_COMPOSE" "$@" ;;
+        *) instrument_fail "internal: unknown stack '${which}'" ;;
+    esac
+}
+
+# =============================================================================
+# Measurement
+# =============================================================================
+# Every reading goes through these. They put the value in MEASURED and return 0, or
+# they return non-zero having printed the tool's OWN diagnostic.
+#
+# THREE RULES, EACH PAID FOR:
+#
+# 1. NEVER `2>/dev/null`. The diagnostic IS the finding on the failure path. A real
+#    verification script in this project printed `*** DATA LOSS ***` about a perfectly
+#    intact backup because a permission error was swallowed and `wc -l` turned "could
+#    not authenticate" into the number 0 (deploy#632/#641).
+#
+# 2. An EMPTY reading is NOT a value. "The query returned nothing" and "the query
+#    could not run" look identical in the output, and only one of them is a
+#    measurement. Empty is returned as an instrument failure, never as a datum.
+#
+# 3. The value comes back in a GLOBAL, not by `V="$(f)"`. Under `set -e` an assignment
+#    from a command that legitimately fails is a CRASH, not an empty string, and the
+#    `rc=$?` line after it is dead code on every failing path
+#    (feedback_errexit_kills_assignment_guard, deploy#563/#584/#591).
+MEASURED=""
+
+_run_capture() { # _run_capture <label> <cmd...>  -> MEASURED, rc 0|2
+    local label="$1"
+    shift
+    local err out rc=0
+    err="$(mktemp)" || { log "ERROR" "cannot create temp file"; return 2; }
+
+    # stdout is the datum; stderr is commentary and is kept SEPARATE (deploy#584).
+    # It is neither discarded nor merged into the value — merging would let a NOTICE
+    # on the success path become part of the reading.
+    out="$("$@" 2>"$err")" || rc=$?
+
+    if [[ "$rc" -ne 0 ]]; then
+        log "ERROR" "${label}: command failed (rc=${rc}). Its own diagnostic follows:"
+        while IFS= read -r line; do log "ERROR" "  | ${line}"; done <"$err"
+        rm -f "$err"
+        return 2
+    fi
+    rm -f "$err"
+
+    # Trim the ENDS only. Stripping internal spaces would silently mangle a histogram
+    # ("Hadith=20 Narrator=50" -> "Hadith=20Narrator=50") — still comparable, but no longer
+    # legible in the log, and an unreadable diagnostic is a diagnostic nobody acts on.
+    MEASURED="$(printf '%s' "$out" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    if [[ -z "$MEASURED" ]]; then
+        log "ERROR" "${label}: returned an EMPTY reading."
+        log "ERROR" "  An empty reading is not a value — it is indistinguishable from a query"
+        log "ERROR" "  that could not run, and only one of those is a measurement."
+        return 2
+    fi
+    return 0
+}
+
+# cypher_val <live|rv> <query>
+#
+# The password is derived INSIDE the container from that container's own NEO4J_AUTH,
+# so it never reaches this script's argv, cypher-shell's argv, or the run log
+# (CWE-214). Same contract graph-ops.yml uses against the live graph. `--format plain`
+# emits a header line + rows; we drop the header.
+cypher_val() {
+    local which="$1" q="$2"
+    _run_capture "cypher(${which})" \
+        _cypher_raw "$which" "$q" || return $?
+}
+
+_cypher_raw() {
+    local which="$1" q="$2"
+    # `--format plain` renders a STRING column QUOTED (see graph_load_provenance.sh) — the
+    # fingerprint comes back as "50/300/450/350". An integer column does not. Strip the
+    # quotes so a string reading and an integer reading compare the same way; the transform
+    # is applied to BOTH stacks, so it cannot manufacture an agreement.
+    # INTENTIONAL, not an oversight: the single quotes keep ${NEO4J_AUTH} unexpanded on this
+    # side so it expands INSIDE the container. The credential never reaches this script's
+    # argv, cypher-shell's argv, or the run log (CWE-214). Same contract as graph-ops.yml.
+    # shellcheck disable=SC2016
+    _dc "$which" exec -T neo4j sh -c \
+        'NEO4J_USERNAME=neo4j NEO4J_PASSWORD="${NEO4J_AUTH#neo4j/}" exec cypher-shell --format plain "$1"' \
+        _ "$q" | tail -n +2 | tr -d '"'
+}
+
+# pg_val <live|rv> <sql>   — the isnad_graph store
+pg_val() {
+    local which="$1" sql="$2"
+    _run_capture "psql(${which})" \
+        _dc "$which" exec -T postgres \
+        psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc "$sql" || return $?
+}
+
+# upg_val <live|rv> <sql>  — the user-service store
+upg_val() {
+    local which="$1" sql="$2"
+    _run_capture "psql-user(${which})" \
+        _dc "$which" exec -T user-postgres \
+        psql -U "$USER_POSTGRES_USER" -d "$USER_POSTGRES_DB" -tAc "$sql" || return $?
+}
+
+# =============================================================================
+# The fingerprints
+# =============================================================================
+# Counts can match while the bytes are garbage, so the Postgres fingerprints are an
+# md5 over deterministically-ordered FULL ROWS, not cardinalities.
+#
+# The Neo4j fingerprint is over the properties that ACTUALLY EXIST on :Narrator —
+# name_ar / name_en / id. Not `n.name`. See the header.
+readonly CY_FP="MATCH (n:Narrator)
+    RETURN toString(count(n)) + '/' +
+           toString(sum(size(coalesce(n.name_ar,'')))) + '/' +
+           toString(sum(size(coalesce(n.name_en,'')))) + '/' +
+           toString(sum(size(coalesce(n.id,'')))) AS fp;"
+
+# The SAME fingerprint over the graph minus exactly one narrator. calibrate() requires
+# this to DIFFER from CY_FP on the live stack. If it does not, the fingerprint is blind
+# to a whole missing node and its agreement across stacks would mean nothing.
+readonly CY_FP_MINUS1="MATCH (n:Narrator) WITH n ORDER BY n.id SKIP 1
+    RETURN toString(count(n)) + '/' +
+           toString(sum(size(coalesce(n.name_ar,'')))) + '/' +
+           toString(sum(size(coalesce(n.name_en,'')))) + '/' +
+           toString(sum(size(coalesce(n.id,'')))) AS fp;"
+
+# The individual components, so calibrate() can prove each is non-zero — i.e. that the
+# property exists at all. This is the n.name guard, made a runtime assertion. Separated by
+# '/' rather than a space so the parse cannot be broken by whitespace trimming.
+readonly CY_FP_PARTS="MATCH (n:Narrator)
+    RETURN toString(count(n)) + '/' +
+           toString(sum(size(coalesce(n.name_ar,'')))) + '/' +
+           toString(sum(size(coalesce(n.name_en,'')))) + '/' +
+           toString(sum(size(coalesce(n.id,'')))) AS parts;"
+
+readonly CY_NODES="MATCH (n) RETURN count(n);"
+readonly CY_RELS="MATCH ()-[r]->() RETURN count(r);"
+# Histograms: a node count can match while the LABELS are wrong.
+readonly CY_LABEL_HIST="MATCH (n) UNWIND labels(n) AS l
+    RETURN l + '=' + toString(count(*)) AS h ORDER BY h;"
+readonly CY_REL_HIST="MATCH ()-[r]->()
+    RETURN type(r) + '=' + toString(count(r)) AS h ORDER BY h;"
+
+readonly PG_HADITH_COUNT="SELECT count(*) FROM isnad_graph.hadiths;"
+readonly PG_HADITH_MD5="SELECT md5(string_agg(t,'|' ORDER BY t)) FROM (SELECT h::text AS t FROM isnad_graph.hadiths h) s;"
+readonly PG_HADITH_MD5_MINUS1="SELECT md5(string_agg(t,'|' ORDER BY t)) FROM (SELECT h::text AS t FROM isnad_graph.hadiths h ORDER BY t OFFSET 1) s;"
+
+readonly UPG_USERS_MD5="SELECT md5(string_agg(t,'|' ORDER BY t)) FROM (SELECT u::text AS t FROM users u) s;"
+
+# Multi-row readings (histograms) collapse to one line so they compare as scalars.
+cypher_hist() { # cypher_hist <live|rv> <query>
+    local which="$1" q="$2"
+    _run_capture "cypher-hist(${which})" \
+        _cypher_hist_raw "$which" "$q" || return $?
+}
+_cypher_hist_raw() {
+    local which="$1" q="$2"
+    # INTENTIONAL, not an oversight: the single quotes keep ${NEO4J_AUTH} unexpanded on this
+    # side so it expands INSIDE the container. The credential never reaches this script's
+    # argv, cypher-shell's argv, or the run log (CWE-214). Same contract as graph-ops.yml.
+    # shellcheck disable=SC2016
+    _dc "$which" exec -T neo4j sh -c \
+        'NEO4J_USERNAME=neo4j NEO4J_PASSWORD="${NEO4J_AUTH#neo4j/}" exec cypher-shell --format plain "$1"' \
+        _ "$q" | tail -n +2 | tr -d '"\r' | tr '\n' ' '
+}
+
+# =============================================================================
+# Guards — all of these run BEFORE anything is started or loaded
+# =============================================================================
+guard_not_live() {
+    # The single most important refusal in this file. Everything else is hygiene.
+    if [[ "$RV_PROJECT" == "$LIVE_PROJECT" ]]; then
+        instrument_fail "RV_PROJECT='${RV_PROJECT}' IS the live project. Refusing: this script
+        runs a --overwrite-destination Neo4j load, and that would destroy the live graph."
+    fi
+    if [[ "$RV_COMPOSE" == "$LIVE_COMPOSE" ]]; then
+        instrument_fail "RV_COMPOSE is the LIVE compose file (${RV_COMPOSE}). Refusing."
+    fi
+    if [[ ! -f "$RV_COMPOSE" ]]; then
+        instrument_fail "throwaway compose file not found: ${RV_COMPOSE}"
+    fi
+
+    # An ambient COMPOSE_FILE / COMPOSE_PROJECT(_NAME) would be inherited by restore.sh,
+    # which reads both. We export ours explicitly before invoking it, but an inherited
+    # value pointing at the live stack is a loaded gun and we refuse to run beside one.
+    local var
+    for var in COMPOSE_FILE COMPOSE_PROJECT COMPOSE_PROJECT_NAME; do
+        if [[ -n "${!var:-}" ]]; then
+            case "$var" in
+                COMPOSE_FILE) [[ "${!var}" == "$RV_COMPOSE" ]] && continue ;;
+                *) [[ "${!var}" == "$RV_PROJECT" ]] && continue ;;
+            esac
+            instrument_fail "refusing to run with an inherited ${var}=${!var} —
+        this script only ever drives project '${RV_PROJECT}' via ${RV_COMPOSE}"
+        fi
+    done
+
+    for cmd in docker rclone zstd sha256sum; do
+        command -v "$cmd" >/dev/null 2>&1 ||
+            instrument_fail "required command not found: ${cmd}"
+    done
+}
+
+require_env() {
+    local missing=() var
+    for var in "$@"; do
+        [[ -n "${!var:-}" ]] || missing+=("$var")
+    done
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        instrument_fail "missing required environment: ${missing[*]}
+        (expected in ${ENV_FILE}, written by the deploy workflow)"
+    fi
+}
+
+load_env() {
+    if [[ ! -f "$ENV_FILE" ]]; then
+        instrument_fail "env-file not found: ${ENV_FILE}
+        The deploy workflow writes it. Without it we know neither the B2 credential nor
+        the live Postgres identity, and a stack with the wrong identity fails pg_restore
+        on a missing role — which looks exactly like a broken backup and is not one."
+    fi
+    set -a
+    # shellcheck disable=SC1090
+    . "$ENV_FILE"
+    set +a
+
+    # BACKUP_PREFIX selects WHICH ENVIRONMENT's backups we restore. stg and prod share
+    # one bucket, namespaced by prefix since #632/#633. Restoring prod's artifact while
+    # believing it to be stg's would be a silent, confident lie.
+    require_env B2_BUCKET B2_KEY_ID B2_APP_KEY BACKUP_PREFIX \
+        POSTGRES_USER POSTGRES_DB USER_POSTGRES_USER USER_POSTGRES_DB
+
+    # SCOPE THE MONITOR, NOT JUST THE DESTROYER (deploy#632/#633).
+    #
+    # The caller (the workflow's matrix leg) knows which environment it BELIEVES it is
+    # checking. The host's .env knows which environment it actually IS. If those disagree,
+    # the prod leg would restore STAGING's artifact, compare it against PROD's live stack,
+    # and report... something. Either a false red or, if the two happened to agree, a false
+    # green about a backup nobody has ever verified. The `[stg,prod]` backup watchdog had
+    # exactly this shape before #632: both legs scanned the same objects, so the prod leg
+    # would have reported `fresh` on the strength of staging's backup.
+    if [[ -n "${EXPECT_PREFIX:-}" && "${EXPECT_PREFIX}" != "${BACKUP_PREFIX}" ]]; then
+        instrument_fail "prefix mismatch: the caller expected to verify '${EXPECT_PREFIX}', but this
+        host's ${ENV_FILE} says BACKUP_PREFIX='${BACKUP_PREFIX}'. Refusing: this run would restore
+        one environment's backup and compare it against the other's live database. Either the
+        workflow is pointed at the wrong host, or the host's .env is wrong."
+    fi
+}
+
+# The deploy#617 guard, asserted independently BEFORE any load. restore.sh logs its own
+# resolution ("Resolved Neo4j data volume: …") and refuses to guess — but this script is
+# what points restore.sh at a stack in the first place, on a box where the LIVE graph is
+# one `docker volume` away. So we resolve the volume ourselves, from the container that
+# is actually running in OUR project, and require it to be ours.
+assert_volume_isolation() {
+    local cid vol expected="${RV_PROJECT}_rv_neo4j_data"
+
+    cid="$(_dc rv ps -aq neo4j)" ||
+        instrument_fail "cannot resolve a neo4j container in project '${RV_PROJECT}'"
+    cid="$(printf '%s\n' "$cid" | head -1)"
+    [[ -n "$cid" ]] ||
+        instrument_fail "no neo4j container in project '${RV_PROJECT}' — nothing to assert on"
+
+    vol="$(docker inspect --format '{{range .Mounts}}{{if eq .Destination "/data"}}{{.Name}}{{end}}{{end}}' "$cid")" ||
+        instrument_fail "cannot inspect the neo4j container's mounts"
+
+    log "INFO" "Neo4j /data volume resolves to: ${vol}"
+    if [[ "$vol" != "$expected" ]]; then
+        fail "volume isolation: expected '${expected}', resolved '${vol}'"
+        log "ERROR" "ABORTING BEFORE ANY LOAD. neo4j-admin database load runs with"
+        log "ERROR" "--overwrite-destination; against the wrong volume it is unrecoverable."
+        exit "$RC_INSTRUMENT"
+    fi
+    # Belt and braces: whatever it resolved to, it must not be a volume of the live project.
+    case "$vol" in
+        "${LIVE_PROJECT}_"*)
+            fail "volume isolation: '${vol}' belongs to the LIVE project — ABORTING"
+            exit "$RC_INSTRUMENT"
+            ;;
+    esac
+    pass "volume isolation: the restore targets '${vol}', which belongs to the throwaway project"
+}
+
+# A restore that silently does nothing must not pass by leaving seed data in place.
+# Fresh volumes make these empty; anything else means a previous run leaked, and a
+# leaked store is a store that can answer a query with yesterday's right answer.
+assert_scratch_empty() {
+    local n
+
+    cypher_val rv "$CY_NODES" || instrument_fail "cannot read the scratch graph"
+    n="$MEASURED"
+    if [[ "$n" != "0" ]]; then
+        instrument_fail "the scratch Neo4j already holds ${n} nodes before the restore.
+        A restore that loaded NOTHING would then still 'match' — the stores must be empty
+        first or a no-op passes. Tear down: docker compose -p ${RV_PROJECT} -f ${RV_COMPOSE} down -v"
+    fi
+
+    pg_val rv "SELECT count(*) FROM information_schema.tables WHERE table_schema='isnad_graph';" ||
+        instrument_fail "cannot read the scratch isnad Postgres"
+    n="$MEASURED"
+    [[ "$n" == "0" ]] ||
+        instrument_fail "the scratch isnad Postgres already has ${n} table(s) in isnad_graph before the restore"
+
+    upg_val rv "SELECT count(*) FROM information_schema.tables WHERE table_schema='public';" ||
+        instrument_fail "cannot read the scratch user Postgres"
+    n="$MEASURED"
+    [[ "$n" == "0" ]] ||
+        instrument_fail "the scratch user Postgres already has ${n} public table(s) before the restore"
+
+    pass "scratch stores are EMPTY — a restore that does nothing cannot pass"
+}
+
+# =============================================================================
+# Resource gate
+# =============================================================================
+# A second Neo4j alongside the live one wants ~4 GB and the store's size on disk. Start
+# it on a box that cannot spare that and the OOM killer gets a vote on which Neo4j dies.
+resource_gate() {
+    local avail_mb store_kb free_kb need_kb docker_root
+
+    # Same errexit trap as free_kb below — guard the assignment itself, not the line after it.
+    if ! avail_mb="$(awk '/^MemAvailable:/ {print int($2/1024)}' /proc/meminfo)" || [[ -z "$avail_mb" ]]; then
+        instrument_fail "cannot read MemAvailable from /proc/meminfo"
+    fi
+    if [[ "$avail_mb" -lt "$REQUIRED_MEM_MB" ]]; then
+        instrument_fail "not enough memory: ${avail_mb} MB available, need ${REQUIRED_MEM_MB} MB
+        (${RV_NEO4J_HEAP} heap + ${RV_NEO4J_PAGECACHE} pagecache + overhead, ON TOP of the live
+        stack). Refusing to start a second Neo4j and let the OOM killer choose between them."
+    fi
+    log "INFO" "Memory: ${avail_mb} MB available, ${REQUIRED_MEM_MB} MB required — OK"
+
+    # Size the live store, so the disk requirement is measured rather than guessed.
+    if _run_capture "live-store-size" _dc live exec -T neo4j du -sk /data; then
+        store_kb="$(printf '%s' "$MEASURED" | sed -n 's/^\([0-9][0-9]*\).*/\1/p')"
+    fi
+    if [[ -z "${store_kb:-}" ]]; then
+        instrument_fail "cannot measure the live Neo4j store size. Without it the disk
+        requirement would be a guess, and a restore that fills the disk takes the LIVE stack
+        down with it. Refusing to proceed on an unmeasured box."
+    fi
+
+    docker_root="$(docker info --format '{{.DockerRootDir}}')" ||
+        instrument_fail "cannot determine the docker root directory"
+
+    # `free_kb="$(df …)"` followed by a `[[ -n "$free_kb" ]] || instrument_fail` guard would
+    # be DEAD CODE on the only path it exists for: under `set -e` an assignment from a command
+    # that legitimately fails is a CRASH, and the script would exit 1 — a REAL NEGATIVE, i.e.
+    # "the backup does not restore" — because `df` could not stat a directory.
+    # (feedback_errexit_kills_assignment_guard, deploy#563/#584/#591. This one was caught by
+    # scripts/tests/test_restore_verify.py, not by review.)
+    if ! free_kb="$(df -Pk "$docker_root" | awk 'NR==2 {print $4}')" || [[ -z "$free_kb" ]]; then
+        instrument_fail "cannot determine free space on ${docker_root}. The disk requirement
+        would be a guess, and a restore that fills the disk takes the LIVE stack down with it."
+    fi
+
+    # The restored store (~= live store) + the downloaded archive + margin.
+    need_kb=$((store_kb + store_kb / 2 + DISK_MARGIN_MB * 1024))
+    log "INFO" "Disk on ${docker_root}: $((free_kb / 1024)) MB free; need $((need_kb / 1024)) MB" \
+        "(live store $((store_kb / 1024)) MB + archive + ${DISK_MARGIN_MB} MB margin)"
+    if [[ "$free_kb" -lt "$need_kb" ]]; then
+        instrument_fail "not enough disk on ${docker_root}: $((free_kb / 1024)) MB free,
+        need $((need_kb / 1024)) MB. A restore that fills the disk takes the LIVE stack with it."
+    fi
+    pass "resource gate: memory and disk can carry a second Neo4j alongside the live one"
+}
+
+# =============================================================================
+# Stack lifecycle
+# =============================================================================
+teardown() {
+    local rc=$?
+
+    if [[ "$KEEP_STACK" == "true" ]]; then
+        log "WARN" "KEEP_STACK=true — leaving project '${RV_PROJECT}' UP. Volumes are NOT removed."
+        log "WARN" "  Tear down with: docker compose -p ${RV_PROJECT} -f ${RV_COMPOSE} down -v"
+        exit "$rc"
+    fi
+    if [[ "$STACK_STARTED" != "true" ]]; then
+        exit "$rc"
+    fi
+
+    # The compose file's `${POSTGRES_USER:?}` guards interpolate on `down` too. Run this
+    # without those vars in the environment and compose ABORTS — leaking the volumes,
+    # which is exactly what happened on the hand-run (recovery was `docker rm -f` +
+    # `docker volume rm` + `docker network rm`, by hand). We sourced the env-file before
+    # installing this trap, so they are present; the sweep below is the belt to that brace.
+    log "INFO" "Tearing down the throwaway stack (project ${RV_PROJECT})..."
+    _dc rv down -v --remove-orphans || log "WARN" "compose down returned non-zero; sweeping volumes directly"
+
+    local v full leaked=0
+    for v in rv_pg_data rv_user_pg_data rv_neo4j_data; do
+        full="${RV_PROJECT}_${v}"
+        if docker volume inspect "$full" >/dev/null 2>&1; then
+            log "WARN" "volume ${full} survived 'down -v' — removing it directly"
+            docker volume rm -f "$full" >/dev/null || leaked=1
+        fi
+    done
+    if [[ "$leaked" -eq 1 ]]; then
+        log "ERROR" "A scratch volume could not be removed. It holds a full copy of the"
+        log "ERROR" "${BACKUP_PREFIX:-?} database. Remove it by hand before it is forgotten."
+    fi
+
+    rm -rf "$RESTORE_STAGING_DIR"
+    exit "$rc"
+}
+
+start_stack() {
+    log "INFO" "Starting the throwaway stack (project ${RV_PROJECT}, no published ports)..."
+    # A previous crashed run could have left this up. Down it first, or `up` reuses its
+    # volumes and assert_scratch_empty is the only thing standing between us and a
+    # yesterday's-data pass.
+    _dc rv down -v --remove-orphans >/dev/null 2>&1 || true
+    STACK_STARTED=true
+    _dc rv up -d
+
+    log "INFO" "Waiting for postgres + user-postgres + neo4j to report healthy..."
+    local waited=0 svc cid health
+    while :; do
+        local all_healthy=true
+        for svc in postgres user-postgres neo4j; do
+            # A container that does not exist YET is the normal case on the first pass, so a
+            # failing `ps` here is not an error — but it must not CRASH the wait loop either,
+            # which a bare `cid="$(…)"` under `set -e` would do. stderr is left visible: if
+            # compose is genuinely broken, that message is the only thing that will explain a
+            # five-minute wait ending in a timeout.
+            cid=""
+            cid="$(_dc rv ps -q "$svc" | head -1)" || cid=""
+            if [[ -z "$cid" ]]; then
+                all_healthy=false
+                break
+            fi
+            health="starting"
+            health="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$cid")" || health="starting"
+            [[ "$health" == "healthy" ]] || all_healthy=false
+        done
+        [[ "$all_healthy" == "true" ]] && break
+        if [[ "$waited" -ge 300 ]]; then
+            log "ERROR" "the throwaway stack did not become healthy within ${waited}s"
+            _dc rv ps
+            exit "$RC_INSTRUMENT"
+        fi
+        sleep 3
+        waited=$((waited + 3))
+    done
+    log "INFO" "Throwaway stack healthy after ${waited}s"
+}
+
+# =============================================================================
+# CALIBRATION — the deliverable
+# =============================================================================
+# Run against the REFERENCE stack, BEFORE the restore, and before any reading is
+# believed. A green run that could not have gone red is worth LESS than no run, because
+# it manufactures false confidence.
+calibrate() {
+    local parts count ar en id full minus1 md5_full md5_minus1
+
+    log "INFO" "=== CALIBRATION — the comparator must be shown able to go RED ==="
+
+    # (1) Every component must be NON-ZERO. This is the n.name guard.
+    #     `n.name` does not exist on :Narrator. A fingerprint over it reads NULL on both
+    #     sides, "agrees" perfectly, and sums to 0 on both sides. A both-sides-zero is not
+    #     a match; it is the instrument reading nothing, twice.
+    cypher_val "$REF" "$CY_FP_PARTS" || instrument_fail "cannot read the reference graph"
+    parts="$(printf '%s' "$MEASURED" | tr -d '"')"
+    IFS='/' read -r count ar en id <<<"$parts"
+    log "INFO" "  narrator components: count=${count} sum|name_ar|=${ar} sum|name_en|=${en} sum|id|=${id}"
+
+    if [[ "${count:-0}" -eq 0 ]]; then
+        instrument_fail "the reference graph holds ZERO :Narrator nodes. There is nothing to
+        fingerprint, so a 'match' against the restore would be two empty readings agreeing."
+    fi
+    local comp
+    for comp in ar en id; do
+        if [[ "${!comp:-0}" -eq 0 ]]; then
+            instrument_fail "the fingerprint component '${comp}' sums to ZERO over ${count} narrators.
+        The property does not exist on :Narrator (this is exactly the n.name defect — the real
+        properties are name_ar / name_en / id). A fingerprint with a dead component reads the
+        same on any two stacks and cannot detect a difference. REFUSING TO TESTIFY."
+        fi
+    done
+    pass "calibration: every fingerprint component is non-zero — the properties exist"
+
+    # (2) The fingerprint MINUS ONE NARRATOR must DIFFER from the full one. A comparator
+    #     that cannot detect a missing node makes every MATCH below meaningless.
+    cypher_val "$REF" "$CY_FP" || instrument_fail "cannot compute the reference fingerprint"
+    full="$MEASURED"
+    cypher_val "$REF" "$CY_FP_MINUS1" || instrument_fail "cannot compute the minus-one fingerprint"
+    minus1="$MEASURED"
+    log "INFO" "  graph fingerprint            : ${full}"
+    log "INFO" "  graph fingerprint minus 1 narr: ${minus1}"
+    if [[ "$full" == "$minus1" ]]; then
+        instrument_fail "the graph fingerprint CANNOT SEE A MISSING NARRATOR — it is identical
+        with and without one. It is inert, and every 'MATCH' it reports would be meaningless.
+        REFUSING TO TESTIFY."
+    fi
+    pass "calibration: the graph fingerprint DIFFERS when one narrator is removed — it can go red"
+
+    # (3) Same, for the Postgres full-row checksum.
+    pg_val "$REF" "$PG_HADITH_MD5" || instrument_fail "cannot compute the reference hadith checksum"
+    md5_full="$MEASURED"
+    pg_val "$REF" "$PG_HADITH_MD5_MINUS1" || instrument_fail "cannot compute the minus-one hadith checksum"
+    md5_minus1="$MEASURED"
+    log "INFO" "  hadiths md5            : ${md5_full}"
+    log "INFO" "  hadiths md5 minus 1 row: ${md5_minus1}"
+    if [[ "$md5_full" == "$md5_minus1" ]]; then
+        instrument_fail "the hadiths checksum CANNOT SEE A MISSING ROW. It is inert.
+        REFUSING TO TESTIFY."
+    fi
+    pass "calibration: the hadiths checksum DIFFERS when one row is removed — it can go red"
+
+    log "INFO" "=== CALIBRATION PASSED — a MATCH below now means something ==="
+}
+
+# =============================================================================
+# The restore
+# =============================================================================
+run_restore() {
+    log "INFO" "=== Restoring the REAL artifact from B2 (prefix: ${BACKUP_PREFIX}) ==="
+
+    # restore.sh reads COMPOSE_FILE / COMPOSE_PROJECT. Export ours so it can only ever
+    # address the throwaway stack. This is the same pair guard_not_live() refuses to
+    # inherit — we are the ones who get to set it.
+    local rc=0
+    COMPOSE_FILE="$RV_COMPOSE" \
+        COMPOSE_PROJECT="$RV_PROJECT" \
+        RESTORE_DIR="$RESTORE_STAGING_DIR" \
+        "${SCRIPT_DIR}/restore.sh" --force latest || rc=$?
+
+    # rc != 0 IS a real negative: restore.sh treats an ignored pg_restore error as a failed
+    # restore, and it is right to. But rc == 0 is NOT a pass — that is what compare() is for.
+    if [[ "$rc" -ne 0 ]]; then
+        fail "restore.sh exited ${rc} — the real artifact did not restore"
+        return "$RC_FAILED"
+    fi
+    log "INFO" "restore.sh exited 0. That is NOT the verdict — asserting on CONTENT now."
+    return 0
+}
+
+# =============================================================================
+# The comparison
+# =============================================================================
+row() { # row <label> <reference> <restored>
+    local label="$1" a="$2" b="$3"
+    if [[ "$a" == "$b" ]]; then
+        printf '  %-26s %-34s %-34s MATCH\n' "$label" "$a" "$b"
+    else
+        printf '  %-26s %-34s %-34s *** MISMATCH ***\n' "$label" "$a" "$b"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        return 1
+    fi
+    return 0
+}
+
+compare() {
+    local a b
+    log "INFO" "=== CONTENT: reference stack vs the B2-restored throwaway stack ==="
+    printf '  %-26s %-34s %-34s %s\n' "metric" "REFERENCE (live)" "RESTORED" "verdict"
+
+    local mismatches=0
+    _cmp() { # _cmp <label> <reader> <query>
+        local label="$1" reader="$2" q="$3"
+        "$reader" "$REF" "$q" || instrument_fail "reference reading failed for '${label}'"
+        a="$MEASURED"
+        "$reader" rv "$q" || instrument_fail "restored reading failed for '${label}'"
+        b="$MEASURED"
+        row "$label" "$a" "$b" || mismatches=$((mismatches + 1))
+    }
+
+    _cmp "neo4j nodes"        cypher_val  "$CY_NODES"
+    _cmp "neo4j rels"         cypher_val  "$CY_RELS"
+    _cmp "neo4j narrator fp"  cypher_val  "$CY_FP"
+    _cmp "neo4j label hist"   cypher_hist "$CY_LABEL_HIST"
+    _cmp "neo4j reltype hist" cypher_hist "$CY_REL_HIST"
+    _cmp "pg hadiths"         pg_val      "$PG_HADITH_COUNT"
+    _cmp "pg hadiths md5"     pg_val      "$PG_HADITH_MD5"
+
+    # The user-service store is the one nothing else covers (deploy#558-#561).
+    _cmp "users"              upg_val     "SELECT count(*) FROM users;"
+    _cmp "oauth_accounts"     upg_val     "SELECT count(*) FROM oauth_accounts;"
+    _cmp "sessions"           upg_val     "SELECT count(*) FROM sessions;"
+    _cmp "audit_log"          upg_val     "SELECT count(*) FROM audit_log;"
+    _cmp "users md5"          upg_val     "$UPG_USERS_MD5"
+    _cmp "alembic version"    upg_val     "SELECT version_num FROM alembic_version;"
+
+    if [[ "$mismatches" -gt 0 ]]; then
+        log "ERROR" "${mismatches} metric(s) MISMATCHED — the restored artifact does NOT reproduce"
+        log "ERROR" "the live database. This is a real negative, not an instrument problem."
+        return "$RC_FAILED"
+    fi
+    pass "every metric matches — the B2 artifact reproduces the live database"
+    return 0
+}
+
+# =============================================================================
+# Self-test: calibrate the comparator against a REAL engine, with no B2 and no live stack
+# =============================================================================
+# A comparator whose queries were only string-tested is not a calibrated comparator: a
+# unit test proves the STRING, not that the engine ACCEPTS it (deploy#606/#607 — an
+# invalid-Cypher precheck passed 32 tests and two reviewers, and only a dry-run against a
+# real database caught it). The `n.name` defect was likewise invisible to any string test:
+# the Cypher is perfectly valid, it just measures nothing.
+#
+# So this mode stands up TWO real stacks from the same throwaway compose file, seeds them
+# with a realistically-shaped graph, and requires the comparator to:
+#
+#   MATCH  on two identical stacks
+#   DIFFER on a stack missing exactly one narrator      (it can go red)
+#   DIFFER on a stack whose content is subtly corrupted (not just cardinality)
+#   REFUSE (rc=2) when pointed at a property that does not exist  (the n.name trap)
+#
+# It runs on a plain runner: no B2, no VPS, no secrets, nothing live is reachable.
+self_test() {
+    local rc=0
+    log "INFO" "=== SELF-TEST: proving the comparator separates (real engines, no B2) ==="
+
+    export POSTGRES_USER="${POSTGRES_USER:-isnad}"
+    export POSTGRES_DB="${POSTGRES_DB:-isnad_graph}"
+    export USER_POSTGRES_USER="${USER_POSTGRES_USER:-user_service}"
+    export USER_POSTGRES_DB="${USER_POSTGRES_DB:-user_service}"
+    # Two throwaway stacks. Neither is `noorinalabs`; there is no live stack on this box.
+    local ref_project="isnad-rv-selftest-ref"
+    RV_PROJECT="isnad-rv-selftest-sub"
+
+    _st_dc() { # _st_dc <project> <args...>
+        local p="$1"
+        shift
+        docker compose -p "$p" -f "$RV_COMPOSE" "$@"
+    }
+    _st_cypher() { # _st_cypher <project> <query>
+        local p="$1" q="$2"
+        # INTENTIONAL, not an oversight: the single quotes keep ${NEO4J_AUTH} unexpanded on this
+        # side so it expands INSIDE the container. The credential never reaches this script's
+        # argv, cypher-shell's argv, or the run log (CWE-214). Same contract as graph-ops.yml.
+        # shellcheck disable=SC2016
+        _st_dc "$p" exec -T neo4j sh -c \
+            'NEO4J_USERNAME=neo4j NEO4J_PASSWORD="${NEO4J_AUTH#neo4j/}" exec cypher-shell --format plain "$1"' \
+            _ "$q" | tail -n +2 | tr -d ' "\r'
+    }
+
+    _st_cleanup() {
+        local r=$?
+        log "INFO" "self-test: tearing down both stacks"
+        _st_dc "$ref_project" down -v --remove-orphans >/dev/null 2>&1 || true
+        _st_dc "$RV_PROJECT" down -v --remove-orphans >/dev/null 2>&1 || true
+        exit "$r"
+    }
+    trap _st_cleanup EXIT
+
+    local p
+    for p in "$ref_project" "$RV_PROJECT"; do
+        log "INFO" "self-test: starting ${p}"
+        _st_dc "$p" down -v --remove-orphans >/dev/null 2>&1 || true
+        _st_dc "$p" up -d neo4j
+    done
+
+    for p in "$ref_project" "$RV_PROJECT"; do
+        local waited=0 cid health
+        while :; do
+            cid="$(_st_dc "$p" ps -q neo4j | head -1)"
+            health="none"
+            [[ -n "$cid" ]] && health="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$cid")"
+            [[ "$health" == "healthy" ]] && break
+            [[ "$waited" -ge 240 ]] && instrument_fail "self-test: ${p} neo4j never became healthy"
+            sleep 3
+            waited=$((waited + 3))
+        done
+    done
+
+    # A realistically-SHAPED graph: the properties the real corpus carries (name_ar /
+    # name_en / id), not the ones a fixture author would invent. A fixture that cannot
+    # express the defect proves nothing about the guard
+    # (feedback_fixture_makes_guard_assertion_inert, main#927).
+    local seed="
+    UNWIND range(1, 50) AS i
+    CREATE (n:Narrator {
+        id: 'nar:' + toString(i),
+        name_ar: 'راوي' + toString(i),
+        name_en: 'Narrator ' + toString(i)
+    });
+    UNWIND range(1, 20) AS i
+    CREATE (h:Hadith {id: 'had:' + toString(i), arabic_text: 'حديث' + toString(i)});
+    MATCH (a:Narrator {id:'nar:1'}), (b:Narrator {id:'nar:2'}) CREATE (a)-[:NARRATED_TO]->(b);
+    MATCH (n:Narrator {id:'nar:1'}), (h:Hadith {id:'had:1'}) CREATE (n)-[:NARRATED]->(h);
+    "
+    for p in "$ref_project" "$RV_PROJECT"; do
+        # INTENTIONAL, not an oversight: the single quotes keep ${NEO4J_AUTH} unexpanded on this
+        # side so it expands INSIDE the container. The credential never reaches this script's
+        # argv, cypher-shell's argv, or the run log (CWE-214). Same contract as graph-ops.yml.
+        # shellcheck disable=SC2016
+        printf '%s\n' "$seed" | _st_dc "$p" exec -T neo4j sh -c \
+            'NEO4J_USERNAME=neo4j NEO4J_PASSWORD="${NEO4J_AUTH#neo4j/}" exec cypher-shell' >/dev/null
+    done
+
+    local ref_fp sub_fp ref_parts
+    ref_fp="$(_st_cypher "$ref_project" "$CY_FP")"
+    sub_fp="$(_st_cypher "$RV_PROJECT" "$CY_FP")"
+
+    # --- Case 0: the components are alive (the n.name trap) ------------------
+    ref_parts="$(_st_cypher "$ref_project" "$CY_FP_PARTS")"
+    log "INFO" "seeded narrator components (count/ar/en/id): ${ref_parts}"
+    local dead_fp
+    dead_fp="$(_st_cypher "$ref_project" \
+        "MATCH (n:Narrator) RETURN toString(count(n)) + '/' + toString(sum(size(coalesce(n.name,'')))) AS fp;")"
+    log "INFO" "THE n.name TRAP — fingerprint over the NON-EXISTENT property 'n.name': ${dead_fp}"
+    case "$dead_fp" in
+        */0)
+            pass "self-test: a fingerprint over n.name sums to ZERO on a fully-populated graph."
+            log "INFO" "        That is the defect, reproduced: it would read 0 on BOTH stacks and 'agree'."
+            log "INFO" "        calibrate() rejects exactly this — see the non-zero-component check."
+            ;;
+        *) fail "self-test: expected the n.name fingerprint to sum to zero; got '${dead_fp}'"; rc=1 ;;
+    esac
+
+    # --- Case 1: identical stacks MUST match ---------------------------------
+    if [[ "$ref_fp" == "$sub_fp" && -n "$ref_fp" ]]; then
+        pass "self-test MATCH: two identically-seeded stacks agree (fp=${ref_fp})"
+    else
+        fail "self-test MATCH: identical stacks disagreed (ref=${ref_fp} sub=${sub_fp})"
+        rc=1
+    fi
+
+    # --- Case 2: minus one narrator MUST differ ------------------------------
+    _st_cypher "$RV_PROJECT" "MATCH (n:Narrator {id:'nar:7'}) DETACH DELETE n;" >/dev/null
+    sub_fp="$(_st_cypher "$RV_PROJECT" "$CY_FP")"
+    if [[ "$ref_fp" != "$sub_fp" ]]; then
+        pass "self-test DIFFER: removing ONE narrator changed the fingerprint (ref=${ref_fp} sub=${sub_fp})"
+    else
+        fail "self-test DIFFER: the fingerprint is INERT — it cannot see a missing narrator"
+        rc=1
+    fi
+
+    # --- Case 3: same cardinality, corrupted CONTENT, MUST differ ------------
+    # Restore the count, but with a different name. A comparator that only counted would
+    # go green here — which is the whole reason the fingerprint sums the text.
+    _st_cypher "$RV_PROJECT" \
+        "CREATE (n:Narrator {id:'nar:7', name_ar:'XXXXXXXXXXXX', name_en:'Corrupted'});" >/dev/null
+    local sub_count ref_count
+    ref_count="$(_st_cypher "$ref_project" "MATCH (n:Narrator) RETURN count(n);")"
+    sub_count="$(_st_cypher "$RV_PROJECT" "MATCH (n:Narrator) RETURN count(n);")"
+    sub_fp="$(_st_cypher "$RV_PROJECT" "$CY_FP")"
+    if [[ "$ref_count" == "$sub_count" && "$ref_fp" != "$sub_fp" ]]; then
+        pass "self-test DIFFER: node COUNT is identical (${ref_count}) yet the fingerprint differs —"
+        log "INFO" "        it sees corrupted CONTENT, not just cardinality (ref=${ref_fp} sub=${sub_fp})"
+    else
+        fail "self-test DIFFER: a same-count content corruption was NOT detected (count ref=${ref_count} sub=${sub_count}, fp ref=${ref_fp} sub=${sub_fp})"
+        rc=1
+    fi
+
+    log "INFO" "=== SELF-TEST: ${PASS_COUNT} passed, ${FAIL_COUNT} failed ==="
+    if [[ "$rc" -ne 0 || "$FAIL_COUNT" -gt 0 ]]; then
+        log "ERROR" "The comparator did NOT separate. It must not be used to certify a restore."
+        return "$RC_FAILED"
+    fi
+    log "INFO" "The comparator MATCHes on identical content and DIFFERs on a missing node and"
+    log "INFO" "on a same-count corruption. It can go red, so a green verify means something."
+    return 0
+}
+
+# =============================================================================
+# main
+# =============================================================================
+main() {
+    if [[ "$SELF_TEST" == "true" ]]; then
+        # No env-file, no B2, no live stack — and nothing live is reachable from the runner
+        # this mode is built for, so the isolation is structural rather than careful.
+        [[ -f "$RV_COMPOSE" ]] || instrument_fail "throwaway compose file not found: ${RV_COMPOSE}"
+        command -v docker >/dev/null 2>&1 || instrument_fail "required command not found: docker"
+        self_test
+        return $?
+    fi
+
+    load_env
+    guard_not_live
+
+    log "INFO" "=== restore-verify: environment '${BACKUP_PREFIX}' ==="
+    log "INFO" "  reference (live) : project ${LIVE_PROJECT} (${LIVE_COMPOSE})"
+    log "INFO" "  throwaway        : project ${RV_PROJECT} (${RV_COMPOSE})"
+    log "INFO" "  B2 prefix        : ${B2_BUCKET}/${BACKUP_PREFIX}"
+    log "INFO" "  pg identity      : ${POSTGRES_USER}/${POSTGRES_DB} (taken from the live env)"
+
+    resource_gate
+
+    trap teardown EXIT
+    start_stack
+    assert_volume_isolation
+    assert_scratch_empty
+
+    # Calibrate against the LIVE stack BEFORE spending twenty minutes on a restore whose
+    # result we would not be able to read.
+    calibrate
+
+    local rc=0
+    run_restore || rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+        return "$rc"
+    fi
+
+    compare || return $?
+
+    log "INFO" "=== VERIFIED: the ${BACKUP_PREFIX} backup in B2 restores to a database that"
+    log "INFO" "    matches live, on every metric, with a comparator proven able to go red. ==="
+    return "$RC_VERIFIED"
+}
+
+main "$@"

--- a/scripts/restore_verify.sh
+++ b/scripts/restore_verify.sh
@@ -807,38 +807,59 @@ run_restore() {
 
     # VERIFY THE HANDOFF; DO NOT TRUST IT.
     #
-    # restore.sh announces the volume it resolved ("Resolved Neo4j data volume: …") precisely so
-    # this is auditable. Read it back and require it to be OURS. Everything else in this script
-    # asserts rather than assumes; the one hand-off that can destroy production should not be the
-    # exception. This catches the whole class — a dropped export, an inherited COMPOSE_PROJECT, a
-    # future edit to compose_project.sh's fallback — at the only place that sees the truth: what
-    # restore.sh ITSELF says it is about to write to.
-    local resolved=""
-    if ! resolved="$(sed -n 's/.*Resolved Neo4j data volume: \([^ ]*\).*/\1/p' "$out" | head -1)"; then
-        resolved=""
-    fi
+    # restore.sh announces exactly what it is about to write to, on one line:
+    #     Resolved Neo4j data volume: <VOL> (project <PROJECT>, <COMPOSE_FILE>)
+    # Read it back and require ALL THREE to be OURS. Everything else in this script asserts
+    # rather than assumes; the one hand-off that can destroy production should not be the
+    # exception. This catches the whole class at the only place that sees the truth — what
+    # restore.sh ITSELF resolved:
+    #   * VOL      — a dropped COMPOSE_PROJECT export, an inherited value, a future edit to
+    #                compose_project.sh's `noorinalabs` fallback → a non-`rv_` (live) volume;
+    #   * PROJECT  — the same, made explicit;
+    #   * FILE     — a dropped COMPOSE_FILE export. restore.sh:62 defaults COMPOSE_FILE to
+    #                compose/docker-compose.prod.yml (Weronika Zielinska, PR#642 review): the
+    #                SECOND single point of failure of the same class, the line immediately above
+    #                the COMPOSE_PROJECT one. A throwaway run must use the throwaway compose file.
+    local rline=""
+    rline="$(grep -F 'Resolved Neo4j data volume:' "$out" | tail -1)" || rline=""
     rm -f "$out"
 
-    if [[ -z "$resolved" ]]; then
+    if [[ -z "$rline" ]]; then
         instrument_fail "restore.sh never reported which Neo4j volume it resolved.
         Without that line this script CANNOT confirm the load went to the throwaway stack rather
         than the live graph, so it will not certify the restore. (If restore.sh's log wording
         changed, scripts/tests/test_restore_verify.py pins the string and will say so.)"
     fi
-    log "INFO" "restore.sh resolved Neo4j volume: ${resolved}"
 
+    local resolved rproj rfile
+    resolved="${rline##*Resolved Neo4j data volume: }"
+    resolved="${resolved%% *}"
+    rproj="${rline##*(project }"
+    rproj="${rproj%%,*}"
+    rfile="${rline##*, }"
+    rfile="${rfile%)}"
+    log "INFO" "restore.sh resolved: volume='${resolved}' project='${rproj}' compose-file='${rfile}'"
+
+    local violation=""
     case "$resolved" in
-        "${RV_PROJECT}_rv_"*)
-            pass "handoff verified: restore.sh loaded into '${resolved}', the throwaway volume"
-            ;;
-        *)
-            fail "HANDOFF VIOLATION: restore.sh resolved '${resolved}', which is NOT a volume of"
-            log "ERROR" "the throwaway project '${RV_PROJECT}'. It runs neo4j-admin database load"
-            log "ERROR" "with --overwrite-destination. If this names a live volume, the production"
-            log "ERROR" "graph has just been overwritten and it is UNRECOVERABLE."
-            exit "$RC_INSTRUMENT"
-            ;;
+        "${RV_PROJECT}_rv_"*) ;;
+        *) violation="volume '${resolved}' is not a throwaway (${RV_PROJECT}_rv_*) volume" ;;
     esac
+    if [[ -z "$violation" && "$rproj" != "$RV_PROJECT" ]]; then
+        violation="project '${rproj}' is not the throwaway project '${RV_PROJECT}'"
+    fi
+    if [[ -z "$violation" && "$rfile" != "$RV_COMPOSE" ]]; then
+        violation="compose-file '${rfile}' is not the throwaway file '${RV_COMPOSE}'"
+    fi
+
+    if [[ -n "$violation" ]]; then
+        fail "HANDOFF VIOLATION: ${violation}."
+        log "ERROR" "restore.sh runs neo4j-admin database load with --overwrite-destination against"
+        log "ERROR" "what it resolved above. If that is a live target, the production graph has just"
+        log "ERROR" "been overwritten and it is UNRECOVERABLE. Refusing to certify this restore."
+        exit "$RC_INSTRUMENT"
+    fi
+    pass "handoff verified: restore.sh resolved the throwaway volume, project AND compose file"
 
     # rc != 0 IS a real negative: restore.sh treats an ignored pg_restore error as a failed
     # restore, and it is right to. But rc == 0 is NOT a pass — that is what compare() is for.

--- a/scripts/restore_verify.sh
+++ b/scripts/restore_verify.sh
@@ -525,43 +525,119 @@ resource_gate() {
 }
 
 # =============================================================================
+# Leak audit — and the rc discipline that goes with it
+# =============================================================================
+# A teardown that dies partway is how volumes leak, and a leaked scratch volume holds a FULL
+# COPY OF THE PRODUCTION DATABASE. `docker compose down -v` is not sufficient evidence that it
+# is gone: the compose file's `${POSTGRES_USER:?}` guards interpolate on `down` too, so a
+# teardown run without those vars ABORTS. That is not hypothetical — it is what the hand-run
+# did, and recovery was `docker rm -f` + `docker volume rm` + `docker network rm` by hand.
+#
+# So we do not trust `down -v`. We ENUMERATE what is left, using compose's own project label
+# (the same label compose itself uses to decide what `down` owns), sweep it, and re-enumerate.
+#
+# THE EXIT-CODE RULE, which is the whole point:
+#
+#   * The comparator's verdict is captured BEFORE any teardown runs and is NEVER overwritten
+#     by a teardown outcome. A cleanup fault cannot turn a FAILING comparator into a passing
+#     run — a real negative always survives to the exit code.
+#
+#   * A leak on an otherwise-GREEN run is still a fault, and it exits 2 (INSTRUMENT), not 0.
+#     It is reported as exactly what it is: "the comparator PASSED; the teardown LEAKED."
+#     Those are two different facts and collapsing them would hide a live copy of production
+#     sitting on the box.
+#
+# Verdict-before-cleanup, and cleanup never speaks for the verdict
+# (feedback_your_own_verification_script_must_not_testify: on the hand-run, cleanup ran BEFORE
+# the verdict and destroyed the evidence).
+leak_audit() { # leak_audit <verdict_rc> <project>...
+    local verdict="$1"
+    shift
+    local projects=("$@")
+    local p kind leaked=0 found
+
+    for p in "${projects[@]}"; do
+        for kind in container volume network; do
+            case "$kind" in
+                container) found="$(docker ps -aq --filter "label=com.docker.compose.project=${p}")" || found="" ;;
+                volume) found="$(docker volume ls -q --filter "label=com.docker.compose.project=${p}")" || found="" ;;
+                network) found="$(docker network ls -q --filter "label=com.docker.compose.project=${p}")" || found="" ;;
+            esac
+            [[ -z "$found" ]] && continue
+
+            local id
+            while IFS= read -r id; do
+                [[ -z "$id" ]] && continue
+                log "WARN" "leak: ${kind} ${id} survived 'down -v' in project ${p} — removing it directly"
+                case "$kind" in
+                    container) docker rm -f "$id" >/dev/null || leaked=1 ;;
+                    volume) docker volume rm -f "$id" >/dev/null || leaked=1 ;;
+                    network) docker network rm "$id" >/dev/null || leaked=1 ;;
+                esac
+            done <<<"$found"
+        done
+    done
+
+    # Re-enumerate. The sweep's own exit code is not evidence that the object is gone.
+    local still=0
+    for p in "${projects[@]}"; do
+        found="$(docker ps -aq --filter "label=com.docker.compose.project=${p}")" || found=""
+        [[ -n "$found" ]] && still=1
+        found="$(docker volume ls -q --filter "label=com.docker.compose.project=${p}")" || found=""
+        [[ -n "$found" ]] && still=1
+        found="$(docker network ls -q --filter "label=com.docker.compose.project=${p}")" || found=""
+        [[ -n "$found" ]] && still=1
+    done
+
+    if [[ "$still" -eq 0 && "$leaked" -eq 0 ]]; then
+        pass "teardown audit: no stray containers, volumes or networks remain"
+    else
+        fail "teardown audit: STRAY OBJECTS REMAIN after the sweep — a scratch volume may hold a"
+        log "ERROR" "  full copy of the ${BACKUP_PREFIX:-target} database. Remove it by hand NOW:"
+        log "ERROR" "    docker ps -a  --filter label=com.docker.compose.project=${projects[0]}"
+        log "ERROR" "    docker volume ls --filter label=com.docker.compose.project=${projects[0]}"
+        # A leak must not silently pass. But it must ALSO not overwrite a real negative: if the
+        # comparator already failed, that verdict is the more important fact and it stands.
+        if [[ "$verdict" -eq 0 ]]; then
+            log "ERROR" "The comparator PASSED, but the teardown LEAKED. Exiting ${RC_INSTRUMENT}"
+            log "ERROR" "(INSTRUMENT), not 0: the restore verified, but the box is not clean."
+            exit "$RC_INSTRUMENT"
+        fi
+    fi
+
+    exit "$verdict"
+}
+
+# =============================================================================
 # Stack lifecycle
 # =============================================================================
 teardown() {
-    local rc=$?
+    # THE VERDICT, captured first and never recomputed. See leak_audit() for the rule.
+    local verdict=$?
 
     if [[ "$KEEP_STACK" == "true" ]]; then
         log "WARN" "KEEP_STACK=true — leaving project '${RV_PROJECT}' UP. Volumes are NOT removed."
         log "WARN" "  Tear down with: docker compose -p ${RV_PROJECT} -f ${RV_COMPOSE} down -v"
-        exit "$rc"
+        exit "$verdict"
     fi
     if [[ "$STACK_STARTED" != "true" ]]; then
-        exit "$rc"
+        exit "$verdict"
     fi
 
     # The compose file's `${POSTGRES_USER:?}` guards interpolate on `down` too. Run this
     # without those vars in the environment and compose ABORTS — leaking the volumes,
     # which is exactly what happened on the hand-run (recovery was `docker rm -f` +
     # `docker volume rm` + `docker network rm`, by hand). We sourced the env-file before
-    # installing this trap, so they are present; the sweep below is the belt to that brace.
-    log "INFO" "Tearing down the throwaway stack (project ${RV_PROJECT})..."
-    _dc rv down -v --remove-orphans || log "WARN" "compose down returned non-zero; sweeping volumes directly"
-
-    local v full leaked=0
-    for v in rv_pg_data rv_user_pg_data rv_neo4j_data; do
-        full="${RV_PROJECT}_${v}"
-        if docker volume inspect "$full" >/dev/null 2>&1; then
-            log "WARN" "volume ${full} survived 'down -v' — removing it directly"
-            docker volume rm -f "$full" >/dev/null || leaked=1
-        fi
-    done
-    if [[ "$leaked" -eq 1 ]]; then
-        log "ERROR" "A scratch volume could not be removed. It holds a full copy of the"
-        log "ERROR" "${BACKUP_PREFIX:-?} database. Remove it by hand before it is forgotten."
-    fi
+    # installing this trap, so they are present; leak_audit is the belt to that brace.
+    log "INFO" "Tearing down the throwaway stack (project ${RV_PROJECT}, verdict rc=${verdict})..."
+    _dc rv down -v --remove-orphans ||
+        log "WARN" "compose down returned non-zero — the audit below is what stops a leak"
 
     rm -rf "$RESTORE_STAGING_DIR"
-    exit "$rc"
+
+    # Enumerates containers/volumes/networks by compose's own project label, sweeps them,
+    # re-enumerates, and exits with the VERDICT — never with the teardown's own outcome.
+    leak_audit "$verdict" "$RV_PROJECT"
 }
 
 start_stack() {
@@ -805,11 +881,20 @@ self_test() {
     }
 
     _st_cleanup() {
-        local r=$?
-        log "INFO" "self-test: tearing down both stacks"
-        _st_dc "$ST_REF_PROJECT" down -v --remove-orphans >/dev/null 2>&1 || true
-        _st_dc "$RV_PROJECT" down -v --remove-orphans >/dev/null 2>&1 || true
-        exit "$r"
+        # THE VERDICT. Captured on the first line, before anything here can clobber `$?`,
+        # and never recomputed. Everything below may fail freely without changing it.
+        local verdict=$?
+        log "INFO" "self-test: tearing down both stacks (comparator verdict rc=${verdict})"
+
+        local p
+        for p in "$ST_REF_PROJECT" "$RV_PROJECT"; do
+            # NOT `>/dev/null 2>&1 || true`. If a teardown fails, its own message is the only
+            # thing that will explain the leak it just caused.
+            _st_dc "$p" down -v --remove-orphans ||
+                log "WARN" "compose down failed for ${p} — the sweep below is what stops a leak"
+        done
+
+        leak_audit "$verdict" "$ST_REF_PROJECT" "$RV_PROJECT"
     }
     trap _st_cleanup EXIT
 

--- a/scripts/restore_verify.sh
+++ b/scripts/restore_verify.sh
@@ -109,6 +109,10 @@ DISK_MARGIN_MB="${DISK_MARGIN_MB:-2048}"
 
 STACK_STARTED=false
 
+# The self-test's reference project. Script-scope, NOT a function-local, because the EXIT
+# trap that tears it down runs after the installing function's scope is gone. See self_test().
+ST_REF_PROJECT="${ST_REF_PROJECT:-isnad-rv-selftest-ref}"
+
 # --- Logging -----------------------------------------------------------------
 log() { printf '%s [%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" "${*:2}"; }
 
@@ -774,7 +778,14 @@ self_test() {
     export USER_POSTGRES_USER="${USER_POSTGRES_USER:-user_service}"
     export USER_POSTGRES_DB="${USER_POSTGRES_DB:-user_service}"
     # Two throwaway stacks. Neither is `noorinalabs`; there is no live stack on this box.
-    local ref_project="isnad-rv-selftest-ref"
+    #
+    # ST_REF_PROJECT is deliberately NOT `local`. An EXIT trap runs AFTER the function's scope
+    # is gone, so a trap that references a function-local dies on `set -u` with "unbound
+    # variable" — and it dies BEFORE tearing anything down, leaking the stacks and their
+    # volumes. That is not hypothetical: it is what this very function did on its first CI run
+    # (the four calibration cases all passed, then the teardown crashed on this line). Every
+    # name a teardown trap touches must outlive the function that installed it.
+    ST_REF_PROJECT="isnad-rv-selftest-ref"
     RV_PROJECT="isnad-rv-selftest-sub"
 
     _st_dc() { # _st_dc <project> <args...>
@@ -796,20 +807,20 @@ self_test() {
     _st_cleanup() {
         local r=$?
         log "INFO" "self-test: tearing down both stacks"
-        _st_dc "$ref_project" down -v --remove-orphans >/dev/null 2>&1 || true
+        _st_dc "$ST_REF_PROJECT" down -v --remove-orphans >/dev/null 2>&1 || true
         _st_dc "$RV_PROJECT" down -v --remove-orphans >/dev/null 2>&1 || true
         exit "$r"
     }
     trap _st_cleanup EXIT
 
     local p
-    for p in "$ref_project" "$RV_PROJECT"; do
+    for p in "$ST_REF_PROJECT" "$RV_PROJECT"; do
         log "INFO" "self-test: starting ${p}"
         _st_dc "$p" down -v --remove-orphans >/dev/null 2>&1 || true
         _st_dc "$p" up -d neo4j
     done
 
-    for p in "$ref_project" "$RV_PROJECT"; do
+    for p in "$ST_REF_PROJECT" "$RV_PROJECT"; do
         local waited=0 cid health
         while :; do
             cid="$(_st_dc "$p" ps -q neo4j | head -1)"
@@ -838,7 +849,7 @@ self_test() {
     MATCH (a:Narrator {id:'nar:1'}), (b:Narrator {id:'nar:2'}) CREATE (a)-[:NARRATED_TO]->(b);
     MATCH (n:Narrator {id:'nar:1'}), (h:Hadith {id:'had:1'}) CREATE (n)-[:NARRATED]->(h);
     "
-    for p in "$ref_project" "$RV_PROJECT"; do
+    for p in "$ST_REF_PROJECT" "$RV_PROJECT"; do
         # INTENTIONAL, not an oversight: the single quotes keep ${NEO4J_AUTH} unexpanded on this
         # side so it expands INSIDE the container. The credential never reaches this script's
         # argv, cypher-shell's argv, or the run log (CWE-214). Same contract as graph-ops.yml.
@@ -848,14 +859,14 @@ self_test() {
     done
 
     local ref_fp sub_fp ref_parts
-    ref_fp="$(_st_cypher "$ref_project" "$CY_FP")"
+    ref_fp="$(_st_cypher "$ST_REF_PROJECT" "$CY_FP")"
     sub_fp="$(_st_cypher "$RV_PROJECT" "$CY_FP")"
 
     # --- Case 0: the components are alive (the n.name trap) ------------------
-    ref_parts="$(_st_cypher "$ref_project" "$CY_FP_PARTS")"
+    ref_parts="$(_st_cypher "$ST_REF_PROJECT" "$CY_FP_PARTS")"
     log "INFO" "seeded narrator components (count/ar/en/id): ${ref_parts}"
     local dead_fp
-    dead_fp="$(_st_cypher "$ref_project" \
+    dead_fp="$(_st_cypher "$ST_REF_PROJECT" \
         "MATCH (n:Narrator) RETURN toString(count(n)) + '/' + toString(sum(size(coalesce(n.name,'')))) AS fp;")"
     log "INFO" "THE n.name TRAP — fingerprint over the NON-EXISTENT property 'n.name': ${dead_fp}"
     case "$dead_fp" in
@@ -891,7 +902,7 @@ self_test() {
     _st_cypher "$RV_PROJECT" \
         "CREATE (n:Narrator {id:'nar:7', name_ar:'XXXXXXXXXXXX', name_en:'Corrupted'});" >/dev/null
     local sub_count ref_count
-    ref_count="$(_st_cypher "$ref_project" "MATCH (n:Narrator) RETURN count(n);")"
+    ref_count="$(_st_cypher "$ST_REF_PROJECT" "MATCH (n:Narrator) RETURN count(n);")"
     sub_count="$(_st_cypher "$RV_PROJECT" "MATCH (n:Narrator) RETURN count(n);")"
     sub_fp="$(_st_cypher "$RV_PROJECT" "$CY_FP")"
     if [[ "$ref_count" == "$sub_count" && "$ref_fp" != "$sub_fp" ]]; then

--- a/scripts/restore_verify.sh
+++ b/scripts/restore_verify.sh
@@ -328,6 +328,38 @@ _cypher_hist_raw() {
 # Guards — all of these run BEFORE anything is started or loaded
 # =============================================================================
 guard_not_live() {
+    # EMPTY IS AS DANGEROUS AS ABSENT, and it is more dangerous than WRONG.
+    #
+    # restore.sh resolves its OWN project (scripts/compose_project.sh:48):
+    #
+    #     COMPOSE_PROJECT="${COMPOSE_PROJECT:-${COMPOSE_PROJECT_NAME:-noorinalabs}}"
+    #
+    # and `${VAR:-default}` treats "" EXACTLY like unset. So a BLANK RV_PROJECT does not
+    # produce a harmless no-op — it silently resolves to `noorinalabs`, THE LIVE PROJECT, and
+    # `neo4j-admin database load --overwrite-destination` writes the production graph.
+    #
+    # This is reachable today: load_env() sources the host `.env` with `set -a`, AFTER the
+    # `RV_PROJECT="${RV_PROJECT:-…}"` default at the top of this file has already been applied.
+    # An `RV_PROJECT=` line in that .env would blank it. Nothing writes that key today; nothing
+    # REFUSED it either, and the "!= noorinalabs" check below passes happily on "".
+    #
+    # So: an empty project is not a missing setting, it is an aimed gun. (Weronika Zielinska,
+    # PR#642 review.)
+    # `-z` alone would let a whitespace-only value through, and `-p '   '` is not a project —
+    # it is garbage that no guard downstream is looking for. Strip before testing.
+    local var stripped
+    for var in RV_PROJECT RV_COMPOSE LIVE_PROJECT; do
+        stripped="${!var:-}"
+        stripped="${stripped//[[:space:]]/}"
+        if [[ -z "$stripped" ]]; then
+            instrument_fail "${var} is EMPTY or unset. Refusing.
+        restore.sh resolves its own compose project and FALLS BACK TO THE LIVE ONE
+        ('${LIVE_PROJECT:-noorinalabs}') when COMPOSE_PROJECT is empty — \${VAR:-default} does not
+        distinguish \"\" from unset. An empty RV_PROJECT would aim a --overwrite-destination
+        Neo4j load at the PRODUCTION graph."
+        fi
+    done
+
     # The single most important refusal in this file. Everything else is hygiene.
     if [[ "$RV_PROJECT" == "$LIVE_PROJECT" ]]; then
         instrument_fail "RV_PROJECT='${RV_PROJECT}' IS the live project. Refusing: this script
@@ -753,14 +785,60 @@ calibrate() {
 run_restore() {
     log "INFO" "=== Restoring the REAL artifact from B2 (prefix: ${BACKUP_PREFIX}) ==="
 
-    # restore.sh reads COMPOSE_FILE / COMPOSE_PROJECT. Export ours so it can only ever
-    # address the throwaway stack. This is the same pair guard_not_live() refuses to
-    # inherit — we are the ones who get to set it.
-    local rc=0
+    # THE DESTRUCTIVE WRITE DOES NOT HAPPEN IN THIS FILE.
+    #
+    # `neo4j-admin database load --overwrite-destination` is executed by restore.sh, which
+    # RESOLVES ITS OWN PROJECT and falls back to the LIVE one (compose_project.sh:48). The
+    # `COMPOSE_PROJECT=` below is therefore not a convenience — it is the entire thing standing
+    # between a scheduled run and `noorinalabs_neo4j_data`. Delete it and this workflow
+    # overwrites the production graph, unattended, on a cron.
+    #
+    # assert_volume_isolation() does NOT protect this. It inspects the container running in
+    # $RV_PROJECT and confirms its volume is the throwaway one — a claim that stays TRUE while
+    # a DIFFERENT process addressing a DIFFERENT project destroys the live graph. It guards the
+    # stack the load will not touch. (Weronika Zielinska, PR#642 review.)
+    local rc=0 out
+    out="$(mktemp)"
+
     COMPOSE_FILE="$RV_COMPOSE" \
         COMPOSE_PROJECT="$RV_PROJECT" \
         RESTORE_DIR="$RESTORE_STAGING_DIR" \
-        "${SCRIPT_DIR}/restore.sh" --force latest || rc=$?
+        "${SCRIPT_DIR}/restore.sh" --force latest 2>&1 | tee "$out" || rc=$?
+
+    # VERIFY THE HANDOFF; DO NOT TRUST IT.
+    #
+    # restore.sh announces the volume it resolved ("Resolved Neo4j data volume: …") precisely so
+    # this is auditable. Read it back and require it to be OURS. Everything else in this script
+    # asserts rather than assumes; the one hand-off that can destroy production should not be the
+    # exception. This catches the whole class — a dropped export, an inherited COMPOSE_PROJECT, a
+    # future edit to compose_project.sh's fallback — at the only place that sees the truth: what
+    # restore.sh ITSELF says it is about to write to.
+    local resolved=""
+    if ! resolved="$(sed -n 's/.*Resolved Neo4j data volume: \([^ ]*\).*/\1/p' "$out" | head -1)"; then
+        resolved=""
+    fi
+    rm -f "$out"
+
+    if [[ -z "$resolved" ]]; then
+        instrument_fail "restore.sh never reported which Neo4j volume it resolved.
+        Without that line this script CANNOT confirm the load went to the throwaway stack rather
+        than the live graph, so it will not certify the restore. (If restore.sh's log wording
+        changed, scripts/tests/test_restore_verify.py pins the string and will say so.)"
+    fi
+    log "INFO" "restore.sh resolved Neo4j volume: ${resolved}"
+
+    case "$resolved" in
+        "${RV_PROJECT}_rv_"*)
+            pass "handoff verified: restore.sh loaded into '${resolved}', the throwaway volume"
+            ;;
+        *)
+            fail "HANDOFF VIOLATION: restore.sh resolved '${resolved}', which is NOT a volume of"
+            log "ERROR" "the throwaway project '${RV_PROJECT}'. It runs neo4j-admin database load"
+            log "ERROR" "with --overwrite-destination. If this names a live volume, the production"
+            log "ERROR" "graph has just been overwritten and it is UNRECOVERABLE."
+            exit "$RC_INSTRUMENT"
+            ;;
+    esac
 
     # rc != 0 IS a real negative: restore.sh treats an ignored pg_restore error as a failed
     # restore, and it is right to. But rc == 0 is NOT a pass — that is what compare() is for.

--- a/scripts/tests/test_restore_verify.py
+++ b/scripts/tests/test_restore_verify.py
@@ -115,55 +115,71 @@ def _run_restore_body(text: str) -> str:
     return m.group(1)
 
 
-def test_run_restore_hands_restore_sh_the_throwaway_project() -> None:
-    """THE line the whole workflow's safety rests on.
+HANDOFF_EXPORTS = {
+    "COMPOSE_PROJECT": (
+        r'COMPOSE_PROJECT="\$(RV_PROJECT|\{RV_PROJECT\})"',
+        "restore.sh resolves its own project and falls back to the LIVE one "
+        "(compose_project.sh: COMPOSE_PROJECT=${COMPOSE_PROJECT:-...:-noorinalabs})",
+    ),
+    "COMPOSE_FILE": (
+        r'COMPOSE_FILE="\$(RV_COMPOSE|\{RV_COMPOSE\})"',
+        "restore.sh:62 defaults COMPOSE_FILE to compose/docker-compose.prod.yml — the second "
+        "single point of failure of the same class, pointing at the same live stack",
+    ),
+}
 
-    `restore.sh` does not take a project argument — it RESOLVES ITS OWN, and the fallback is
-    the LIVE project (scripts/compose_project.sh:48):
 
-        COMPOSE_PROJECT="${COMPOSE_PROJECT:-${COMPOSE_PROJECT_NAME:-noorinalabs}}"
+@pytest.mark.parametrize("var", sorted(HANDOFF_EXPORTS))
+def test_run_restore_hands_restore_sh_the_throwaway_target(var) -> None:
+    """THE two lines the whole workflow's safety rests on.
 
-    `restore.sh` is what runs `neo4j-admin database load --overwrite-destination`. So the ONLY
-    thing between a scheduled restore-verify run and `noorinalabs_neo4j_data` is that this
-    export is present. Delete it and the workflow overwrites the production graph, on a cron,
-    unattended — and every other guard in the script still passes, because they all inspect the
-    stack the load will not touch.
+    `restore.sh` takes no project or compose-file argument — it RESOLVES ITS OWN, and BOTH
+    fallbacks point at the live stack. It is the process that runs `neo4j-admin database load
+    --overwrite-destination`. So the ONLY thing between a scheduled restore-verify run and the
+    production graph is that run_restore exports BOTH `COMPOSE_PROJECT="$RV_PROJECT"` and
+    `COMPOSE_FILE="$RV_COMPOSE"`. Drop either and the workflow can address the live stack, on a
+    cron, unattended — and every other guard still passes, because they inspect the stack the
+    load will not touch.
 
     This scan is the same shape as the `-p` scan above, applied to the env handoff instead of
-    the compose argv. It exists because deleting that one line left the whole suite green.
-    (Weronika Zielinska, PR#642 review.)
+    the compose argv. It exists because deleting one of these lines left the whole suite green.
+    (Weronika Zielinska, PR#642 review — both the project and the COMPOSE_FILE sibling.)
     """
+    pattern, why = HANDOFF_EXPORTS[var]
     body = _run_restore_body(_source())
-    assert re.search(r'COMPOSE_PROJECT="\$(RV_PROJECT|\{RV_PROJECT\})"', body), (
-        'run_restore() does not pass COMPOSE_PROJECT="$RV_PROJECT" to restore.sh.\n'
-        "restore.sh will then resolve its own project and FALL BACK TO THE LIVE ONE, and it is\n"
-        "the process that runs `neo4j-admin database load --overwrite-destination`.\n"
-        "This overwrites the PRODUCTION GRAPH. Unrecoverable."
+    assert re.search(pattern, body), (
+        f'run_restore() does not pass {var}="$RV_..." to restore.sh.\n{why}.\n'
+        "It overwrites the PRODUCTION GRAPH. Unrecoverable."
     )
 
 
-def test_the_handoff_scan_can_actually_see_the_missing_export() -> None:
-    """Calibrate the scan above against the EXACT mutation that survived: delete the
-    `COMPOSE_PROJECT="$RV_PROJECT"` line from run_restore's var-prefix.
+@pytest.mark.parametrize("dropped", sorted(HANDOFF_EXPORTS))
+def test_the_handoff_scan_can_actually_see_each_missing_export(dropped) -> None:
+    """Calibrate the scan against the EXACT mutations that must be caught: delete each of the
+    two `RV_` exports from run_restore's var-prefix, one at a time.
 
     Without this, the scan could be a no-op and its silence would mean nothing — which is
-    precisely the state the suite was in when it reported `33 passed` on a tree that would have
+    precisely the state the suite was in when it reported `40 passed` on a tree that would have
     destroyed the production graph.
     """
-    mutated = textwrap.dedent(
-        """\
-        run_restore() {
-            local rc=0
-            COMPOSE_FILE="$RV_COMPOSE" \\
-                RESTORE_DIR="$RESTORE_STAGING_DIR" \\
-                "${SCRIPT_DIR}/restore.sh" --force latest || rc=$?
-        }
-        """
+    lines = {
+        "COMPOSE_PROJECT": '    COMPOSE_PROJECT="$RV_PROJECT" \\\n',
+        "COMPOSE_FILE": '    COMPOSE_FILE="$RV_COMPOSE" \\\n',
+    }
+    kept = "".join(v for k, v in lines.items() if k != dropped)
+    mutated = (
+        "run_restore() {\n"
+        "    local rc=0\n"
+        f"{kept}"
+        '        RESTORE_DIR="$RESTORE_STAGING_DIR" \\\n'
+        '        "${SCRIPT_DIR}/restore.sh" --force latest || rc=$?\n'
+        "}\n"
     )
+    pattern = HANDOFF_EXPORTS[dropped][0]
     body = _run_restore_body(mutated)
-    assert not re.search(r'COMPOSE_PROJECT="\$(RV_PROJECT|\{RV_PROJECT\})"', body), (
-        "the scan cannot see a run_restore() that has DROPPED the COMPOSE_PROJECT export — "
-        "it would not have caught the live-graph-overwrite mutation, so it proves nothing"
+    assert not re.search(pattern, body), (
+        f"the scan cannot see a run_restore() that DROPPED the {dropped} export — "
+        "it would not have caught that overwrite mutation, so it proves nothing"
     )
 
 
@@ -548,26 +564,35 @@ class Harness:
         # the world model could not represent, and the mutation that causes it survived.
         self.restore_project = tmp / "restore_project"
 
-        # THE REAL compose_project.sh, not a paraphrase of it. Its line 48 —
-        #   COMPOSE_PROJECT="${COMPOSE_PROJECT:-${COMPOSE_PROJECT_NAME:-noorinalabs}}"
-        # — is the fallback that makes a dropped export catastrophic, and a restatement of it
-        # here would drift from the original and quietly stop modelling the hazard
-        # (feedback_paraphrase_in_the_product). So the fake restore.sh SOURCES the real file and
-        # resolves its project exactly the way the real restore.sh does.
-        shutil.copy(SCRIPTS_DIR / "compose_project.sh", self.scripts / "compose_project.sh")
+        # Which COMPOSE_FILE the restore resolved — the second single point of failure of the
+        # same class (restore.sh:62 defaults COMPOSE_FILE to compose/docker-compose.prod.yml).
+        self.restore_file = tmp / "restore_file"
 
-        # A fake restore.sh that RESOLVES ITS OWN PROJECT the way the real one does, records it,
-        # and announces the volume it would load into — including, when it has been aimed at the
-        # live project, the LIVE volume. Whether it is reached at all is the assertion for every
-        # guard that must abort BEFORE any load.
+        # A fake restore.sh that RESOLVES ITS OWN PROJECT AND COMPOSE_FILE exactly as the real
+        # one does — by reading the REAL definitions, not paraphrasing them
+        # (feedback_paraphrase_in_the_product) — records both, and announces the volume it would
+        # load into, including the LIVE volume when it has been aimed at the live project. Whether
+        # it is reached at all is the assertion for every guard that must abort BEFORE any load.
+        #
+        #   * COMPOSE_PROJECT: source the REAL compose_project.sh BY ABSOLUTE PATH. Its fallback
+        #     (`${COMPOSE_PROJECT:-${COMPOSE_PROJECT_NAME:-noorinalabs}}`) is what makes a dropped
+        #     export catastrophic. Sourcing by absolute path (not a copy) means ITS OWN evolving
+        #     dependencies — e.g. scratch.sh, added in #643 — resolve against the real scripts
+        #     dir. A copy drifts and breaks the harness the next time that file grows a dep; the
+        #     original does not.
+        #   * COMPOSE_FILE: eval the REAL `^COMPOSE_FILE=` default line out of restore.sh, so a
+        #     change to restore.sh's default is reflected here rather than silently diverging.
+        real_cp = SCRIPTS_DIR / "compose_project.sh"
+        real_restore = SCRIPTS_DIR / "restore.sh"
         (self.scripts / "restore.sh").write_text(
             "#!/usr/bin/env bash\n"
             "set -uo pipefail\n"
             'log() { echo "[$1] ${*:2}"; }\n'
-            'SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"\n'
+            f'eval "$(grep -E \'^COMPOSE_FILE=\' "{real_restore}" | head -1)"\n'
             "# shellcheck source=/dev/null\n"
-            'source "${SCRIPT_DIR}/compose_project.sh"\n'
+            f'source "{real_cp}"\n'
             f'printf "%s" "${{COMPOSE_PROJECT}}" > {self.restore_project}\n'
+            f'printf "%s" "${{COMPOSE_FILE}}" > {self.restore_file}\n'
             f"echo RESTORE_INVOKED >> {self.marker}\n"
             # The volume it resolves is the /data volume of the neo4j container in WHATEVER
             # project it was pointed at. Aimed at `noorinalabs`, that is the production graph.
@@ -577,8 +602,9 @@ class Harness:
             '  VOL="${COMPOSE_PROJECT}_rv_neo4j_data"\n'
             "fi\n"
             'VOL="${FAKE_RESOLVED_VOLUME:-$VOL}"\n'
+            'RFILE="${FAKE_RESOLVED_FILE:-${COMPOSE_FILE}}"\n'
             'log "INFO" "Resolved Neo4j data volume: ${VOL}'
-            ' (project ${COMPOSE_PROJECT}, ${COMPOSE_FILE:-})"\n'
+            ' (project ${COMPOSE_PROJECT}, ${RFILE})"\n'
             "exit ${FAKE_RESTORE_RC:-0}\n"
         )
         os.chmod(self.scripts / "restore.sh", 0o755)
@@ -646,6 +672,13 @@ class Harness:
         if not self.restore_project.exists():
             return None
         return self.restore_project.read_text().strip()
+
+    @property
+    def restored_with_file(self) -> str | None:
+        """The COMPOSE_FILE restore.sh actually resolved — the second single point of failure."""
+        if not self.restore_file.exists():
+            return None
+        return self.restore_file.read_text().strip()
 
 
 @pytest.fixture
@@ -837,6 +870,29 @@ def test_a_restore_that_reports_a_live_volume_is_refused(harness) -> None:
     assert r.returncode == RC_INSTRUMENT, f"a live-volume handoff must be refused\n{r.stdout}"
     assert "HANDOFF VIOLATION" in r.stdout
     assert "UNRECOVERABLE" in r.stdout
+
+
+def test_a_restore_that_reports_a_non_throwaway_compose_file_is_refused(harness) -> None:
+    """The COMPOSE_FILE sibling, as a runtime assertion. restore.sh:62 defaults COMPOSE_FILE to
+    `compose/docker-compose.prod.yml`; a throwaway run that resolved the prod compose file is a
+    handoff violation even if the volume happens to look right. Require the reported compose file
+    to be OURS. (Weronika Zielinska, PR#642 review — fix both siblings or neither.)
+    """
+    h = harness(FAKE_RESOLVED_FILE="compose/docker-compose.prod.yml")
+    r = h.run()
+    assert r.returncode == RC_INSTRUMENT, f"a prod-compose-file handoff must be refused\n{r.stdout}"
+    assert "HANDOFF VIOLATION" in r.stdout
+    assert "compose-file" in r.stdout
+
+
+def test_the_restore_uses_the_throwaway_compose_file(harness) -> None:
+    """The positive: restore.sh actually resolved OUR compose file, recorded independently."""
+    h = harness()
+    r = h.run()
+    assert r.returncode == RC_VERIFIED
+    assert h.restored_with_file == str(h.tmp / "compose" / "docker-compose.restore-verify.yml"), (
+        f"restore.sh resolved compose file {h.restored_with_file!r}, not the throwaway one"
+    )
 
 
 def test_the_handoff_check_accepts_our_own_volume(harness) -> None:

--- a/scripts/tests/test_restore_verify.py
+++ b/scripts/tests/test_restore_verify.py
@@ -1,0 +1,662 @@
+"""restore_verify.sh — the guards, and the comparator's ability to go RED (deploy#640).
+
+WHAT THIS MODULE CAN AND CANNOT PROVE
+--------------------------------------
+It proves the SCRIPT's decision logic: that it refuses the live project, aborts before any
+load when the Neo4j volume is not its own, refuses a dirty scratch stack, refuses an INERT
+comparator, and — the whole point — that it separates an instrument failure (rc=2) from a
+real negative (rc=1).
+
+It cannot prove the CYPHER IS VALID or that it measures anything. No string test can. The
+`n.name` defect that made the first hand-run's checksum read 0 on both sides and "agree"
+was perfectly valid Cypher — it just addressed a property that does not exist. A unit test
+over the query string is blind to that by construction (cf. deploy#606/#607: an
+invalid-Cypher precheck passed 32 tests and two reviewers, and only executing it against a
+real database caught it).
+
+So the real-engine calibration is `restore_verify.sh --self-test`, run against two actual
+Neo4j instances by the `self-test` job in .github/workflows/restore-verify.yml. THAT is the
+comparator's calibration. This module is the guard suite around it.
+
+EVERY FIXTURE HERE IS SHOWN CAPABLE OF EXPRESSING THE DEFECT BEFORE ITS SILENCE IS READ AS
+PASSING (feedback_calibrate_the_mutation_before_counting_it, deploy#574): each guard test
+has a companion that drives the SAME harness to the opposite verdict. A test that can only
+ever report "BLOCKED" proves every guard holds, including the ones that do not exist.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+REPO_ROOT = SCRIPTS_DIR.parent
+RESTORE_VERIFY = SCRIPTS_DIR / "restore_verify.sh"
+RV_COMPOSE = REPO_ROOT / "compose" / "docker-compose.restore-verify.yml"
+
+RC_VERIFIED, RC_FAILED, RC_INSTRUMENT = 0, 1, 2
+
+LIVE_PROJECT = "noorinalabs"
+RV_PROJECT = "isnad-restore-verify"
+
+
+# ---------------------------------------------------------------------------
+# Static scans
+# ---------------------------------------------------------------------------
+def _source() -> str:
+    return RESTORE_VERIFY.read_text()
+
+
+COMPOSE_CALL = re.compile(r"docker\s+compose\b([^\n|;&]*)")
+
+
+def _unflagged_compose_calls(text: str) -> list[str]:
+    """Every `docker compose` in EXECUTABLE code that does not name its project.
+
+    Full-line comments are dropped first — the script documents the very rule this scan
+    enforces, and prose about `docker compose` is not a call. Comments are dropped by
+    LINE, not by stripping from the first `#`, because `#` is not a comment character
+    inside `${NEO4J_AUTH#neo4j/}` and a naive strip would silently truncate the line the
+    scan most needs to see. (feedback_a_scan_cannot_see_an_emptied_string, deploy#633:
+    keep an orthogonal reading of the source in the loop.)
+    """
+    code = "\n".join(line for line in text.split("\n") if not line.lstrip().startswith("#"))
+    return [m.group(0).strip() for m in COMPOSE_CALL.finditer(code) if "-p " not in m.group(1)]
+
+
+def test_every_docker_compose_call_names_its_project() -> None:
+    """`-f` names the FILE. With no `-p`, Compose derives the project from the compose
+    file's DIRECTORY basename — `compose` — and a restore addressed to a project you never
+    deployed into WRITES: `neo4j-admin database load --overwrite-destination` creates and
+    fills a brand-new volume, reports success, and leaves the real graph untouched. That
+    fallback is the whole of deploy#617.
+    """
+    unflagged = _unflagged_compose_calls(_source())
+    assert not unflagged, (
+        "docker compose invocation(s) without an explicit -p project:\n  " + "\n  ".join(unflagged)
+    )
+
+
+@pytest.mark.parametrize(
+    "evasion",
+    [
+        "docker compose -f compose/x.yml up -d",
+        '    docker compose -f "$RV_COMPOSE" down -v  # trailing comment',
+        'dc() { docker compose -f "$F" "$@"; }',
+    ],
+)
+def test_the_scan_can_actually_see_an_unflagged_call(evasion: str) -> None:
+    """Calibrate the scan. An oracle that can only ever say "clean" proves every rule holds,
+    including the ones it does not implement (feedback_calibrate_the_mutation_before_counting_it).
+
+    The evasions are on BOTH sides of the table: bare, behind an inline comment, and hidden
+    inside a wrapper function — the last is how the real defect looked in backup.sh.
+    """
+    assert _unflagged_compose_calls(evasion), (
+        f"the scan cannot see an unflagged `docker compose` in {evasion!r} — it proves nothing"
+    )
+
+
+def test_the_scan_does_not_false_positive_on_a_comment() -> None:
+    """The other direction: prose about the rule must not fail the build."""
+    assert not _unflagged_compose_calls("# every `docker compose` here carries -p")
+
+
+def test_the_measurement_path_never_discards_stderr() -> None:
+    """`_run_capture` is the only function in the script that produces a value that is read.
+
+    A real verification script in this project printed `*** DATA LOSS ***` about a perfectly
+    intact backup because a permission error was swallowed and `wc -l` turned "could not
+    authenticate" into the number 0 (deploy#632/#641). On the failure path the diagnostic IS
+    the finding.
+    """
+    src = _source()
+    body = src.split("_run_capture() {", 1)[1].split("\n}", 1)[0]
+    assert "2>/dev/null" not in body, "_run_capture discards stderr — the diagnostic IS the finding"
+    assert 'while IFS= read -r line; do log "ERROR"' in body, (
+        "_run_capture must EMIT the captured stderr on the failure path, not merely avoid "
+        "discarding it"
+    )
+
+
+def test_an_empty_reading_is_refused_rather_than_returned_as_a_value() -> None:
+    """ "The query returned nothing" and "the query could not run" are indistinguishable in
+    the output, and only one of them is a measurement. A silent zero is the single most
+    dangerous thing an instrument can return, because it is indistinguishable from good news.
+    """
+    body = _source().split("_run_capture() {", 1)[1].split("\n}", 1)[0]
+    assert 'if [[ -z "$MEASURED" ]]' in body
+    assert "EMPTY reading" in body
+
+
+def test_instrument_failure_is_a_distinct_exit_code_from_a_real_negative() -> None:
+    """A check that cannot run must say so, and must NOT testify. rc=2 ("could not find
+    out") must never collapse into rc=1 ("the backup is broken").
+    """
+    src = _source()
+    assert "readonly RC_INSTRUMENT=2" in src
+    assert "readonly RC_FAILED=1" in src
+    assert 'exit "$RC_INSTRUMENT"' in src
+
+
+# ---------------------------------------------------------------------------
+# The behavioural harness
+# ---------------------------------------------------------------------------
+# A fake `docker` that models the ONE fact the guards turn on: which compose project a call
+# is addressed to, and what that project's stores contain. It also models the state
+# TRANSITION — the scratch stack is empty until restore.sh runs — so a restore that loads
+# NOTHING is a case this harness can actually express. If it could not, the "scratch must be
+# empty first" guard would be untestable and its passing would mean nothing.
+
+FAKE_DOCKER = r"""#!/usr/bin/env python3
+import json, os, sys
+
+world = json.load(open(os.environ["FAKE_WORLD"]))
+argv = sys.argv[1:]
+LIVE = os.environ["LIVE_PROJECT"]
+RV = os.environ["RV_PROJECT"]
+restored = os.path.exists(os.environ["RESTORE_MARKER"])
+
+def log_call():
+    with open(os.environ["FAKE_CALLS"], "a") as fh:
+        fh.write(" ".join(argv) + "\n")
+
+log_call()
+
+def stacks(project):
+    if project == LIVE:
+        return world["live"]
+    # The scratch stack is EMPTY until restore.sh has run.
+    return world["restored"] if restored else world["empty"]
+
+def emit(header, value):
+    # cypher-shell --format plain prints a header line then rows; the script strips the
+    # header with `tail -n +2`. A fake that omitted it would make every reading empty.
+    print(header)
+    print(value)
+
+def die(msg, rc=1):
+    print(msg, file=sys.stderr)
+    sys.exit(rc)
+
+if argv[0] == "info":
+    # A REAL directory: the script runs `df` against it. Returning /var/lib/docker on a box
+    # without docker would make `df` fail, and the script would exit on the df — which is a
+    # different fault than the one under test.
+    print(os.environ["FAKE_DOCKER_ROOT"]); sys.exit(0)
+
+if argv[0] == "volume":
+    if argv[1] == "inspect":
+        sys.exit(1)   # absent -> nothing leaked
+    sys.exit(0)
+
+if argv[0] == "inspect":
+    fmt = argv[2]
+    cid = argv[-1]
+    if "Mounts" in fmt:
+        proj = cid.split("|")[1]
+        print(world["volumes"].get(proj, proj + "_rv_neo4j_data")); sys.exit(0)
+    if "State.Health" in fmt:
+        print("healthy"); sys.exit(0)
+    die("unknown inspect format")
+
+if argv[0] != "compose":
+    die("unexpected docker subcommand: " + argv[0])
+
+# compose -p P -f F <rest...>
+assert argv[1] == "-p", "every compose call must carry -p"
+project = argv[2]
+assert argv[3] == "-f"
+rest = argv[5:]
+S = stacks(project)
+
+if rest[0] in ("up", "down", "start", "stop"):
+    sys.exit(0)
+if rest[0] == "ps":
+    if "-q" in rest or "-aq" in rest:
+        print("cid|" + project); sys.exit(0)
+    print("(ps table)"); sys.exit(0)
+
+if rest[0] == "exec":
+    if "neo4j" in rest and "du" in rest:
+        print("8000000\t/data"); sys.exit(0)
+
+    if "neo4j" in rest:
+        q = rest[-1]
+        if "SKIP 1" in q:
+            emit("fp", '"%s"' % S["fp_minus1"]); sys.exit(0)
+        if "AS parts" in q:
+            emit("parts", '"%s"' % S["parts"]); sys.exit(0)
+        if "AS fp" in q:
+            emit("fp", '"%s"' % S["fp"]); sys.exit(0)
+        if "UNWIND labels" in q:
+            emit("h", S["label_hist"]); sys.exit(0)
+        if "type(r)" in q:
+            emit("h", S["rel_hist"]); sys.exit(0)
+        if "-[r]->" in q:
+            emit("count(r)", S["rels"]); sys.exit(0)
+        if "count(n)" in q:
+            emit("count(n)", S["nodes"]); sys.exit(0)
+        die("fake docker: unmodelled cypher: " + q)
+
+    if "postgres" in rest and "user-postgres" not in rest:
+        sql = rest[-1]
+        if "information_schema" in sql:
+            print(S["pg_tables"]); sys.exit(0)
+        if "OFFSET 1" in sql:
+            print(S["hadith_md5_minus1"]); sys.exit(0)
+        if "md5" in sql:
+            print(S["hadith_md5"]); sys.exit(0)
+        if "count(*)" in sql:
+            print(S["hadiths"]); sys.exit(0)
+        die("fake docker: unmodelled sql: " + sql)
+
+    if "user-postgres" in rest:
+        sql = rest[-1]
+        if "information_schema" in sql:
+            print(S["upg_tables"]); sys.exit(0)
+        for key, tok in (("users_md5", "md5"), ("users", "FROM users"),
+                         ("oauth", "oauth_accounts"), ("sessions", "sessions"),
+                         ("audit", "audit_log"), ("alembic", "alembic_version")):
+            if tok in sql:
+                print(S[key]); sys.exit(0)
+        die("fake docker: unmodelled user sql: " + sql)
+
+die("fake docker: unmodelled call: " + " ".join(argv))
+"""
+
+# A populated, self-consistent world. The scratch stack starts EMPTY and becomes a copy of
+# live once the (fake) restore.sh has run — i.e. the happy path.
+LIVE_WORLD = {
+    "nodes": "107951",
+    "rels": "250000",
+    "fp": "50000/300000/450000/350000",
+    "fp_minus1": "49999/299994/449991/349993",  # DIFFERS -> the comparator can go red
+    "parts": "50000/300000/450000/350000",
+    "label_hist": "Hadith=20000 Narrator=50000",
+    "rel_hist": "NARRATED=90000 NARRATED_TO=160000",
+    "hadiths": "34000",
+    "hadith_md5": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "hadith_md5_minus1": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",  # DIFFERS
+    "pg_tables": "12",
+    "upg_tables": "6",
+    "users": "42",
+    "users_md5": "cccccccccccccccccccccccccccccccc",
+    "oauth": "7",
+    "sessions": "3",
+    "audit": "900",
+    "alembic": "a1b2c3d4",
+}
+
+EMPTY_WORLD = {
+    **{k: "0" for k in LIVE_WORLD},
+    "fp": "0/0/0/0",
+    "fp_minus1": "0/0/0/0",
+    "parts": "0/0/0/0",
+    "label_hist": "",
+    "rel_hist": "",
+    "hadith_md5": "",
+    "hadith_md5_minus1": "",
+    "alembic": "",
+}
+
+
+def _world(live=None, restored=None, empty=None, volumes=None) -> dict:
+    return {
+        "live": {**LIVE_WORLD, **(live or {})},
+        # By default the restore reproduces live exactly.
+        "restored": {**LIVE_WORLD, **(restored or {})},
+        "empty": {**EMPTY_WORLD, **(empty or {})},
+        "volumes": volumes or {RV_PROJECT: f"{RV_PROJECT}_rv_neo4j_data"},
+    }
+
+
+class Harness:
+    def __init__(self, tmp: Path, world: dict, env_extra: dict | None = None):
+        self.tmp = tmp
+        self.scripts = tmp / "scripts"
+        self.scripts.mkdir(parents=True)
+        self.bin = tmp / "bin"
+        self.bin.mkdir()
+
+        # The script under test, in a scripts/ dir whose sibling restore.sh we control.
+        shutil.copy(RESTORE_VERIFY, self.scripts / "restore_verify.sh")
+        os.chmod(self.scripts / "restore_verify.sh", 0o755)
+
+        (tmp / "compose").mkdir()
+        shutil.copy(RV_COMPOSE, tmp / "compose" / "docker-compose.restore-verify.yml")
+        (tmp / "compose" / "docker-compose.prod.yml").write_text("services: {}\n")
+
+        self.marker = tmp / "restore_ran"
+        self.calls = tmp / "calls.log"
+        self.calls.write_text("")
+
+        # A fake restore.sh that records that it ran. Whether it is reached at all is the
+        # assertion for every guard that must abort BEFORE any load.
+        (self.scripts / "restore.sh").write_text(
+            "#!/usr/bin/env bash\n"
+            f"echo RESTORE_INVOKED >> {self.marker}\n"
+            'echo "fake restore.sh: $*"\n'
+            "exit ${FAKE_RESTORE_RC:-0}\n"
+        )
+        os.chmod(self.scripts / "restore.sh", 0o755)
+
+        (self.bin / "docker").write_text(FAKE_DOCKER)
+        os.chmod(self.bin / "docker", 0o755)
+        for stub in ("rclone", "zstd", "sha256sum"):
+            (self.bin / stub).write_text("#!/bin/sh\nexit 0\n")
+            os.chmod(self.bin / stub, 0o755)
+
+        self.world_file = tmp / "world.json"
+        self.world_file.write_text(json.dumps(world))
+
+        (tmp / ".env").write_text(
+            textwrap.dedent(
+                """\
+                B2_BUCKET=noorinalabs-backups
+                B2_KEY_ID=k
+                B2_APP_KEY=s
+                BACKUP_PREFIX=prod
+                POSTGRES_USER=IsnadDbUseer
+                POSTGRES_DB=Isnad-Prod
+                USER_POSTGRES_USER=user_service
+                USER_POSTGRES_DB=user_service
+                """
+            )
+        )
+        self.env_extra = env_extra or {}
+
+    def run(self, **env_over) -> subprocess.CompletedProcess:
+        env = {
+            "PATH": f"{self.bin}:{os.environ['PATH']}",
+            "HOME": str(self.tmp),
+            "FAKE_WORLD": str(self.world_file),
+            "FAKE_CALLS": str(self.calls),
+            "FAKE_DOCKER_ROOT": str(self.tmp),
+            "RESTORE_MARKER": str(self.marker),
+            "LIVE_PROJECT": LIVE_PROJECT,
+            "RV_PROJECT": RV_PROJECT,
+            "ENV_FILE": str(self.tmp / ".env"),
+            # Keep the resource gate satisfiable in CI.
+            "REQUIRED_MEM_MB": "1",
+            "DISK_MARGIN_MB": "0",
+            **self.env_extra,
+            **env_over,
+        }
+        return subprocess.run(
+            ["bash", str(self.scripts / "restore_verify.sh")],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+    @property
+    def restore_was_invoked(self) -> bool:
+        return self.marker.exists()
+
+
+@pytest.fixture
+def harness(tmp_path):
+    def _make(world=None, **env_extra):
+        return Harness(tmp_path, world or _world(), env_extra)
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# The happy path — and it must be a REAL pass, not a vacuous one
+# ---------------------------------------------------------------------------
+def test_a_faithful_restore_verifies(harness) -> None:
+    h = harness()
+    r = h.run()
+    assert r.returncode == RC_VERIFIED, (
+        f"expected VERIFIED\nSTDOUT:\n{r.stdout}\nSTDERR:\n{r.stderr}"
+    )
+    assert "CALIBRATION PASSED" in r.stdout
+    assert "VERIFIED" in r.stdout
+    assert h.restore_was_invoked
+
+
+def test_the_happy_path_actually_exercised_the_comparator(harness) -> None:
+    """Calibrates the test above. If the happy path passed without ever READING the stores,
+    its green would be worth nothing — which is the exact failure mode this whole issue is
+    about. Require the comparison table to have been printed with real values in it.
+    """
+    h = harness()
+    r = h.run()
+    assert r.returncode == RC_VERIFIED
+    assert "neo4j narrator fp" in r.stdout
+    assert LIVE_WORLD["fp"] in r.stdout, "the fingerprint was never actually read"
+    assert "pg hadiths md5" in r.stdout
+    assert r.stdout.count("MATCH") >= 10, "too few metrics compared to call this a verification"
+
+
+# ---------------------------------------------------------------------------
+# The comparator must be able to go RED
+# ---------------------------------------------------------------------------
+def test_a_restore_that_loses_one_narrator_is_caught(harness) -> None:
+    """The single case the whole design turns on."""
+    lossy = {**LIVE_WORLD, "fp": "49999/299994/449991/349993", "nodes": "107950"}
+    h = harness(_world(restored=lossy))
+    r = h.run()
+    assert r.returncode == RC_FAILED, f"a lossy restore must FAIL\n{r.stdout}"
+    assert "*** MISMATCH ***" in r.stdout
+    assert "real negative" in r.stdout
+
+
+def test_a_restore_with_the_right_counts_but_corrupted_content_is_caught(harness) -> None:
+    """Counts can match while the bytes are garbage. A comparator that only counted rows
+    would go green here, which is why the fingerprints checksum the CONTENT.
+    """
+    corrupt = {**LIVE_WORLD, "hadith_md5": "dddddddddddddddddddddddddddddddd"}
+    h = harness(_world(restored=corrupt))
+    r = h.run()
+    assert r.returncode == RC_FAILED
+    assert "pg hadiths md5" in r.stdout
+    assert "*** MISMATCH ***" in r.stdout
+
+
+def test_a_restore_that_silently_did_nothing_is_caught(harness) -> None:
+    """`pg_restore --clean` can warn-and-succeed while restoring nothing, and restore.sh
+    would exit 0. The verdict is never the exit code.
+    """
+    h = harness(_world(restored=EMPTY_WORLD))
+    r = h.run()
+    assert r.returncode != RC_VERIFIED, "a no-op restore must NOT verify"
+    assert r.returncode in (RC_FAILED, RC_INSTRUMENT)
+
+
+# ---------------------------------------------------------------------------
+# INERT COMPARATOR -> refuse to testify (rc=2). The n.name defect, as a guard.
+# ---------------------------------------------------------------------------
+def test_a_fingerprint_that_cannot_see_a_missing_narrator_refuses_to_testify(harness) -> None:
+    """If the minus-one fingerprint equals the full one, the instrument is blind to a whole
+    missing node and every MATCH it reports is meaningless. It must abort — and it must NOT
+    report the backup as broken, because it has learned nothing about the backup.
+    """
+    inert = {**LIVE_WORLD, "fp_minus1": LIVE_WORLD["fp"]}
+    h = harness(_world(live=inert))
+    r = h.run()
+    assert r.returncode == RC_INSTRUMENT, f"an inert comparator must exit 2\n{r.stdout}"
+    assert "CANNOT SEE A MISSING NARRATOR" in r.stdout
+    assert "REFUSING TO TESTIFY" in r.stdout
+    assert not h.restore_was_invoked, "must abort BEFORE spending 20 minutes on a restore"
+
+
+def test_the_n_name_defect_a_dead_property_component_refuses_to_testify(harness) -> None:
+    """THE defect, reproduced. `n.name` does not exist on :Narrator, so the fingerprint
+    component sums to 0 — on BOTH stacks. They "agree" perfectly and the checksum is 0 on
+    both sides.
+
+    A both-sides-zero is not a match. It is the instrument reading nothing, twice.
+    """
+    dead = {**LIVE_WORLD, "parts": "50000/0/0/0"}
+    h = harness(_world(live=dead))
+    r = h.run()
+    assert r.returncode == RC_INSTRUMENT, f"a dead fingerprint component must exit 2\n{r.stdout}"
+    assert "REFUSING TO TESTIFY" in r.stdout
+    assert "does not exist on :Narrator" in r.stdout
+    assert not h.restore_was_invoked
+
+
+def test_an_empty_live_graph_refuses_to_testify(harness) -> None:
+    """Zero narrators on the reference side means a "match" would be two empty readings
+    agreeing. That is the vacuous green the calibration exists to prevent.
+    """
+    h = harness(_world(live={**LIVE_WORLD, "parts": "0/0/0/0"}))
+    r = h.run()
+    assert r.returncode == RC_INSTRUMENT
+    assert "ZERO :Narrator" in r.stdout
+    assert not h.restore_was_invoked
+
+
+# ---------------------------------------------------------------------------
+# The deploy#617 guard — abort BEFORE any load
+# ---------------------------------------------------------------------------
+def test_it_refuses_when_the_neo4j_volume_is_not_its_own(harness) -> None:
+    """`neo4j-admin database load` runs with `--overwrite-destination`. Against the live
+    volume that is unrecoverable. The volume must be asserted BEFORE anything is loaded.
+    """
+    h = harness(_world(volumes={RV_PROJECT: f"{LIVE_PROJECT}_neo4j_data"}))
+    r = h.run()
+    assert r.returncode == RC_INSTRUMENT
+    assert "volume isolation" in r.stdout
+    assert "ABORTING" in r.stdout
+    assert not h.restore_was_invoked, "it loaded into a live volume — this is the #617 disaster"
+
+
+def test_it_refuses_a_stray_volume_that_is_neither_live_nor_its_own(harness) -> None:
+    """THE deploy#617 SHAPE, and the one case only the primary guard can catch.
+
+    #617 was not a volume named `noorinalabs_*`. Compose fell back to the compose file's
+    DIRECTORY basename — `compose` — and `up` CREATED a new, empty Neo4j in a project called
+    `compose`. A guard that only refuses volumes starting with the live project's name would
+    wave that straight through, because `compose_neo4j_data` is not live-prefixed.
+
+    This test exists because a mutation run showed the previous one passing with the primary
+    guard DELETED: the belt-and-braces live-prefix check was catching it, so the assertion
+    that was supposed to be under test was never exercised at all. An author cannot calibrate
+    their own guard by looking at it (feedback_measurement_is_the_thing_that_breaks).
+    """
+    h = harness(_world(volumes={RV_PROJECT: "compose_neo4j_data"}))
+    r = h.run()
+    assert r.returncode == RC_INSTRUMENT, f"a stray non-own volume must abort\n{r.stdout}"
+    assert "volume isolation" in r.stdout
+    assert "ABORTING" in r.stdout
+    assert not h.restore_was_invoked
+
+
+def test_the_volume_guard_passes_on_its_own_volume(harness) -> None:
+    """Calibrates the test above: the guard must also be able to say YES, or it is just an
+    unconditional abort and proves nothing.
+    """
+    h = harness()
+    r = h.run()
+    assert r.returncode == RC_VERIFIED
+    assert "volume isolation: the restore targets" in r.stdout
+
+
+def test_it_refuses_to_run_against_the_live_project(harness) -> None:
+    h = harness(RV_PROJECT=LIVE_PROJECT)
+    r = h.run()
+    assert r.returncode == RC_INSTRUMENT
+    assert "IS the live project" in r.stdout
+    assert not h.restore_was_invoked
+
+
+@pytest.mark.parametrize("var", ["COMPOSE_FILE", "COMPOSE_PROJECT", "COMPOSE_PROJECT_NAME"])
+def test_it_refuses_an_inherited_compose_target(harness, var) -> None:
+    """restore.sh reads COMPOSE_FILE and COMPOSE_PROJECT. An ambient value pointing at the
+    live stack is a loaded gun, and we refuse to run beside one.
+    """
+    h = harness()
+    r = h.run(**{var: "noorinalabs" if "PROJECT" in var else "compose/docker-compose.prod.yml"})
+    assert r.returncode == RC_INSTRUMENT
+    assert "inherited" in r.stdout
+    assert not h.restore_was_invoked
+
+
+# ---------------------------------------------------------------------------
+# A dirty scratch stack cannot be allowed to pass
+# ---------------------------------------------------------------------------
+def test_it_refuses_when_the_scratch_stores_are_not_empty(harness) -> None:
+    """If the scratch graph already holds yesterday's restore, a restore that loads NOTHING
+    still "matches" live. The stores must be empty first or a no-op passes.
+    """
+    h = harness(_world(empty={**EMPTY_WORLD, "nodes": "107951"}))
+    r = h.run()
+    assert r.returncode == RC_INSTRUMENT
+    assert "already holds" in r.stdout
+    assert not h.restore_was_invoked
+
+
+# ---------------------------------------------------------------------------
+# Instrument failure vs real negative — the distinction must survive
+# ---------------------------------------------------------------------------
+def test_a_failing_restore_is_a_real_negative_not_an_instrument_failure(harness) -> None:
+    h = harness(FAKE_RESTORE_RC="1")
+    r = h.run()
+    assert r.returncode == RC_FAILED, "restore.sh failing IS a real negative"
+    assert "did not restore" in r.stdout
+
+
+def test_a_prefix_mismatch_refuses_rather_than_verify_the_wrong_environment(harness) -> None:
+    """The host's .env says prod. A matrix leg that believes it is checking stg must not
+    restore prod's artifact and compare it against prod's live stack while reporting `stg`.
+    Before #632 the backup watchdog had exactly this defect.
+    """
+    h = harness(EXPECT_PREFIX="stg")  # the .env fixture says prod
+    r = h.run()
+    assert r.returncode == RC_INSTRUMENT
+    assert "prefix mismatch" in r.stdout
+    assert not h.restore_was_invoked
+
+
+def test_a_matching_prefix_proceeds(harness) -> None:
+    """Calibrates the guard above — it must be able to say yes."""
+    h = harness(EXPECT_PREFIX="prod")
+    r = h.run()
+    assert r.returncode == RC_VERIFIED
+
+
+def test_a_missing_env_file_is_an_instrument_failure(harness) -> None:
+    h = harness()
+    r = h.run(ENV_FILE=str(h.tmp / "nonexistent.env"))
+    assert r.returncode == RC_INSTRUMENT
+    assert "INSTRUMENT FAILURE" in r.stdout
+    assert not h.restore_was_invoked
+
+
+def test_an_unreadable_store_is_an_instrument_failure_not_a_backup_verdict(harness) -> None:
+    """A query that CANNOT RUN must not be reported as a backup that does not restore.
+    Collapsing rc=2 into rc=1 is how a broken credential became `*** DATA LOSS ***`
+    (deploy#632/#641).
+    """
+    broken = _world()
+    del broken["live"]["parts"]  # the fake will KeyError -> non-zero rc + stderr
+    h = harness(broken)
+    r = h.run()
+    assert r.returncode == RC_INSTRUMENT, "an unreadable store is not a backup verdict"
+    assert "INSTRUMENT FAILURE" in r.stdout
+
+
+def test_the_stderr_of_a_failed_reading_reaches_the_operator(harness) -> None:
+    """The diagnostic IS the finding on the failure path. If it is swallowed, the operator
+    is left to reverse-engineer, at 3am, why the instrument said nothing.
+    """
+    broken = _world()
+    del broken["live"]["parts"]
+    h = harness(broken)
+    r = h.run()
+    combined = r.stdout + r.stderr
+    assert "KeyError" in combined or "Traceback" in combined, (
+        "the failing tool's own diagnostic was discarded — this is the 2>/dev/null defect"
+    )

--- a/scripts/tests/test_restore_verify.py
+++ b/scripts/tests/test_restore_verify.py
@@ -262,9 +262,54 @@ if argv[0] == "info":
     # different fault than the one under test.
     print(os.environ["FAKE_DOCKER_ROOT"]); sys.exit(0)
 
+def _project_of_filter():
+    for a in argv:
+        if a.startswith("label=com.docker.compose.project="):
+            return a.split("=", 2)[2]
+    return None
+
+# The leak model. `leaks` names the projects whose objects SURVIVE `down -v`; `unremovable`
+# names the ones whose objects also survive the direct sweep. Without a fixture that can
+# express a leak, every "no stray objects" assertion would be vacuous.
+LEAKS = set(world.get("leaks", []))
+UNREMOVABLE = set(world.get("unremovable", []))
+SWEPT = os.environ["FAKE_SWEPT"]
+
+def _still_present(project):
+    if project not in LEAKS:
+        return False
+    if project in UNREMOVABLE:
+        return True                       # the sweep cannot remove it
+    return not os.path.exists(SWEPT)      # gone once the sweep has run
+
 if argv[0] == "volume":
     if argv[1] == "inspect":
         sys.exit(1)   # absent -> nothing leaked
+    if argv[1] == "ls":
+        p = _project_of_filter()
+        if p and _still_present(p):
+            print("vol-" + p)
+        sys.exit(0)
+    if argv[1] == "rm":
+        target = argv[-1]
+        if any(u in target for u in UNREMOVABLE):
+            print("Error: volume is in use", file=sys.stderr)
+            sys.exit(1)
+        open(SWEPT, "a").close()
+        sys.exit(0)
+    sys.exit(0)
+
+if argv[0] == "network":
+    if argv[1] == "ls":
+        sys.exit(0)   # networks modelled as always cleaned
+    if argv[1] == "rm":
+        sys.exit(0)
+    sys.exit(0)
+
+if argv[0] == "ps":
+    sys.exit(0)       # no stray containers modelled
+
+if argv[0] == "rm":
     sys.exit(0)
 
 if argv[0] == "inspect":
@@ -378,13 +423,17 @@ EMPTY_WORLD = {
 }
 
 
-def _world(live=None, restored=None, empty=None, volumes=None) -> dict:
+def _world(
+    live=None, restored=None, empty=None, volumes=None, leaks=None, unremovable=None
+) -> dict:
     return {
         "live": {**LIVE_WORLD, **(live or {})},
         # By default the restore reproduces live exactly.
         "restored": {**LIVE_WORLD, **(restored or {})},
         "empty": {**EMPTY_WORLD, **(empty or {})},
         "volumes": volumes or {RV_PROJECT: f"{RV_PROJECT}_rv_neo4j_data"},
+        "leaks": leaks or [],
+        "unremovable": unremovable or [],
     }
 
 
@@ -450,6 +499,7 @@ class Harness:
             "FAKE_WORLD": str(self.world_file),
             "FAKE_CALLS": str(self.calls),
             "FAKE_DOCKER_ROOT": str(self.tmp),
+            "FAKE_SWEPT": str(self.tmp / "swept"),
             "RESTORE_MARKER": str(self.marker),
             "LIVE_PROJECT": LIVE_PROJECT,
             "RV_PROJECT": RV_PROJECT,
@@ -666,6 +716,117 @@ def test_it_refuses_when_the_scratch_stores_are_not_empty(harness) -> None:
     assert r.returncode == RC_INSTRUMENT
     assert "already holds" in r.stdout
     assert not h.restore_was_invoked
+
+
+# ---------------------------------------------------------------------------
+# TEARDOWN: it must run on EVERY exit path, and it must never speak for the verdict
+# ---------------------------------------------------------------------------
+# A teardown that dies partway is how volumes leak, and a leaked scratch volume holds a full
+# copy of production. The hand-run leaked exactly this way when compose's `${POSTGRES_USER:?}`
+# guard aborted `down -v`, and the self-test leaked again on its first CI run when its EXIT
+# trap read a function-local.
+def _torn_down(h: Harness, project: str = RV_PROJECT) -> bool:
+    """Did the TEARDOWN run — as opposed to merely some `down -v`?
+
+    NOT `any("down -v" in c)`. `start_stack()` issues a PRE-CLEAN `down -v` before `up`, and it
+    is textually identical to the teardown's. A helper that matched on `down -v` alone returned
+    True even when the EXIT trap never fired at all — and a mutation that deleted the teardown
+    entirely left `test_teardown_runs_when_the_restore_itself_FAILS` GREEN.
+
+    The teardown is the only caller of `leak_audit()`, and `leak_audit()` is the only thing that
+    enumerates by compose's project LABEL. So that enumeration is the signature that cannot be
+    forged by the pre-clean.
+
+    Third time this session that a helper shared the blind spot of the thing it was measuring
+    (feedback_measurement_is_the_thing_that_breaks). Only the mutation showed it.
+    """
+    calls = h.calls.read_text().splitlines()
+    audited = any(f"label=com.docker.compose.project={project}" in c and "ls" in c for c in calls)
+    downed = any(f"-p {project}" in c and "down" in c and "-v" in c for c in calls)
+    return audited and downed
+
+
+def test_teardown_runs_when_the_comparator_PASSES(harness) -> None:
+    h = harness()
+    r = h.run()
+    assert r.returncode == RC_VERIFIED
+    assert _torn_down(h), "the stack was left up after a passing run"
+    assert "no stray containers, volumes or networks remain" in r.stdout
+
+
+def test_teardown_runs_when_the_comparator_FAILS(harness) -> None:
+    """The path that actually matters. A failing run is exactly when an author stops paying
+    attention — and it is the run most likely to leave a stack up.
+    """
+    h = harness(_world(restored={**LIVE_WORLD, "nodes": "1"}))
+    r = h.run()
+    assert r.returncode == RC_FAILED
+    assert _torn_down(h), "the stack was left up after a FAILING run — this is the leak"
+    assert "no stray containers, volumes or networks remain" in r.stdout
+
+
+def test_teardown_runs_when_the_restore_itself_FAILS(harness) -> None:
+    h = harness(FAKE_RESTORE_RC="1")
+    r = h.run()
+    assert r.returncode == RC_FAILED
+    assert _torn_down(h)
+    assert "no stray containers, volumes or networks remain" in r.stdout
+
+
+def test_the_teardown_calibration_fixture_can_actually_express_a_leak(harness) -> None:
+    """Calibrate the three assertions above. If the harness could not model a stack that
+    SURVIVES `down -v`, then "no stray objects" would be true by construction and every
+    teardown assertion here would be vacuous — the exact shape of a guard that cannot go red.
+    """
+    h = harness(_world(leaks=[RV_PROJECT], unremovable=[RV_PROJECT]))
+    r = h.run()
+    assert "STRAY OBJECTS REMAIN" in r.stdout, (
+        "the fixture cannot express a leak, so the clean-teardown assertions prove nothing"
+    )
+
+
+def test_a_leak_on_a_GREEN_run_does_not_exit_zero(harness) -> None:
+    """The restore verified, but the box is not clean: a scratch volume holding a full copy of
+    production is still sitting there. That must not exit 0. It is an INSTRUMENT fault (2), and
+    it is reported as exactly what it is — the comparator passed AND the teardown leaked.
+    """
+    h = harness(_world(leaks=[RV_PROJECT], unremovable=[RV_PROJECT]))
+    r = h.run()
+    assert r.returncode == RC_INSTRUMENT, f"a leak must not pass as green\n{r.stdout}"
+    assert "The comparator PASSED, but the teardown LEAKED" in r.stdout
+
+
+def test_a_leak_CANNOT_overwrite_a_failing_verdict(harness) -> None:
+    """THE rule. A cleanup fault must never overwrite a failing comparator result — in either
+    direction. Here the comparator FAILED (rc=1) and the teardown ALSO leaked; the run must
+    still exit 1, because "the artifact does not restore" is the more important fact and it is
+    the one an operator acts on. If the leak re-wrote this to 2, a real negative would be
+    reported as a broken instrument and the backup would look merely unverified.
+    """
+    h = harness(
+        _world(
+            restored={**LIVE_WORLD, "nodes": "1"},  # a real negative
+            leaks=[RV_PROJECT],
+            unremovable=[RV_PROJECT],  # and a leaking teardown on top of it
+        )
+    )
+    r = h.run()
+    assert r.returncode == RC_FAILED, (
+        f"the teardown's fault overwrote the comparator's verdict (got {r.returncode}, want 1)"
+    )
+    assert "*** MISMATCH ***" in r.stdout
+    assert "STRAY OBJECTS REMAIN" in r.stdout, "the leak must still be REPORTED, just not obeyed"
+
+
+def test_a_recoverable_leak_is_swept_and_the_run_stays_green(harness) -> None:
+    """`down -v` left the volume behind, the direct sweep removed it. That is a clean box, and
+    a green run — not an alarm. The distinction is what stops this check from crying wolf.
+    """
+    h = harness(_world(leaks=[RV_PROJECT]))  # leaks, but IS removable by the sweep
+    r = h.run()
+    assert r.returncode == RC_VERIFIED
+    assert "survived 'down -v'" in r.stdout, "the sweep never actually ran"
+    assert "no stray containers, volumes or networks remain" in r.stdout
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_restore_verify.py
+++ b/scripts/tests/test_restore_verify.py
@@ -136,6 +136,76 @@ def test_an_empty_reading_is_refused_rather_than_returned_as_a_value() -> None:
     assert "EMPTY reading" in body
 
 
+def test_no_teardown_trap_references_a_function_local() -> None:
+    """An EXIT trap runs AFTER the installing function's scope is gone. A trap that reads a
+    `local` dies on `set -u` with "unbound variable" — and it dies BEFORE tearing anything
+    down, leaking the stack and its volumes.
+
+    This is not hypothetical. `self_test`'s cleanup trap referenced a `local ref_project`, and
+    on its first CI run all four calibration cases passed and then the teardown crashed on
+    exactly that line, leaving both stacks up. The leak is the same class the hand-run hit
+    when compose's `${POSTGRES_USER:?}` guard aborted `down -v`.
+
+    Every name a teardown trap touches must outlive the function that installed it.
+    """
+    src = _source()
+    locals_declared = set(re.findall(r"^\s*local\s+([A-Za-z_][A-Za-z0-9_]*)", src, re.M))
+
+    offenders = []
+    for fn in ("teardown", "_st_cleanup"):
+        m = re.search(rf"^\s*{re.escape(fn)}\(\) \{{(.*?)^\s*\}}", src, re.S | re.M)
+        assert m, f"could not locate {fn}() — the scan must not silently find nothing"
+        body = m.group(1)
+        # Names the trap READS, minus the ones it declares itself.
+        own = set(re.findall(r"^\s*local\s+([A-Za-z_][A-Za-z0-9_]*)", body, re.M))
+        for var in re.findall(r"\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?", body):
+            if var in locals_declared and var not in own:
+                offenders.append(f"{fn}() reads ${var}, which is a `local` elsewhere")
+
+    assert not offenders, "teardown trap(s) reference a function-local:\n  " + "\n  ".join(
+        dict.fromkeys(offenders)
+    )
+
+
+@pytest.mark.parametrize("name", ["ref_project", "ST_REF_PROJECT"])
+def test_the_trap_scan_can_see_the_defect_it_was_written_for(name: str) -> None:
+    """Calibrate the scan against the ACTUAL defect, verbatim: a trap reading a local declared
+    by the function that installed it.
+
+    BOTH CASINGS ARE FIXTURES, and that is not padding. The first version of this scan matched
+    only `[a-z_]`, so when the fix renamed the variable to the UPPERCASE `ST_REF_PROJECT` the
+    guard went blind to precisely the line it had just been written to protect — and a mutation
+    re-introducing the bug SURVIVED. Shell locals are freely cased; a case-sensitive scan of
+    them is a scan with a hole in it.
+
+    An author cannot calibrate their own guard by reading it
+    (feedback_measurement_is_the_thing_that_breaks, deploy#624): the fixture shared the
+    filter's blind spot by construction, exactly as it did there. Only running the mutation
+    exposed it.
+    """
+    broken = textwrap.dedent(
+        f"""\
+        self_test() {{
+            local {name}="isnad-rv-selftest-ref"
+            _st_cleanup() {{
+                local r=$?
+                _st_dc "${name}" down -v || true
+                exit "$r"
+            }}
+            trap _st_cleanup EXIT
+        }}
+        """
+    )
+    locals_declared = set(re.findall(r"^\s*local\s+([A-Za-z_][A-Za-z0-9_]*)", broken, re.M))
+    m = re.search(r"^\s*_st_cleanup\(\) \{(.*?)^\s*\}", broken, re.S | re.M)
+    assert m
+    own = set(re.findall(r"^\s*local\s+([A-Za-z_][A-Za-z0-9_]*)", m.group(1), re.M))
+    reads = set(re.findall(r"\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?", m.group(1)))
+    assert (reads & locals_declared) - own == {name}, (
+        f"the scan cannot see a trap reading the function-local {name!r} — it proves nothing"
+    )
+
+
 def test_instrument_failure_is_a_distinct_exit_code_from_a_real_negative() -> None:
     """A check that cannot run must say so, and must NOT testify. rc=2 ("could not find
     out") must never collapse into rc=1 ("the backup is broken").

--- a/scripts/tests/test_restore_verify.py
+++ b/scripts/tests/test_restore_verify.py
@@ -109,6 +109,82 @@ def test_the_scan_does_not_false_positive_on_a_comment() -> None:
     assert not _unflagged_compose_calls("# every `docker compose` here carries -p")
 
 
+def _run_restore_body(text: str) -> str:
+    m = re.search(r"^run_restore\(\) \{(.*?)^\}", text, re.S | re.M)
+    assert m, "could not locate run_restore() — the scan must not silently find nothing"
+    return m.group(1)
+
+
+def test_run_restore_hands_restore_sh_the_throwaway_project() -> None:
+    """THE line the whole workflow's safety rests on.
+
+    `restore.sh` does not take a project argument — it RESOLVES ITS OWN, and the fallback is
+    the LIVE project (scripts/compose_project.sh:48):
+
+        COMPOSE_PROJECT="${COMPOSE_PROJECT:-${COMPOSE_PROJECT_NAME:-noorinalabs}}"
+
+    `restore.sh` is what runs `neo4j-admin database load --overwrite-destination`. So the ONLY
+    thing between a scheduled restore-verify run and `noorinalabs_neo4j_data` is that this
+    export is present. Delete it and the workflow overwrites the production graph, on a cron,
+    unattended — and every other guard in the script still passes, because they all inspect the
+    stack the load will not touch.
+
+    This scan is the same shape as the `-p` scan above, applied to the env handoff instead of
+    the compose argv. It exists because deleting that one line left the whole suite green.
+    (Weronika Zielinska, PR#642 review.)
+    """
+    body = _run_restore_body(_source())
+    assert re.search(r'COMPOSE_PROJECT="\$(RV_PROJECT|\{RV_PROJECT\})"', body), (
+        'run_restore() does not pass COMPOSE_PROJECT="$RV_PROJECT" to restore.sh.\n'
+        "restore.sh will then resolve its own project and FALL BACK TO THE LIVE ONE, and it is\n"
+        "the process that runs `neo4j-admin database load --overwrite-destination`.\n"
+        "This overwrites the PRODUCTION GRAPH. Unrecoverable."
+    )
+
+
+def test_the_handoff_scan_can_actually_see_the_missing_export() -> None:
+    """Calibrate the scan above against the EXACT mutation that survived: delete the
+    `COMPOSE_PROJECT="$RV_PROJECT"` line from run_restore's var-prefix.
+
+    Without this, the scan could be a no-op and its silence would mean nothing — which is
+    precisely the state the suite was in when it reported `33 passed` on a tree that would have
+    destroyed the production graph.
+    """
+    mutated = textwrap.dedent(
+        """\
+        run_restore() {
+            local rc=0
+            COMPOSE_FILE="$RV_COMPOSE" \\
+                RESTORE_DIR="$RESTORE_STAGING_DIR" \\
+                "${SCRIPT_DIR}/restore.sh" --force latest || rc=$?
+        }
+        """
+    )
+    body = _run_restore_body(mutated)
+    assert not re.search(r'COMPOSE_PROJECT="\$(RV_PROJECT|\{RV_PROJECT\})"', body), (
+        "the scan cannot see a run_restore() that has DROPPED the COMPOSE_PROJECT export — "
+        "it would not have caught the live-graph-overwrite mutation, so it proves nothing"
+    )
+
+
+def test_restore_sh_still_emits_the_volume_line_the_handoff_check_reads() -> None:
+    """run_restore verifies the handoff by reading restore.sh's own "Resolved Neo4j data
+    volume:" announcement. That string belongs to someone else's file.
+
+    A producer-side rename would not break the parser — it would QUIETLY NARROW it, the guard
+    downstream would stop guarding, and the tests would stay green
+    (feedback_paraphrase_in_the_product). So pin the anchor against the REAL producer: if
+    restore.sh's wording changes, this fails and names the guard that depends on it, rather than
+    the guard silently going blind.
+    """
+    restore_sh = (SCRIPTS_DIR / "restore.sh").read_text()
+    assert "Resolved Neo4j data volume:" in restore_sh, (
+        "restore.sh no longer emits 'Resolved Neo4j data volume:'. run_restore()'s handoff "
+        "verification reads that exact string and will now refuse to certify any restore "
+        "(rc=2). Update BOTH, or the guard is dead."
+    )
+
+
 def test_the_measurement_path_never_discards_stderr() -> None:
     """`_run_capture` is the only function in the script that produces a value that is read.
 
@@ -232,7 +308,18 @@ world = json.load(open(os.environ["FAKE_WORLD"]))
 argv = sys.argv[1:]
 LIVE = os.environ["LIVE_PROJECT"]
 RV = os.environ["RV_PROJECT"]
-restored = os.path.exists(os.environ["RESTORE_MARKER"])
+
+# WHICH project did restore.sh actually load into?
+#
+# The scratch stack becomes populated ONLY if the restore was addressed to IT. A restore
+# aimed at the live project loads the PRODUCTION graph and leaves the scratch stack empty —
+# which is exactly what would have happened in production, and exactly what the old model
+# (a bare "did restore.sh run?" marker) could not express. That inability is the root cause
+# of the surviving mutation: a harness that cannot represent the catastrophe cannot rule it
+# out. (Weronika Zielinska, PR#642 review.)
+_pf = os.environ["RESTORE_PROJECT_FILE"]
+restored_into = open(_pf).read().strip() if os.path.exists(_pf) else None
+restored = restored_into == RV
 
 def log_call():
     with open(os.environ["FAKE_CALLS"], "a") as fh:
@@ -456,13 +543,42 @@ class Harness:
         self.marker = tmp / "restore_ran"
         self.calls = tmp / "calls.log"
         self.calls.write_text("")
+        # WHICH PROJECT the restore was actually addressed to. This file is the whole point of
+        # the harness rework: without it, "restore.sh loaded into the LIVE project" was a state
+        # the world model could not represent, and the mutation that causes it survived.
+        self.restore_project = tmp / "restore_project"
 
-        # A fake restore.sh that records that it ran. Whether it is reached at all is the
-        # assertion for every guard that must abort BEFORE any load.
+        # THE REAL compose_project.sh, not a paraphrase of it. Its line 48 —
+        #   COMPOSE_PROJECT="${COMPOSE_PROJECT:-${COMPOSE_PROJECT_NAME:-noorinalabs}}"
+        # — is the fallback that makes a dropped export catastrophic, and a restatement of it
+        # here would drift from the original and quietly stop modelling the hazard
+        # (feedback_paraphrase_in_the_product). So the fake restore.sh SOURCES the real file and
+        # resolves its project exactly the way the real restore.sh does.
+        shutil.copy(SCRIPTS_DIR / "compose_project.sh", self.scripts / "compose_project.sh")
+
+        # A fake restore.sh that RESOLVES ITS OWN PROJECT the way the real one does, records it,
+        # and announces the volume it would load into — including, when it has been aimed at the
+        # live project, the LIVE volume. Whether it is reached at all is the assertion for every
+        # guard that must abort BEFORE any load.
         (self.scripts / "restore.sh").write_text(
             "#!/usr/bin/env bash\n"
+            "set -uo pipefail\n"
+            'log() { echo "[$1] ${*:2}"; }\n'
+            'SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"\n'
+            "# shellcheck source=/dev/null\n"
+            'source "${SCRIPT_DIR}/compose_project.sh"\n'
+            f'printf "%s" "${{COMPOSE_PROJECT}}" > {self.restore_project}\n'
             f"echo RESTORE_INVOKED >> {self.marker}\n"
-            'echo "fake restore.sh: $*"\n'
+            # The volume it resolves is the /data volume of the neo4j container in WHATEVER
+            # project it was pointed at. Aimed at `noorinalabs`, that is the production graph.
+            'if [ "${COMPOSE_PROJECT}" = "' + LIVE_PROJECT + '" ]; then\n'
+            f'  VOL="{LIVE_PROJECT}_neo4j_data"\n'
+            "else\n"
+            '  VOL="${COMPOSE_PROJECT}_rv_neo4j_data"\n'
+            "fi\n"
+            'VOL="${FAKE_RESOLVED_VOLUME:-$VOL}"\n'
+            'log "INFO" "Resolved Neo4j data volume: ${VOL}'
+            ' (project ${COMPOSE_PROJECT}, ${COMPOSE_FILE:-})"\n'
             "exit ${FAKE_RESTORE_RC:-0}\n"
         )
         os.chmod(self.scripts / "restore.sh", 0o755)
@@ -501,6 +617,7 @@ class Harness:
             "FAKE_DOCKER_ROOT": str(self.tmp),
             "FAKE_SWEPT": str(self.tmp / "swept"),
             "RESTORE_MARKER": str(self.marker),
+            "RESTORE_PROJECT_FILE": str(self.restore_project),
             "LIVE_PROJECT": LIVE_PROJECT,
             "RV_PROJECT": RV_PROJECT,
             "ENV_FILE": str(self.tmp / ".env"),
@@ -521,6 +638,14 @@ class Harness:
     @property
     def restore_was_invoked(self) -> bool:
         return self.marker.exists()
+
+    @property
+    def restored_into(self) -> str | None:
+        """The compose project restore.sh actually resolved — i.e. the project whose Neo4j
+        volume `neo4j-admin database load --overwrite-destination` would have written to."""
+        if not self.restore_project.exists():
+            return None
+        return self.restore_project.read_text().strip()
 
 
 @pytest.fixture
@@ -636,6 +761,118 @@ def test_an_empty_live_graph_refuses_to_testify(harness) -> None:
     assert r.returncode == RC_INSTRUMENT
     assert "ZERO :Narrator" in r.stdout
     assert not h.restore_was_invoked
+
+
+# ---------------------------------------------------------------------------
+# THE HANDOFF: which project does the destructive load actually land in?
+# ---------------------------------------------------------------------------
+# The load is NOT performed by any compose call in restore_verify.sh. It is performed by
+# restore.sh, which resolves its OWN project and falls back to the LIVE one. Everything below
+# is about that handoff, and none of it was expressible before the fake restore.sh was taught
+# to source the real compose_project.sh and record what it resolved.
+def test_the_restore_is_addressed_to_the_throwaway_project(harness) -> None:
+    h = harness()
+    r = h.run()
+    assert r.returncode == RC_VERIFIED
+    assert h.restored_into == RV_PROJECT, (
+        f"restore.sh loaded into project {h.restored_into!r}, not the throwaway one"
+    )
+
+
+def test_the_restore_is_NEVER_addressed_to_the_live_project(harness) -> None:
+    """The catastrophe, as an assertion. `-p noorinalabs` + service `neo4j` resolves the LIVE
+    container, whose /data is `noorinalabs_neo4j_data`. restore.sh would resolve it, log it, and
+    load into it with --overwrite-destination. Unrecoverable.
+    """
+    h = harness()
+    h.run()
+    assert h.restored_into not in (LIVE_PROJECT, "", None), (
+        f"THE RESTORE WAS AIMED AT {h.restored_into!r} — this overwrites the production graph"
+    )
+
+
+def test_the_harness_can_express_the_catastrophe(harness) -> None:
+    """THE ROOT CAUSE OF THE SURVIVING MUTATION, made into a test.
+
+    The old fake restore.sh ignored COMPOSE_PROJECT entirely, and the old fake docker decided
+    what the scratch stack contained purely from a "did restore.sh run?" marker. So *"restore.sh
+    loaded into the LIVE project"* was **a state the world model could not represent** — and a
+    mutation deleting the one line that prevents it passed 33/33.
+
+    A mutation harness that cannot express the catastrophe cannot rule it out. This test proves
+    the harness now can: drive restore.sh with no COMPOSE_PROJECT and watch it resolve
+    `noorinalabs` through the REAL compose_project.sh.
+    """
+    h = harness()
+    env = {
+        "PATH": f"{h.bin}:{os.environ['PATH']}",
+        "FAKE_WORLD": str(h.world_file),
+        "FAKE_CALLS": str(h.calls),
+        "RESTORE_MARKER": str(h.marker),
+        "RESTORE_PROJECT_FILE": str(h.restore_project),
+        "LIVE_PROJECT": LIVE_PROJECT,
+        "RV_PROJECT": RV_PROJECT,
+        "COMPOSE_FILE": str(h.tmp / "compose" / "docker-compose.restore-verify.yml"),
+    }
+    # Exactly what run_restore does MINUS the COMPOSE_PROJECT export — i.e. the mutation.
+    subprocess.run(
+        ["bash", str(h.scripts / "restore.sh"), "--force", "latest"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert h.restored_into == LIVE_PROJECT, (
+        "the harness STILL cannot express a restore aimed at the live project — so a green "
+        "suite would still not rule out overwriting production"
+    )
+
+
+def test_a_restore_that_reports_a_live_volume_is_refused(harness) -> None:
+    """Fix 4: verify the handoff, do not trust it. If restore.sh announces that it resolved a
+    volume that is not ours, the run must refuse — loudly — rather than proceed to compare.
+    """
+    h = harness(FAKE_RESOLVED_VOLUME=f"{LIVE_PROJECT}_neo4j_data")
+    r = h.run()
+    assert r.returncode == RC_INSTRUMENT, f"a live-volume handoff must be refused\n{r.stdout}"
+    assert "HANDOFF VIOLATION" in r.stdout
+    assert "UNRECOVERABLE" in r.stdout
+
+
+def test_the_handoff_check_accepts_our_own_volume(harness) -> None:
+    """Calibrate the guard above: it must be able to say YES, or it is an unconditional abort."""
+    h = harness()
+    r = h.run()
+    assert r.returncode == RC_VERIFIED
+    assert "handoff verified" in r.stdout
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_the_env_file_cannot_blank_the_project(harness, blank) -> None:
+    """Fix 1: EMPTY is as dangerous as ABSENT — and more dangerous than WRONG.
+
+    `${VAR:-default}` treats "" exactly like unset, so a blank RV_PROJECT does not no-op: it
+    resolves to `noorinalabs` inside restore.sh and aims --overwrite-destination at production.
+    `guard_not_live`'s `!= noorinalabs` check passes happily on "".
+
+    THE REACHABLE PATH IS THE .env, NOT AN INHERITED ENV VAR — and getting this wrong is
+    instructive. An inherited `RV_PROJECT=""` is REPAIRED by the script's own
+    `RV_PROJECT="${RV_PROJECT:-…}"` default before any guard sees it, so a test that exported an
+    empty var would pass for entirely the wrong reason and prove nothing.
+
+    The dangerous ordering is the one Weronika identified: `load_env()` sources the host `.env`
+    with `set -a` AFTER that default has already been applied. An `RV_PROJECT=` line there lands
+    downstream of the repair, and nothing has refused it since. That is the path under test.
+    """
+    h = harness()
+    (h.tmp / ".env").write_text((h.tmp / ".env").read_text() + f"RV_PROJECT={blank}\n")
+    r = h.run()
+    assert r.returncode == RC_INSTRUMENT, f"a blanked RV_PROJECT must be refused\n{r.stdout}"
+    assert "EMPTY or unset" in r.stdout
+    assert not h.restore_was_invoked, (
+        "restore.sh was invoked with a blank project — it would resolve `noorinalabs` and "
+        "overwrite the production graph"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #640

## The gap this closes

`restore_rehearsal.sh` + `restore-rehearsal.yml` already exercise `restore.sh` against **synthetic seed data** and a **locally-fabricated artifact** (`RESTORE_LOCAL_DIR`, no B2). That is valuable and **it stays**. It proves the restore **code path** works and that `restore.sh` rejects broken artifacts.

It cannot prove **this artifact** loads. Those came apart in practice: the real artifact only became restorable after #613/#617/#623/#632, and the synthetic rehearsal was **green through all of it** — it supplies `COMPOSE_PROJECT_NAME`, the one input production omits, so it could never have caught #617.

On 2026-07-14 the real thing was done twice, **by hand** (stg, then prod). That is the evidence #612 was closed on. But the procedure lived nowhere: an ad-hoc compose file `scp`'d to `/var/tmp`, driven by shell written in the moment. *"Can we restore prod?"* was answered by a **transcript, not a green check**. This PR is that procedure as IaC.

## What's here

| File | Role |
|---|---|
| `compose/docker-compose.restore-verify.yml` | Throwaway stack: `rv_*` volumes, **no published ports**, Postgres identity from the **environment** |
| `scripts/restore_verify.sh` | Guards → resource gate → **calibrate** → shipped `restore.sh --force latest` → content comparison |
| `.github/workflows/restore-verify.yml` | `self-test` job (PR, real engines, no B2) + `verify` job (scheduled/dispatch, on-host, per-env matrix) |
| `scripts/tests/test_restore_verify.py` | 30 tests: static scans + behavioural guard suite |

`restore.sh` is **invoked, never modified**.

The Postgres identity is taken from the environment because the live role is `IsnadDbUseer` / `Isnad-Prod`. A stack with different names fails `pg_restore` on a **missing role** (ALTER OWNER → exit 1), and `restore.sh` correctly treats an ignored error as a **failed** restore — so a mismatched stack fails for a reason that has nothing to do with the backup.

## The verdict is never the exit code

`pg_restore --clean` can warn-and-succeed while restoring nothing. Every claim is an assertion about **content**: row counts, full-table checksums, `count(n)`, label + relationship-type histograms, the user-service store (`users` / `oauth_accounts` / `sessions` / `audit_log` / `alembic_version`), all compared against live.

## THE COMPARATOR IS CALIBRATED BEFORE IT IS READ

The first hand-run attempt fingerprinted **`n.name`**, which **does not exist** on `:Narrator` (the real properties are `name_ar` / `name_en` / `id`). Both sides read `NULL`, "agreed" perfectly, and the checksum was `0` on both sides.

> **A both-sides-zero is not a match. It is the instrument reading nothing, twice.**

So `calibrate()` runs against the live stack **before** the restore and **refuses to testify** unless:

1. every fingerprint component is **non-zero** (the property exists at all), and
2. the fingerprint of the graph **minus one narrator DIFFERS** from the full one (it can go red).

**No string test can catch the `n.name` class** — the Cypher is perfectly valid, it just measures nothing (cf. #606/#607: an invalid-Cypher precheck passed 32 tests and two reviewers; only a dry-run against a real database caught it). So the calibration is a **real-engine self-test job**: two actual Neo4j instances on the runner, no B2, no VPS.

### Calibration evidence — the `self-test` job on this PR

Real Neo4j engines, run 29331604114, **4 passed / 0 failed**:

```
[INFO] THE n.name TRAP — fingerprint over the NON-EXISTENT property 'n.name': 50/0
[PASS] self-test: a fingerprint over n.name sums to ZERO on a fully-populated graph.
[PASS] self-test MATCH:  two identically-seeded stacks agree (fp=50/291/541/291)
[PASS] self-test DIFFER: removing ONE narrator changed the fingerprint
                         (ref=50/291/541/291  sub=49/286/531/286)
[PASS] self-test DIFFER: node COUNT is identical (50) yet the fingerprint differs —
                         it sees corrupted CONTENT, not just cardinality
                         (ref=50/291/541/291  sub=50/298/540/291)
```

The `n.name` row is the defect reproduced: on a graph with **50 fully-populated narrators**, a fingerprint over the non-existent property sums to **`50/0`**. On two stacks it would read `0` on both sides and "agree" — which is what happened on the first hand-run. `calibrate()` rejects exactly this before any restore is attempted.

The third row is the one a count-only comparator would miss: **the node count is identical (50 vs 50)** and the fingerprint still separates them.

## Guardrails

- **Refuses the live project / live compose file**, and refuses to run beside an inherited `COMPOSE_FILE` / `COMPOSE_PROJECT(_NAME)` — `restore.sh` reads both.
- **Asserts the resolved Neo4j volume is its own BEFORE any load.** This is the #617 guard and the only reason restore-on-a-live-box is safe to automate. It catches the real #617 shape: not a `noorinalabs_*` volume, but Compose falling back to the compose file's **directory basename** (`compose`).
- **Asserts the scratch stores are EMPTY first**, so a restore that silently does nothing cannot pass on leftover data.
- **Resource-gated**: a second Neo4j wants ~4 GB + the store's size on disk. The live store is **measured**, not guessed; it refuses on an unmeasurable box rather than risk filling the disk out from under the live stack.
- **`EXPECT_PREFIX`**: the matrix leg says which environment it *believes* it is checking, the host's `.env` says which it *is*. Disagreement → refuse. Before #632 the backup watchdog had exactly this defect — the prod leg would have reported `fresh` on the strength of **staging's** backup.
- **Teardown sources the env first**, then verifies the volumes are actually gone and force-removes any that survive. (The `${POSTGRES_USER:?}` interpolation guard aborts `down -v` without it — that happened on the hand-run and leaked volumes holding a full copy of the database.)

## `rc=2` — a check that cannot run must not testify

| exit | meaning |
|---|---|
| 0 | **VERIFIED** — the artifact reproduces live, comparator proven able to go red first |
| 1 | **FAILED** — a real negative |
| 2 | **INSTRUMENT FAILURE** — could not find out (creds, resources, inert comparator, dirty scratch) |

`rc=2` is **never** a claim about the backup. Collapsing it into `rc=1` is how a broken credential became `*** DATA LOSS ***` about an intact backup (#632/#641).

## A bug the tests caught that review would not have

`free_kb="$(df …)"` followed by a `[[ -n "$free_kb" ]] || instrument_fail` guard is **dead code** under `set -e`: a `df` failure is a **crash**, so the script exited **1** — *"the backup does not restore"* — because a directory could not be `stat`'d. Same trap fixed in two more places (`avail_mb`, the health-wait loop). This is `feedback_errexit_kills_assignment_guard` recurring for the fourth time.

## A second bug, caught by the self-test's FIRST CI run

The four calibration cases passed against real engines — and then the **teardown crashed**:

```
[INFO] self-test: tearing down both stacks
./scripts/restore_verify.sh: line 799: ref_project: unbound variable
```

The EXIT trap referenced a `local` declared by the function that installed it. An EXIT trap runs **after** that scope is gone, so under `set -u` it died with "unbound variable" — **before tearing anything down**, leaking both stacks and their volumes. Same leak class the hand-run hit when compose's `${POSTGRES_USER:?}` guard aborted `down -v`.

Fixed (hoisted to script scope) and guarded: a static test now fails if any teardown trap reads a name declared `local` elsewhere.

**That guard was itself born inert.** Its first version matched only `[a-z_]`, so the fix's uppercase rename made it blind to the very line it was written to protect — a mutation re-introducing the bug **SURVIVED**. Now case-insensitive, with both casings as fixtures. An author cannot calibrate their own guard by reading it (#624); only running the mutation exposed it.

## The COMPOSE_FILE sibling (Weronika, round 2) — and the harness made dep-robust

`restore.sh:62` defaults `COMPOSE_FILE` to `compose/docker-compose.prod.yml`, so `COMPOSE_FILE="$RV_COMPOSE"` — the line immediately above the `COMPOSE_PROJECT` one — is a **second** unguarded single point of failure of the same class. Now closed exactly like the first, and the runtime handoff parses **all three** fields of restore.sh's own resolved-volume line (`volume`, `project`, `compose-file`) and refuses (rc=2) unless every one is the throwaway's.

The fake `restore.sh` now sources the **real** `compose_project.sh` by absolute path (not a copy) so its evolving deps — `scratch.sh`, added by #643 — resolve against the real scripts dir. That was also the cause of a transient CI red after rebasing onto #643: the copy didn't carry the new dep, so the fake died before its resolved-volume line and my own handoff guard fired. Sourcing the real file is more faithful and won't break the next time that file grows a dependency.

### Both mutations, with collection counts (a run that collects nothing is BROKEN, not RED)

```
baseline:                            54 collected, 54 passed
drop COMPOSE_PROJECT="$RV_PROJECT":  54 collected, 18 failed
drop COMPOSE_FILE="$RV_COMPOSE":     54 collected, 17 failed
restored:                            54 passed
```

Named catchers: the parametrized static scan `test_run_restore_hands_restore_sh_the_throwaway_target[COMPOSE_PROJECT|COMPOSE_FILE]` plus the runtime/behavioural handoff assertions.

## The finding Weronika Zielinska caught (BLOCKING) — one deleted line from overwriting prod

The destructive write — `neo4j-admin database load --overwrite-destination` — is **not** performed by any compose call in this script. It is performed by `restore.sh`, which **resolves its own project** and **falls back to the LIVE one** (`compose_project.sh:48`). The only thing between a scheduled run and `noorinalabs_neo4j_data` was the single `COMPOSE_PROJECT="$RV_PROJECT"` export in `run_restore`. She deleted it and the suite stayed green (40 passed). `assert_volume_isolation` could not catch it: it inspects the container in `$RV_PROJECT` — true, and about the stack the load will not touch.

Four fixes, all calibrated against her mutation (delete the export):

1. **`guard_not_live` refuses an empty/unset/whitespace `RV_PROJECT` / `RV_COMPOSE`.** `${VAR:-default}` treats `""` like unset → resolves to `noorinalabs`. Reachable via an `RV_PROJECT=` line in the host `.env`, which `load_env` sources with `set -a` *after* the default is applied.
2. **A static scan over the env handoff** (same shape as the `-p` scan): `run_restore` must pass `COMPOSE_PROJECT="$RV_PROJECT"`. Calibrated — a fixture without the export fails it.
3. **The harness can now express the catastrophe** (root cause). The fake `restore.sh` **sources the real `compose_project.sh`** (not a paraphrase), records the project it resolved, and the scratch stack is populated only if the restore was addressed to it. "restore.sh loaded into the LIVE project" is now a representable state.
4. **`run_restore` verifies the handoff:** it reads back `restore.sh`'s own `Resolved Neo4j data volume:` line and requires an `rv_` volume, refusing (rc=2) otherwise. The anchor string is pinned against the real `restore.sh` by a test.

**Her mutation, before → after:**

```
before:  40 passed   (nothing noticed)
after:   17 failed, including
  test_run_restore_hands_restore_sh_the_throwaway_project
  test_the_restore_is_NEVER_addressed_to_the_live_project:
    AssertionError: THE RESTORE WAS AIMED AT 'noorinalabs' — this overwrites the production graph
```

## Teardown: it runs on EVERY exit path, and it never speaks for the verdict

A teardown that dies partway is how volumes leak, and a leaked scratch volume holds **a full copy of production**. Both teardown paths now share `leak_audit()`, which does not trust `down -v`: it **enumerates** by compose's own project label, sweeps, and **re-enumerates** (a sweep's exit code is not evidence the object is gone).

The rule:

- The comparator's verdict is captured **before** any teardown runs and is **never** overwritten by a teardown outcome. A cleanup fault cannot turn a **failing** comparator into a passing run.
- A leak on an otherwise-**green** run is still a fault: exit **2** (INSTRUMENT), reported as exactly what it is — *"the comparator PASSED, but the teardown LEAKED."*

The workflow also asks **Docker** independently, with `if: always()` so it runs precisely when the self-test failed. A verification script must not be the only witness to its own cleanliness (#632/#641).

### Negative-control run — forced failure, real engines (run 29333026088)

Seeded the subject stack with 49 narrators instead of 50 so the comparator genuinely fails:

```
[FAIL] self-test MATCH: identical stacks disagreed (ref=50/291/541/291 sub=49/285/530/285)
[INFO] === SELF-TEST: 2 passed, 2 failed ===
[ERROR] The comparator did NOT separate. It must not be used to certify a restore.
[INFO] self-test: tearing down both stacks (comparator verdict rc=1)
       Container isnad-rv-selftest-ref-neo4j-1  Removed
       Volume    isnad-rv-selftest-ref_rv_neo4j_data  Removed
       Network   isnad-rv-selftest-ref_default  Removed
       Container isnad-rv-selftest-sub-neo4j-1  Removed
       Volume    isnad-rv-selftest-sub_rv_neo4j_data  Removed
       Network   isnad-rv-selftest-sub_default  Removed
[PASS] teardown audit: no stray containers, volumes or networks remain
##[error]Process completed with exit code 1
```

Step conclusions on that run:

| step | conclusion |
|---|---|
| The comparator must separate MATCH from DIFFER | **failure** ← the comparator's verdict |
| Independently verify the self-test left nothing behind | **success** ← ran anyway, via `if: always()` |

**(a)** the teardown ran on the failing verdict and left **zero** strays — confirmed by Docker, not by the script's own say-so; **(b)** the job exited **1**, the *comparator's* verdict, not the teardown's. Branch closed and deleted (#660).

## Mutation-testing the guards

A suite that passes proves nothing until it is shown able to fail. Four guards were deliberately broken:

| mutation | result |
|---|---|
| minus-one calibration removed | test **died** |
| scratch-empty guard removed | test **died** |
| `n.name` dead-component guard removed | test **died** |
| primary volume-isolation guard removed | **SURVIVED** |
| teardown-trap scope guard removed (uppercase) | **SURVIVED** → guard fixed, now dies |
| leak tolerated on a green run | test **died** |
| teardown allowed to overwrite a real negative | test **died** |
| teardown deleted entirely | **SURVIVED 1 of 3** → helper fixed, now dies |

The survivor mattered: the volume test was passing for the **wrong reason** — the belt-and-braces live-prefix check was catching it, so the assertion under test was never exercised. Fixed by adding the real #617 shape (a stray `compose_*` volume, neither live-prefixed nor its own); that mutation now dies.

## Gates

- `pre-commit run --all-files` — clean (incl. actionlint, cspell, gitleaks, ruff)
- `actionlint` — clean, **with shellcheck on PATH** (it silently skips it otherwise)
- `shellcheck -x scripts/restore_verify.sh` — clean
- `python3 -m pytest scripts/tests -q` — **584 passed, 3 skipped** (54 of them new)
- CI on this PR (head `b8cf847`, rebased onto #679): **18 SUCCESS, 1 SKIPPED** (`verify` correctly skipped — it cannot see the bucket or the live stack from a PR)

## Not yet run against a live host

Per the brief, this has **not** been dispatched against stg or prod. The `verify` job needs a merged, CI-green workflow on the host's `main` checkout; the first live dispatch is the orchestrator's to run and watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfLUh7qrqfYdfxa2jNKS5f
