### PR TITLE
fix(backup): make retention's failure visible; bind BACKUP_PREFIX to its host

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -343,33 +343,49 @@ hand-edited file on the box.
 
 | Path | GH secret names (env scope) | VPS env-var names | Bucket | Consumer |
 |---|---|---|---|---|
-| Backups | `BACKUP_B2_KEY_ID`, `BACKUP_B2_APP_KEY`, `BACKUP_B2_BUCKET` | `B2_KEY_ID`, `B2_APP_KEY`, `B2_BUCKET` | `noorinalabs-backups` | `scripts/backup.sh`, `scripts/restore.sh` (rclone-native via `RCLONE_CONFIG_ISNAD_*` exports inside the script) |
+| Backups | `BACKUP_B2_KEY_ID`, `BACKUP_B2_APP_KEY`, `BACKUP_B2_BUCKET` | `B2_KEY_ID`, `B2_APP_KEY`, `B2_BUCKET` | `${B2_BUCKET}` (⚠️ see below — never hardcode it) | `scripts/backup.sh`, `scripts/restore.sh` (rclone-native via `RCLONE_CONFIG_ISNAD_*` exports inside the script) |
 | Terraform state | `TF_STATE_B2_KEY_ID`, `TF_STATE_B2_APP_KEY` (also exposed as `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` to the S3-protocol backend) | n/a (Actions only) | `noorinalabs-terraform-state` | `terraform.yml` |
 | Pipeline ingest | `PIPELINE_B2_KEY_ID`, `PIPELINE_B2_KEY` | `PIPELINE_B2_KEY_ID`, `PIPELINE_B2_KEY` | (declared in data-acquisition repo) | data-acquisition / ingest workers |
 
 Rotating one path does not affect the others.
 
-> ### ⚠️ Two similar names. One of them is a trap. (deploy#636)
+> ### ⚠️ Never type a bucket name. Use `${B2_BUCKET}`. (deploy#636)
+>
+> **In any command you run, write `isnad:${B2_BUCKET}/<env>/…` — never a literal
+> bucket name.** `${B2_BUCKET}` resolves to whatever the `BACKUP_B2_BUCKET`
+> secret actually says, which is the only thing true by construction. A literal
+> is a stale artifact waiting to happen, and this table is the proof: it used to
+> name the wrong bucket, and it did so confidently, for months.
+>
+> Three names in this repo look alike. Two are buckets and only one is real:
 >
 > | Name | What it is |
 > |---|---|
-> | **`noorinalabs-backups`** | the **B2 bucket** — every real backup lives here |
-> | **`/var/lib/noorinalabs-backups`** | a **local directory** on the VPS — the staging area `backup.sh` writes to before the rclone upload. **Not** a bucket. Does not need rotation. |
-> | **`isnad-graph-backups`** | a **legacy, EMPTY B2 bucket**. Nothing writes to it and nothing ever will. |
+> | **`${B2_BUCKET}`** | the **B2 bucket** — every real backup lives here (9 `stg/` + 18 `prod/` objects, 2026-07-14). **Use this form.** Its literal value is the `BACKUP_B2_BUCKET` secret; do not hardcode it. |
+> | **`/var/lib/noorinalabs-backups`** | a **local directory** on the VPS — the staging area `backup.sh` writes to before the rclone upload. **Not** a bucket at all. Does not need rotation. Its name is *confusingly close* to the bucket's; that resemblance is what misled this document. |
+> | **`isnad-graph-backups`** | a **legacy, EMPTY B2 bucket**. It EXISTS, so nothing errors — it simply holds nothing, and never will. |
 >
-> This table used to name `isnad-graph-backups` as the backup bucket, and that
-> is worse than a stale doc: an operator mid-incident copies the line, runs
-> `rclone lsf isnad:isnad-graph-backups/`, gets **zero objects**, and concludes
-> **the backups do not exist**. Measured 2026-07-14: `isnad-graph-backups` = 0
-> objects, `noorinalabs-backups` = 27 (9 `stg/` + 18 `prod/`). A silent zero is
-> not a measurement — least of all in the document someone reads when they are
-> already in trouble.
+> The last row is the trap, and it is worse than a stale doc. An operator
+> mid-incident copies a line naming it, runs
+> `rclone lsf isnad:isnad-graph-backups/prod`, and gets `status=absent dumps=0
+> bucket_objects=0` — a clean, confident **zero**, from the one check that reads
+> B2 rather than a host-local gauge — and concludes **production has no
+> restorable backup**. Measured against stg at the same moment:
 >
-> **Always name the environment prefix too.** stg and prod share this one
-> bucket, namespaced as `noorinalabs-backups/stg/…` and
-> `noorinalabs-backups/prod/…` (deploy#632). A path at the bucket **root**
-> reads both environments' objects as one pool, so a prod check can report
-> healthy on the strength of a staging backup.
+> ```text
+> isnad:isnad-graph-backups/prod  ->  status=absent  dumps=0  objects=0
+> isnad:${B2_BUCKET}/prod         ->  status=fresh   dumps=3  objects=20  age=5h
+> ```
+>
+> A false **RED**, and it sticks: an empty bucket lists `rc=0` with nothing in
+> it, which is byte-for-byte the signature of a healthy-but-empty prefix. *A
+> silent zero is not a measurement* — least of all in the document you only read
+> when you are already in trouble.
+>
+> **And always name the environment.** stg and prod share this one bucket,
+> namespaced `${B2_BUCKET}/stg/…` and `${B2_BUCKET}/prod/…` (deploy#632). A path
+> at the bucket **root** reads both environments' objects as one pool, so a prod
+> check can report healthy on the strength of a staging backup.
 
 **Rotation procedure (backup path — most common):**
 
@@ -394,15 +410,18 @@ Rotating one path does not affect the others.
    sudo journalctl -u isnad-backup.service -n 200
    ```
    Confirm the rclone upload step exits 0 and a new dated subdirectory
-   appears under **that host's own prefix** — never at the bucket root:
+   appears under **that host's own prefix** — never at the bucket root, and
+   never against a hardcoded bucket name:
    ```bash
-   rclone lsf isnad:noorinalabs-backups/stg/daily/    # on stg
-   rclone lsf isnad:noorinalabs-backups/prod/daily/   # on prod
+   rclone lsf "isnad:${B2_BUCKET}/stg/daily/"    # on stg
+   rclone lsf "isnad:${B2_BUCKET}/prod/daily/"   # on prod
    ```
-   An empty result here is **not** proof the backup is missing: a key that
-   is not permitted to list a prefix returns `rc=0` and an empty listing,
-   not an error (deploy#634/#638). Check `isnad_backup_retention_ok` and the
-   journal before concluding anything from a zero.
+   An empty result here is **not** proof the backup is missing. Two different
+   things both return `rc=0` with no output: a prefix the key is not permitted
+   to list (deploy#634/#638), and a bucket that is simply empty — which is what
+   you get if you typed a bucket name and typed the wrong one. Check
+   `isnad_backup_retention_ok` and the journal before concluding anything from
+   a zero.
 5. Revoke the old keys in the Backblaze console only after step 4 has
    passed on **both** stg and prod.
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -343,19 +343,38 @@ hand-edited file on the box.
 
 | Path | GH secret names (env scope) | VPS env-var names | Bucket | Consumer |
 |---|---|---|---|---|
-| Backups | `BACKUP_B2_KEY_ID`, `BACKUP_B2_APP_KEY`, `BACKUP_B2_BUCKET` | `B2_KEY_ID`, `B2_APP_KEY`, `B2_BUCKET` | `isnad-graph-backups` | `scripts/backup.sh`, `scripts/restore.sh` (rclone-native via `RCLONE_CONFIG_ISNAD_*` exports inside the script) |
+| Backups | `BACKUP_B2_KEY_ID`, `BACKUP_B2_APP_KEY`, `BACKUP_B2_BUCKET` | `B2_KEY_ID`, `B2_APP_KEY`, `B2_BUCKET` | `noorinalabs-backups` | `scripts/backup.sh`, `scripts/restore.sh` (rclone-native via `RCLONE_CONFIG_ISNAD_*` exports inside the script) |
 | Terraform state | `TF_STATE_B2_KEY_ID`, `TF_STATE_B2_APP_KEY` (also exposed as `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` to the S3-protocol backend) | n/a (Actions only) | `noorinalabs-terraform-state` | `terraform.yml` |
 | Pipeline ingest | `PIPELINE_B2_KEY_ID`, `PIPELINE_B2_KEY` | `PIPELINE_B2_KEY_ID`, `PIPELINE_B2_KEY` | (declared in data-acquisition repo) | data-acquisition / ingest workers |
 
-Rotating one path does not affect the others. The local FS path
-`/var/lib/noorinalabs-backups` is the staging directory `backup.sh`
-writes to before the rclone upload — it is **not** a B2 bucket name and
-does not need rotation.
+Rotating one path does not affect the others.
+
+> ### ⚠️ Two similar names. One of them is a trap. (deploy#636)
+>
+> | Name | What it is |
+> |---|---|
+> | **`noorinalabs-backups`** | the **B2 bucket** — every real backup lives here |
+> | **`/var/lib/noorinalabs-backups`** | a **local directory** on the VPS — the staging area `backup.sh` writes to before the rclone upload. **Not** a bucket. Does not need rotation. |
+> | **`isnad-graph-backups`** | a **legacy, EMPTY B2 bucket**. Nothing writes to it and nothing ever will. |
+>
+> This table used to name `isnad-graph-backups` as the backup bucket, and that
+> is worse than a stale doc: an operator mid-incident copies the line, runs
+> `rclone lsf isnad:isnad-graph-backups/`, gets **zero objects**, and concludes
+> **the backups do not exist**. Measured 2026-07-14: `isnad-graph-backups` = 0
+> objects, `noorinalabs-backups` = 27 (9 `stg/` + 18 `prod/`). A silent zero is
+> not a measurement — least of all in the document someone reads when they are
+> already in trouble.
+>
+> **Always name the environment prefix too.** stg and prod share this one
+> bucket, namespaced as `noorinalabs-backups/stg/…` and
+> `noorinalabs-backups/prod/…` (deploy#632). A path at the bucket **root**
+> reads both environments' objects as one pool, so a prod check can report
+> healthy on the strength of a staging backup.
 
 **Rotation procedure (backup path — most common):**
 
 1. Generate a new B2 application key in the Backblaze console scoped to
-   the `isnad-graph-backups` bucket only (read+write+delete).
+   the `noorinalabs-backups` bucket only (read+write+delete).
 2. Update the env-scoped GH secrets:
    ```bash
    gh secret set BACKUP_B2_KEY_ID  --env staging    --body "$NEW_KEY_ID"
@@ -375,7 +394,15 @@ does not need rotation.
    sudo journalctl -u isnad-backup.service -n 200
    ```
    Confirm the rclone upload step exits 0 and a new dated subdirectory
-   appears in the B2 bucket.
+   appears under **that host's own prefix** — never at the bucket root:
+   ```bash
+   rclone lsf isnad:noorinalabs-backups/stg/daily/    # on stg
+   rclone lsf isnad:noorinalabs-backups/prod/daily/   # on prod
+   ```
+   An empty result here is **not** proof the backup is missing: a key that
+   is not permitted to list a prefix returns `rc=0` and an empty listing,
+   not an error (deploy#634/#638). Check `isnad_backup_retention_ok` and the
+   journal before concluding anything from a zero.
 5. Revoke the old keys in the Backblaze console only after step 4 has
    passed on **both** stg and prod.
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -106,6 +106,67 @@ if [[ ! "$BACKUP_PREFIX" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
     exit 1
 fi
 
+# ---------------------------------------------------------------------------
+# IS THIS PREFIX THE PREFIX FOR THE HOST WE ARE ACTUALLY STANDING ON? (deploy#636)
+# ---------------------------------------------------------------------------
+# The charset guard above refuses `../prod` and `prod/../stg`. It cannot — by construction —
+# refuse the one accepted value that is catastrophic:
+#
+#     BACKUP_PREFIX=prod          ...on the STAGING host
+#
+# A perfectly legal bare name. Staging then writes its dumps into `prod/`, and staging's
+# retention purge — now correctly scoped to "its own" prefix — DELETES PRODUCTION'S BACKUPS.
+# That is deploy#632 walked back in through the front door. No regex over the value alone can
+# see it, because the value is not malformed: it is wrong only RELATIVE TO THIS HOST.
+#
+# So we need a SECOND, INDEPENDENT witness of which environment this box is. BASE_DOMAIN is
+# one, and it is in scope here because isnad-backup.service loads the whole of
+# /opt/noorinalabs-deploy/.env (`EnvironmentFile=`). The deploy composite writes it from the
+# workflow's `base_domain:` input — `stg.noorinalabs.com` on stg, `noorinalabs.com` on prod.
+#
+# WHY BASE_DOMAIN IS A WITNESS WORTH BELIEVING, rather than a second copy of the same guess:
+# IT IS LOAD-BEARING FOR CADDY. If it were wrong, TLS and every route on the box would be
+# wrong — loudly, immediately, in daylight, with a human already looking. BACKUP_PREFIX is
+# load-bearing for NOTHING until the purge runs at 03:00, unattended, against the other
+# environment's backups. That asymmetry is the entire reason one can testify about the other:
+# we are cross-checking the silent variable against the noisy one.
+#
+# THE THREAT IS THE HAND-EDITED .env, and only that. `write-deploy-env` TRUNCATES and rewrites
+# .env on every deploy (`: > "$env_file"`), so a workflow-injected prefix is authoritative and
+# self-repairing — a bad value there is fixed by the next deploy. The file an operator edits AT
+# 3AM DURING AN INCIDENT is not, and the nightly timer fires before anyone re-deploys. A
+# single-line edit to BACKUP_PREFIX leaves BASE_DOMAIN still telling the truth. This catches
+# exactly that, which is the path deploy#636 names as real.
+#
+# WHAT THIS DELIBERATELY DOES NOT DO: TESTIFY WHEN IT CANNOT SEE. An absent or unrecognised
+# BASE_DOMAIN means WE DO NOT KNOW which host this is. It is NOT evidence that the prefix is
+# wrong. Refusing there would take a backup outage on a host that is perfectly healthy (a new
+# environment, a restore drill, a hand-run invocation) — and it would be the deploy#613 shape
+# exactly: a check that could not run, reporting its own blindness as a fact about the system
+# it was supposed to be checking. So it WARNS and PROCEEDS, and it refuses ONLY on a positive
+# contradiction between two things that both claim to know the answer.
+case "${BASE_DOMAIN:-}" in
+    stg.noorinalabs.com) HOST_ENV="stg" ;;
+    noorinalabs.com)     HOST_ENV="prod" ;;
+    *)                   HOST_ENV="" ;;
+esac
+
+if [[ -n "$HOST_ENV" && "$BACKUP_PREFIX" != "$HOST_ENV" ]]; then
+    echo "FATAL: BACKUP_PREFIX='${BACKUP_PREFIX}' but this host is '${HOST_ENV}'" >&2
+    echo "       (BASE_DOMAIN='${BASE_DOMAIN}')." >&2
+    echo "       Refusing to run. This backup would write into the '${BACKUP_PREFIX}' namespace," >&2
+    echo "       and its retention purge would DELETE THAT ENVIRONMENT'S BACKUPS (deploy#632/#636)." >&2
+    echo "       If this host really IS '${BACKUP_PREFIX}', then BASE_DOMAIN is the thing that is" >&2
+    echo "       wrong — fix that. Do not 'fix' this check." >&2
+    exit 1
+fi
+
+if [[ -z "$HOST_ENV" ]]; then
+    echo "WARNING: cannot verify BACKUP_PREFIX='${BACKUP_PREFIX}' against this host:" >&2
+    echo "         BASE_DOMAIN='${BASE_DOMAIN:-<unset>}' is not a known environment domain." >&2
+    echo "         Proceeding on the prefix alone. This says NOTHING about whether it is right." >&2
+fi
+
 # The REMOTE path is namespaced; the LOCAL one is not. BACKUP_DIR is already
 # per-host, so a prefix there would buy nothing and would churn restore.sh's
 # local-run selection for no reason. Only the shared bucket needs the namespace.
@@ -170,6 +231,23 @@ source "$COMPOSE_PROJECT_LIB"
 TEXTFILE_DIR="${TEXTFILE_DIR:-/var/lib/node_exporter/textfile_collector}"
 SUCCESS_TEXTFILE="${TEXTFILE_DIR}/isnad_backup_success.prom"
 FAILURE_TEXTFILE="${TEXTFILE_DIR}/isnad_backup_failure.prom"
+RETENTION_TEXTFILE="${TEXTFILE_DIR}/isnad_backup_retention.prom"
+
+# Did the retention pass actually RUN? (deploy#635)
+#
+# Set false by prune_old_backups() when it could not LIST a category. Deliberately a SEPARATE
+# fact from the three _OK dump flags, for the same reason NEO4J_DOWN is separate from
+# NEO4J_OK: they answer different questions and the interesting case is where they disagree.
+#
+#   PG_OK/USER_PG_OK/NEO4J_OK — is the ARTIFACT good?   (did we produce a restorable backup)
+#   RETENTION_OK              — is the STORE tidy?      (did we manage to prune the old ones)
+#
+# A run can produce a perfect, complete, restorable backup AND fail entirely to prune, and
+# before this flag that run reported unblemished success: the listing failed, `2>/dev/null`
+# ate the diagnostic, `|| true` ate the return code, the empty string read as "nothing to
+# prune", the loop iterated nothing, and the script logged "=== Backup finished ===" and
+# emitted the success gauge. B2 then grows without bound and NO SIGNAL ANYWHERE SAYS SO.
+RETENTION_OK=true
 
 # Emitted ONLY on a fully-successful run (every dump OK + upload OK). A partial
 # backup must not advance the success timestamp: doing so would silence
@@ -209,6 +287,48 @@ EOF
     rm -f "$FAILURE_TEXTFILE"
 
     log "INFO" "Emitted success metric: ${SUCCESS_TEXTFILE} (ts=${now_epoch})"
+}
+
+# The retention pass's own verdict, as a scrapeable gauge. (deploy#635)
+#
+# Emitted on EVERY run that reaches retention — including a partial backup, which exits
+# non-zero further down. Retention and the artifact are independent facts and each gets its
+# own signal; folding retention into the success gauge would mean a broken purge SUPPRESSED
+# the success gauge on a genuinely complete backup, firing BackupStale falsely and walking
+# straight back into the alert-fatigue trap deploy#559/#565 closed.
+#
+# The failure direction here is SAFE-BUT-SILENT, and that is precisely why it needs a gauge
+# rather than an exit code. `rclone lsf` failing means we could not LIST, so we cannot PURGE:
+# nothing is deleted, no data is lost, and B2 simply keeps growing. Exiting non-zero on it
+# would convert a storage-cost problem into a TOTAL BACKUP OUTAGE — strictly worse, and it
+# would take the run down before emit_success_metric on a night the backup itself was fine.
+# So the run continues, the artifact is honoured, and the gauge carries the bad news.
+emit_retention_metric() {
+    local ok="$1" now_epoch tmp
+    now_epoch="$(date -u +%s)"
+
+    install -d -m 0755 "$TEXTFILE_DIR"
+
+    # Same discipline as emit_success_metric: atomic temp+rename, the temp NAMES ITS PARENT
+    # explicitly (`-p`) so it lands beside the target and not in the read-only /tmp
+    # (deploy#613/#623), and its name ends in .XXXXXX rather than .prom so the collector does
+    # not scrape it half-written.
+    tmp="$(mktemp -p "$(dirname "$RETENTION_TEXTFILE")" "$(basename "$RETENTION_TEXTFILE").XXXXXX")"
+    cat > "$tmp" <<EOF
+# HELP isnad_backup_retention_ok Whether the last backup run's retention pass completed (1) or could not run (0).
+# TYPE isnad_backup_retention_ok gauge
+isnad_backup_retention_ok ${ok}
+# HELP isnad_backup_retention_last_run_timestamp_seconds Unix timestamp of the most recent retention pass.
+# TYPE isnad_backup_retention_last_run_timestamp_seconds gauge
+isnad_backup_retention_last_run_timestamp_seconds ${now_epoch}
+EOF
+    # `umask 077` (set at the top) would otherwise leave this 0600 and root-owned, and
+    # node-exporter reads it as an unprivileged uid through a read-only bind mount — written
+    # and never scraped, the same silent gap deploy#565 exists to close.
+    chmod 644 "$tmp"
+    mv "$tmp" "$RETENTION_TEXTFILE"
+
+    log "INFO" "Emitted retention metric: ${RETENTION_TEXTFILE} (isnad_backup_retention_ok=${ok})"
 }
 
 # ---------------------------------------------------------------------------
@@ -717,9 +837,98 @@ prune_old_backups() {
     # older than the cutoff — so prod's nightly retention would have deleted STG's
     # backups, and stg's would have deleted PROD's. Each environment can now only
     # ever see, and therefore only ever delete, its own.
-    local dirs
-    dirs=$(rclone lsf "${RCLONE_REMOTE}:${B2_BUCKET}/${BACKUP_PREFIX}/${category}/" --dirs-only 2>/dev/null || true)
+    #
+    # -----------------------------------------------------------------------------
+    # AN EMPTY LISTING AND A FAILED LISTING ARE THE SAME EMPTY STRING. (deploy#635)
+    # -----------------------------------------------------------------------------
+    # This was:
+    #
+    #     dirs=$(rclone lsf "…/${BACKUP_PREFIX}/${category}/" --dirs-only 2>/dev/null || true)
+    #
+    # `2>/dev/null` discarded the diagnostic and `|| true` discarded the return code, so a bad
+    # credential, a network fault, a wrong bucket and a wrong prefix ALL COLLAPSED INTO THE
+    # SAME VALUE as the legitimate "this environment has no old backups": the empty string.
+    # The `while` loop then iterated nothing, retention silently no-op'd, and the run went on
+    # to log "=== Backup finished ===" and emit the success gauge. B2 grows without bound and
+    # nothing anywhere says so.
+    #
+    # `restore.sh` has read this exact instrument correctly since deploy#584 (`list_category`,
+    # `resolve_latest`) — capture the rc, capture stderr to a file, log rclone's OWN WORDS on a
+    # non-zero rc, and say out loud that an instrument failure is NOT a verdict about the data.
+    # The two scripts disagreed about how to read the same tool. They now agree.
+    #
+    # The stderr capture MUST come from `scratch_file()` and never a bare `mktemp`: under
+    # isnad-backup.service /tmp is READ-ONLY (ProtectSystem=strict, PrivateTmp deliberately
+    # unset — deploy#121 Bug A), the allocation would fail, `$lerr` would be empty, the
+    # `2>"$lerr"` redirect would die, and this guard would report ITS OWN breakage as a fact
+    # about B2. That is deploy#613/#623, which has shipped twice, and CI cannot see it because
+    # CI has a writable /tmp.
+    local dirs lrc=0 lerr
+    if ! lerr="$(scratch_file)"; then
+        log "ERROR" "Retention (${category}): could not RUN — no writable scratch file."
+        log "ERROR" "  This says NOTHING about B2 or about your backups. Scratch parent tried:"
+        log "ERROR" "  ${BACKUP_DIR:-${TMPDIR:-/tmp}} — the unit grants it via ReadWritePaths."
+        log "ERROR" "  Check free space first (BACKUP_DIR is the volume the dumps just filled)."
+        RETENTION_OK=false
+        return 1
+    fi
 
+    # `|| lrc=$?`, never a bare assignment: under `set -euo pipefail` an assignment whose
+    # command substitution exits non-zero IS a failing simple command, and errexit fires AT THE
+    # ASSIGNMENT — the rc check below would be dead code on every failing path (deploy#563).
+    dirs="$(rclone lsf "${RCLONE_REMOTE}:${B2_BUCKET}/${BACKUP_PREFIX}/${category}/" --dirs-only 2>"$lerr")" || lrc=$?
+    if [[ "$lrc" -ne 0 ]]; then
+        log "ERROR" "Retention (${category}): could not LIST ${BACKUP_PREFIX}/${category}/ (rclone rc=${lrc}):"
+        log_captured_stderr "$lerr"
+        log "ERROR" "  This is an INSTRUMENT failure — NOT a claim that there is nothing to prune."
+        log "ERROR" "  Nothing has been deleted and no backup is at risk; the failure direction is"
+        log "ERROR" "  safe. But retention DID NOT RUN for '${category}', so B2 keeps growing until"
+        log "ERROR" "  this is fixed. isnad_backup_retention_ok will be 0 for this run."
+        rm -f "$lerr"
+        RETENTION_OK=false
+        return 1
+    fi
+    rm -f "$lerr"
+
+    # -------------------------------------------------------------------------------
+    # rc=0 IS NOT PROOF THAT WE SAW ANYTHING. (deploy#634/#638)
+    # -------------------------------------------------------------------------------
+    # rclone returns rc=0 WITH EMPTY OUTPUT for a listing the key is not permitted to see. It is
+    # not a 403 — it is a successful listing of nothing. So the rc check above closes the
+    # bad-credential and network-fault classes and CANNOT, even in principle, close this one: a
+    # key scoped away from this prefix returns byte-for-byte what "no old backups" returns.
+    # An exit code reports whether a tool finished its work, never whether it was ALLOWED to.
+    #
+    # But we know something this listing does not: WE JUST UPLOADED INTO THIS PREFIX, a few lines
+    # ago, and `rclone copy` said it succeeded. So for the category THIS RUN WROTE TO,
+    # `${DATE_STAMP}/` is necessarily present in the bucket. If the listing cannot show it to us,
+    # the listing is not describing the bucket, and nothing downstream of it may be believed —
+    # least of all a decision about what to DELETE.
+    #
+    # That is a positive control carried in production, and it is the only reason the empty
+    # string below can be trusted at all: prove the instrument can see a thing we KNOW is there
+    # before believing it when it tells us a thing is NOT there.
+    #
+    # Scoped to the category this run actually wrote to. The OTHER category is legitimately empty
+    # on a young environment — no Sunday has happened yet — and demanding a directory there would
+    # refuse to prune on a perfectly healthy host.
+    if [[ "$category" == "$BACKUP_CATEGORY" ]] && ! grep -qE "^${DATE_STAMP}/?$" <<< "$dirs"; then
+        log "ERROR" "Retention (${category}): the listing came back rc=0 but does NOT contain"
+        log "ERROR" "  ${DATE_STAMP}/ — the directory THIS RUN JUST UPLOADED into it."
+        log "ERROR" "  That is impossible for a listing that is actually describing the bucket, so"
+        log "ERROR" "  this one is not. The most likely cause is an application key that cannot"
+        log "ERROR" "  LIST this prefix: rclone renders that as rc=0 and an EMPTY listing, not as a"
+        log "ERROR" "  permission error (deploy#634/#638)."
+        log "ERROR" "  REFUSING to prune from a listing that cannot see a directory known to exist."
+        log "ERROR" "  Nothing has been deleted. isnad_backup_retention_ok will be 0 for this run."
+        RETENTION_OK=false
+        return 1
+    fi
+
+    # rc=0 with EMPTY output is NOW a legitimate "nothing to prune" — a young environment, or one
+    # whose every directory is still inside the retention window. It is a measurement, and it is
+    # the ONLY empty string this function is willing to believe, because the control above has
+    # just established that this listing CAN see what is really there.
     while IFS= read -r dir; do
         [[ -z "$dir" ]] && continue
         # Strip trailing slash
@@ -736,16 +945,45 @@ prune_old_backups() {
                     log "INFO" "[DRY RUN] Would prune: ${BACKUP_PREFIX}/${category}/${dir}/"
                 else
                     log "INFO" "Pruning: ${BACKUP_PREFIX}/${category}/${dir}/"
-                    rclone purge "${RCLONE_REMOTE}:${B2_BUCKET}/${BACKUP_PREFIX}/${category}/${dir}/" 2>>"$LOG_FILE" || \
-                        log "WARNING" "Failed to prune ${BACKUP_PREFIX}/${category}/${dir}/"
+                    # A purge that FAILED is retention that did not happen, and it used to say
+                    # so at WARNING and leave every other signal reading clean. The directory is
+                    # still there, still costing money, still counted as pruned by nobody. Same
+                    # gauge, same reason: the failure is safe (nothing was deleted) but it must
+                    # not be silent.
+                    local prc=0
+                    rclone purge "${RCLONE_REMOTE}:${B2_BUCKET}/${BACKUP_PREFIX}/${category}/${dir}/" 2>>"$LOG_FILE" || prc=$?
+                    if [[ "$prc" -ne 0 ]]; then
+                        log "ERROR" "Retention: FAILED to prune ${BACKUP_PREFIX}/${category}/${dir}/ (rclone rc=${prc})"
+                        log "ERROR" "  rclone's own words are in ${LOG_FILE}. The directory REMAINS in B2."
+                        RETENTION_OK=false
+                    fi
                 fi
             fi
         fi
     done <<< "$dirs"
 }
 
-prune_old_backups "daily" "$DAILY_RETAIN"
-prune_old_backups "weekly" "$((WEEKLY_RETAIN * 7))"
+# `|| true` here is DELIBERATE and is not the deploy#584 anti-pattern it resembles.
+#
+# prune_old_backups returns non-zero when it could not LIST — an honest function contract. But
+# these are bare simple commands under `set -e`, so a bare call would ABORT THE RUN on that rc:
+# no summary, no success gauge, no retention gauge, and a complete, uploaded, restorable backup
+# reported to systemd as a total failure. That is the outcome deploy#635 explicitly rules out —
+# it converts a storage-cost problem into a backup outage, which is strictly worse.
+#
+# The rc is therefore NOT the signal, and nothing here reads it. RETENTION_OK is the signal, the
+# function sets it before returning, and the gauge below carries it off the box. The diagnostic
+# was already logged, with rclone's own words, inside the function.
+prune_old_backups "daily" "$DAILY_RETAIN" || true
+prune_old_backups "weekly" "$((WEEKLY_RETAIN * 7))" || true
+
+# Emitted on EVERY run that reaches retention, success or partial, so the gauge always describes
+# THIS run rather than decaying into a stale reading from the last one that happened to get here.
+if [[ "$RETENTION_OK" == "true" ]]; then
+    emit_retention_metric 1
+else
+    emit_retention_metric 0
+fi
 
 # ---------------------------------------------------------------------------
 # Summary
@@ -754,8 +992,19 @@ log "INFO" "=== Backup summary ==="
 log "INFO" "PostgreSQL (isnad):        $(if $PG_OK; then echo "OK"; else echo "FAILED"; fi)"
 log "INFO" "PostgreSQL (user-service): $(if $USER_PG_OK; then echo "OK"; else echo "FAILED"; fi)"
 log "INFO" "Neo4j:                     $(if $NEO4J_OK; then echo "OK"; else echo "FAILED"; fi)"
+log "INFO" "Retention:                 $(if $RETENTION_OK; then echo "OK"; else echo "FAILED"; fi)"
 log "INFO" "Category:   ${BACKUP_CATEGORY}"
 log "INFO" "Remote:     ${RCLONE_REMOTE}:${B2_BUCKET}/${REMOTE_SUBDIR}/"
+
+# A run whose retention could not run must not be able to print an unqualified finish. The
+# artifact is still good and still uploaded — that is why this is an ERROR line and not an
+# `exit 1` — but "=== Backup finished ===" on its own is the sentence that made this invisible.
+if [[ "$RETENTION_OK" != "true" ]]; then
+    log "ERROR" "Retention did NOT run to completion — see the errors above. The backup ARTIFACT"
+    log "ERROR" "  is unaffected and nothing was deleted, but old backups are NOT being pruned"
+    log "ERROR" "  and B2 will grow without bound. isnad_backup_retention_ok=0."
+fi
+
 log "INFO" "=== Backup finished ==="
 
 # A partial backup is a failed backup: exit non-zero WITHOUT emitting the

--- a/scripts/tests/test_backup_retention_and_host_binding.py
+++ b/scripts/tests/test_backup_retention_and_host_binding.py
@@ -44,6 +44,7 @@ is not. Saying so in the narrow words, because the wide words are how deploy#613
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -54,7 +55,11 @@ BACKUP_SH = REPO_ROOT / "scripts" / "backup.sh"
 DEPLOY_STG = REPO_ROOT / ".github" / "workflows" / "deploy-stg.yml"
 DEPLOY_PROD = REPO_ROOT / ".github" / "workflows" / "deploy-prod.yml"
 
-BUCKET = "isnad-graph-backups"
+# The REAL bucket, matching the fixtures in test_b2_preflight.py and
+# test_compose_project_scoping.py. Not `isnad-graph-backups` — that is a legacy, EMPTY bucket
+# that nothing writes to, and naming it in a fixture would quietly teach the next reader the
+# same wrong thing the runbook did (deploy#636).
+BUCKET = "noorinalabs-backups"
 
 # The words rclone's stub writes to STDERR when the listing fails. The point of the fix is
 # that THESE WORDS REACH THE OPERATOR — the pre-fix `2>/dev/null` ate them. An assertion on a
@@ -613,11 +618,121 @@ def test_an_unknown_host_WARNS_and_does_not_testify(tmp_path: Path) -> None:
 
 
 def _workflow_prefix(workflow: Path) -> str:
-    import re
-
     m = re.search(r"^\s*BACKUP_PREFIX=(\S+)", workflow.read_text(), re.MULTILINE)
     assert m, f"{workflow.name} does not inject BACKUP_PREFIX at all"
     return m.group(1)
+
+
+# ---------------------------------------------------------------------------
+# deploy#636 — an operator-facing example must not be a loaded gun.
+# ---------------------------------------------------------------------------
+
+RUNBOOK = REPO_ROOT / "RUNBOOK.md"
+VERIFY_SH = REPO_ROOT / "scripts" / "verify_b2_backup_artifact.sh"
+
+# The legacy bucket. It EXISTS in B2 and it is EMPTY — nothing writes to it. Measured
+# 2026-07-14: `isnad-graph-backups` = 0 objects, `noorinalabs-backups` = 27 (9 stg + 18 prod).
+EMPTY_LEGACY_BUCKET = "isnad-graph-backups"
+LIVE_BUCKET = "noorinalabs-backups"
+
+# An rclone path into the backups remote, as it appears in a RUNNABLE example.
+_RCLONE_PATH = re.compile(r"isnad:(?P<bucket>[a-z0-9-]+)(?P<rest>/\S*)?")
+
+# The environment must appear immediately under the bucket. `${B2_BUCKET}/${{ matrix.env }}`
+# and a literal `stg`/`prod` both qualify; a bare bucket root does not.
+_HAS_ENV = re.compile(r"^/(?:stg|prod|\$)")
+
+
+def _runnable_rclone_paths() -> list[tuple[str, str]]:
+    """Every rclone backups path an operator could COPY AND RUN, as (source, line).
+
+    Prose that *names* the empty bucket in order to warn about it is not a runnable example
+    and must not be flagged — otherwise the only way to satisfy this guard would be to delete
+    the warning, which is the one thing that must survive. So this reads exactly two things:
+
+      * fenced ```bash blocks in RUNBOOK.md  — what an operator copies
+      * `#   B2_ROOT="isnad:…` usage lines   — the shell scripts' copy-paste examples
+
+    The blockquote warning in RUNBOOK.md and the explanatory comments in the scripts are
+    neither, and are correctly invisible here.
+    """
+    out: list[tuple[str, str]] = []
+
+    in_bash = False
+    for line in RUNBOOK.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_bash = stripped.startswith("```bash")
+            continue
+        if in_bash and "isnad:" in line:
+            out.append((RUNBOOK.name, line.strip()))
+
+    for line in VERIFY_SH.read_text().splitlines():
+        if re.match(r'^#\s+B2_ROOT="isnad:', line.strip()):
+            out.append((VERIFY_SH.name, line.strip()))
+
+    return out
+
+
+def test_the_detector_sees_a_runnable_example_and_ignores_the_warning() -> None:
+    """Calibrate before reading. A guard that flags nothing is not a guard, and one that
+    flags the WARNING would force someone to delete the warning to get green."""
+    found = _runnable_rclone_paths()
+    assert found, (
+        "the detector found NO runnable rclone examples at all — it is inert, and every "
+        "assertion below it is worthless."
+    )
+    # It must be reading the real examples, not the prose that merely mentions the bucket.
+    joined = " ".join(line for _, line in found)
+    assert LIVE_BUCKET in joined, f"the detector is not seeing the real examples: {found}"
+
+
+def test_no_operator_example_names_the_EMPTY_bucket() -> None:
+    """RUNBOOK.md:346 named `isnad-graph-backups` — a bucket that exists and holds NOTHING.
+
+    This is not a stale-doc nit. An operator doing a DR restore follows the line, runs
+    `rclone lsf isnad:isnad-graph-backups/`, gets a clean and confident ZERO, and concludes
+    THE BACKUPS DO NOT EXIST — while 27 objects sit in `noorinalabs-backups`. A silent zero is
+    not a measurement, and this one was pre-baked into the document you only ever read when
+    you are already in trouble.
+    """
+    offenders = [
+        f"{src}: {line}" for src, line in _runnable_rclone_paths() if EMPTY_LEGACY_BUCKET in line
+    ]
+    assert not offenders, (
+        f"a runnable example names the EMPTY legacy bucket `{EMPTY_LEGACY_BUCKET}`. Copy-pasted "
+        f"during an incident it returns zero objects and reads as 'there are no backups':\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_every_operator_example_names_its_environment() -> None:
+    """stg and prod share one bucket. A path at the ROOT reads both environments as one pool,
+    so a prod check reports healthy on the strength of a staging backup (deploy#632/#633).
+
+    THE ENVIRONMENT HAS TWO LEGAL SPELLINGS, and a gate that knows only one of them is a gate
+    that blocks the correct fix. `verify_b2_backup_artifact.sh` accepts the environment either
+    baked into B2_ROOT (`isnad:<bucket>/prod`) or carried alongside it (`B2_PREFIX="prod"`), and
+    both are correct. The first cut of this detector matched only the path form and went RED on
+    the script's own documented B2_PREFIX example — a line-scan gate must match EVERY syntactic
+    form, not the one the author happened to write first
+    (`feedback_lint_gate_cover_all_syntactic_forms`).
+    """
+    offenders = []
+    for src, line in _runnable_rclone_paths():
+        # The environment may be supplied out-of-band on the same line.
+        if re.search(r'B2_PREFIX="?(?:stg|prod|\$)', line):
+            continue
+        for m in _RCLONE_PATH.finditer(line):
+            rest = m.group("rest") or ""
+            if not _HAS_ENV.match(rest):
+                offenders.append(f"{src}: {line}")
+
+    assert not offenders, (
+        "a runnable example reaches into the backups bucket without naming an environment. "
+        "stg and prod share it, so this scans BOTH and reports fresh on whichever it finds:\n  "
+        + "\n  ".join(offenders)
+    )
 
 
 def test_each_deploy_workflow_injects_ITS_OWN_environment() -> None:

--- a/scripts/tests/test_backup_retention_and_host_binding.py
+++ b/scripts/tests/test_backup_retention_and_host_binding.py
@@ -586,6 +586,135 @@ def test_each_host_accepts_exactly_its_own_prefix(tmp_path: Path, domain: str) -
     )
 
 
+# Domains that are NOT stg and NOT prod — but which a careless matcher would happily call one.
+#
+# Every one of these CONTAINS `noorinalabs.com` as a substring. That is the whole point: the
+# anchored `case` arms cannot substring-match, but a globbed arm (`*noorinalabs.com*`) can, and
+# would classify each of these as **prod**. A restore-drill box, a new environment, a lookalike
+# domain — each silently declared production, and then permitted to write into `prod/` and to
+# run `rclone purge` against PRODUCTION'S BACKUPS.
+UNRECOGNISED_DOMAINS = [
+    "restore.noorinalabs.com",  # a restore-drill / rehearsal box
+    "dev.noorinalabs.com",  # a future environment nobody told backup.sh about
+    "noorinalabs.com.attacker.test",  # a lookalike; suffix-anchored matching also fails here
+    "foo.example.com",  # unrelated entirely — the easy case, kept as the control
+]
+
+
+@pytest.mark.parametrize("domain", UNRECOGNISED_DOMAINS)
+@pytest.mark.parametrize("prefix", ["stg", "prod"])
+def test_a_PRESENT_but_unrecognised_host_warns_and_is_never_classified(
+    tmp_path: Path, domain: str, prefix: str
+) -> None:
+    """deploy#653 — the hole Nino Kavtaradze found: ABSENT was tested, PRESENT-BUT-UNKNOWN was not.
+
+    The code is correct — an anchored `case` cannot substring-match — but nothing PINNED it, and
+    "correct today" is not the property we need. The property is that it cannot silently STOP
+    being correct. A `*noorinalabs.com*` glob would pass every other test in this file (the arms
+    are ordered stg-first, so both KNOWN hosts still resolve correctly) and would quietly
+    classify every domain above as **prod**.
+
+    Read what that buys on a restore-drill box called `restore.noorinalabs.com`:
+
+        BACKUP_PREFIX=prod  ->  HOST_ENV=prod  ->  MATCH  ->  ALLOWED
+                            ->  it writes into prod/ and PURGES PRODUCTION'S BACKUPS
+
+    That is the single catastrophic direction, and it is the entire reason deploy#636 exists.
+
+    So this asserts the honest outcome for BOTH prefixes: an unrecognised host is not stg and is
+    not prod — it is UNKNOWN. Warn, proceed, and testify to nothing. The `prefix` axis is what
+    makes the mutant unable to hide: under the glob it is silently ALLOWED for `prod` (no
+    warning) and wrongly REFUSED for `stg` (a contradiction that does not exist).
+    """
+    proc, _ = _run_backup(tmp_path, prefix=prefix, base_domain=domain, lsf_mode="ok_old")
+    combined = proc.stdout + proc.stderr
+
+    assert "cannot verify BACKUP_PREFIX" in combined, (
+        f"BASE_DOMAIN={domain!r} is neither stg nor prod, but the run did not warn that it "
+        f"could not verify the prefix — so it CLASSIFIED this host as something. A matcher that "
+        f"substring-matches would call this 'prod', and a prod-prefixed backup here would purge "
+        f"production's backups:\n{combined[-2000:]}"
+    )
+    assert _CONTRADICTION not in combined, (
+        f"BASE_DOMAIN={domain!r} was treated as a KNOWN host and found to CONTRADICT "
+        f"BACKUP_PREFIX={prefix!r}. It contradicts nothing — it is unrecognised, and the check "
+        f"has no business having an opinion about it:\n{combined[-2000:]}"
+    )
+    assert proc.returncode == 0, (
+        f"an unrecognised host refused the run outright:\n{combined[-2000:]}"
+    )
+
+
+def test_the_substring_glob_mutant_is_KILLED(tmp_path: Path) -> None:
+    """Calibrate the fixtures above by reintroducing the exact defect they exist to catch.
+
+    Nino Kavtaradze (#644 review, deploy#653): "the unknown-host branch is only tested ABSENT,
+    never present-but-unrecognised — a substring-glob mutant survives the suite." It did. This
+    kills it.
+
+    Note the arms stay in the SAME ORDER. The mutant is not a reordering trick — `stg` is still
+    matched first, so both KNOWN hosts still resolve correctly and every other assertion in this
+    module still passes. That is precisely what made it survive: it is invisible everywhere
+    except on a host that is neither, which is the case nothing tested.
+    """
+    body = BACKUP_SH.read_text()
+
+    anchored = (
+        'case "${BASE_DOMAIN:-}" in\n'
+        '    stg.noorinalabs.com) HOST_ENV="stg" ;;\n'
+        '    noorinalabs.com)     HOST_ENV="prod" ;;\n'
+        '    *)                   HOST_ENV="" ;;\n'
+        "esac"
+    )
+    assert anchored in body, (
+        "backup.sh no longer has the anchored `case` this mutation targets — the mutation would "
+        "be a no-op and this calibration would be vacuous."
+    )
+
+    globbed = (
+        'case "${BASE_DOMAIN:-}" in\n'
+        '    *stg.noorinalabs.com*) HOST_ENV="stg" ;;\n'
+        '    *noorinalabs.com*)     HOST_ENV="prod" ;;\n'
+        '    *)                     HOST_ENV="" ;;\n'
+        "esac"
+    )
+    mutant_dir = tmp_path / "scripts"
+    mutant_dir.mkdir(parents=True)
+    for lib in ("compose_project.sh", "b2_preflight.sh"):
+        (mutant_dir / lib).write_bytes((REPO_ROOT / "scripts" / lib).read_bytes())
+    mutant = mutant_dir / "backup.sh"
+    mutant.write_text(body.replace(anchored, globbed))
+
+    # THE MUTANT MUST STILL BE CORRECT ON THE KNOWN HOSTS. If it broke those, it would be caught
+    # by tests that already exist, it would not be the bug Nino described, and this calibration
+    # would be proving something else entirely.
+    ok, _ = _run_backup(
+        tmp_path / "known", prefix="stg", base_domain="stg.noorinalabs.com", script=mutant
+    )
+    assert _CONTRADICTION not in (ok.stdout + ok.stderr), (
+        "the mutant is not the bug under test — it broke a KNOWN host, so the existing tests "
+        "would catch it and it demonstrates nothing about the unknown-host hole."
+    )
+
+    # AND IT MUST MISCLASSIFY THE UNKNOWN ONE. `restore.noorinalabs.com` contains
+    # `noorinalabs.com`, so the globbed arm calls it PROD — and a prod-prefixed backup on that
+    # box is then ALLOWED to purge production's backups. Silently. No warning.
+    bad, _ = _run_backup(
+        tmp_path / "unknown",
+        prefix="prod",
+        base_domain="restore.noorinalabs.com",
+        script=mutant,
+    )
+    combined = bad.stdout + bad.stderr
+    assert "Running retention pruning" in combined, (
+        f"the mutant never reached retention, so its silence proves nothing:\n{combined[-2000:]}"
+    )
+    assert "cannot verify BACKUP_PREFIX" not in combined, (
+        "the substring-glob mutant still WARNED on an unrecognised host — it is not reproducing "
+        "deploy#653, so it calibrates nothing."
+    )
+
+
 def test_an_unknown_host_WARNS_and_does_not_testify(tmp_path: Path) -> None:
     """A check that cannot run must say so — and must NOT convert its own blindness into a
     verdict about the system it was checking.
@@ -635,11 +764,16 @@ VERIFY_SH = REPO_ROOT / "scripts" / "verify_b2_backup_artifact.sh"
 EMPTY_LEGACY_BUCKET = "isnad-graph-backups"
 LIVE_BUCKET = "noorinalabs-backups"
 
-# An rclone path into the backups remote, as it appears in a RUNNABLE example.
-_RCLONE_PATH = re.compile(r"isnad:(?P<bucket>[a-z0-9-]+)(?P<rest>/\S*)?")
+# An rclone path into the backups remote, as it appears in a RUNNABLE example. The bucket is
+# either a `${B2_BUCKET}`-style expansion (correct) or a hardcoded literal (never correct).
+# `[A-Z0-9_]+`, not `[A-Z_]+`: the variable is `B2_BUCKET` and it has a DIGIT in it. The first
+# cut stopped at `${B`, left `2_BUCKET}/prod` as the "rest", and duly reported the correct line
+# as missing its environment — a detector that cannot spell the name of the thing it is looking
+# for will fail the fix and pass the bug.
+_RCLONE_PATH = re.compile(r"isnad:(?P<bucket>\$\{?[A-Z0-9_]+\}?|[a-z0-9-]+)(?P<rest>/\S*)?")
 
-# The environment must appear immediately under the bucket. `${B2_BUCKET}/${{ matrix.env }}`
-# and a literal `stg`/`prod` both qualify; a bare bucket root does not.
+# The environment must appear immediately under the bucket. A literal `stg`/`prod` and an
+# expansion (`${{ matrix.env }}`) both qualify; a bare bucket root does not.
 _HAS_ENV = re.compile(r"^/(?:stg|prod|\$)")
 
 
@@ -682,19 +816,61 @@ def test_the_detector_sees_a_runnable_example_and_ignores_the_warning() -> None:
         "the detector found NO runnable rclone examples at all — it is inert, and every "
         "assertion below it is worthless."
     )
-    # It must be reading the real examples, not the prose that merely mentions the bucket.
-    joined = " ".join(line for _, line in found)
-    assert LIVE_BUCKET in joined, f"the detector is not seeing the real examples: {found}"
+    # It must be READING the examples, not merely finding lines: every one it returns must parse
+    # into a bucket + path. A detector that matched the lines but extracted nothing from them
+    # would pass every assertion below by vacuity.
+    parsed = [m for _, line in found for m in _RCLONE_PATH.finditer(line)]
+    assert parsed, f"the detector found lines but could not PARSE a single rclone path: {found}"
+    assert any(m.group("bucket").startswith("$") for m in parsed), (
+        f"the detector cannot see the `${{B2_BUCKET}}` form at all — the very form it is meant "
+        f"to require. It would report every correct example as an offender: {found}"
+    )
+    # And it must be reading the runnable examples, not the blockquote prose that mentions the
+    # legacy bucket in order to WARN about it. That warning must survive this guard.
+    assert not any(EMPTY_LEGACY_BUCKET in line for _, line in found), (
+        f"the detector is picking up the prose warning as if it were a runnable example. It "
+        f"would force someone to DELETE the warning to go green: {found}"
+    )
+
+
+def test_no_operator_example_HARDCODES_a_bucket_name() -> None:
+    """The property is not "name the right bucket". It is "never name a bucket at all".
+
+    `RUNBOOK.md:346` hardcoded `isnad-graph-backups` — a bucket that exists and holds NOTHING —
+    and it did so confidently, for months. An operator doing a DR restore follows the line, gets
+    `status=absent dumps=0 bucket_objects=0` from the one check that reads B2 rather than a
+    host-local gauge, and concludes THE BACKUPS DO NOT EXIST. Meanwhile the real bucket holds a
+    healthy five-hour-old backup.
+
+    The first fix was to swap in the correct literal. That is not enough, and Bereket Tadesse was
+    right to block on it: a hardcoded bucket is a stale artifact waiting to happen, and it is
+    exactly how the previous one went wrong. `${B2_BUCKET}` resolves to whatever the
+    BACKUP_B2_BUCKET secret actually says, which is the only thing that is true BY CONSTRUCTION —
+    immune to this entire class of error and to the next rename.
+
+    So the guard forbids ANY literal, including today's correct one. A test that only banned the
+    known-bad name would be a blocklist of one, and the next wrong bucket would sail past it.
+    """
+    offenders = []
+    for src, line in _runnable_rclone_paths():
+        for m in _RCLONE_PATH.finditer(line):
+            if not m.group("bucket").startswith("$"):
+                offenders.append(f"{src}: {line}")
+
+    assert not offenders, (
+        "a runnable example HARDCODES a bucket name. Use `isnad:${B2_BUCKET}/<env>` — a literal "
+        "is a stale artifact waiting to happen, and the last one named an EMPTY bucket, which "
+        "reads as 'there are no backups' when copy-pasted during an incident:\n  "
+        + "\n  ".join(offenders)
+    )
 
 
 def test_no_operator_example_names_the_EMPTY_bucket() -> None:
-    """RUNBOOK.md:346 named `isnad-graph-backups` — a bucket that exists and holds NOTHING.
+    """Belt and braces on the one literal we KNOW is a loaded gun.
 
-    This is not a stale-doc nit. An operator doing a DR restore follows the line, runs
-    `rclone lsf isnad:isnad-graph-backups/`, gets a clean and confident ZERO, and concludes
-    THE BACKUPS DO NOT EXIST — while 27 objects sit in `noorinalabs-backups`. A silent zero is
-    not a measurement, and this one was pre-baked into the document you only ever read when
-    you are already in trouble.
+    Subsumed by the hardcoding ban above, and kept anyway: this is the specific name that cost
+    real time in review, and it names its own failure mode in the assertion message. If someone
+    ever relaxes the general rule, this is the line that must still hold.
     """
     offenders = [
         f"{src}: {line}" for src, line in _runnable_rclone_paths() if EMPTY_LEGACY_BUCKET in line

--- a/scripts/tests/test_backup_retention_and_host_binding.py
+++ b/scripts/tests/test_backup_retention_and_host_binding.py
@@ -1,0 +1,645 @@
+"""Retention must know the difference between "nothing to prune" and "I could not look",
+and the backup prefix must be bound to the host it is actually running on.
+
+deploy#635 — `prune_old_backups` read its instrument with `2>/dev/null || true`:
+
+    dirs=$(rclone lsf "…/${BACKUP_PREFIX}/${category}/" --dirs-only 2>/dev/null || true)
+
+`2>/dev/null` discards the diagnostic; `|| true` discards the return code. A bad credential,
+a network fault, a wrong bucket and a wrong prefix therefore ALL COLLAPSED INTO THE SAME
+VALUE as the legitimate "this environment has no old backups": the empty string. The `while`
+loop iterated nothing, retention silently no-op'd, and the run went on to log
+"=== Backup finished ===" and emit the success gauge. B2 grows without bound and NOTHING
+ANYWHERE SAYS SO.
+
+deploy#636 — the charset guard (`^[a-z0-9][a-z0-9-]*$`) refuses `../prod`, but it cannot, by
+construction, refuse the accepted value that is catastrophic:
+
+    BACKUP_PREFIX=prod          ...on the STAGING host
+
+Staging then writes into `prod/` and its retention purge — correctly scoped to "its own"
+prefix — DELETES PRODUCTION'S BACKUPS. The value is not malformed; it is wrong only RELATIVE
+TO THE HOST, and no regex over the value alone can see that.
+
+WHY THESE TESTS RUN THE SCRIPT INSTEAD OF GREPPING IT
+----------------------------------------------------
+Both bugs are about what the script DOES when an instrument fails, and a source-text scan
+cannot see that: the pre-fix line and the fixed line differ by a redirect, and it is the
+*runtime consequence* of that redirect — an empty string that reads as a measurement — that
+is the defect. So every assertion below drives the REAL `scripts/backup.sh` through the real
+`compose_project.sh` and the real `b2_preflight.sh`, under the real `set -euo pipefail`, with
+stubbed `docker`/`rclone`/`zstd` on PATH. A harness running prod code under a weaker `set -…`
+is not running prod code (`feedback_errexit_kills_assignment_guard`).
+
+WHAT A GREEN RUN HERE DOES NOT MEAN
+-----------------------------------
+It does not mean the retention path is safe under the unit's hardening. These tests run where
+`/tmp` is WRITABLE; under `isnad-backup.service` it is not (`ProtectSystem=strict`, `PrivateTmp`
+deliberately unset — deploy#121 Bug A), which is why the stderr capture added here goes through
+`scratch_file()` and never a bare `mktemp`. That property is pinned by
+`test_scratch_under_hardening.py`, which is structurally capable of failing on it; this module
+is not. Saying so in the narrow words, because the wide words are how deploy#613 shipped twice.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+BACKUP_SH = REPO_ROOT / "scripts" / "backup.sh"
+DEPLOY_STG = REPO_ROOT / ".github" / "workflows" / "deploy-stg.yml"
+DEPLOY_PROD = REPO_ROOT / ".github" / "workflows" / "deploy-prod.yml"
+
+BUCKET = "isnad-graph-backups"
+
+# The words rclone's stub writes to STDERR when the listing fails. The point of the fix is
+# that THESE WORDS REACH THE OPERATOR — the pre-fix `2>/dev/null` ate them. An assertion on a
+# generic "error" string would pass against a script that printed its own guess instead of
+# rclone's diagnosis, which is the deploy#613 failure mode exactly.
+RCLONE_LSF_DIAGNOSTIC = "CRITICAL: you must use bucket(s) [...] with this application key"
+
+# A date far enough back that both the daily (7d) and weekly (28d) cutoffs select it.
+ANCIENT_DIR = "2020-01-01"
+
+
+def _write(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(0o755)
+
+
+def _stubs(tmp_path: Path, *, lsf_mode: str, purge_mode: str = "ok") -> Path:
+    """A stub bin/ that carries the real backup.sh all the way to the retention pass.
+
+    `docker` is STATEFUL — backup.sh stops neo4j and then polls `ps` until it is no longer
+    running, so a stub that reported `neo4j:running` forever would hang the stop-wait loop for
+    30s and then take a DIFFERENT code path (the stop-timeout branch) than the one under test.
+    """
+    stub = tmp_path / "stub"
+    stub.mkdir(parents=True)
+    state = tmp_path / "neo4j_state"
+    state.write_text("running")
+
+    _write(
+        stub / "docker",
+        f"""#!/usr/bin/env bash
+STATE="{state}"
+args="$*"
+
+# `docker run … neo4j-admin database dump …` — write the dump into the host path bind-mounted
+# at /backups, exactly where the real neo4j-admin puts it.
+if [[ "$1" == "run" ]]; then
+    backups=""
+    prev=""
+    for a in "$@"; do
+        if [[ "$prev" == "-v" && "$a" == *":/backups" ]]; then
+            backups="${{a%%:/backups}}"
+        fi
+        prev="$a"
+    done
+    [[ -n "$backups" ]] && printf 'neo4j-dump-bytes\\n' > "${{backups}}/neo4j.dump"
+    exit 0
+fi
+
+if [[ "$1" == "inspect" ]]; then
+    printf 'noorinalabs_neo4j_data\\n'
+    exit 0
+fi
+
+# Everything below is `docker compose -p … -f … <verb> …`.
+case "$args" in
+    *" stop neo4j"*)  printf 'stopped'  > "$STATE"; exit 0 ;;
+    *" start neo4j"*) printf 'running'  > "$STATE"; exit 0 ;;
+esac
+
+if [[ "$args" == *"ps -aq neo4j"* ]]; then
+    printf 'deadbeefcafe\\n'
+    exit 0
+fi
+
+if [[ "$args" == *"{{{{.Service}}}}:{{{{.Health}}}}"* ]]; then
+    printf 'neo4j:healthy\\n'
+    exit 0
+fi
+
+if [[ "$args" == *"{{{{.Service}}}}:{{{{.State}}}}"* ]]; then
+    printf 'postgres:running\\nuser-postgres:running\\n'
+    [[ "$(cat "$STATE")" == "running" ]] && printf 'neo4j:running\\n'
+    exit 0
+fi
+
+# `exec -T <svc> pg_dump …` — a non-empty dump on stdout. backup.sh rejects a zero-byte one.
+if [[ "$args" == *"pg_dump"* ]]; then
+    printf 'PGDMP-fake-custom-format-dump\\n'
+    exit 0
+fi
+
+exit 0
+""",
+    )
+
+    # `lsf` is the instrument under test. Every OTHER rclone verb succeeds, so a failure in the
+    # run can only have come from the one we aimed at — a probe that fails everywhere proves
+    # nothing about the path it was supposed to isolate.
+    #
+    # EVERY HEALTHY MODE EMITS TODAY'S DIRECTORY, because a healthy listing in production
+    # NECESSARILY CONTAINS IT: the run uploaded into this prefix a few lines earlier and rclone
+    # said it succeeded. A fixture that omitted it would be modelling a state the bucket cannot
+    # be in, and the "nothing to prune" assertion built on it would be testing fiction
+    # (`feedback_fixture_makes_guard_assertion_inert`). The stub computes the date the same way
+    # backup.sh does — `date -u +%Y-%m-%d` — rather than hardcoding it, so this does not rot at
+    # midnight UTC or care which weekday CI runs on (the category flips to `weekly` on Sundays).
+    lsf_branch = {
+        # The listing sees today's upload, and nothing is old enough to prune. THE HEALTHY
+        # STEADY STATE of a young environment.
+        "ok_nothing_to_prune": "printf '%s/\\n' \"$(date -u +%Y-%m-%d)\"; exit 0",
+        # Today's upload plus one ancient directory: retention has work, and does it.
+        "ok_old": f"printf '%s/\\n{ANCIENT_DIR}/\\n' \"$(date -u +%Y-%m-%d)\"; exit 0",
+        # rc != 0: the instrument failed and SAID SO. Pre-fix, indistinguishable from empty.
+        "fail": f"echo '{RCLONE_LSF_DIAGNOSTIC}' >&2; exit 1",
+        # rc=0 AND EMPTY — the deploy#634/#638 case. rclone returns exactly this for a listing
+        # the key is NOT PERMITTED to see: not a 403, a successful listing of nothing. No rc
+        # check can catch it. Only the "where is the directory we just uploaded?" control can.
+        "blind_empty": "exit 0",
+    }[lsf_mode]
+
+    purge_branch = {
+        "ok": "exit 0",
+        "fail": "echo 'CRITICAL: delete not permitted for this key' >&2; exit 1",
+    }[purge_mode]
+
+    _write(
+        stub / "rclone",
+        f"""#!/usr/bin/env bash
+case "$1" in
+    lsd)
+        # awk '{{print $NF}}' must yield the bucket name — b2_preflight's visibility probe.
+        printf '          -1 2020-01-01 00:00:00        -1 {BUCKET}\\n'
+        exit 0
+        ;;
+    copyto|deletefile|copy) exit 0 ;;
+    lsf)   {lsf_branch} ;;
+    purge) {purge_branch} ;;
+esac
+exit 0
+""",
+    )
+
+    _write(
+        stub / "zstd",
+        """#!/usr/bin/env bash
+# `zstd -3 --rm SRC -o DST`
+src=""; dst=""; prev=""
+for a in "$@"; do
+    [[ "$prev" == "-o" ]] && dst="$a"
+    [[ "$a" != -* && "$prev" != "-o" ]] && src="$a"
+    prev="$a"
+done
+[[ -n "$dst" ]] && printf 'zstd-fake\\n' > "$dst"
+[[ -n "$src" ]] && rm -f "$src"
+exit 0
+""",
+    )
+    return stub
+
+
+def _run_backup(
+    tmp_path: Path,
+    *,
+    lsf_mode: str = "ok_old",
+    purge_mode: str = "ok",
+    prefix: str = "stg",
+    base_domain: str | None = None,
+    script: Path | None = None,
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    """Run the real backup.sh as the systemd unit does. Returns (proc, textfile_dir)."""
+    stub = _stubs(tmp_path, lsf_mode=lsf_mode, purge_mode=purge_mode)
+    textfile_dir = tmp_path / "textfile_collector"
+
+    env = dict(os.environ)
+    env["PATH"] = f"{stub}:/usr/bin:/bin"
+    env.update(
+        B2_KEY_ID="fake-key-id",
+        B2_APP_KEY="fake-app-key",
+        B2_BUCKET=BUCKET,
+        BACKUP_PREFIX=prefix,
+        BACKUP_DIR=str(tmp_path / "backups"),
+        COMPOSE_FILE="/dev/null",
+        # The gauge must land somewhere observable — this is why backup.sh takes TEXTFILE_DIR
+        # from the environment at all (deploy#618). Nothing in production sets it.
+        TEXTFILE_DIR=str(textfile_dir),
+    )
+    env.pop("BASE_DOMAIN", None)
+    if base_domain is not None:
+        env["BASE_DOMAIN"] = base_domain
+
+    proc = subprocess.run(
+        ["bash", str(script or BACKUP_SH)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=180,
+    )
+    return proc, textfile_dir
+
+
+def _retention_gauge(textfile_dir: Path) -> str | None:
+    """The value of `isnad_backup_retention_ok`, or None if the gauge was never written."""
+    prom = textfile_dir / "isnad_backup_retention.prom"
+    if not prom.exists():
+        return None
+    for line in prom.read_text().splitlines():
+        if line.startswith("isnad_backup_retention_ok "):
+            return line.split()[1]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Calibrate the harness BEFORE reading anything with it (deploy#574, #641).
+# ---------------------------------------------------------------------------
+
+
+def test_the_harness_reaches_retention_at_all(tmp_path: Path) -> None:
+    """THE POSITIVE CONTROL, and it comes first for a reason.
+
+    Every assertion in this module is of the form "when the listing fails, X happens". If the
+    harness never got AS FAR AS the listing — a preflight that refused the stub key, a
+    project-identity gate that refused the stub docker, a stop-wait loop that timed out — then
+    `X did not happen` would be trivially true of a run that never reached the code under test,
+    and every test below would be green and worthless. That is the silent zero
+    (`feedback_silent_zero_is_not_a_measurement`).
+
+    So: prove the instrument is pointed at the thing. A healthy run must PRUNE the ancient
+    directory, which can only happen if the listing ran, returned it, and the purge fired.
+    """
+    proc, textfile_dir = _run_backup(tmp_path, lsf_mode="ok_old")
+    combined = proc.stdout + proc.stderr
+
+    assert "=== Backup started" in combined, f"backup.sh never started:\n{combined[-3000:]}"
+    assert "Running retention pruning" in combined, (
+        f"the run never REACHED retention — every retention assertion in this module would be "
+        f"vacuous:\n{combined[-3000:]}"
+    )
+    assert f"Pruning: stg/daily/{ANCIENT_DIR}/" in combined, (
+        f"retention did not prune the ancient directory the listing offered it, so the purge "
+        f"path is not being exercised:\n{combined[-3000:]}"
+    )
+    assert proc.returncode == 0, f"the healthy run did not succeed:\n{combined[-3000:]}"
+    assert _retention_gauge(textfile_dir) == "1"
+
+
+# ---------------------------------------------------------------------------
+# deploy#635 — an empty listing and a failed listing are not the same thing.
+# ---------------------------------------------------------------------------
+
+
+def test_a_failed_listing_is_reported_as_an_instrument_failure(tmp_path: Path) -> None:
+    """rc != 0 is NOT "no old backups". It is "I could not look", and it must say so."""
+    proc, _ = _run_backup(tmp_path, lsf_mode="fail")
+    combined = proc.stdout + proc.stderr
+
+    assert "INSTRUMENT failure" in combined, (
+        f"a failed listing was not reported as an instrument failure — it is still "
+        f"indistinguishable from 'nothing to prune':\n{combined[-3000:]}"
+    )
+    # rclone's OWN WORDS, not our paraphrase of them. `2>/dev/null` ate exactly this.
+    assert RCLONE_LSF_DIAGNOSTIC in combined, (
+        f"rclone's diagnostic was discarded. The operator is told the listing failed but not "
+        f"WHY, which is the half of deploy#635 that `2>/dev/null` caused:\n{combined[-3000:]}"
+    )
+
+
+def test_a_failed_listing_drives_the_gauge_to_zero(tmp_path: Path) -> None:
+    """The signal has to leave the box. A log line nobody greps is not a signal."""
+    proc, textfile_dir = _run_backup(tmp_path, lsf_mode="fail")
+    assert _retention_gauge(textfile_dir) == "0", (
+        f"isnad_backup_retention_ok is not 0 after a failed listing, so nothing off-box knows "
+        f"retention stopped running:\n{(proc.stdout + proc.stderr)[-3000:]}"
+    )
+
+
+def test_a_failed_listing_does_NOT_take_the_backup_down(tmp_path: Path) -> None:
+    """The fix must not overcorrect into a worse bug.
+
+    Retention could not LIST, so it could not PURGE: nothing was deleted and no data is at
+    risk. Exiting non-zero on that would convert a storage-cost problem into a TOTAL BACKUP
+    OUTAGE — and it would abort before `emit_success_metric`, so a night with a perfectly good,
+    uploaded, restorable backup would report as a failed backup and BackupStale would fire.
+    Strictly worse than the bug being fixed.
+
+    So the artifact is still honoured: the dumps ran, the upload ran, the run exits 0, and the
+    success gauge IS emitted. The bad news rides on the retention gauge instead.
+    """
+    proc, textfile_dir = _run_backup(tmp_path, lsf_mode="fail")
+    combined = proc.stdout + proc.stderr
+
+    assert proc.returncode == 0, (
+        f"a retention listing failure took the whole backup down (rc={proc.returncode}). The "
+        f"backup itself was fine:\n{combined[-3000:]}"
+    )
+    assert (textfile_dir / "isnad_backup_success.prom").exists(), (
+        "the success gauge was suppressed by a retention failure — a complete, restorable "
+        "backup is now invisible and BackupStale will fire falsely (deploy#559/#565)."
+    )
+    assert _retention_gauge(textfile_dir) == "0"
+
+
+def test_nothing_to_prune_is_still_a_legitimate_measurement(tmp_path: Path) -> None:
+    """THE OTHER HALF OF THE SEPARATION, and the one that keeps the fix honest.
+
+    A listing that shows today's upload and no directory old enough to prune is a MEASUREMENT —
+    the healthy steady state of a young environment, and of every environment on most nights.
+    If the fix flagged that as a failure too, it would be a detector that says FAILED to
+    everything, which proves nothing when it says FAILED to the case we care about, and would
+    page someone every single night on a perfectly healthy stg.
+
+    A guard that cannot go green is not a guard (deploy#574).
+    """
+    proc, textfile_dir = _run_backup(tmp_path, lsf_mode="ok_nothing_to_prune")
+    combined = proc.stdout + proc.stderr
+
+    assert proc.returncode == 0, f"a healthy listing failed the run:\n{combined[-3000:]}"
+    assert "INSTRUMENT failure" not in combined, (
+        f"a HEALTHY listing was misreported as an instrument failure. The detector cannot "
+        f"separate the two classes, so its verdict carries no information:\n{combined[-3000:]}"
+    )
+    assert "Pruning:" not in combined, "it pruned something on a listing with nothing old in it."
+    assert _retention_gauge(textfile_dir) == "1"
+
+
+def test_an_rc0_listing_that_cannot_see_todays_upload_is_REFUSED(tmp_path: Path) -> None:
+    """rc=0 AND EMPTY — and the rc check is structurally blind to it. (deploy#634/#638)
+
+    rclone returns rc=0 with an empty listing for a prefix the application key is NOT PERMITTED
+    to see. It is not a 403; it is a successful listing of nothing. So an exit-code check — the
+    whole of the deploy#635 fix — cannot catch this class even in principle: a scoped-away key
+    returns byte-for-byte what "no old backups" returns.
+
+    What catches it is the one thing the listing cannot argue with: THIS RUN JUST UPLOADED into
+    that prefix and rclone said it succeeded, so today's directory is necessarily there. A
+    listing that cannot show it to us is not describing the bucket, and a `purge` decision must
+    never be read off it.
+
+    Without this the fix would close the loud failures and leave the silent one — which is the
+    failure that actually shipped.
+    """
+    proc, textfile_dir = _run_backup(tmp_path, lsf_mode="blind_empty")
+    combined = proc.stdout + proc.stderr
+
+    assert "does NOT contain" in combined, (
+        f"an rc=0 listing that could not see the directory we had just uploaded was accepted as "
+        f"'nothing to prune'. A key scoped away from this prefix now reads as a healthy, empty "
+        f"environment:\n{combined[-3000:]}"
+    )
+    assert "REFUSING to prune" in combined, (
+        f"the run did not refuse to prune from a listing it had just caught lying:\n"
+        f"{combined[-3000:]}"
+    )
+    assert "Pruning:" not in combined, "it PURGED on the strength of a listing it could not trust."
+    assert _retention_gauge(textfile_dir) == "0"
+    # Still not an outage: the artifact is good and the success gauge stands.
+    assert proc.returncode == 0
+    assert (textfile_dir / "isnad_backup_success.prom").exists()
+
+
+def test_a_failed_purge_also_drives_the_gauge_to_zero(tmp_path: Path) -> None:
+    """A purge that failed is retention that did not happen.
+
+    This used to be `|| log "WARNING" …` — the directory stays in B2, still costing money, and
+    every other signal reads clean.
+    """
+    proc, textfile_dir = _run_backup(tmp_path, lsf_mode="ok_old", purge_mode="fail")
+    combined = proc.stdout + proc.stderr
+
+    assert "FAILED to prune" in combined, f"a failed purge was not surfaced:\n{combined[-3000:]}"
+    assert _retention_gauge(textfile_dir) == "0", (
+        f"a failed purge left isnad_backup_retention_ok at 1:\n{combined[-3000:]}"
+    )
+
+
+def test_a_broken_retention_cannot_report_an_unqualified_clean_finish(tmp_path: Path) -> None:
+    """The sentence that made this invisible was "=== Backup finished ===" on its own."""
+    proc, _ = _run_backup(tmp_path, lsf_mode="fail")
+    combined = proc.stdout + proc.stderr
+
+    assert "Retention:                 FAILED" in combined, (
+        f"the run summary does not report the retention failure, so an operator reading the "
+        f"summary sees an unblemished backup:\n{combined[-3000:]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# THE MUTATION. Prove the assertions above have teeth (deploy#574, #624).
+# ---------------------------------------------------------------------------
+
+
+def test_the_pre_fix_line_would_FAIL_these_assertions(tmp_path: Path) -> None:
+    """Reintroduce deploy#635 verbatim and watch the guard go RED.
+
+    An assertion that has only ever been watched agreeing with the code it was written beside
+    has demonstrated nothing. So: take the REAL backup.sh, put the historical line back — the
+    one copied out of the pre-fix tree, `2>/dev/null || true` — run it against the SAME failing
+    rclone, and require that the fixed script's evidence DISAPPEARS.
+
+    If this test ever goes green, the mutation has become inert and every assertion above is
+    resting on nothing (`feedback_calibrate_the_mutation_before_counting_it`).
+    """
+    body = BACKUP_SH.read_text()
+
+    # MUTATE THE WHOLE INSTRUMENTED BLOCK, not just the `lsf` line.
+    #
+    # Reverting only the redirect leaves the "where is the directory we just uploaded?" control
+    # standing, and THAT control catches the failing listing on its own (rc swallowed -> dirs
+    # empty -> today's dir missing -> refused). The mutant would then still behave correctly,
+    # this calibration would go red for the wrong reason, and I would have "proved" the rc check
+    # matters using a script in which it does not. The historical tree had NEITHER guard, so the
+    # faithful mutant removes both and restores the original two lines verbatim.
+    start_marker = "    local dirs lrc=0 lerr\n"
+    end_marker = "    while IFS= read -r dir; do"
+    assert start_marker in body and end_marker in body, (
+        "backup.sh no longer has the instrumented-listing block this mutation targets — the "
+        "mutation would be a no-op and this calibration would be vacuous."
+    )
+    start = body.index(start_marker)
+    end = body.index(end_marker)
+
+    # deploy#635, verbatim: stderr to /dev/null, rc swallowed by `|| true`, no control.
+    pre_fix = (
+        "    local dirs\n"
+        '    dirs=$(rclone lsf "${RCLONE_REMOTE}:${B2_BUCKET}/${BACKUP_PREFIX}/${category}/" '
+        "--dirs-only 2>/dev/null || true)\n\n"
+    )
+    mutant_body = body[:start] + pre_fix + body[end:]
+    assert mutant_body != body, "the mutation did not change the script — it is INERT."
+
+    # The mutant must live in a directory that ALSO holds the libraries backup.sh sources by
+    # `$(dirname "${BASH_SOURCE[0]}")` — compose_project.sh and b2_preflight.sh. Dropping it in a
+    # bare tmp dir makes it die on line 1 with "Missing …/compose_project.sh", and then the two
+    # "the diagnostic is absent" assertions below PASS VACUOUSLY — absent from the output of a
+    # script that never ran. That is not a calibration, it is a coincidence, and it is exactly
+    # the shape of bug this module exists to catch. (It happened while writing this test; only
+    # the gauge assertion noticed.)
+    mutant_dir = tmp_path / "scripts"
+    mutant_dir.mkdir(parents=True)
+    for lib in ("compose_project.sh", "b2_preflight.sh"):
+        (mutant_dir / lib).write_bytes((REPO_ROOT / "scripts" / lib).read_bytes())
+    mutant = mutant_dir / "backup.sh"
+    mutant.write_text(mutant_body)
+
+    proc, textfile_dir = _run_backup(tmp_path, lsf_mode="fail", script=mutant)
+    combined = proc.stdout + proc.stderr
+
+    # PROVE THE MUTANT ACTUALLY RAN before reading anything from its silence. Every assertion
+    # below is of the form "X is ABSENT from the output", and absence is exactly what a script
+    # that crashed at startup also produces.
+    assert "Running retention pruning" in combined, (
+        f"the mutant never reached retention, so its silence proves nothing and this "
+        f"calibration is vacuous:\n{combined[-3000:]}"
+    )
+
+    # THE BUG, reproduced: a failed listing is silently indistinguishable from "nothing to
+    # prune". No diagnostic, no instrument-failure verdict, and the gauge says everything is
+    # fine while retention did precisely nothing.
+    assert "INSTRUMENT failure" not in combined, (
+        "the pre-fix line still reported an instrument failure — the mutation is not "
+        "reproducing deploy#635, so it does not calibrate anything."
+    )
+    assert RCLONE_LSF_DIAGNOSTIC not in combined, (
+        "rclone's diagnostic survived `2>/dev/null` — the mutation is not the historical bug."
+    )
+    assert _retention_gauge(textfile_dir) == "1", (
+        "the pre-fix line did not produce the FALSE-CLEAN gauge that is the entire bug. "
+        "Something else in the fix is carrying the signal, and the listing line is not what "
+        "these tests are actually measuring."
+    )
+
+
+# ---------------------------------------------------------------------------
+# deploy#636 — the prefix must be bound to the host, not merely well-formed.
+# ---------------------------------------------------------------------------
+
+_CONTRADICTION = "but this host is"
+
+
+def test_a_prefix_that_contradicts_the_host_is_REFUSED(tmp_path: Path) -> None:
+    """`BACKUP_PREFIX=prod` on the STAGING host. Legal bare name; catastrophic value.
+
+    Unrefused, staging writes its dumps into `prod/` and its retention purge deletes
+    production's backups — deploy#632 through the front door, with no attacker and no typo in
+    the value itself.
+    """
+    proc, textfile_dir = _run_backup(
+        tmp_path, prefix="prod", base_domain="stg.noorinalabs.com", lsf_mode="ok_old"
+    )
+    combined = proc.stdout + proc.stderr
+
+    assert proc.returncode != 0, f"the run was ALLOWED to proceed:\n{combined[-3000:]}"
+    assert _CONTRADICTION in combined, (
+        f"the refusal does not name the contradiction between the prefix and the host:\n"
+        f"{combined[-3000:]}"
+    )
+    # And it must refuse BEFORE it can do any harm — no dump, no upload, and above all no purge.
+    assert "Pruning:" not in combined, "it reached the PURGE despite the prefix being refused."
+    assert "=== Backup started" not in combined, (
+        f"the refusal came too late — the run had already begun dumping:\n{combined[-3000:]}"
+    )
+    assert _retention_gauge(textfile_dir) is None
+
+
+def test_the_matching_prefix_is_NOT_refused(tmp_path: Path) -> None:
+    """The positive control. Without it, "the refusal fired" could be true of EVERY input —
+    including the correct one — and the guard would be refusing every legitimate backup on both
+    hosts while this suite stayed green. A one-way oracle proves nothing (deploy#574)."""
+    proc, textfile_dir = _run_backup(
+        tmp_path, prefix="stg", base_domain="stg.noorinalabs.com", lsf_mode="ok_old"
+    )
+    combined = proc.stdout + proc.stderr
+
+    assert _CONTRADICTION not in combined, (
+        f"the guard REFUSED the correct prefix for this host. It is rejecting valid deploys, "
+        f"and the refusal assertion above is vacuous:\n{combined[-3000:]}"
+    )
+    assert proc.returncode == 0, f"the legitimate run did not succeed:\n{combined[-3000:]}"
+
+
+@pytest.mark.parametrize("domain", ["noorinalabs.com", "stg.noorinalabs.com"])
+def test_each_host_accepts_exactly_its_own_prefix(tmp_path: Path, domain: str) -> None:
+    """Both directions of the swap. `stg` on prod is as wrong as `prod` on stg, and a guard
+    that only checks one of them leaves the other half of the bug in place."""
+    expected = "stg" if domain.startswith("stg.") else "prod"
+    wrong = "prod" if expected == "stg" else "stg"
+
+    ok, _ = _run_backup(tmp_path / "ok", prefix=expected, base_domain=domain, lsf_mode="ok_old")
+    assert _CONTRADICTION not in (ok.stdout + ok.stderr)
+
+    bad, _ = _run_backup(tmp_path / "bad", prefix=wrong, base_domain=domain, lsf_mode="ok_old")
+    assert bad.returncode != 0 and _CONTRADICTION in (bad.stdout + bad.stderr), (
+        f"BACKUP_PREFIX={wrong} was accepted on the {expected} host ({domain})."
+    )
+
+
+def test_an_unknown_host_WARNS_and_does_not_testify(tmp_path: Path) -> None:
+    """A check that cannot run must say so — and must NOT convert its own blindness into a
+    verdict about the system it was checking.
+
+    An absent or unrecognised BASE_DOMAIN means we do not know which host this is. That is not
+    evidence the prefix is wrong. Refusing here would take a backup outage on a perfectly
+    healthy box (a new environment, a restore drill, a hand-run invocation) and would be
+    deploy#613's shape exactly: a check reporting its own breakage as a fact about B2.
+    """
+    proc, textfile_dir = _run_backup(tmp_path, prefix="stg", base_domain=None, lsf_mode="ok_old")
+    combined = proc.stdout + proc.stderr
+
+    assert "cannot verify BACKUP_PREFIX" in combined, (
+        f"an unverifiable host produced no warning at all — the operator has no idea the "
+        f"binding check was skipped:\n{combined[-3000:]}"
+    )
+    assert _CONTRADICTION not in combined, (
+        "an UNKNOWN host was treated as a CONTRADICTED one. The check is testifying about "
+        "something it cannot see."
+    )
+    assert proc.returncode == 0, (
+        f"the run was refused merely because the host could not be identified:\n{combined[-3000:]}"
+    )
+    assert _retention_gauge(textfile_dir) == "1"
+
+
+# ---------------------------------------------------------------------------
+# deploy#636 — the workflow literal is the source of truth. Bind it to its own env.
+# ---------------------------------------------------------------------------
+
+
+def _workflow_prefix(workflow: Path) -> str:
+    import re
+
+    m = re.search(r"^\s*BACKUP_PREFIX=(\S+)", workflow.read_text(), re.MULTILINE)
+    assert m, f"{workflow.name} does not inject BACKUP_PREFIX at all"
+    return m.group(1)
+
+
+def test_each_deploy_workflow_injects_ITS_OWN_environment() -> None:
+    """`test_the_two_environments_get_different_prefixes` asserts only that stg != prod.
+
+    A full SWAP satisfies that:
+
+        deploy-stg.yml  -> BACKUP_PREFIX=prod
+        deploy-prod.yml -> BACKUP_PREFIX=stg
+
+    They differ, so the existing assertion is happy — and it is the most destructive
+    configuration possible. Staging purges production's backups on a schedule, and production
+    purges staging's, and the deploy writes both values authoritatively into each host's .env
+    on every single run, so unlike the hand-edit it never self-repairs.
+
+    "Different from each other" is not the property. "Equal to the environment it deploys" is.
+    """
+    assert _workflow_prefix(DEPLOY_STG) == "stg", (
+        "deploy-stg.yml does not inject BACKUP_PREFIX=stg. Staging would write into — and "
+        "purge — another environment's namespace."
+    )
+    assert _workflow_prefix(DEPLOY_PROD) == "prod", (
+        "deploy-prod.yml does not inject BACKUP_PREFIX=prod. Production would write into — and "
+        "purge — another environment's namespace."
+    )

--- a/scripts/tests/test_backup_retention_and_host_binding.py
+++ b/scripts/tests/test_backup_retention_and_host_binding.py
@@ -76,6 +76,33 @@ def _write(path: Path, body: str) -> None:
     path.chmod(0o755)
 
 
+def _stage_mutant(tmp_path: Path, mutant_body: str) -> Path:
+    """Write a mutated `backup.sh` into a temp `scripts/` dir that ALSO holds every library it
+    could source, and return the mutant's path.
+
+    `backup.sh` sources its siblings by `$(dirname "${BASH_SOURCE[0]}")/<lib>.sh`, and each is
+    fail-closed if absent — so a mutant dropped in a bare dir dies on line 1, before it reaches
+    the code under test, and any "the diagnostic is absent" assertion then passes VACUOUSLY on
+    the silence of a script that never ran. That already bit this module once (the compose_project
+    lib), and deploy#661 made it bite again: `backup.sh` now sources `scratch.sh` transitively
+    through `compose_project.sh`, and a hand-maintained `(compose_project.sh, b2_preflight.sh)`
+    list did not know to stage it. Each PR was green in isolation; the merged tree broke.
+
+    So DERIVE THE SET, don't hand-type it (the lesson that has cost this wave three times): copy
+    EVERY sibling `*.sh` from the real scripts dir, then overwrite `backup.sh` with the mutant.
+    A new sourced dependency lands in the fixture automatically, and the only cost is copying a
+    few unused shell files — cheap, and the correct direction to be wrong in.
+    """
+    mutant_dir = tmp_path / "scripts"
+    mutant_dir.mkdir(parents=True)
+    real_scripts = REPO_ROOT / "scripts"
+    for sh in real_scripts.glob("*.sh"):
+        (mutant_dir / sh.name).write_bytes(sh.read_bytes())
+    mutant = mutant_dir / "backup.sh"
+    mutant.write_text(mutant_body)
+    return mutant
+
+
 def _stubs(tmp_path: Path, *, lsf_mode: str, purge_mode: str = "ok") -> Path:
     """A stub bin/ that carries the real backup.sh all the way to the retention pass.
 
@@ -480,19 +507,11 @@ def test_the_pre_fix_line_would_FAIL_these_assertions(tmp_path: Path) -> None:
     mutant_body = body[:start] + pre_fix + body[end:]
     assert mutant_body != body, "the mutation did not change the script — it is INERT."
 
-    # The mutant must live in a directory that ALSO holds the libraries backup.sh sources by
-    # `$(dirname "${BASH_SOURCE[0]}")` — compose_project.sh and b2_preflight.sh. Dropping it in a
-    # bare tmp dir makes it die on line 1 with "Missing …/compose_project.sh", and then the two
-    # "the diagnostic is absent" assertions below PASS VACUOUSLY — absent from the output of a
-    # script that never ran. That is not a calibration, it is a coincidence, and it is exactly
-    # the shape of bug this module exists to catch. (It happened while writing this test; only
-    # the gauge assertion noticed.)
-    mutant_dir = tmp_path / "scripts"
-    mutant_dir.mkdir(parents=True)
-    for lib in ("compose_project.sh", "b2_preflight.sh"):
-        (mutant_dir / lib).write_bytes((REPO_ROOT / "scripts" / lib).read_bytes())
-    mutant = mutant_dir / "backup.sh"
-    mutant.write_text(mutant_body)
+    # Stage the mutant beside EVERY library backup.sh could source — see _stage_mutant. A bare
+    # tmp dir makes it die on line 1 (a sourced lib is fail-closed if absent), and the two "the
+    # diagnostic is absent" assertions below would then PASS VACUOUSLY on the silence of a script
+    # that never ran. That is the exact shape this module exists to catch.
+    mutant = _stage_mutant(tmp_path, mutant_body)
 
     proc, textfile_dir = _run_backup(tmp_path, lsf_mode="fail", script=mutant)
     combined = proc.stdout + proc.stderr
@@ -678,12 +697,7 @@ def test_the_substring_glob_mutant_is_KILLED(tmp_path: Path) -> None:
         '    *)                     HOST_ENV="" ;;\n'
         "esac"
     )
-    mutant_dir = tmp_path / "scripts"
-    mutant_dir.mkdir(parents=True)
-    for lib in ("compose_project.sh", "b2_preflight.sh"):
-        (mutant_dir / lib).write_bytes((REPO_ROOT / "scripts" / lib).read_bytes())
-    mutant = mutant_dir / "backup.sh"
-    mutant.write_text(body.replace(anchored, globbed))
+    mutant = _stage_mutant(tmp_path, body.replace(anchored, globbed))
 
     # THE MUTANT MUST STILL BE CORRECT ON THE KNOWN HOSTS. If it broke those, it would be caught
     # by tests that already exist, it would not be the bug Nino described, and this calibration

--- a/scripts/verify_b2_backup_artifact.sh
+++ b/scripts/verify_b2_backup_artifact.sh
@@ -74,38 +74,59 @@
 # shown to return all four cannot be believed when it returns one.
 #
 # Usage:
-#   # NAME THE REAL BUCKET, AND ALWAYS NAME THE ENVIRONMENT. (deploy#636)
+#   # NEVER HARDCODE THE BUCKET. NAME THE ENVIRONMENT. (deploy#636)
 #   #
-#   # This example used to read `B2_ROOT="isnad:isnad-graph-backups"`, and it was wrong TWICE
-#   # over — each wrong in a way that fails toward "you have no backups":
-#   #
-#   #   1. WRONG BUCKET. `isnad-graph-backups` is a legacy bucket and it is EMPTY. The live
-#   #      bucket is `noorinalabs-backups` (measured 2026-07-14: 0 objects vs 27). An operator
-#   #      who copies the old line gets a clean, confident ZERO and concludes the backups do
-#   #      not exist — a silent zero pre-baked into the one document you read mid-incident.
-#   #      (Do not confuse it with `/var/lib/noorinalabs-backups`, which is the LOCAL staging
-#   #      directory on the VPS and not a bucket at all. The names really are that close.)
-#   #
-#   #   2. BUCKET ROOT, NO ENVIRONMENT. stg and prod SHARE one bucket (deploy#632), so a root
-#   #      path scans BOTH environments' objects and reports `fresh` on whichever it finds
-#   #      first. That is the cross-environment false-green deploy#633 removed from
-#   #      verify-backup-artifact.yml, where the PROD leg would have reported healthy on the
-#   #      strength of STAGING's backup — on the one check that exists precisely because every
-#   #      other backup signal can lie.
-#   #
-#   # The workflow itself invokes it correctly — B2_ROOT="isnad:${B2_BUCKET}/${{ matrix.env }}"
-#   # (.github/workflows/verify-backup-artifact.yml) — so this is the form to copy:
-#   B2_ROOT="isnad:noorinalabs-backups/prod" ./scripts/verify_b2_backup_artifact.sh
-#   B2_ROOT="isnad:noorinalabs-backups/stg"  ./scripts/verify_b2_backup_artifact.sh
+#   # Export the B2 credentials FIRST — this script, unlike backup.sh, does NOT configure
+#   # rclone for you. backup.sh sets RCLONE_CONFIG_ISNAD_{TYPE,ACCOUNT,KEY} itself; this one
+#   # inherits them. Run it from a bare shell without them and rclone dies with
+#   # "didn't find section in config file", which names neither the bucket nor the key and
+#   # sends you looking for an rclone.conf that does not exist (Bereket Tadesse, #644 review).
+#   export RCLONE_CONFIG_ISNAD_TYPE=b2
+#   export RCLONE_CONFIG_ISNAD_ACCOUNT="$B2_KEY_ID"
+#   export RCLONE_CONFIG_ISNAD_KEY="$B2_APP_KEY"
 #
-#   # Equivalently, via the sub-path variable:
-#   B2_ROOT="isnad:noorinalabs-backups" B2_PREFIX="prod" ./scripts/verify_b2_backup_artifact.sh
+#   B2_ROOT="isnad:${B2_BUCKET}/prod" ./scripts/verify_b2_backup_artifact.sh   # production
+#   B2_ROOT="isnad:${B2_BUCKET}/stg"  ./scripts/verify_b2_backup_artifact.sh   # staging
 #
 #   ./scripts/verify_b2_backup_artifact.sh --self-test
 #
+#   # ---------------------------------------------------------------------------------------
+#   # WHY `${B2_BUCKET}` AND NOT A LITERAL. Both halves of this line have already been wrong.
+#   # ---------------------------------------------------------------------------------------
+#   # It once read `B2_ROOT="isnad:isnad-graph-backups"`, and each half failed toward the same
+#   # sentence — "you have no backups" — which is the sentence that changes what a human does
+#   # next, and mid-incident is the worst possible place to be handed it.
+#   #
+#   #   1. WRONG BUCKET. `isnad-graph-backups` is a REAL bucket and it is EMPTY; nothing has
+#   #      ever written to it. Run the scanner against it and you get status=absent, dumps=0,
+#   #      bucket_objects=0 — a clean, confident zero, from the one check that reads B2 rather
+#   #      than a host-local gauge. Measured against stg at the same moment (#644 review):
+#   #
+#   #          isnad:isnad-graph-backups/prod  -> status=absent dumps=0  objects=0
+#   #          isnad:${B2_BUCKET}/prod         -> status=fresh  dumps=3  objects=20  age=5h
+#   #
+#   #      A false RED, and it STICKS, because an empty bucket lists rc=0 with nothing in it —
+#   #      byte-for-byte the signature deploy#635 exists to teach us not to trust.
+#   #
+#   #   2. BUCKET ROOT, NO ENVIRONMENT. stg and prod SHARE one bucket (deploy#632), so a root
+#   #      path scans BOTH environments' objects and reports `fresh` on whichever it finds
+#   #      first. That is the cross-environment false-GREEN deploy#633 removed from
+#   #      verify-backup-artifact.yml, where the PROD leg would have reported healthy on the
+#   #      strength of STAGING's backup.
+#   #
+#   # `${B2_BUCKET}` is immune to BOTH, and to the next rename: it resolves to whatever the
+#   # BACKUP_B2_BUCKET secret actually says, which is the only thing that is true by
+#   # construction. A hardcoded bucket in a usage example is a stale artifact waiting to
+#   # happen — and it is exactly how the last person was misled. Same form the workflow uses
+#   # (B2_ROOT="isnad:${B2_BUCKET}/${{ matrix.env }}") and docs/runbooks/backup-alerts.md.
+#
 # Env:
+#   RCLONE_CONFIG_ISNAD_TYPE/ACCOUNT/KEY
+#                    REQUIRED, and NOT set by this script (backup.sh sets its own). Without
+#                    them rclone fails with "didn't find section in config file".
 #   B2_ROOT          rclone path to the bucket AND the environment prefix under it
-#                    (reachability probe + scan root). NEVER the bare bucket: see above.
+#                    (reachability probe + scan root). Use `isnad:${B2_BUCKET}/<env>`; never a
+#                    literal bucket name, and never the bare bucket root. See above.
 #   B2_PREFIX        optional sub-path under B2_ROOT to scan. Either this or a prefix baked
 #                    into B2_ROOT must name the environment — scanning the bare bucket reads
 #                    stg's and prod's objects as one pool (deploy#632/#633/#636).

--- a/scripts/verify_b2_backup_artifact.sh
+++ b/scripts/verify_b2_backup_artifact.sh
@@ -74,25 +74,32 @@
 # shown to return all four cannot be believed when it returns one.
 #
 # Usage:
-#   # ALWAYS NAME THE ENVIRONMENT. (deploy#636)
+#   # NAME THE REAL BUCKET, AND ALWAYS NAME THE ENVIRONMENT. (deploy#636)
 #   #
-#   # This example used to read `B2_ROOT="isnad:isnad-graph-backups"` — the BUCKET ROOT, with
-#   # no environment in it. stg and prod SHARE one bucket, so that scans BOTH environments'
-#   # objects at once and reports `fresh` on whichever it happens to find. It is the exact
-#   # cross-environment false-green that deploy#633 removed from verify-backup-artifact.yml —
-#   # where the prod leg of the [stg, prod] matrix would have reported healthy on the strength
-#   # of STAGING's backup, on the one check that exists because every other signal can lie.
+#   # This example used to read `B2_ROOT="isnad:isnad-graph-backups"`, and it was wrong TWICE
+#   # over — each wrong in a way that fails toward "you have no backups":
 #   #
-#   # It survived here as a copy-pasteable line in a runbook comment, which is worse than it
-#   # sounds: this is a file an operator reaches for DURING AN INCIDENT, when they are least
-#   # likely to notice the missing path segment.
+#   #   1. WRONG BUCKET. `isnad-graph-backups` is a legacy bucket and it is EMPTY. The live
+#   #      bucket is `noorinalabs-backups` (measured 2026-07-14: 0 objects vs 27). An operator
+#   #      who copies the old line gets a clean, confident ZERO and concludes the backups do
+#   #      not exist — a silent zero pre-baked into the one document you read mid-incident.
+#   #      (Do not confuse it with `/var/lib/noorinalabs-backups`, which is the LOCAL staging
+#   #      directory on the VPS and not a bucket at all. The names really are that close.)
+#   #
+#   #   2. BUCKET ROOT, NO ENVIRONMENT. stg and prod SHARE one bucket (deploy#632), so a root
+#   #      path scans BOTH environments' objects and reports `fresh` on whichever it finds
+#   #      first. That is the cross-environment false-green deploy#633 removed from
+#   #      verify-backup-artifact.yml, where the PROD leg would have reported healthy on the
+#   #      strength of STAGING's backup — on the one check that exists precisely because every
+#   #      other backup signal can lie.
 #   #
 #   # The workflow itself invokes it correctly — B2_ROOT="isnad:${B2_BUCKET}/${{ matrix.env }}"
 #   # (.github/workflows/verify-backup-artifact.yml) — so this is the form to copy:
-#   B2_ROOT="isnad:isnad-graph-backups/prod" ./scripts/verify_b2_backup_artifact.sh
+#   B2_ROOT="isnad:noorinalabs-backups/prod" ./scripts/verify_b2_backup_artifact.sh
+#   B2_ROOT="isnad:noorinalabs-backups/stg"  ./scripts/verify_b2_backup_artifact.sh
 #
 #   # Equivalently, via the sub-path variable:
-#   B2_ROOT="isnad:isnad-graph-backups" B2_PREFIX="prod" ./scripts/verify_b2_backup_artifact.sh
+#   B2_ROOT="isnad:noorinalabs-backups" B2_PREFIX="prod" ./scripts/verify_b2_backup_artifact.sh
 #
 #   ./scripts/verify_b2_backup_artifact.sh --self-test
 #

--- a/scripts/verify_b2_backup_artifact.sh
+++ b/scripts/verify_b2_backup_artifact.sh
@@ -74,12 +74,34 @@
 # shown to return all four cannot be believed when it returns one.
 #
 # Usage:
-#   B2_ROOT="isnad:isnad-graph-backups" ./scripts/verify_b2_backup_artifact.sh
+#   # ALWAYS NAME THE ENVIRONMENT. (deploy#636)
+#   #
+#   # This example used to read `B2_ROOT="isnad:isnad-graph-backups"` — the BUCKET ROOT, with
+#   # no environment in it. stg and prod SHARE one bucket, so that scans BOTH environments'
+#   # objects at once and reports `fresh` on whichever it happens to find. It is the exact
+#   # cross-environment false-green that deploy#633 removed from verify-backup-artifact.yml —
+#   # where the prod leg of the [stg, prod] matrix would have reported healthy on the strength
+#   # of STAGING's backup, on the one check that exists because every other signal can lie.
+#   #
+#   # It survived here as a copy-pasteable line in a runbook comment, which is worse than it
+#   # sounds: this is a file an operator reaches for DURING AN INCIDENT, when they are least
+#   # likely to notice the missing path segment.
+#   #
+#   # The workflow itself invokes it correctly — B2_ROOT="isnad:${B2_BUCKET}/${{ matrix.env }}"
+#   # (.github/workflows/verify-backup-artifact.yml) — so this is the form to copy:
+#   B2_ROOT="isnad:isnad-graph-backups/prod" ./scripts/verify_b2_backup_artifact.sh
+#
+#   # Equivalently, via the sub-path variable:
+#   B2_ROOT="isnad:isnad-graph-backups" B2_PREFIX="prod" ./scripts/verify_b2_backup_artifact.sh
+#
 #   ./scripts/verify_b2_backup_artifact.sh --self-test
 #
 # Env:
-#   B2_ROOT          rclone path to the BUCKET (reachability probe + scan root)
-#   B2_PREFIX        optional sub-path under the bucket to scan (default: whole bucket)
+#   B2_ROOT          rclone path to the bucket AND the environment prefix under it
+#                    (reachability probe + scan root). NEVER the bare bucket: see above.
+#   B2_PREFIX        optional sub-path under B2_ROOT to scan. Either this or a prefix baked
+#                    into B2_ROOT must name the environment — scanning the bare bucket reads
+#                    stg's and prod's objects as one pool (deploy#632/#633/#636).
 #   MAX_AGE_HOURS    freshness bound (default 30 — one nightly run plus slack)
 # =============================================================================
 set -euo pipefail


### PR DESCRIPTION
Closes #635
Closes #636

Both issues are one code path: the destructive end of the backup script. #635 is about retention not being able to tell a failure from a measurement; #636 is about the prefix that scopes the destruction not being bound to anything.

---

## #635 — retention could not tell "no old backups" from "I could not look"

**Premise verified at base** (`fd42c4b`, `scripts/backup.sh:711`):

```bash
dirs=$(rclone lsf "${RCLONE_REMOTE}:${B2_BUCKET}/${BACKUP_PREFIX}/${category}/" --dirs-only 2>/dev/null || true)
```

`2>/dev/null` discards the diagnostic; `|| true` discards the return code. A bad credential, a network fault, a wrong bucket and a wrong prefix therefore all collapsed into the **same value** as the legitimate "this environment has no old backups": the empty string. The `while` loop iterated nothing, retention silently no-op'd, and the run went on to log `=== Backup finished ===` and emit the success gauge. B2 grows without bound and **no signal anywhere says so.**

The failure direction is safe — it cannot purge what it cannot list — which is exactly why it was invisible.

### What changed

- **The rc and the stderr are now read.** Capture rc into a variable, capture stderr to a file, `log ERROR` with rclone's own words. This is the discipline `restore.sh` has used on this same instrument since deploy#584 (`list_category`, `resolve_latest`); the two scripts no longer disagree about how to read the same tool.
- **The stderr capture comes from `scratch_file()`, never a bare `mktemp`.** `/tmp` is read-only under `isnad-backup.service` (`ProtectSystem=strict`, `PrivateTmp` deliberately unset — deploy#121 Bug A). A bare `mktemp` would fail, `$lerr` would be empty, the `2>"$lerr"` redirect would die, and this guard would report *its own breakage as a fact about B2*. That is deploy#613/#623, which has shipped twice.
- **A failed `purge` is also retention that did not happen.** It was `|| log "WARNING"`; the directory stays in B2 and every other signal reads clean. It now drives the same signal.
- **A new gauge: `isnad_backup_retention_ok{0,1}`**, written to the node-exporter textfile directory alongside the existing success gauge, on every run that reaches retention (including a partial backup). Plus a `Retention:` line in the run summary and an explicit `ERROR` before the finish banner, so a broken retention cannot print an unqualified clean finish.

### What it deliberately does NOT do

**Retention failure does not exit non-zero.** It deleted nothing, so failing the run would convert a storage-cost problem into a **total backup outage** — and it would abort before `emit_success_metric`, so a night with a perfectly good, uploaded, restorable backup would report as a failed backup and `BackupStale` would fire falsely. Strictly worse than the bug being fixed. The artifact is honoured; the bad news rides on the gauge. `test_a_failed_listing_does_NOT_take_the_backup_down` pins this.

### rc=0 is not proof that we saw anything (deploy#634/#638)

A memory landed mid-implementation that is load-bearing here: **rclone returns rc=0 with an EMPTY listing for a prefix the application key is not permitted to read.** Not a 403 — a successful listing of nothing. So the rc check above closes the loud classes (bad credential, network fault) and **cannot, even in principle, close this one**: a scoped-away key returns byte-for-byte what "no old backups" returns. An exit code reports whether a tool finished its work, never whether it was *allowed* to.

What catches it is the one thing the listing cannot argue with: **this run just uploaded into that prefix, and `rclone copy` said it succeeded** — so today's directory is necessarily there. If the listing cannot show it to us, the listing is not describing the bucket, and no `purge` decision may be read off it. A positive control, carried in production, scoped to the category this run actually wrote to (the other category is legitimately empty on a young environment).

Without this, the fix would have closed the loud failures and left the silent one — which is the failure that actually shipped.

---

## #636 — nothing bound `BACKUP_PREFIX` to the host it runs on

**Premise verified**: `scripts/env_validate_schemas.py` has no `BACKUP_PREFIX` entry at all.

`#633` makes `BACKUP_PREFIX` required and refuses anything outside `^[a-z0-9][a-z0-9-]*$`. But one accepted-by-regex value is catastrophic and the regex **cannot** catch it by construction:

```
BACKUP_PREFIX=prod     # ...on the STAGING host
```

A perfectly legal bare name. Staging writes its dumps into `prod/`, and staging's retention purge — now correctly scoped to "its own" prefix — **deletes production's backups**. deploy#632 through the front door. The value is not malformed; it is wrong only *relative to the host*.

### ⚠️ I did NOT add a `BACKUP_PREFIX` entry to `env_validate_schemas.py`. It would be inert.

The issue asks for a schema entry asserting the value is in `{stg, prod}` and equals the environment being deployed. **That file cannot make that check**, and I'd rather say so than ship a green check over a fiction. Four independent findings:

1. **The shims validate `assemble_env(env, svc)`** — `env/base.env` + `env/services/<svc>.env` + `env/<env>.env` + `secrets/<env>.env.example`. All repo-side files.
2. **`BACKUP_PREFIX` is in none of them.** It is injected by the deploy workflows' `extra_env:` → `write-deploy-env` → the host's `/opt/noorinalabs-deploy/.env`. So a strict schema entry is a permanent false RED (the key is absent), and a defensive "if present" entry is **inert** — never present, therefore never checked. Exactly the assertion-no-fixture-can-violate trap.
3. **`env_validate.py` is not part of the deploy at all.** Only `env-validate.yml` (a PR/push CI gate) invokes it. Neither `deploy-stg.yml` nor `deploy-prod.yml` ever calls it — so it never sees the host it is supposedly binding to.
4. **The `env/` tiers are not deployed.** `compose/docker-compose.prod.yml` declares **no `env_file:`**, and `write-deploy-env` never reads `env/` — it *truncates* (`: > "$env_file"`) and rewrites the host `.env` from workflow inputs. So a `BACKUP_PREFIX` added to `env/stg.env` to make the schema check "work" would be validating a file that never reaches the box.

The schema mechanism *does* know which env it is (the shims take an `env` param). What it does not have is **the value under test**, and it is not in the deploy path. It is the wrong instrument.

### The two smallest things that actually bind, and where they live

**(a) CI — bind each workflow's literal to its own environment.** The existing `test_the_two_environments_get_different_prefixes` asserts only that stg **differs from** prod. A full **swap** satisfies it:

```
deploy-stg.yml  -> BACKUP_PREFIX=prod
deploy-prod.yml -> BACKUP_PREFIX=stg
```

They differ, so the existing assertion is happy — and it is the most destructive configuration possible. Staging purges production's backups on a schedule and production purges staging's, and unlike the hand-edit the deploy rewrites both values authoritatively on every run, so **it never self-repairs**. "Different from each other" is not the property; "equal to the environment it deploys" is. Now pinned.

**(b) Runtime — cross-check the prefix against an independent witness of the host.** `backup.sh` now compares `BACKUP_PREFIX` against `BASE_DOMAIN`, which is in scope because the unit loads the whole of `/opt/noorinalabs-deploy/.env` (`EnvironmentFile=`), and which the deploy composite writes from the workflow's `base_domain:` input.

Why `BASE_DOMAIN` is a witness worth believing rather than a second copy of the same guess: **it is load-bearing for Caddy.** If it were wrong, TLS and every route on the box would be wrong — loudly, immediately, in daylight, with a human already looking. `BACKUP_PREFIX` is load-bearing for *nothing* until the purge runs at 03:00, unattended, against the other environment's backups. We are cross-checking the silent variable against the noisy one.

This targets the path the issue names as real — **the hand-edited `.env` during an incident**. A workflow-injected prefix is self-repairing (the next deploy truncates and rewrites `.env`); the file an operator edits at 3am is not, and the nightly timer fires before anyone re-deploys. A single-line edit to `BACKUP_PREFIX` leaves `BASE_DOMAIN` still telling the truth.

**It refuses only on a positive contradiction.** An absent or unrecognised `BASE_DOMAIN` means we do not know which host this is — that is *not* evidence the prefix is wrong. Refusing there would take a backup outage on a healthy box (a new environment, a restore drill, a hand-run invocation) and would be deploy#613's shape exactly: a check converting its own blindness into a verdict about the system. So it **warns and proceeds**.

### The operator-facing examples were a loaded gun — in **two** independent ways

The stale usage line at `verify_b2_backup_artifact.sh:77` was:

```
#   B2_ROOT="isnad:isnad-graph-backups" ./scripts/verify_b2_backup_artifact.sh
```

It is wrong twice, and **each error fails toward "you have no backups"**:

**1. It names an EMPTY bucket.** Measured against the live B2 account 2026-07-14:

```
rclone lsf -R --files-only isnad:isnad-graph-backups/  ->   0 objects   (legacy, nothing writes to it)
rclone lsf -R --files-only isnad:noorinalabs-backups/  ->  27 objects   (9 stg + 18 prod — ALL the real backups)
B2_BUCKET on stg = B2_BUCKET on prod = 'noorinalabs-backups'
```

Both names are real buckets. An operator doing a DR restore follows `RUNBOOK.md:346`, runs `rclone lsf isnad:isnad-graph-backups/`, gets a clean and confident **zero**, and concludes **the backups do not exist** — while 27 objects sit in the other bucket. That is a silent zero pre-baked into the one document you only ever read when you are already in trouble.

The name collision is genuinely nasty and is what misled the runbook in the first place: `noorinalabs-backups` is the **bucket**, and `/var/lib/noorinalabs-backups` is *also* the **local staging directory** on the VPS. Both now appear in the doc, so the clarifying note is *more* necessary than before, not less — `RUNBOOK.md` gets an explicit three-row table making the distinction unmissable.

*(I initially pushed back on this and was wrong. My evidence was `RUNBOOK.md` itself — the very artifact that is broken — and it is circular to verify a doc against itself. The tree did corroborate the truth and I missed it: `test_b2_preflight.py:238` and `test_compose_project_scoping.py:828` already use `B2_BUCKET="noorinalabs-backups"`. The account measurement settled it.)*

**2. It names the bucket ROOT, with no environment prefix** — the exact cross-environment false-green #633 removed from `verify-backup-artifact.yml`, left copy-pasteable in a comment. stg and prod share one bucket, so a root path scans both environments' objects and reports `fresh` on whichever it finds first.

### The fix is not "name the right bucket" — it is **never name a bucket**

My first pass swapped in the correct literal. Bereket Tadesse blocked on that, and he was right: **a hardcoded bucket in a usage example is a stale artifact waiting to happen, and it is exactly how the last one went wrong.** Worse, the line I *added* (`isnad:isnad-graph-backups/prod`) fixed the missing prefix while keeping the wrong bucket — so it was wrong in a **more confident** way, under a comment block declaring it the form to copy. He ran the watchdog both ways on stg at the same moment:

```
B2_ROOT="isnad:isnad-graph-backups/prod"  ->  status=absent  dumps=0  bucket_objects=0   [ERROR] no fresh restorable backup
B2_ROOT="isnad:${B2_BUCKET}/prod"         ->  status=fresh   dumps=3  bucket_objects=20  age=5h
```

A false **RED**, from the one check that reads B2 rather than a host-local gauge — and in cutover week *"we have no backups"* is the more dangerous direction, because it is the sentence that changes what a human does next.

So every runnable example now uses **`${B2_BUCKET}`**, which resolves to whatever the `BACKUP_B2_BUCKET` secret actually says — the only thing true by construction, immune to this class of error *and* to the next rename. Same form the workflow already uses (`B2_ROOT="isnad:${B2_BUCKET}/${{ matrix.env }}"`) and `docs/runbooks/backup-alerts.md`. Applied in `RUNBOOK.md` and `verify_b2_backup_artifact.sh`. The `BACKUP_B2_BUCKET` secret and its `changeme` catalogue defaults are untouched.

**Plus an operator note Bereket hit in review:** `verify_b2_backup_artifact.sh`, unlike `backup.sh`, does **not** set `RCLONE_CONFIG_ISNAD_{TYPE,ACCOUNT,KEY}` itself. From a bare shell without them exported, rclone dies with `didn't find section in config file` — which names neither the bucket nor the key and sends you hunting for an `rclone.conf` that does not exist. The usage block now says so and shows the exports.

**And it is guarded.** New tests read only what an operator would actually *copy* — fenced ```bash blocks in `RUNBOOK.md` and `#   B2_ROOT="isnad:…` usage lines in the scripts — and assert that **no runnable example hardcodes any bucket at all** (not merely "not the empty one" — a blocklist of one would let the next wrong bucket sail past), and that every one names its environment. The blockquote *warning* that mentions `isnad-graph-backups` in order to warn about it is deliberately invisible to the detector: a guard that flagged the warning would force the next person to delete the warning to go green.

### #653 — the code was right; the test was inert

Nino Kavtaradze approved the #636 design after running twelve live prefix/domain pairs through the real `backup.sh`, but filed one finding: **the unknown-host branch is only tested ABSENT, never present-but-unrecognised — so a substring-glob mutant survives the suite.** Escalated to blocking, and correctly so.

The code is right: an anchored `case` cannot substring-match. But nothing *pinned* it, and "correct today" is not the property — the property is that it **cannot silently stop being correct**. Swap the anchored arms for globs and, because they are ordered `stg`-first, **both known hosts still resolve correctly and every existing test stays green.** The mutant is invisible everywhere except on a host that is neither — which is the case nothing tested. On `restore.noorinalabs.com` (a restore-drill box), `*noorinalabs.com*` matches, the box is silently declared **prod**, and `BACKUP_PREFIX=prod` there is then *allowed* — to write into `prod/` and run `rclone purge` against production's backups. That is the single catastrophic direction and the entire reason deploy#636 exists.

Closed with fixtures for `BASE_DOMAIN` **present but unrecognised** (`restore.noorinalabs.com`, `dev.noorinalabs.com`, `noorinalabs.com.attacker.test`, plus `foo.example.com` as the control), across **both** prefixes — which is what leaves the mutant nowhere to hide: under the glob it is silently *allowed* for `prod` (no warning) and wrongly *refused* for `stg` (a contradiction that does not exist).

---

## Calibration — every new guard was watched going RED

An assertion that has only ever been watched agreeing with the code it was written beside has demonstrated nothing. Four calibrations, each run against the real `backup.sh` with the fix reverted:

| # | Mutation | Result |
|---|---|---|
| 1 | Revert the whole instrumented listing block to the historical `2>/dev/null \|\| true` two-liner | **6 RED.** The empty-listing test and the positive control stay GREEN — the suite *separates* the classes rather than failing indiscriminately. |
| 2 | Remove the `#636` host-binding guard | **4 RED.** `test_the_matching_prefix_is_NOT_refused` stays green, as it must. |
| 3 | **Swap** the workflow literals (stg→`prod`, prod→`stg`) | My `test_each_deploy_workflow_injects_ITS_OWN_environment` goes **RED**; the existing `test_the_two_environments_get_different_prefixes` stays **GREEN** on the same swapped tree. This is the proof the gap was real. |
| 4 | Remove **only** the "today's directory must be present" control, leaving the rc check intact | **Exactly 1 RED** — the rc=0-but-blind test, and nothing else. Proves the control is independently load-bearing and not merely shadowing the rc check. |
| 5 | Restore the pre-fix RUNBOOK example (`rclone lsf isnad:isnad-graph-backups/`) | **2 RED** — the empty-bucket guard *and* the missing-environment guard, each firing on its own defect. The detector's own calibration test stays green. |
| 6 | **The #653 mutant** — swap the anchored `case` arms for substring globs (`*noorinalabs.com*`), arms kept in the **same order** | **7 RED** — all six present-but-unrecognised fixtures (3 lookalike domains × both prefixes) plus the in-suite mutation test. Every **known-host** test stays **GREEN**, which is precisely why it survived before. And `foo.example.com` stays green too — it contains no `noorinalabs.com`, so the glob cannot misclassify it, proving the fixtures *discriminate* rather than failing indiscriminately. |
| 7 | Hardcode a bucket back into a usage example | Hardcoding the **correct** bucket → **1 RED** (the hardcoding ban fires; the empty-bucket guard correctly does not). Hardcoding the **empty** one → **2 RED**. The two guards are distinct and both load-bearing. |

**Guards of mine that calibration caught being wrong, before review:**

- The mutant in calibration 1 first wrote itself to a bare tmp dir. `backup.sh` sources `compose_project.sh` from its own `dirname`, so it **died at startup** — and two of its three assertions ("the diagnostic is absent") passed *vacuously*, absent from the output of a script that never ran. Only the gauge assertion noticed. The mutant now runs beside the real libraries and must prove it **reached retention** before its silence is read.
- My first "nothing to prune" fixture returned an **empty listing for the category the run had just uploaded into** — a state the bucket cannot physically be in. The new production control fired on it, correctly.
- `test_every_operator_example_names_its_environment` first matched only the `isnad:<bucket>/<env>` spelling and went **red on the script's own correct `B2_PREFIX="prod"` example** — a legitimate second spelling of the same property.
- The same detector's bucket group was `[A-Z_]+`, which **cannot match the digit in `B2_BUCKET`**. It stopped at `${B`, treated `2_BUCKET}/prod` as the path, and reported every *correct* `${B2_BUCKET}` line as missing its environment. A detector that cannot spell the name of the thing it is looking for will fail the fix and pass the bug.

**Two of my own guards were caught being vacuous, by the calibration, before review:**

- The mutation test first wrote the mutant to a bare tmp dir. `backup.sh` sources `compose_project.sh` from its own `dirname`, so the mutant **died at startup** — and two of its three assertions ("the diagnostic is absent") passed *vacuously*, absent from the output of a script that never ran. Only the gauge assertion noticed. The mutant now runs in a directory holding the real libraries and must prove it **reached retention** before its silence is read.
- My first "nothing to prune" fixture returned an **empty listing for the category the run had just uploaded into** — a state the bucket cannot physically be in. The new production control fired on it, correctly. The fixtures now emit today's directory in every healthy mode, computed with `date -u +%Y-%m-%d` the same way `backup.sh` does, so they do not rot at midnight UTC or care that the category flips to `weekly` on Sundays.

The tests **run the real `backup.sh`** — through the real `compose_project.sh` and `b2_preflight.sh`, under the real `set -euo pipefail`, with stubbed `docker`/`rclone`/`zstd` — because both bugs are about what the script *does* when an instrument fails, and a source-text scan cannot see that. The first test in the module is a positive control asserting the harness *reaches retention at all*; without it, every "when the listing fails, X happens" assertion would be trivially true of a run that never got there.

**What a green run here does not mean:** it does not mean the retention path is safe under the unit's hardening. These tests run where `/tmp` is writable; under `isnad-backup.service` it is not. That property is pinned by `test_scratch_under_hardening.py`, which is structurally capable of failing on it. This module is not, and says so in its docstring.

---

## Follow-ups (tracked separately, deliberately not in this PR)

- **#645 — `isnad_backup_retention_ok` has no alert rule.** A metric nothing alerts on reads as healthy forever; that is deploy#565's lesson verbatim (its `BackupFailure` keyed off a gauge nothing wrote, so the expression was structurally incapable of firing — for months, with no restorable backup at all). This is the same shape one step earlier: the producer now exists, the consumer does not. Not fixed here because `infra/prometheus/alerts.yml` is outside this PR's file set, and **`promtool` cannot run on this machine** (its pre-push hooks shell out to Docker, unavailable in this WSL distro, and hard-fail rather than silently skip by design). Pushing a Prometheus rule I could not validate is precisely the red-gate-as-speed-bump main#684 forbids. *(I filed #649 for this before seeing #645; closed as a duplicate.)*
- **#650 — `RUNBOOK.md`'s key-rotation procedure.** Tied to the B2 key migration; left alone here on instruction. One caveat, stated plainly: my earlier commit had **already** corrected that step away from the empty bucket, and I have **not reverted it**, because reverting would reintroduce the exact live trap #650 exists to describe — a doc telling you to scope a new key to a bucket the backups do not use. It now names `${B2_BUCKET}` like everything else. #650's substantive fix (the scoping/migration) is untouched.

## Gates

- `pre-commit run --all-files` — **pass** (ruff-format, ruff-lint, gitleaks, actionlint, cspell, terraform, dockerfile-base-pin, env-example-check)
- `shellcheck -x scripts/backup.sh scripts/verify_b2_backup_artifact.sh` — **clean** (shellcheck is not in pre-commit, deploy#578)
- `python3 -m pytest scripts/tests -q` — **472 passed, 3 skipped**, no regressions
- pre-push: `mypy`, `pytest`, `pytest-scripts` — pass. The `promtool-*` hooks are scoped `files: ^infra/prometheus/`, which this diff does not touch, so they are correctly not selected on this push. (They *do* fire under a forced `--all-files` run and hard-fail there for want of Docker — by design, "a check that silently no-ops is the exact failure class these hooks exist to catch" — which is the other half of why the alert rule below is a follow-up rather than something I could validate here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfLUh7qrqfYdfxa2jNKS5f
