### PR TITLE
test(backup): run the real backup path under the unit's OWN hardening, in CI

### DIFF
--- a/.github/workflows/backup-hardening.yml
+++ b/.github/workflows/backup-hardening.yml
@@ -1,0 +1,83 @@
+# Run the backup path under the BACKUP UNIT'S OWN HARDENING. (deploy#626 / deploy#627)
+#
+# deploy#613 and deploy#623 are the same bug, shipped twice, past a full green CI and four
+# reviewers: a script under isnad-backup.service allocated scratch in /tmp, which is READ-ONLY
+# there (ProtectSystem=strict, PrivateTmp deliberately unset — deploy#121 Bug A), and then
+# reported its own broken instrument as a fact about the subsystem it was meant to check.
+#
+# It got through because EVERY OTHER CHECK WE HAVE RUNS WHERE THE BUG CANNOT HAPPEN. GitHub
+# runners, the rehearsal containers and the dev box all have a writable /tmp. The tests were not
+# weak; they were structurally incapable of failing.
+#
+# This job is the one place that is not true. It builds a mount namespace FROM THE DIRECTIVES IN
+# systemd/*.service — ProtectSystem=, ReadWritePaths=, ProtectHome=, PrivateTmp= — and runs the
+# real ExecStart inside it, with docker/rclone/zstd stubbed. The constraint is READ OUT OF THE
+# UNIT, never re-typed here: a hand-written "read-only /tmp" step would be a third place to
+# encode the same assumption and would go stale the moment somebody edited ReadWritePaths=.
+#
+# Exit codes from scripts/tests/unit_hardening.py, and the middle one is the point:
+#   0  the entry point ran clean under its own unit's hardening
+#   1  it FAILED under the hardening — a finding
+#   2  WE COULD NOT FIND OUT (no namespace, a directive we cannot emulate). NEVER green.
+name: Backup hardening
+
+# The trigger paths are spelled out on both events rather than shared via a YAML anchor:
+# actionlint rejects an alias node for `paths` ("must be sequence node but got alias node").
+on:
+  push:
+    branches: [main]
+    paths:
+      - "scripts/**"
+      - "systemd/**"
+      - ".github/workflows/backup-hardening.yml"
+  pull_request:
+    paths:
+      - "scripts/**"
+      - "systemd/**"
+      - ".github/workflows/backup-hardening.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  backup-under-unit-hardening:
+    name: backup.sh under systemd hardening
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install pytest
+        run: pip install pytest
+
+      # Ubuntu 24.04 ships kernel.apparmor_restrict_unprivileged_userns=1, which blocks the
+      # rootless user namespace the harness prefers (the one a developer gets from pre-commit
+      # with no sudo). Lift it if it is set.
+      #
+      # `|| true` is deliberate and it is NOT a swallowed failure: this step only makes the
+      # ROOTLESS backend available. If it does nothing, the harness probes its backends, finds
+      # none, and exits 2 — loudly, as an instrument failure. The gate does not depend on this
+      # step succeeding; it depends on the harness being honest when it cannot run, which is
+      # asserted by test_the_harness_refuses_to_testify_when_it_cannot_build_the_sandbox.
+      - name: Allow rootless user namespaces (Ubuntu 24.04 AppArmor)
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+
+      # THE GATE. The real scripts/backup.sh and scripts/emit-backup-failure-marker.sh, driven
+      # end to end, inside a namespace built from their own units. Units are DISCOVERED from
+      # systemd/*.service — add one tomorrow and it is gated from that moment, with nobody
+      # remembering to edit this file.
+      - name: Run every hardened unit's ExecStart under its own hardening
+        run: python3 scripts/tests/unit_hardening.py
+
+      # The calibration. The gate above is worth exactly what its ability to FAIL is worth, and
+      # the previous suite's was zero. These tests put the defect back — a bare mktemp, a
+      # `> /tmp/…` redirect that no mktemp-scan can see, a $HOME write under ProtectHome=, and
+      # deploy#613 itself — and assert the harness goes RED for each. They also prove the sandbox
+      # is DERIVED: the same write passes or fails according to what ReadWritePaths= says.
+      #
+      # A harness that has not been shown to fail is not evidence. It is decoration.
+      - name: Calibration — prove the harness can actually fail
+        run: python3 -m pytest scripts/tests/test_backup_under_unit_hardening.py -v

--- a/.github/workflows/backup-hardening.yml
+++ b/.github/workflows/backup-hardening.yml
@@ -79,5 +79,14 @@ jobs:
       # is DERIVED: the same write passes or fails according to what ReadWritePaths= says.
       #
       # A harness that has not been shown to fail is not evidence. It is decoration.
+      #
+      # HARNESS_REQUIRE_NAMESPACE=1 is the load-bearing part. The tests `skipif` when there is no
+      # mount namespace, so that a stock Ubuntu 24.04 dev box does not red-line the shared
+      # `pytest (scripts)` gate on every unrelated push. That skip is only defensible because THIS
+      # job cannot take it: with the var set, a missing namespace is a HARD FAIL, not a skip.
+      # A bare skip on its own would be the false green this whole gate exists to kill.
+      # test_the_dedicated_workflow_cannot_skip_this_suite asserts this stays true.
       - name: Calibration — prove the harness can actually fail
+        env:
+          HARNESS_REQUIRE_NAMESPACE: "1"
         run: python3 -m pytest scripts/tests/test_backup_under_unit_hardening.py -v

--- a/.github/workflows/compose-validate.yml
+++ b/.github/workflows/compose-validate.yml
@@ -371,6 +371,20 @@ jobs:
         # bucket, and a suite that quietly tests nothing is the exact defect class this
         # scanner exists to close. Install it instead.
         run: sudo apt-get update && sudo apt-get install -y rclone
+      - name: Allow rootless user namespaces (Ubuntu 24.04 AppArmor)
+        # scripts/tests/test_backup_under_unit_hardening.py builds a mount namespace out of the
+        # directives in systemd/*.service and runs the REAL backup.sh inside it (deploy#626/#627
+        # — the writable-/tmp blind spot that shipped deploy#613 twice). ubuntu-latest is 24.04,
+        # which ships kernel.apparmor_restrict_unprivileged_userns=1 and refuses the rootless
+        # user namespace the harness prefers.
+        #
+        # `|| true` is NOT a swallowed failure. This step only makes the ROOTLESS backend
+        # available; if it does nothing, the harness probes its backends, finds none, and exits
+        # 2 — COULD NOT FIND OUT — so the suite goes RED with the remediation printed rather
+        # than green. That is not a theory: on PR #654 this job failed with exactly that
+        # instrument-failure message before this step existed, which is the behaviour
+        # test_the_harness_refuses_to_testify_when_it_cannot_build_the_sandbox asserts.
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
       - name: Run scripts unit tests
         run: python3 -m pytest scripts/tests -q
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@
 #   * actionlint (workflow lint) ...... lint-workflows.yml + docs.yml
 #   * ruff lint + format, mypy ........ hooks-lint.yml (over .claude/hooks/)
 #   * gitleaks (secret detection) ..... stricter-local (no CI gate yet; kept)
+#   * backup under unit hardening ..... backup-hardening.yml (deploy#626/#627)
 #
 # Stage split (fail-fast, cheapest first):
 #   pre-commit (every commit) — terraform fmt/validate, gitleaks, actionlint,
@@ -155,6 +156,32 @@ repos:
       - id: pytest-scripts
         name: pytest-scripts (pre-push)
         entry: python3 -m pytest scripts/tests -q
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
+
+      # The backup path under the BACKUP UNIT'S OWN HARDENING (mirrors backup-hardening.yml,
+      # deploy#626/#627). Runs scripts/backup.sh and scripts/emit-backup-failure-marker.sh
+      # inside a mount namespace built from the ProtectSystem=/ReadWritePaths=/ProtectHome=
+      # directives in systemd/*.service, with docker/rclone/zstd stubbed.
+      #
+      # THIS IS MIRRORED LOCALLY BECAUSE IT CAN BE (main#684 — full local<->CI parity). The
+      # sandbox is rootless (`unshare --user --map-root-user --mount`), so a developer gets the
+      # gate from `pre-commit` with no sudo and no ceremony. That matters more than usual here:
+      # deploy#613 shipped TWICE, and the second time was inside the fix for the first, because
+      # nothing anyone could run locally could express the defect. Now they can.
+      #
+      # Exits 2 — never 0 — if it cannot build the namespace. A check that cannot run must say
+      # so and must NOT testify; on Ubuntu 24.04 that may need
+      # `sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0`. Heavier, so pre-push.
+      #
+      # The CALIBRATION half (scripts/tests/test_backup_under_unit_hardening.py — the mutations
+      # that prove this harness can actually FAIL) is already carried by pytest-scripts above,
+      # which runs the whole scripts/tests suite.
+      - id: backup-under-unit-hardening
+        name: backup-under-unit-hardening (pre-push)
+        entry: python3 scripts/tests/unit_hardening.py
         language: system
         pass_filenames: false
         always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -177,8 +177,13 @@ repos:
       # `sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0`. Heavier, so pre-push.
       #
       # The CALIBRATION half (scripts/tests/test_backup_under_unit_hardening.py — the mutations
-      # that prove this harness can actually FAIL) is already carried by pytest-scripts above,
-      # which runs the whole scripts/tests suite.
+      # that prove this harness can actually FAIL) is carried by pytest-scripts above, which runs
+      # the whole scripts/tests suite — but ONLY on a box that can build a namespace. On a stock
+      # Ubuntu 24.04 box those tests SKIP (loudly, naming the sysctl) rather than red-lining a
+      # shared gate for reasons unrelated to the developer's change. CI cannot skip them:
+      # backup-hardening.yml lifts the AppArmor restriction AND sets HARNESS_REQUIRE_NAMESPACE=1,
+      # which turns a missing namespace into a hard failure. That guarantee is itself asserted by
+      # test_the_dedicated_workflow_cannot_skip_this_suite. (deploy#654 review — Bereket Tadesse.)
       - id: backup-under-unit-hardening
         name: backup-under-unit-hardening (pre-push)
         entry: python3 scripts/tests/unit_hardening.py

--- a/scripts/tests/test_backup_under_unit_hardening.py
+++ b/scripts/tests/test_backup_under_unit_hardening.py
@@ -1,0 +1,507 @@
+"""The real backup path, run under the real unit's real hardening — and PROVEN able to fail.
+
+deploy#626 / deploy#627.
+
+READ THIS FIRST, BECAUSE IT IS THE WHOLE POINT
+----------------------------------------------
+deploy#613 and deploy#623 are the same bug, shipped twice, past a full green CI and four
+reviewers. The tests did not miss it because they were weak. They missed it because **they were
+structurally incapable of failing**: every runner, container and dev box has a writable ``/tmp``,
+and the defect only exists where ``/tmp`` is read-only. A suite that cannot express a defect is
+not a weak instrument, it is not an instrument at all.
+
+So the first duty of THIS module is not to test ``backup.sh``. It is to prove that it CAN. That
+is what the calibration tests below are: a fixture copy of ``backup.sh`` with the defect put
+back, asserted to go **RED**. Four of them, spanning the class:
+
+  1. a bare ``mktemp``                      — deploy#613/#623's spelling
+  2. a ``> /tmp/…`` redirect                — NOT mktemp; a text-scan for mktemp sees nothing
+  3. a ``$HOME`` write under ProtectHome=   — NOT mktemp, NOT /tmp
+  4. b2_preflight's scratch back on /tmp    — deploy#613 ITSELF, restored, end to end
+
+If only (1) went red, this module would have reimplemented ``test_scratch_under_hardening.py``'s
+static pin at 100x the cost and closed nothing. (2), (3) and (4) are the reason it exists.
+
+AND THE SANDBOX IS DERIVED, NOT RESTATED
+----------------------------------------
+The constraint is READ OUT OF ``systemd/isnad-backup.service`` — ``ProtectSystem=``,
+``ReadWritePaths=``, ``ProtectHome=``, ``PrivateTmp=``. A hand-written "read-only /tmp" fixture
+would be a THIRD place to encode the same assumption, stale the moment someone edits the unit.
+
+"Derived" is a claim, so it is TESTED, twice, and both tests are two-sided — the SAME mutation,
+under two different units, must produce two different verdicts:
+
+  * ``test_a_write_is_refused_or_allowed_according_to_ReadWritePaths`` — grant the path in the
+    unit and the write passes; take the grant away and the identical write fails.
+  * ``test_PrivateTmp_yes_makes_a_bare_mktemp_legal_because_production_would`` — a bare
+    ``mktemp`` is a defect *because the unit does not set PrivateTmp*. Set it, and the harness
+    says PASS — because production would too.
+
+A test that only ever says NO proves nothing (feedback_calibrate_the_mutation_before_counting_it).
+Both directions, or it is theatre.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+import unit_hardening as uh
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+REAL_UNIT = REPO_ROOT / "systemd" / "isnad-backup.service"
+
+# Sentences that claim something about a subsystem the run never actually reached. deploy#613
+# said "your B2 key is invalid" about a good key; deploy#623 said "is the daemon running?" about
+# a healthy daemon. In this harness docker and B2 are HEALTHY BY CONSTRUCTION, so any of these
+# appearing in the output is the script testifying about a system it never touched.
+FALSE_CLAIMS = (
+    "verdict=KEY_INVALID",
+    "verdict=KEY_READ_ONLY",
+    "verdict=BUCKET_UNREACHABLE",
+    "is the daemon running",
+    "Cannot reach Docker Compose",
+    "Could not START neo4j",
+    "Neo4j is NOT running",
+)
+
+
+def _stage(tmp_path: Path) -> Path:
+    """A private copy of the tree the unit executes. Never the worktree — see stage_repo()."""
+    return uh.stage_repo(tmp_path / "opt", source=REPO_ROOT)
+
+
+def _run(repo: Path, unit: Path = REAL_UNIT) -> uh.Result:
+    return uh.run_unit_under_hardening(unit, repo, extra_env=dict(uh.HARNESS_ENV))
+
+
+def _mutate(repo: Path, script: str, anchor: str, injected: str) -> None:
+    """Put a defect back into a FIXTURE COPY of a real script.
+
+    The anchor is a line from the real file, so if that line is ever reworded this raises
+    instead of silently injecting nothing and reporting a calibration that never ran. A
+    calibration that cannot fire is the same false green as a test that cannot fail
+    (feedback_calibrate_the_mutation_before_counting_it).
+    """
+    path = repo / "scripts" / script
+    text = path.read_text()
+    if anchor not in text:
+        raise AssertionError(
+            f"calibration anchor not found in {script}: {anchor!r}\n"
+            f"The mutation would have injected NOTHING and this test would have 'passed' by "
+            f"doing nothing at all. Re-anchor it on a line that exists."
+        )
+    path.write_text(text.replace(anchor, anchor + "\n" + injected, 1))
+
+
+# ===========================================================================
+# 0. THE INSTRUMENT ITSELF
+# ===========================================================================
+
+
+def test_the_harness_refuses_to_testify_when_it_cannot_build_the_sandbox(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No `unshare` => rc=2, NEVER rc=0.
+
+    A gate that silently skips green when its instrument is missing is precisely the false green
+    this whole issue exists to kill. rc=2 is "I could not find out" and it is a different fact
+    from "nothing is wrong" — the same distinction compose_project.sh had to learn the hard way
+    (service_is_running: rc=1 is about the stack, rc=2 is about us).
+    """
+    monkeypatch.setattr(uh.shutil, "which", lambda _name: None)
+    res = uh.run_unit_under_hardening(REAL_UNIT, _stage(tmp_path))
+    assert res.rc == 2, "a missing `unshare` must be an INSTRUMENT failure, not a pass"
+    assert res.rc != 0
+    assert "CANNOT RUN" in res.output
+
+
+def test_an_unknown_directive_is_an_instrument_failure_not_a_silent_pass(tmp_path: Path) -> None:
+    """Add a constraint the harness cannot emulate and it must STOP, not shrug.
+
+    This is the anti-drift core. If someone adds `InaccessiblePaths=/var/lib/secrets` to the
+    unit tomorrow, a harness that quietly ignored it would keep reporting green over a sandbox
+    that no longer matches production — which is the exact shape of the original bug, one level
+    up. The harness must say "I no longer know what production allows".
+    """
+    unit = tmp_path / "fixture.service"
+    unit.write_text(
+        REAL_UNIT.read_text() + "\nInaccessiblePaths=/var/lib/secrets\n",
+    )
+    with pytest.raises(uh.Unsupported, match="InaccessiblePaths"):
+        uh.parse_unit(unit)
+
+
+def test_every_hardened_unit_on_the_box_is_gated(tmp_path: Path) -> None:
+    """The unit set is DISCOVERED from systemd/, never hand-listed.
+
+    A hand-typed list drifts the moment someone adds a unit — and a new hardened unit with an
+    unchecked scratch write is deploy#613 for the fourth time. Both of today's units must be
+    found, and both must run clean.
+    """
+    units = uh.hardened_units()
+    names = {u.name for u in units}
+    assert names == {"isnad-backup.service", "isnad-backup-failure-marker.service"}, (
+        f"the hardened-unit discovery does not see what is in systemd/: {sorted(names)}"
+    )
+
+    for unit in units:
+        res = _run(_stage(tmp_path / unit.stem), unit=unit)
+        assert res.rc == 0, (
+            f"{unit.name}'s ExecStart FAILED under its own hardening (rc={res.rc}, "
+            f"exec_rc={res.exec_rc}):\n{res.output}"
+        )
+
+
+# ===========================================================================
+# 1. POSITIVE CONTROL — the real thing, unmutated, must go GREEN
+# ===========================================================================
+
+
+def test_the_real_backup_runs_clean_under_the_real_units_own_hardening(tmp_path: Path) -> None:
+    """The baseline. Without it, every RED below is satisfied by a harness that always fails.
+
+    This is also the honest test of the sandbox's fidelity in the OTHER direction: the sandbox
+    hides more than the unit does in places (it tmpfs's the ancestors of the granted paths), and
+    if that over-restriction broke the real script, it would show up right here as a false RED.
+    It does not — backup.sh runs end to end.
+    """
+    res = _run(_stage(tmp_path))
+
+    assert res.rc == 0, f"the REAL backup.sh failed under the REAL unit's hardening:\n{res.output}"
+    assert res.exec_rc == 0
+
+    # rc alone is not enough, and this is not belt-and-braces. deploy#613 was a write that failed
+    # and was SWALLOWED; the exit code was collateral, the LIE was the product. So assert on what
+    # the run actually produced, and on what it said.
+    assert any("isnad_backup_success.prom" in a for a in res.artifacts), (
+        f"no success metric was written. A backup that exits 0 without emitting the success "
+        f"gauge is invisible to BackupStale (deploy#565).\nartifacts={res.artifacts}"
+    )
+    for claim in FALSE_CLAIMS:
+        assert claim not in res.output, (
+            f"the run claimed {claim!r}. docker and B2 are HEALTHY in this harness by "
+            f"construction, so this is the script testifying about a subsystem it never "
+            f"reached — deploy#613/#623 exactly.\n{res.output}"
+        )
+
+
+# ===========================================================================
+# 2. CALIBRATION — the harness must be PROVEN able to fail, across the CLASS
+# ===========================================================================
+
+
+def test_calibration_bare_mktemp_goes_red(tmp_path: Path) -> None:
+    """(1) deploy#613/#623's own spelling. `mktemp` with no -p lands in the read-only /tmp."""
+    repo = _stage(tmp_path)
+    _mutate(repo, "backup.sh", "umask 077", 'HARNESS_MUT="$(mktemp)"')
+    res = _run(repo)
+
+    assert res.rc == 1, (
+        f"A BARE MKTEMP RAN CLEAN. /tmp is read-only under ProtectSystem=strict, so this must "
+        f"fail — if it does not, the sandbox is not the unit's and every green in this file is "
+        f"worthless.\n{res.output}"
+    )
+    assert "Read-only file system" in res.output
+
+
+def test_calibration_a_tmp_redirect_goes_red_and_it_is_not_a_mktemp(tmp_path: Path) -> None:
+    """(2) THE TEST THAT JUSTIFIES THIS MODULE'S EXISTENCE.
+
+    A `> /tmp/foo` redirect contains no `mktemp`. The static pin in
+    test_scratch_under_hardening.py — which scans for `mktemp` calls that do not name a parent —
+    cannot see it. Neither could a repo-wide lint banning bare `mktemp`.
+
+    It fails in production identically to deploy#613. If this does not go RED, then this harness
+    has merely reimplemented the static pin, at enormous cost, and closed NOTHING.
+    """
+    repo = _stage(tmp_path)
+    _mutate(repo, "backup.sh", "umask 077", "printf 'x\\n' > /tmp/harness-scratch.txt")
+
+    # Prove the mutation is invisible to the mktemp-shaped guard, or the claim above is hot air.
+    assert "mktemp" not in (repo / "scripts" / "backup.sh").read_text().split("umask 077")[1][:80]
+
+    res = _run(repo)
+    assert res.rc == 1, (
+        f"A `> /tmp/…` REDIRECT RAN CLEAN under the unit's hardening. This is the whole class "
+        f"the mktemp pin cannot see, and it is the reason deploy#626 exists.\n{res.output}"
+    )
+    assert "Read-only file system" in res.output
+
+
+def test_calibration_a_home_write_goes_red_under_ProtectHome(tmp_path: Path) -> None:
+    """(3) Not mktemp. Not /tmp. Still fatal — and only because ProtectHome= is read out too.
+
+    `ProtectHome=yes` makes $HOME inaccessible. A script that drops a config or a credential
+    under ~/.config dies on the box and nowhere else. Note this is the exact hazard behind the
+    rclone note in the stub: rclone escapes ProtectHome today ONLY because backup.sh configures
+    it through RCLONE_CONFIG_ISNAD_* env vars rather than a config file.
+    """
+    repo = _stage(tmp_path)
+    _mutate(repo, "backup.sh", "umask 077", "printf 'x\\n' > \"${HOME}/.harness-rclone.conf\"")
+    res = _run(repo)
+
+    assert res.rc == 1, (
+        f"A WRITE TO $HOME RAN CLEAN. ProtectHome=yes makes it inaccessible on the box. This "
+        f"mutation contains no mktemp and never touches /tmp — no text scan would catch it, and "
+        f"it is fatal in production.\n{res.output}"
+    )
+
+
+def test_calibration_deploy613_itself_restored_goes_red(tmp_path: Path) -> None:
+    """(4) THE ORIGINAL DEFECT, PUT BACK, END TO END.
+
+    b2_preflight.sh's scratch moved off /tmp and onto BACKUP_DIR precisely because of deploy#613.
+    Move it back and the preflight cannot allocate its scratch dir under the read-only /tmp.
+
+    The strongest calibration available: the harness must reproduce, from the real scripts, the
+    bug that shipped TWICE past a green CI. Note what the FIXED code does when its scratch dies —
+    it reports PROBE_FAILED, which is honest. The PRE-#613 code reported KEY_INVALID about a
+    perfectly good key. Either way the run must be RED here.
+    """
+    repo = _stage(tmp_path)
+    pre = repo / "scripts" / "b2_preflight.sh"
+    text = pre.read_text()
+    anchor = 'scratch_parent="${BACKUP_DIR:-${TMPDIR:-/tmp}}"'
+    assert anchor in text, "b2_preflight.sh no longer sites its scratch the way this test mutates"
+    # Send it back to /tmp — the pre-deploy#613 behaviour, verbatim in effect.
+    pre.write_text(text.replace(anchor, 'scratch_parent="/tmp"'))
+
+    res = _run(repo)
+    assert res.rc == 1, (
+        f"deploy#613 ITSELF ran clean. The B2 preflight allocated scratch in a READ-ONLY /tmp "
+        f"and the harness did not notice. This is the bug that killed every backup this project "
+        f"ever attempted.\n{res.output}"
+    )
+    assert "PROBE_FAILED" in res.output, (
+        "the preflight failed but did not report PROBE_FAILED. If it condemned the CREDENTIAL "
+        f"instead, deploy#613's false verdict is back.\n{res.output}"
+    )
+    assert "verdict=KEY_INVALID" not in res.output, (
+        "THE PREFLIGHT BLAMED THE KEY. The key is fine — the harness's rclone stub is a healthy, "
+        f"write-capable key by construction. This is deploy#613's lie, verbatim.\n{res.output}"
+    )
+
+
+# ===========================================================================
+# 3. DERIVED FROM THE UNIT — not restated. Both tests are TWO-SIDED.
+# ===========================================================================
+
+
+def _unit_with(tmp_path: Path, name: str, old: str, new: str) -> Path:
+    text = REAL_UNIT.read_text()
+    assert old in text, f"fixture anchor {old!r} is not in the real unit any more"
+    unit = tmp_path / name
+    unit.write_text(text.replace(old, new))
+    return unit
+
+
+def test_a_write_is_refused_or_allowed_according_to_ReadWritePaths(tmp_path: Path) -> None:
+    """PROOF THE SANDBOX IS DERIVED: the SAME write, two units, two verdicts.
+
+    The identical mutation — a write to /var/lib/harness-extra — must FAIL under the real unit
+    and PASS under a unit that grants that path in ReadWritePaths=. Nothing in the harness
+    mentions /var/lib/harness-extra; the only thing that changed is a line in a .service file.
+
+    This is what "derived from the unit" has to mean to be worth saying. Grant a path in the unit
+    tomorrow and the gate grants it in the same commit — no second edit, nowhere to drift.
+    """
+    grant_line = (
+        "ReadWritePaths=/var/lib/noorinalabs-backups /opt/noorinalabs-deploy /var/lib/node_exporter"
+    )
+    # Two SIMPLE commands, deliberately. The first draft wrote `mkdir X && printf … > X/f`, and
+    # under `set -e` a failure on the LEFT of an `&&` does not abort — so the mutation swallowed
+    # its own failure, the run exited 0, and the calibration "passed" while proving nothing. Same
+    # family as feedback_errexit_kills_assignment_guard, met head-on while calibrating a guard
+    # against it. A mutation that cannot fire is not evidence; see test_the_gate_cannot_see_a_
+    # write_the_script_itself_swallows for the boundary this exposed.
+    mutation = "mkdir -p /var/lib/harness-extra\nprintf 'x\\n' > /var/lib/harness-extra/f"
+
+    # (a) NOT granted -> the write must be refused.
+    ungranted = _stage(tmp_path / "ungranted")
+    _mutate(ungranted, "backup.sh", "umask 077", mutation)
+    res_denied = _run(ungranted, unit=REAL_UNIT)
+    assert res_denied.rc == 1, (
+        f"a write to a path the unit does NOT grant was allowed:\n{res_denied.output}"
+    )
+
+    # (b) granted in the unit -> the SAME write must now succeed.
+    granted_unit = _unit_with(
+        tmp_path, "granted.service", grant_line, grant_line + " /var/lib/harness-extra"
+    )
+    granted = _stage(tmp_path / "granted")
+    _mutate(granted, "backup.sh", "umask 077", mutation)
+    res_allowed = _run(granted, unit=granted_unit)
+    assert res_allowed.rc == 0, (
+        f"THE SANDBOX IS NOT DERIVED FROM THE UNIT. The unit's ReadWritePaths= grants "
+        f"/var/lib/harness-extra, production would allow this write, and the harness refused it. "
+        f"A gate that disagrees with production about what production allows is worse than no "
+        f"gate: it trains people to work around it.\n{res_allowed.output}"
+    )
+
+
+def test_PrivateTmp_yes_makes_a_bare_mktemp_legal_because_production_would(tmp_path: Path) -> None:
+    """PROOF, THE OTHER WAY ROUND: the harness has no opinion about mktemp. It reads the unit.
+
+    A bare `mktemp` is a defect *because isnad-backup.service does not set PrivateTmp* (deploy#121
+    Bug A explains why it cannot). Set PrivateTmp=yes and /tmp becomes a private, WRITABLE tmpfs —
+    and the identical `mktemp` that goes RED in the calibration above must go GREEN here, because
+    on that box it would work.
+
+    A harness with "bare mktemp is bad" wired into it would fail this test. That harness would be
+    a third restatement of the rule, and it would drift the day the unit changed. This one cannot:
+    it does not know what mktemp is.
+    """
+    unit = _unit_with(
+        tmp_path,
+        "privatetmp.service",
+        "NoNewPrivileges=yes",
+        "PrivateTmp=yes\nNoNewPrivileges=yes",
+    )
+    repo = _stage(tmp_path)
+    _mutate(repo, "backup.sh", "umask 077", 'HARNESS_MUT="$(mktemp)"')
+
+    res = _run(repo, unit=unit)
+    assert res.rc == 0, (
+        f"With PrivateTmp=yes the unit HAS a writable /tmp, so a bare mktemp is legal there and "
+        f"the harness must say so. It said rc={res.rc}. That means the read-only /tmp is baked "
+        f"into the harness rather than read out of the unit — which is the restatement this "
+        f"whole issue exists to prevent.\n{res.output}"
+    )
+
+
+# ===========================================================================
+# 4. THE PROPERTY NOBODY WROTE DOWN
+# ===========================================================================
+
+
+def test_rclone_is_configured_by_env_not_by_a_file_under_the_masked_HOME(tmp_path: Path) -> None:
+    """rclone escapes ProtectHome=yes ONLY because backup.sh configures it through the env.
+
+    Nino Kavtaradze raised this in the #624 review and it was never written down anywhere. Real
+    rclone reads ~/.config/rclone/rclone.conf. The unit sets ProtectHome=yes, so $HOME is
+    INACCESSIBLE — a config-file-based rclone would fail on every backup on the box, and rclone
+    would blame the credential while doing it (deploy#613's exact failure mode).
+
+    It works today only because backup.sh exports RCLONE_CONFIG_ISNAD_TYPE/ACCOUNT/KEY and never
+    writes a file. That is load-bearing, invisible, and one refactor from being the next defect.
+
+    So the rclone stub REFUSES to answer unless those variables are set, and this test proves the
+    refusal is real rather than a comment: strip the export from a fixture copy and the run must
+    go RED, naming the reason.
+    """
+    repo = _stage(tmp_path)
+    path = repo / "scripts" / "backup.sh"
+    text = path.read_text()
+    anchor = 'export RCLONE_CONFIG_ISNAD_ACCOUNT="${B2_KEY_ID}"'
+    assert anchor in text, "backup.sh no longer configures rclone through the environment"
+    path.write_text(text.replace(anchor, "# (removed by the harness to prove the guard bites)"))
+
+    res = _run(repo)
+    assert res.rc == 1, (
+        f"backup.sh stopped configuring rclone through RCLONE_CONFIG_ISNAD_* and nothing "
+        f"noticed. Under ProtectHome=yes the unit cannot read ~/.config/rclone/rclone.conf, so "
+        f"the env form is the ONLY thing keeping rclone working on the box.\n{res.output}"
+    )
+    # The stub's objection is asserted via its SENTINEL, not its stderr — and that is a finding
+    # in itself. b2_preflight captures `rclone lsd … > "$lsd_out" 2>&1`, so the stub's message is
+    # swallowed by the capture and the operator sees only `verdict=KEY_INVALID`: an accusation
+    # against a CREDENTIAL, produced by a refactor that never touched one. deploy#613's shape,
+    # one level up. The sentinel lands in BACKUP_DIR, where nothing can eat it.
+    assert any(".harness-rclone-unconfigured" in a for a in res.artifacts), (
+        f"the run failed, but not because rclone was left unconfigured — so this test is not "
+        f"measuring what it claims to.\nartifacts={res.artifacts}\n{res.output}"
+    )
+    assert "verdict=KEY_INVALID" in res.output, (
+        "NOTE, for whoever reads this next: the preflight really does render an rclone that "
+        "cannot be CONFIGURED as an invalid KEY. It is pinned here because it is exactly the "
+        "deploy#613 lie in a new place — and because if a future b2_preflight learns to tell "
+        "the two apart, this assertion should be the thing that fails and gets updated."
+    )
+
+
+# ===========================================================================
+# 5. WHAT THIS DOES *NOT* CATCH — stated, not hidden
+# ===========================================================================
+
+
+def test_a_bare_cd_into_tmp_is_NOT_a_finding_and_that_is_correct(tmp_path: Path) -> None:
+    """The honest boundary of the gate, pinned so nobody later 'fixes' it into a false positive.
+
+    A read-only directory is still TRAVERSABLE. `cd /tmp` succeeds under ProtectSystem=strict —
+    on the real box, today. It is only the WRITE that fails. So this harness does not flag it,
+    and it must not: a gate that fails on a legal operation gets disabled by the third person it
+    inconveniences.
+
+    The write that follows the `cd` is what dies, and that IS caught — by
+    test_calibration_a_tmp_redirect_goes_red.
+    """
+    repo = _stage(tmp_path)
+    _mutate(repo, "backup.sh", "umask 077", "cd /tmp && cd - > /dev/null")
+    res = _run(repo)
+    assert res.rc == 0, (
+        f"`cd /tmp` was flagged. It is legal under ProtectSystem=strict — read-only is not "
+        f"inaccessible — and flagging it would make this gate lie in the other direction.\n"
+        f"{res.output}"
+    )
+
+
+def test_the_gate_cannot_see_a_write_the_script_itself_swallows(tmp_path: Path) -> None:
+    """THE HONEST LIMIT OF THIS GATE. Pinned, with the exact shape, so nobody has to discover it.
+
+    I found this by writing it into my own calibration by accident, which is the only reason it
+    is documented rather than latent:
+
+        mkdir -p /var/lib/harness-extra && printf 'x' > /var/lib/harness-extra/f
+
+    Under `set -e`, a command that fails on the LEFT of an `&&` does NOT abort the script (same
+    family as feedback_errexit_kills_assignment_guard). So the forbidden write is attempted,
+    refused by the kernel, and the script sails on and exits 0. This harness's oracle is the
+    entry point's exit status plus its artifacts and its verdict text — and a write that fails
+    silently, changes no artifact and produces no false claim leaves NONE of those marks.
+
+    So this gate does not catch it, and this test says so out loud rather than letting a green
+    tick imply otherwise (feedback_silent_zero_is_not_a_measurement).
+
+    Two things bound the damage, and they are the reason this is a limit and not a hole:
+
+      * A swallowed write that changes nothing observable has, by construction, no effect on the
+        backup. The dangerous ones — deploy#613 and #623 — were not silent: they surfaced as a
+        wrong exit code and a false verdict, which is what the other tests in this file assert on.
+      * The STATIC pin (test_scratch_under_hardening.py, widened over the unit-reachable closure
+        in deploy#626 item 1) reads the source text and does not care whether the failure
+        propagates. The two gates are complementary, and this is precisely the seam where the
+        static one still earns its keep.
+
+    If this test ever starts FAILING, that is good news: something taught the harness to observe
+    the write itself (an strace/LD_PRELOAD oracle on EROFS). Delete it and say so.
+    """
+    repo = _stage(tmp_path)
+    _mutate(
+        repo,
+        "backup.sh",
+        "umask 077",
+        "mkdir -p /var/lib/harness-swallowed && printf 'x\\n' > /var/lib/harness-swallowed/f",
+    )
+    res = _run(repo)
+    assert res.rc == 0, (
+        "The harness caught a SWALLOWED write outside ReadWritePaths=. That is better than the "
+        "documented behaviour — so update this test and the module docstring: the gate is now "
+        "stronger than they claim."
+    )
+
+
+def test_the_stub_set_is_declared_so_the_blind_spots_are_countable(tmp_path: Path) -> None:
+    """docker/rclone/zstd/systemd-cat are STUBS. That is the harness's blind spot; name it.
+
+    A green run here does NOT mean the backup works against a real Postgres, a real Neo4j or a
+    real B2 — there is no daemon, no network and no bucket in CI. It means the SCRIPT wrote only
+    where the unit grants. Anyone reading a green tick should be able to find out, in one grep,
+    exactly which binaries were not real.
+    """
+    assert set(uh._STUBS) == {"docker", "rclone", "zstd", "systemd-cat"}, (
+        "the stub set changed. Update the module docstring's blind-spot list with it — an "
+        "undeclared stub is an undeclared blind spot."
+    )
+    assert shutil.which("bash"), "the harness needs a real bash; everything else is stubbed"

--- a/scripts/tests/test_backup_under_unit_hardening.py
+++ b/scripts/tests/test_backup_under_unit_hardening.py
@@ -11,16 +11,27 @@ and the defect only exists where ``/tmp`` is read-only. A suite that cannot expr
 not a weak instrument, it is not an instrument at all.
 
 So the first duty of THIS module is not to test ``backup.sh``. It is to prove that it CAN. That
-is what the calibration tests below are: a fixture copy of ``backup.sh`` with the defect put
-back, asserted to go **RED**. Four of them, spanning the class:
+is what the calibration tests below are: a fixture copy of a real script with the defect put
+back, asserted to go **RED**. Seven of them, spanning the class:
 
   1. a bare ``mktemp``                      — deploy#613/#623's spelling
   2. a ``> /tmp/…`` redirect                — NOT mktemp; a text-scan for mktemp sees nothing
   3. a ``$HOME`` write under ProtectHome=   — NOT mktemp, NOT /tmp
   4. b2_preflight's scratch back on /tmp    — deploy#613 ITSELF, restored, end to end
+  5. the success gauge in the un-scraped parent dir     — deploy#565 ITSELF, restored
+  6. the failure marker in the un-scraped parent dir    — deploy#565, in the OnFailure= handler
+  7. a defect in the FIRST of several ``ExecStart=``    — a command that was never even RUN
 
 If only (1) went red, this module would have reimplemented ``test_scratch_under_hardening.py``'s
 static pin at 100x the cost and closed nothing. (2), (3) and (4) are the reason it exists.
+
+(5), (6) and (7) exist because the first version of this module SHIPPED WITH ALL THREE HOLES, and
+two reviewers found them by running it. The oracle was a substring match, so a gauge written to
+the un-scraped parent — deploy#565, "emitted faithfully and scraped never" — passed while the
+harness printed the wrong path in its own artifact listing. And ``ExecStart`` was read as
+``vals[-1]``, so on a ``Type=oneshot`` unit (which legally takes several) a defect in the FIRST
+command was silently never executed. The lesson is the module's own: **an oracle is not calibrated
+until someone has made it fail.** (Nurul Hakim + Bereket Tadesse, #654 review.)
 
 AND THE SANDBOX IS DERIVED, NOT RESTATED
 ----------------------------------------
@@ -43,6 +54,7 @@ Both directions, or it is theatre.
 
 from __future__ import annotations
 
+import os
 import shutil
 from pathlib import Path
 
@@ -51,6 +63,53 @@ import unit_hardening as uh
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 REAL_UNIT = REPO_ROOT / "systemd" / "isnad-backup.service"
+MARKER_UNIT = REPO_ROOT / "systemd" / "isnad-backup-failure-marker.service"
+
+# The directory node-exporter ACTUALLY SCRAPES, read out of compose's
+# `--collector.textfile.directory` — never hand-typed. See uh.scraped_textfile_dir().
+SCRAPED_DIR = uh.scraped_textfile_dir()
+SUCCESS_GAUGE = f"{SCRAPED_DIR}/isnad_backup_success.prom"
+FAILURE_GAUGE = f"{SCRAPED_DIR}/isnad_backup_failure.prom"
+
+
+# ---------------------------------------------------------------------------
+# "Could not find out" is not "found nothing wrong" — AT THE PYTEST LEVEL TOO
+# ---------------------------------------------------------------------------
+# The module already distinguishes rc=2 (no namespace) from rc=1 (a finding). The TESTS did not:
+# they asserted `rc == 0` / `rc == 1`, so on a box with no namespace every one of them failed with
+# `assert 2 == 1` — rendering an INSTRUMENT failure as a FINDING.
+#
+# That red-lined `pytest (scripts)`, a shared gate, for every future PR touching scripts/ on a
+# stock Ubuntu 24.04 box (kernel.apparmor_restrict_unprivileged_userns=1). Bereket Tadesse caught
+# it, and named it exactly right: deploy#613 was a broken instrument reporting GREEN; this was a
+# broken instrument reporting RED. The red direction is the safe one and it is still fatal, because
+# a suite that fails on every unrelated push is a suite people delete — which is the "gate people
+# route around" failure arriving through the other door.
+#
+# So: ONE probe, at session scope, and the two outcomes are treated as the different facts they are.
+#
+#   * CI, or HARNESS_REQUIRE_NAMESPACE=1  -> HARD FAIL. Never skip green where the gate must hold.
+#   * anywhere else                        -> skip LOUDLY, naming the sysctl.
+#
+# A bare pytest.skip would be the false green this whole module is fighting. It is defensible ONLY
+# because backup-hardening.yml runs these same tests with AppArmor lifted and with
+# HARNESS_REQUIRE_NAMESPACE set, so they CANNOT skip there. That guarantee is load-bearing, so it
+# is asserted, not assumed — see test_the_dedicated_workflow_cannot_skip_this_suite.
+_BACKEND = uh.sandbox_backend()
+_REQUIRED = bool(os.environ.get("CI") or os.environ.get("HARNESS_REQUIRE_NAMESPACE"))
+
+_NO_NAMESPACE = (
+    "no private mount namespace on this box, so the hardening harness CANNOT RUN.\n"
+    "This is rc=2 — COULD NOT FIND OUT — not a pass and not a finding.\n"
+    "Ubuntu 24.04 blocks unprivileged user namespaces by default:\n"
+    "    sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0\n"
+    "...or run as root. CI lifts it (backup-hardening.yml, compose-validate.yml) and CANNOT skip."
+)
+
+if _BACKEND is None and _REQUIRED:
+    raise RuntimeError("HARD FAIL (CI or HARNESS_REQUIRE_NAMESPACE is set): " + _NO_NAMESPACE)
+
+needs_namespace = pytest.mark.skipif(_BACKEND is None, reason=_NO_NAMESPACE)
 
 # Sentences that claim something about a subsystem the run never actually reached. deploy#613
 # said "your B2 key is invalid" about a good key; deploy#623 said "is the daemon running?" about
@@ -74,6 +133,26 @@ def _stage(tmp_path: Path) -> Path:
 
 def _run(repo: Path, unit: Path = REAL_UNIT) -> uh.Result:
     return uh.run_unit_under_hardening(unit, repo, extra_env=dict(uh.HARNESS_ENV))
+
+
+def assert_gauge_is_scraped(res: uh.Result, gauge: str) -> None:
+    """THE GAUGE ORACLE. One function, called by the real tests AND by their calibration.
+
+    Deliberately not duplicated into the calibration as a copy of the assertion: a paraphrased
+    oracle can drift away from the real one and go on passing while the real one rots (see
+    feedback_paraphrase_in_the_product). The calibration below wraps THIS function in
+    `pytest.raises`, so what is proven able to fail is the very code that guards the real run.
+
+    `gauge` is a FULL path under compose's `--collector.textfile.directory`. A substring match
+    here was how deploy#565 walked through the first version of this suite.
+    """
+    assert gauge in res.artifacts, (
+        f"the gauge is not at {gauge} — the directory node-exporter ACTUALLY READS "
+        f"(compose: --collector.textfile.directory).\n"
+        f"A .prom written anywhere else is emitted faithfully and scraped NEVER. That is "
+        f"deploy#565: the alert keying off this metric could not fire, for months.\n"
+        f"artifacts={res.artifacts}"
+    )
 
 
 def _mutate(repo: Path, script: str, anchor: str, injected: str) -> None:
@@ -133,6 +212,7 @@ def test_an_unknown_directive_is_an_instrument_failure_not_a_silent_pass(tmp_pat
         uh.parse_unit(unit)
 
 
+@needs_namespace
 def test_every_hardened_unit_on_the_box_is_gated(tmp_path: Path) -> None:
     """The unit set is DISCOVERED from systemd/, never hand-listed.
 
@@ -159,6 +239,7 @@ def test_every_hardened_unit_on_the_box_is_gated(tmp_path: Path) -> None:
 # ===========================================================================
 
 
+@needs_namespace
 def test_the_real_backup_runs_clean_under_the_real_units_own_hardening(tmp_path: Path) -> None:
     """The baseline. Without it, every RED below is satisfied by a harness that always fails.
 
@@ -175,10 +256,19 @@ def test_the_real_backup_runs_clean_under_the_real_units_own_hardening(tmp_path:
     # rc alone is not enough, and this is not belt-and-braces. deploy#613 was a write that failed
     # and was SWALLOWED; the exit code was collateral, the LIE was the product. So assert on what
     # the run actually produced, and on what it said.
-    assert any("isnad_backup_success.prom" in a for a in res.artifacts), (
-        f"no success metric was written. A backup that exits 0 without emitting the success "
-        f"gauge is invisible to BackupStale (deploy#565).\nartifacts={res.artifacts}"
-    )
+    #
+    # THE FULL PATH, NOT A SUBSTRING. (deploy#654 review — Nurul Hakim.)
+    #
+    # This was `any("isnad_backup_success.prom" in a for a in res.artifacts)`. That string is a
+    # substring of the WRONG path as well as the right one, so deploy#565 — the gauge written to
+    # `/var/lib/node_exporter`, the UN-SCRAPED PARENT of the collector dir, "emitted faithfully
+    # and scraped never" for months — walked straight through it. The harness printed the wrong
+    # path in its own artifact listing and passed. The evidence was in `res.artifacts`; the oracle
+    # just did not look at it.
+    #
+    # SCRAPED_DIR comes from compose's `--collector.textfile.directory`, so this asserts the gauge
+    # lands where node-exporter ACTUALLY READS, and it is not one more re-typed constant.
+    assert_gauge_is_scraped(res, SUCCESS_GAUGE)
     for claim in FALSE_CLAIMS:
         assert claim not in res.output, (
             f"the run claimed {claim!r}. docker and B2 are HEALTHY in this harness by "
@@ -187,11 +277,157 @@ def test_the_real_backup_runs_clean_under_the_real_units_own_hardening(tmp_path:
         )
 
 
+@needs_namespace
+def test_the_failure_marker_lands_where_node_exporter_actually_reads(tmp_path: Path) -> None:
+    """The OnFailure= handler's ENTIRE PURPOSE, asserted. It was not. (Nurul Hakim, #654 review)
+
+    `test_every_hardened_unit_on_the_box_is_gated` checked `rc == 0` for
+    isnad-backup-failure-marker.service and NOTHING ELSE. The one thing that unit exists to do —
+    land `isnad_backup_failure.prom` in the directory node-exporter reads — was never asserted,
+    even though the harness already captured it in its artifact listing.
+
+    This is the script that runs AFTER everything else is already broken. If it is wrong, the
+    failure signal itself never arrives and you find out during the incident, from the silence.
+
+    deploy#565 is exactly this bug in this exact file: it used to write to the PARENT directory,
+    which node-exporter does not read, so the metric was emitted and scraped never.
+    """
+    res = _run(_stage(tmp_path), unit=MARKER_UNIT)
+
+    assert res.rc == 0, f"the failure-marker unit failed under its own hardening:\n{res.output}"
+    # This unit IS the OnFailure= handler. A marker written anywhere node-exporter does not read
+    # means a failed backup raises no signal at all — and you learn that during the incident.
+    assert_gauge_is_scraped(res, FAILURE_GAUGE)
+
+
+@needs_namespace
+def test_calibration_deploy565_the_un_scraped_parent_dir_goes_red(tmp_path: Path) -> None:
+    """CALIBRATION for the two tests above: re-inject deploy#565 verbatim. Must go RED.
+
+    Nurul's reproduction, turned into a permanent gate. Point `TEXTFILE_DIR` at
+    `/var/lib/node_exporter` — the un-scraped PARENT — exactly as the code did before deploy#565.
+    The gauge is still written. The run still exits 0. Prometheus still never sees it.
+
+    Under the old substring oracle this passed. It must now fail, or the oracle is decoration.
+    """
+    repo = _stage(tmp_path)
+    path = repo / "scripts" / "backup.sh"
+    text = path.read_text()
+    anchor = 'TEXTFILE_DIR="${TEXTFILE_DIR:-/var/lib/node_exporter/textfile_collector}"'
+    assert anchor in text, "backup.sh no longer sites TEXTFILE_DIR the way this calibration mutates"
+    parent = str(Path(SCRAPED_DIR).parent)
+    path.write_text(text.replace(anchor, f'TEXTFILE_DIR="${{TEXTFILE_DIR:-{parent}}}"'))
+
+    res = _run(repo)
+
+    # The run still SUCCEEDS — that is the whole horror of deploy#565, and why an exit-code oracle
+    # cannot see it. The gauge is written faithfully. It is simply written where nothing reads it.
+    assert res.rc == 0, (
+        "sanity: the deploy#565 mutation does not break the run, it breaks the SCRAPE"
+    )
+    assert any(a.endswith("isnad_backup_success.prom") for a in res.artifacts), (
+        "sanity: the mutated run must still WRITE a gauge — otherwise this calibration is "
+        "measuring a crash, not the un-scraped-directory defect."
+    )
+    assert SUCCESS_GAUGE not in res.artifacts, (
+        "the mutation did not actually move the gauge — this calibration is inert."
+    )
+
+    # THE ORACLE MUST NOW REJECT IT — and it is the REAL oracle, the same function the real test
+    # calls, not a paraphrase of it. A copied assertion could drift from the original and keep
+    # passing while the original rotted (feedback_paraphrase_in_the_product).
+    with pytest.raises(AssertionError, match="deploy#565"):
+        assert_gauge_is_scraped(res, SUCCESS_GAUGE)
+
+
+@needs_namespace
+def test_calibration_the_failure_marker_in_the_wrong_dir_goes_red(tmp_path: Path) -> None:
+    """And the failure-marker oracle must be able to fail too, or it is decoration.
+
+    Same defect, the other unit: point the marker at the un-scraped parent. The `.prom` is still
+    written, the unit still exits 0 — and the failure signal is invisible. deploy#565 lived in
+    THIS file originally.
+    """
+    repo = _stage(tmp_path)
+    path = repo / "scripts" / "emit-backup-failure-marker.sh"
+    text = path.read_text()
+    anchor = 'TEXTFILE_DIR="/var/lib/node_exporter/textfile_collector"'
+    assert anchor in text, "emit-backup-failure-marker.sh no longer sites TEXTFILE_DIR this way"
+    parent = str(Path(SCRAPED_DIR).parent)
+    path.write_text(text.replace(anchor, f'TEXTFILE_DIR="{parent}"'))
+
+    res = _run(repo, unit=MARKER_UNIT)
+    assert res.rc == 0, "sanity: the mutation must not crash the marker — it misplaces its output"
+
+    with pytest.raises(AssertionError, match="deploy#565"):
+        assert_gauge_is_scraped(res, FAILURE_GAUGE)
+
+
+@needs_namespace
+def test_calibration_a_defect_in_the_FIRST_of_several_ExecStarts_goes_red(tmp_path: Path) -> None:
+    """Nurul's blocker 2, turned into a gate. `Type=oneshot` legally takes SEVERAL ExecStart=.
+
+    `Unit.one()` returned `vals[-1]` — the LAST ExecStart — so a unit like
+
+        ExecStart=…/prestep.sh    <- writes the read-only /tmp; DIES on the box
+        ExecStart=…/backup.sh
+
+    ran only backup.sh and reported PASS. **The command carrying the defect was never executed.**
+
+    This was the sharpest finding in the review, because of WHERE it lands: the DIRECTIVES table
+    is armour against directives the harness does not KNOW. `ExecStart` is known — so a second one
+    was not an instrument failure, it was a silently dropped command, on the single directive that
+    selects what code runs at all.
+
+    The fix runs all of them in order (systemd's own oneshot semantics), so the defect executes and
+    the gate goes red.
+    """
+    repo = _stage(tmp_path)
+
+    # A prestep carrying deploy#613's own defect: scratch in the read-only /tmp.
+    prestep = repo / "scripts" / "prestep.sh"
+    prestep.write_text('#!/usr/bin/env bash\nset -euo pipefail\nMUT="$(mktemp)"\necho "$MUT"\n')
+    prestep.chmod(0o755)
+
+    text = REAL_UNIT.read_text()
+    anchor = "ExecStart=/opt/noorinalabs-deploy/scripts/backup.sh"
+    assert anchor in text
+    unit = tmp_path / "multi.service"
+    unit.write_text(
+        text.replace(anchor, "ExecStart=/opt/noorinalabs-deploy/scripts/prestep.sh\n" + anchor)
+    )
+
+    # Both ExecStarts must be SEEN...
+    sb = uh.plan(uh.parse_unit(unit))
+    assert sb.exec_starts == [
+        "/opt/noorinalabs-deploy/scripts/prestep.sh",
+        "/opt/noorinalabs-deploy/scripts/backup.sh",
+    ], f"the harness did not parse both ExecStart= lines: {sb.exec_starts}"
+
+    # ...and the defect in the FIRST one must be EXECUTED, and must go RED.
+    res = _run(repo, unit=unit)
+    assert res.rc == 1, (
+        f"THE FIRST ExecStart WAS NOT RUN. It writes to the read-only /tmp and would die on the "
+        f"box; the harness reported PASS. A silently skipped command is a gate that tested "
+        f"nothing.\n{res.output}"
+    )
+    assert "Read-only file system" in res.output
+    assert "[harness] ExecStart: /opt/noorinalabs-deploy/scripts/prestep.sh" in res.output, (
+        "the prestep was never even announced — it was not executed at all"
+    )
+    # oneshot stops at the first failure: backup.sh must NOT have run.
+    assert "ExecStart NOT REACHED" in res.output, (
+        "systemd's Type=oneshot stops at the first failing ExecStart=; the harness must too, or "
+        "it is running code the box would never reach."
+    )
+
+
 # ===========================================================================
 # 2. CALIBRATION — the harness must be PROVEN able to fail, across the CLASS
 # ===========================================================================
 
 
+@needs_namespace
 def test_calibration_bare_mktemp_goes_red(tmp_path: Path) -> None:
     """(1) deploy#613/#623's own spelling. `mktemp` with no -p lands in the read-only /tmp."""
     repo = _stage(tmp_path)
@@ -206,6 +442,7 @@ def test_calibration_bare_mktemp_goes_red(tmp_path: Path) -> None:
     assert "Read-only file system" in res.output
 
 
+@needs_namespace
 def test_calibration_a_tmp_redirect_goes_red_and_it_is_not_a_mktemp(tmp_path: Path) -> None:
     """(2) THE TEST THAT JUSTIFIES THIS MODULE'S EXISTENCE.
 
@@ -230,6 +467,7 @@ def test_calibration_a_tmp_redirect_goes_red_and_it_is_not_a_mktemp(tmp_path: Pa
     assert "Read-only file system" in res.output
 
 
+@needs_namespace
 def test_calibration_a_home_write_goes_red_under_ProtectHome(tmp_path: Path) -> None:
     """(3) Not mktemp. Not /tmp. Still fatal — and only because ProtectHome= is read out too.
 
@@ -249,6 +487,7 @@ def test_calibration_a_home_write_goes_red_under_ProtectHome(tmp_path: Path) -> 
     )
 
 
+@needs_namespace
 def test_calibration_deploy613_itself_restored_goes_red(tmp_path: Path) -> None:
     """(4) THE ORIGINAL DEFECT, PUT BACK, END TO END.
 
@@ -297,6 +536,7 @@ def _unit_with(tmp_path: Path, name: str, old: str, new: str) -> Path:
     return unit
 
 
+@needs_namespace
 def test_a_write_is_refused_or_allowed_according_to_ReadWritePaths(tmp_path: Path) -> None:
     """PROOF THE SANDBOX IS DERIVED: the SAME write, two units, two verdicts.
 
@@ -341,6 +581,7 @@ def test_a_write_is_refused_or_allowed_according_to_ReadWritePaths(tmp_path: Pat
     )
 
 
+@needs_namespace
 def test_PrivateTmp_yes_makes_a_bare_mktemp_legal_because_production_would(tmp_path: Path) -> None:
     """PROOF, THE OTHER WAY ROUND: the harness has no opinion about mktemp. It reads the unit.
 
@@ -376,6 +617,7 @@ def test_PrivateTmp_yes_makes_a_bare_mktemp_legal_because_production_would(tmp_p
 # ===========================================================================
 
 
+@needs_namespace
 def test_rclone_is_configured_by_env_not_by_a_file_under_the_masked_HOME(tmp_path: Path) -> None:
     """rclone escapes ProtectHome=yes ONLY because backup.sh configures it through the env.
 
@@ -413,12 +655,22 @@ def test_rclone_is_configured_by_env_not_by_a_file_under_the_masked_HOME(tmp_pat
         f"the run failed, but not because rclone was left unconfigured — so this test is not "
         f"measuring what it claims to.\nartifacts={res.artifacts}\n{res.output}"
     )
-    assert "verdict=KEY_INVALID" in res.output, (
-        "NOTE, for whoever reads this next: the preflight really does render an rclone that "
-        "cannot be CONFIGURED as an invalid KEY. It is pinned here because it is exactly the "
-        "deploy#613 lie in a new place — and because if a future b2_preflight learns to tell "
-        "the two apart, this assertion should be the thing that fails and gets updated."
-    )
+
+    # WHAT IS DELIBERATELY *NOT* ASSERTED HERE, AND WHY. (deploy#654 review — Bereket Tadesse.)
+    #
+    # Today this run ends with `verdict=KEY_INVALID`: b2_preflight renders a CONFIGURATION failure
+    # as an accusation against a CREDENTIAL — from a fault that never touched one. That is
+    # deploy#613's exact signature, in a new place, and it is tracked as **deploy#658**.
+    #
+    # The first version of this test ASSERTED that string. That was a mistake, and a bad one: a
+    # test that encodes a bug as the contract makes the bug LOAD-BEARING. The next person to fix
+    # b2_preflight would have seen this test go red and "fixed" their fix. A pinned lie is worse
+    # than no test.
+    #
+    # So the verdict text is not asserted in either direction. What IS asserted is the honest,
+    # stable fact — the run FAILS and the sentinel says why — which holds both before and after
+    # #658 lands.
+    assert res.exec_rc != 0
 
 
 # ===========================================================================
@@ -426,6 +678,7 @@ def test_rclone_is_configured_by_env_not_by_a_file_under_the_masked_HOME(tmp_pat
 # ===========================================================================
 
 
+@needs_namespace
 def test_a_bare_cd_into_tmp_is_NOT_a_finding_and_that_is_correct(tmp_path: Path) -> None:
     """The honest boundary of the gate, pinned so nobody later 'fixes' it into a false positive.
 
@@ -447,6 +700,7 @@ def test_a_bare_cd_into_tmp_is_NOT_a_finding_and_that_is_correct(tmp_path: Path)
     )
 
 
+@needs_namespace
 def test_the_gate_cannot_see_a_write_the_script_itself_swallows(tmp_path: Path) -> None:
     """THE HONEST LIMIT OF THIS GATE. Pinned, with the exact shape, so nobody has to discover it.
 
@@ -489,6 +743,38 @@ def test_the_gate_cannot_see_a_write_the_script_itself_swallows(tmp_path: Path) 
         "The harness caught a SWALLOWED write outside ReadWritePaths=. That is better than the "
         "documented behaviour — so update this test and the module docstring: the gate is now "
         "stronger than they claim."
+    )
+
+
+def test_the_dedicated_workflow_cannot_skip_this_suite() -> None:
+    """The guarantee that makes the local `skipif` defensible. ASSERTED, not assumed.
+
+    `needs_namespace` skips when there is no mount namespace. On its own that would be the exact
+    false green this module exists to kill — a gate that quietly tests nothing.
+
+    It is only defensible because ONE workflow runs these same tests with AppArmor lifted and
+    `HARNESS_REQUIRE_NAMESPACE=1` set, where a missing namespace is a HARD FAIL and a skip is
+    impossible. That guarantee is load-bearing, so it is checked here rather than trusted
+    (Bereket Tadesse, #654 review: "assert it, do not assume it").
+
+    If someone deletes the sysctl step, or the env var, or stops running this file in CI, this
+    test goes red and tells them what they just disarmed.
+    """
+    wf = (REPO_ROOT / ".github" / "workflows" / "backup-hardening.yml").read_text()
+
+    assert "kernel.apparmor_restrict_unprivileged_userns=0" in wf, (
+        "backup-hardening.yml no longer lifts the AppArmor restriction, so on ubuntu-latest the "
+        "harness cannot build a namespace — and every namespace test would SKIP. The local "
+        "skipif is only safe because this workflow cannot skip."
+    )
+    assert "HARNESS_REQUIRE_NAMESPACE" in wf, (
+        "backup-hardening.yml no longer sets HARNESS_REQUIRE_NAMESPACE, so a missing namespace "
+        "would SKIP GREEN there instead of hard-failing. That is the false green this whole "
+        "module exists to prevent."
+    )
+    assert Path(__file__).name in wf, (
+        f"backup-hardening.yml no longer runs {Path(__file__).name}, so nothing guarantees these "
+        f"calibrations ever execute where they cannot skip."
     )
 
 

--- a/scripts/tests/unit_hardening.py
+++ b/scripts/tests/unit_hardening.py
@@ -1,0 +1,905 @@
+"""Run a systemd unit's ExecStart under THAT UNIT'S OWN hardening — in CI, rootlessly.
+
+WHY THIS EXISTS
+---------------
+deploy#613, then deploy#623: a script under ``isnad-backup.service`` allocated scratch in
+``/tmp``, which is **READ-ONLY** there (``ProtectSystem=strict``, ``PrivateTmp`` deliberately
+unset — deploy#121 Bug A), and then reported its own broken instrument as a fact about the
+subsystem it was meant to check. *"Your B2 key is invalid"* on a good key. *"Is the daemon
+running?"* on a healthy daemon.
+
+Both shipped past a full green CI and four reviewers. **Not because the tests were weak —
+because they were structurally incapable of failing.** GitHub Actions runners, the rehearsal
+containers and the dev box all have a writable ``/tmp``. Every test we had, *including* the
+e2e tests that drive the real ``backup.sh``, ran in an environment where the defect class is
+unreachable. A suite that cannot express the defect is not a weak instrument; it is not an
+instrument at all.
+
+THE CLASS IS NOT "BARE MKTEMP"
+------------------------------
+It is **"writes outside ``ReadWritePaths=``"**. ``scripts/tests/test_scratch_under_hardening.py``
+pins the ``mktemp`` spelling structurally, and that pin is worth having — but a ``> /tmp/foo``,
+a ``python -c 'tempfile.mkstemp()'``, a ``$HOME`` write under ``ProtectHome=yes`` are none of
+them ``mktemp``, all fail identically under the unit, and a text-scan for ``mktemp`` catches
+none of them. ``mktemp`` being the only current instance is a **coincidence**, and relying on
+it is how we get a fourth one.
+
+So this module does not scan text. It **runs the real script in a namespace built from the
+unit's own directives** and observes what happens.
+
+THE LOAD-BEARING PROPERTY: THE CONSTRAINT IS READ OUT OF THE UNIT, NEVER RE-TYPED
+--------------------------------------------------------------------------------
+``ProtectSystem=``, ``ReadWritePaths=``, ``ProtectHome=``, ``PrivateTmp=`` are **parsed out of
+the .service file** and the sandbox is constructed from them. A hand-written "read-only /tmp"
+job would be a **third place** to encode the same assumption, stale the moment somebody edits
+``ReadWritePaths=``. Derived from the unit, the harness **cannot disagree with production about
+what production allows** — grant a new path in the unit and the sandbox grants it too, in the
+same commit, with no second edit anywhere.
+
+AND WHAT IT REFUSES TO DO
+-------------------------
+A directive this module does not know how to emulate is an **instrument failure** (``rc=2``),
+never a silent pass. If someone adds ``InaccessiblePaths=`` or switches to
+``ProtectSystem=full``, the harness stops and says it cannot testify, rather than quietly
+ignoring the directive and reporting green over an emulation that no longer matches the unit.
+That refusal is the whole reason to trust a green run.
+
+Exit codes (the driver, and every caller of it):
+
+* ``0`` — the entry point ran under the unit's own hardening and exited 0.
+* ``1`` — the entry point FAILED under the hardening. **A finding.**
+* ``2`` — **WE COULD NOT FIND OUT.** No ``unshare``, a directive we cannot emulate, a sandbox
+  that failed its own self-check. Never conflate this with ``0``: a silently-skipped job is
+  exactly the false green this module exists to kill.
+
+WHAT A GREEN RUN MEANS — AND WHAT IT DOES NOT
+---------------------------------------------
+Green means: **the real entry point, driven end-to-end, wrote only where the unit grants, and
+produced its artifacts.** It does NOT mean the backup works against a real Postgres/Neo4j/B2 —
+``docker``, ``rclone`` and ``zstd`` are stubbed (there is no daemon, no network and no B2 in
+CI). The stubs are faithful to the *contract* each real tool has with the script, and they are
+where the harness's remaining blind spots live. They are enumerated in ``_STUBS`` below, in
+their own words.
+
+One residual gap, stated plainly: a write outside the grant that the script *attempts, fails,
+and swallows* (``> /tmp/x 2>/dev/null || true``) is invisible to an exit-code oracle. That is
+why the caller asserts on **three** things and not one — the exit code, the **artifacts the run
+left behind**, and the **absence of a false claim** in its output. deploy#613 was precisely a
+swallowed failure, and it is caught here by the second and third of those, not the first.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SYSTEMD_DIR = REPO_ROOT / "systemd"
+
+# Directories systemd's ProtectSystem= leaves alone (systemd.exec(5)). Not a policy choice of
+# ours — a restatement of what the directive means, which is unavoidable when emulating it.
+API_FILESYSTEMS = ("/proc", "/sys", "/dev")
+
+# ProtectHome=yes makes these inaccessible (systemd.exec(5)).
+HOME_PATHS = ("/home", "/root", "/run/user")
+
+
+class Unsupported(Exception):
+    """A unit directive we cannot faithfully emulate. Refuse to testify — never pass silently.
+
+    This is the anti-drift core of the module. The moment the emulation and the unit can
+    disagree, the harness must stop being an instrument and say so out loud.
+    """
+
+
+# Every directive that may appear in a unit we gate, and what this harness does with it.
+#
+# EMULATED  — changes what the process may write. Reproduced in the namespace.
+# CONFIG    — tells the harness WHAT to run, not what to forbid. Consumed.
+# INERT     — cannot affect where a shell script writes, and we say why. Ignored deliberately.
+#
+# A directive absent from this table raises Unsupported -> rc=2. That is deliberate and it is
+# the reason a green run means anything: the harness cannot silently ignore a constraint that
+# production applies. Adding a directive to a unit is therefore a two-file change — the unit
+# and this table — and the CI gate will tell you so rather than drifting.
+DIRECTIVES: dict[str, str] = {
+    # --- hardening: emulated ---
+    "ProtectSystem": "EMULATED",
+    "ProtectHome": "EMULATED",
+    "ReadWritePaths": "EMULATED",
+    "PrivateTmp": "EMULATED",
+    # --- config: consumed by the harness ---
+    "ExecStart": "CONFIG",
+    "WorkingDirectory": "CONFIG",
+    "Environment": "CONFIG",
+    "EnvironmentFile": "CONFIG",
+    # --- inert for "where does this script write?", with the reason ---
+    # No process here is setuid, so the no-new-privs bit changes nothing about reachable paths.
+    "NoNewPrivileges": "INERT",
+    # Restricts /dev to a minimal set. backup.sh writes no device node; /dev/null still works.
+    "PrivateDevices": "INERT",
+    # /proc/sys, /sys knobs, cgroup fs, SUID/SGID bits, personality(2). None is a path the
+    # backup path writes, and none changes whether a write to /tmp or $HOME succeeds.
+    "ProtectKernelTunables": "INERT",
+    "ProtectKernelModules": "INERT",
+    "ProtectControlGroups": "INERT",
+    "RestrictSUIDSGID": "INERT",
+    "LockPersonality": "INERT",
+    # --- unit bookkeeping: no runtime effect on the process's filesystem view ---
+    "Description": "INERT",
+    "Documentation": "INERT",
+    "After": "INERT",
+    "Requires": "INERT",
+    "OnFailure": "INERT",
+    "Type": "INERT",
+    "StandardOutput": "INERT",
+    "StandardError": "INERT",
+    "SyslogIdentifier": "INERT",
+}
+
+
+@dataclass
+class Unit:
+    """The hardening + config directives of a .service file, as written."""
+
+    path: Path
+    directives: dict[str, list[str]] = field(default_factory=dict)
+
+    def one(self, key: str, default: str | None = None) -> str | None:
+        vals = self.directives.get(key)
+        return vals[-1] if vals else default
+
+    @property
+    def is_hardened(self) -> bool:
+        return self.one("ProtectSystem") is not None
+
+    @property
+    def read_write_paths(self) -> list[str]:
+        """Every path the unit GRANTS. Repeated ReadWritePaths= lines accumulate."""
+        out: list[str] = []
+        for line in self.directives.get("ReadWritePaths", []):
+            # A leading '-' means "ignore if missing" (systemd.exec(5)); it is not part of the
+            # path. Everything else is shell-like whitespace separation.
+            out.extend(tok.lstrip("-") for tok in shlex.split(line))
+        return out
+
+    @property
+    def exec_start(self) -> str:
+        line = self.one("ExecStart")
+        if not line:
+            raise Unsupported(f"{self.path.name} has no ExecStart=")
+        # ExecStart= may carry prefix characters (-, @, +, !) before the binary.
+        return shlex.split(line)[0].lstrip("-@+!")
+
+    @property
+    def environment(self) -> dict[str, str]:
+        env: dict[str, str] = {}
+        for line in self.directives.get("Environment", []):
+            for tok in shlex.split(line):
+                if "=" in tok:
+                    k, v = tok.split("=", 1)
+                    env[k] = v
+        return env
+
+
+def parse_unit(path: Path) -> Unit:
+    """Read a .service file into directives, rejecting anything we cannot account for.
+
+    Deliberately dumb: no systemd, no drop-ins, no specifier expansion. It reads the same bytes
+    the box reads. If it meets a directive that is not in DIRECTIVES it raises — see Unsupported.
+    """
+    unit = Unit(path=path)
+    in_service = False
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith(("#", ";")):
+            continue
+        if line.startswith("["):
+            in_service = line == "[Service]"
+            continue
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key, value = key.strip(), value.strip()
+        if not in_service:
+            continue
+        if key not in DIRECTIVES:
+            raise Unsupported(
+                f"{path.name} sets {key}= and this harness does not know what that means for "
+                f"where the process may write.\n"
+                f"It will NOT guess, and it will NOT report green over an emulation that no "
+                f"longer matches the unit — that is exactly how deploy#613 shipped twice.\n"
+                f"Teach it: add {key!r} to DIRECTIVES in {Path(__file__).name} as EMULATED "
+                f"(and implement it) or INERT (and say why it cannot affect a write)."
+            )
+        unit.directives.setdefault(key, []).append(value)
+    return unit
+
+
+def hardened_units(systemd_dir: Path = SYSTEMD_DIR) -> list[Path]:
+    """Every hardened unit on the box, discovered — never hard-coded.
+
+    Add a unit tomorrow and it is gated from that moment, without anyone remembering to add it
+    to a list here. An UNhardened unit has a writable /tmp and is genuinely not in scope.
+    """
+    found = []
+    for unit in sorted(systemd_dir.glob("*.service")):
+        try:
+            if parse_unit(unit).is_hardened:
+                found.append(unit)
+        except Unsupported:
+            # An unparseable unit is NOT a reason to skip it — it is the loudest possible
+            # reason to look at it. Surface it to the caller, which will exit 2.
+            found.append(unit)
+    return found
+
+
+# ---------------------------------------------------------------------------
+# The stubs. Every external binary the entry points shell out to.
+# ---------------------------------------------------------------------------
+# There is no docker daemon, no B2 bucket and no network in CI, so these three cannot be real.
+# They are the harness's blind spot and they are listed here rather than buried:
+#
+#   docker  — a HEALTHY stack. If the script under test blames docker, that accusation is
+#             coming from its own broken scratch, not from docker. (deploy#623's whole shape.)
+#   rclone  — a working, write-capable, delete-capable B2 key. Same logic: a KEY_INVALID
+#             verdict out of this harness is never about the key. (deploy#613's whole shape.)
+#   zstd    — real zstd is not installed on every dev box, and a gate that only runs where a
+#             tool happens to be installed is the non-hermetic trap this whole issue is about.
+#
+# What the stubs CANNOT catch: a write the REAL tool would make outside the grant (rclone
+# writing ~/.config/rclone/rclone.conf, say). The rclone stub pins the one property that keeps
+# that from mattering today — see its RCLONE_CONFIG_ISNAD_* assertion, which is load-bearing
+# and, until now, written down nowhere.
+_STUBS: dict[str, str] = {
+    "docker": r"""#!/usr/bin/env bash
+# A HEALTHY docker. Any complaint about the daemon from the script under test is therefore
+# a complaint about the script's own scratch, which is the entire point of the harness.
+set -uo pipefail
+STATE="${BACKUP_DIR:?BACKUP_DIR unset in docker stub}/.harness-docker-state"
+[[ -f "$STATE" ]] || echo "neo4j=running" > "$STATE"
+neo4j_state() { sed -n 's/^neo4j=//p' "$STATE"; }
+set_neo4j() { echo "neo4j=$1" > "$STATE"; }
+
+if [[ "${1:-}" == "compose" ]]; then
+    shift
+    # Consume `-p <proj> -f <file>`; the script always passes both (compose_project.sh dc()).
+    while [[ "${1:-}" == -* ]]; do
+        case "$1" in
+            -p|-f) shift 2 ;;
+            *) shift ;;
+        esac
+    done
+    sub="${1:-}"; shift || true
+    case "$sub" in
+        ps)
+            if [[ "${1:-}" == "-aq" ]]; then echo "harness-neo4j-cid"; exit 0; fi
+            fmt=""
+            [[ "${1:-}" == "--format" ]] && fmt="${2:-}"
+            if [[ "$fmt" == *".Health"* ]]; then
+                [[ "$(neo4j_state)" == "running" ]] && echo "neo4j:healthy"
+                exit 0
+            fi
+            # Default: the {{.Service}}:{{.State}} listing.
+            echo "postgres:running"
+            echo "user-postgres:running"
+            if [[ "$(neo4j_state)" == "running" ]]; then
+                echo "neo4j:running"
+            else
+                echo "neo4j:exited"
+            fi
+            exit 0
+            ;;
+        exec)
+            # `exec -T <svc> pg_dump …` — emit a non-empty dump on stdout. backup.sh rejects a
+            # zero-byte dump, so an empty stub would look like a broken Postgres, not a pass.
+            printf 'PGDMP\x00harness-fake-custom-format-dump\n'
+            exit 0
+            ;;
+        stop)  set_neo4j exited;  exit 0 ;;
+        start) set_neo4j running; exit 0 ;;
+        *)     exit 0 ;;
+    esac
+fi
+
+case "${1:-}" in
+    inspect) echo "harness_neo4j_data"; exit 0 ;;
+    run)
+        # `docker run … -v <LOCAL_BACKUP_PATH>:/backups … neo4j-admin database dump`.
+        # Write the dump where the REAL neo4j-admin would: the host side of the /backups bind.
+        backups=""
+        while [[ $# -gt 0 ]]; do
+            if [[ "$1" == "-v" && "${2:-}" == *":/backups" ]]; then backups="${2%%:/backups}"; fi
+            shift
+        done
+        [[ -n "$backups" ]] || { echo "stub: no :/backups bind in docker run" >&2; exit 1; }
+        printf 'harness-fake-neo4j-dump\n' > "${backups}/neo4j.dump"
+        exit 0
+        ;;
+esac
+exit 0
+""",
+    "rclone": r"""#!/usr/bin/env bash
+# A working, write-capable, delete-capable B2 key.
+#
+# THE ASSERTION BELOW IS THE POINT OF THIS STUB, AND IT IS WRITTEN DOWN NOWHERE ELSE.
+#
+# The unit runs ProtectHome=yes, so $HOME is INACCESSIBLE. Real rclone reads its config from
+# ~/.config/rclone/rclone.conf — and it escapes ProtectHome today ONLY because backup.sh
+# configures it entirely through RCLONE_CONFIG_ISNAD_* environment variables and never writes
+# a config file. That is load-bearing and it is one refactor away from being the next defect:
+# swap the env vars for `rclone config create` and every backup dies under the unit, with
+# rclone blaming the credential.
+#
+# So the stub REFUSES to answer unless it was configured the way that survives the hardening.
+# A refactor to a config file turns this into a hard failure instead of a mystery. (Nino
+# Kavtaradze raised this in the #624 review; nobody had written it down.)
+set -uo pipefail
+for v in RCLONE_CONFIG_ISNAD_TYPE RCLONE_CONFIG_ISNAD_ACCOUNT RCLONE_CONFIG_ISNAD_KEY; do
+    if [[ -z "${!v:-}" ]]; then
+        # A SENTINEL FILE, not just a message on stderr.
+        #
+        # b2_preflight runs `rclone lsd … > "$lsd_out" 2>&1` — it captures BOTH streams into a
+        # scratch file it then parses. So a complaint on stderr is swallowed whole, and all the
+        # caller sees is a non-zero rc, which its classifier renders as `verdict=KEY_INVALID`:
+        # a statement about a CREDENTIAL, caused by a refactor that never touched one. That is
+        # deploy#613's exact shape, one level up, and it is why the stub's objection must land
+        # somewhere the capture cannot eat. BACKUP_DIR is granted, and the harness lists what it
+        # finds there as an artifact.
+        echo "rclone stub: ${v} is not set." >&2
+        echo "  The caller is no longer configuring rclone through the environment. Under" >&2
+        echo "  ProtectHome=yes the unit CANNOT read ~/.config/rclone/rclone.conf, so a" >&2
+        echo "  config-file-based rclone breaks every backup on the box. Keep the env form." >&2
+        : > "${BACKUP_DIR:-/dev/null}/.harness-rclone-unconfigured" 2>/dev/null || true
+        exit 3
+    fi
+done
+if [[ -n "${RCLONE_DUMP:-}" ]]; then
+    echo "rclone stub: RCLONE_DUMP is set — it leaks credentials into logs. Refusing." >&2
+    exit 3
+fi
+
+case "${1:-}" in
+    lsd)
+        # b2_preflight reads the LAST field of each line as a bucket name.
+        printf '          -1 2026-01-01 00:00:00        -1 %s\n' "${B2_BUCKET:?}"
+        ;;
+    lsf)   ;;  # no pre-existing date dirs -> the retention prune has nothing to purge
+    copyto|deletefile|copy|purge) ;;
+    *) ;;
+esac
+exit 0
+""",
+    "zstd": r"""#!/usr/bin/env bash
+# `zstd -3 --rm <in> -o <out>` — write <out>, remove <in>. Writes exactly where real zstd
+# writes, which is all this harness observes about it.
+set -uo pipefail
+inp=""; out=""; rm_src=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -o) out="${2:-}"; shift 2 ;;
+        --rm) rm_src=1; shift ;;
+        -*) shift ;;
+        *) inp="$1"; shift ;;
+    esac
+done
+[[ -n "$inp" && -n "$out" ]] || { echo "zstd stub: need <in> -o <out>" >&2; exit 1; }
+cp -- "$inp" "$out"
+[[ "$rm_src" -eq 1 ]] && rm -f -- "$inp"
+exit 0
+""",
+    "systemd-cat": r"""#!/usr/bin/env bash
+# There is no journal in the sandbox. emit-backup-failure-marker.sh pipes its journal line
+# through systemd-cat under `set -o pipefail`, so an absent binary would break the pipeline and
+# be read as a failure of the marker script. Drain stdin; the .prom file is the assertable part.
+set -uo pipefail
+cat > /dev/null
+exit 0
+""",
+}
+
+
+def _write_stubs(stub_dir: Path) -> None:
+    stub_dir.mkdir(parents=True, exist_ok=True)
+    for name, body in _STUBS.items():
+        p = stub_dir / name
+        p.write_text(body)
+        p.chmod(0o755)
+
+
+def sandbox_backend() -> list[str] | None:
+    """How to get a private mount namespace on THIS box — or None, which means rc=2.
+
+    Two backends, and the order matters:
+
+      1. ROOTLESS (`unshare --user --map-root-user --mount`). The one that matters, because it
+         is the one a developer gets from `pre-commit` with no sudo and no ceremony. A gate that
+         only runs in CI is a gate people discover after they push.
+      2. ROOT (`unshare --mount`). Ubuntu 24.04 can refuse (1) outright —
+         `kernel.apparmor_restrict_unprivileged_userns=1` blocks unprivileged user namespaces —
+         and ubuntu-latest is 24.04. When the job already runs as root, no user namespace is
+         needed at all.
+
+    PROBED, not assumed: each candidate is actually executed. `unshare` being on PATH says
+    nothing about whether the kernel will hand you a namespace, and "the binary exists" is the
+    kind of proxy that produces a green tick over a check that never ran.
+
+    None means we could not get a namespace. The caller MUST turn that into rc=2 — never 0.
+    """
+    candidates = [
+        ["unshare", "--user", "--map-root-user", "--mount"],
+        *([["unshare", "--mount"]] if os.geteuid() == 0 else []),
+    ]
+    for argv in candidates:
+        probe = subprocess.run([*argv, "true"], capture_output=True, text=True)
+        if probe.returncode == 0:
+            return argv
+    return None
+
+
+# ---------------------------------------------------------------------------
+# The sandbox
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Sandbox:
+    """A mount plan derived from a unit. Every field traces to a directive, or it is a bug."""
+
+    rw_paths: list[str]
+    masked_paths: list[str]  # ProtectHome=yes
+    private_tmp: bool
+    workdir: str
+    exec_start: str
+    deploy_root: str
+    environment: dict[str, str]
+
+    def granted(self, path: str) -> bool:
+        """Does the unit's ReadWritePaths= cover this path?
+
+        THE ONE RULE. Everything else in the sandbox falls out of it: the repo tree is
+        read-write under isnad-backup.service (which grants /opt/noorinalabs-deploy) and
+        READ-ONLY under isnad-backup-failure-marker.service (which does not). Nothing
+        special-cases either unit — they just have different ReadWritePaths=, and the sandbox
+        reads it.
+        """
+        p = Path(path)
+        return any(p == Path(rw) or Path(rw) in p.parents for rw in self.rw_paths)
+
+    @property
+    def denied_probe_paths(self) -> list[str]:
+        """Paths the sandbox must REFUSE to write, derived from the grant list.
+
+        Not a hand-typed "/tmp must be read-only" — that is the third-place restatement this
+        whole module exists to avoid. These are simply paths the unit does NOT grant. Add /tmp
+        to ReadWritePaths= and it drops out of here automatically, because it would then be
+        writable in production too.
+        """
+        candidates = ["/etc", "/usr", "/var", *([] if self.private_tmp else ["/tmp"])]
+        # The parent of each granted path: production grants the CHILD, not the parent, and a
+        # sandbox that let the parent through would be strictly LESS restrictive than the unit.
+        candidates += [str(Path(p).parent) for p in self.rw_paths]
+        # And the repo tree itself, when the unit does not grant it — which is exactly the case
+        # for isnad-backup-failure-marker.service.
+        candidates.append(self.deploy_root)
+        return [c for c in dict.fromkeys(candidates) if not self.granted(c)]
+
+
+def plan(unit: Unit) -> Sandbox:
+    """Turn a parsed unit into a mount plan. Every unemulatable value raises."""
+    protect_system = unit.one("ProtectSystem")
+    if protect_system != "strict":
+        raise Unsupported(
+            f"{unit.path.name} has ProtectSystem={protect_system!r}; this harness emulates "
+            f"'strict' only.\n"
+            f"'yes' and 'full' make a DIFFERENT set of paths read-only, so running under a "
+            f"'strict' sandbox would test something production does not do. Refusing to "
+            f"testify. Implement the value in plan(), or accept that the gate is red."
+        )
+
+    protect_home = unit.one("ProtectHome", "no")
+    if protect_home not in ("yes", "no"):
+        raise Unsupported(
+            f"{unit.path.name} has ProtectHome={protect_home!r}; this harness emulates "
+            f"'yes' and 'no' only ('read-only' and 'tmpfs' are not implemented)."
+        )
+
+    private_tmp = unit.one("PrivateTmp", "no") == "yes"
+
+    rw = unit.read_write_paths
+    if not rw:
+        raise Unsupported(
+            f"{unit.path.name} is ProtectSystem=strict with NO ReadWritePaths= — it cannot "
+            f"write anywhere at all. That is almost certainly not what was meant."
+        )
+
+    # Where the repo has to be for ExecStart= to resolve at all. The units name an absolute
+    # path — /opt/noorinalabs-deploy/scripts/backup.sh — so the harness must site the tree
+    # there. Derived from ExecStart and this repo's layout (scripts/ sits at the root), never
+    # from a hard-coded "/opt/noorinalabs-deploy": the self-check below re-verifies by asserting
+    # ExecStart is executable inside the sandbox, so a wrong derivation is rc=2, not a lie.
+    exec_start = unit.exec_start
+    deploy_root = str(Path(exec_start).parent.parent)
+    if deploy_root == "/":
+        raise Unsupported(
+            f"{unit.path.name}: ExecStart={exec_start} is not <root>/scripts/<script>, so the "
+            f"harness cannot work out where to site the repo."
+        )
+
+    # systemd runs a unit with no WorkingDirectory= from `/`. backup.sh resolves COMPOSE_FILE
+    # relatively and therefore sets one; the failure-marker script uses absolute paths and does
+    # not. Take whichever the unit says — including its absence.
+    workdir = (unit.one("WorkingDirectory") or "/").rstrip("/") or "/"
+
+    return Sandbox(
+        rw_paths=rw,
+        masked_paths=list(HOME_PATHS) if protect_home == "yes" else [],
+        private_tmp=private_tmp,
+        workdir=workdir,
+        exec_start=exec_start,
+        deploy_root=deploy_root,
+        environment=unit.environment,
+    )
+
+
+def _nearest_existing_ancestor(path: str) -> str:
+    p = Path(path)
+    for parent in p.parents:
+        if parent.exists():
+            return str(parent)
+    return "/"
+
+
+def render_namespace_script(sb: Sandbox, repo_root: Path) -> str:
+    """The bash program that BUILDS the namespace and then execs the entry point.
+
+    Read the ordering as the argument it is:
+
+      1. Seal EVERYTHING read-only            <- ProtectSystem=strict, in one line
+      2. Carve the granted paths back out     <- ReadWritePaths=, and nothing else
+      3. Mask $HOME                           <- ProtectHome=yes
+      4. SELF-CHECK, and refuse to run if the sandbox is not what the unit says  <- rc=2
+      5. exec the real ExecStart
+
+    Step 4 is not decoration. An instrument that has not been checked against both classes —
+    "the granted path IS writable" and "the ungranted path is NOT" — is exactly the instrument
+    that shipped deploy#613 twice (cf. feedback_calibrate_the_mutation_before_counting_it,
+    feedback_silent_zero_is_not_a_measurement).
+    """
+    q = shlex.quote
+    lines: list[str] = [
+        "set -uo pipefail",
+        "",
+        "# rc=2 is 'could not find out'. It must NEVER be confused with a clean run.",
+        'instrument_fail() { echo "[harness] INSTRUMENT FAILURE: $*" >&2; exit 2; }',
+        "",
+        "mount --make-rprivate / || instrument_fail 'cannot make mounts private'",
+        "",
+    ]
+
+    # --- 2a. Substrate for the granted paths, BEFORE the read-only pass. -------------------
+    # A granted path usually does not exist on a CI runner (/var/lib/noorinalabs-backups), and
+    # its parent is root-owned, so we cannot mkdir it even as namespace-root. So: tmpfs the
+    # nearest EXISTING ancestor, create the path inside it, then give the path its own writable
+    # tmpfs and seal the ancestor read-only again. The ancestor ends up read-only exactly as
+    # production has it — a tmpfs left writable there would make the sandbox LESS restrictive
+    # than the unit, which is a false-green hole.
+    # Every path that needs a mountpoint: the granted paths, plus wherever the repo has to sit
+    # for ExecStart= to resolve (whether or not the unit grants the repo read-write).
+    needs_mountpoint = [*sb.rw_paths, sb.deploy_root]
+    ancestors: list[str] = []
+    for path in needs_mountpoint:
+        anc = _nearest_existing_ancestor(path)
+        if anc == "/":
+            raise Unsupported(
+                f"{path} has no existing ancestor below /. The harness would have to tmpfs the "
+                f"root filesystem to create it, which would hide the very tree under test. "
+                f"Create the parent on the runner, or use a path under one that exists."
+            )
+        if anc not in ancestors:
+            ancestors.append(anc)
+
+    lines.append("# --- Mountpoints. A granted path rarely exists on a CI runner, and its ---")
+    lines.append("# --- parent is root-owned, so even namespace-root cannot mkdir it. tmpfs ---")
+    lines.append("# --- the nearest existing ancestor and build inside it. The ancestor is  ---")
+    lines.append("# --- NOT granted, and the read-only pass below seals it right back up.   ---")
+    for anc in ancestors:
+        lines.append(f"mount -t tmpfs tmpfs {q(anc)} || instrument_fail 'tmpfs on {anc}'")
+    for path in needs_mountpoint:
+        lines.append(f"mkdir -p {q(path)} || instrument_fail 'mkdir {path}'")
+
+    lines += [
+        "",
+        "# The tree ExecStart= lives in. Bound READ-WRITE here; if the unit does not grant it",
+        "# (isnad-backup-failure-marker.service does not), the read-only pass below takes it",
+        "# straight back — because it is not in ReadWritePaths=. One rule, no special cases.",
+        f"mount --bind {q(str(repo_root))} {q(sb.deploy_root)} "
+        f"|| instrument_fail 'bind repo at {sb.deploy_root}'",
+        "",
+        "# --- ReadWritePaths=: the ONLY writable paths, straight out of the unit ---",
+    ]
+    for rw in sb.rw_paths:
+        if rw == sb.deploy_root:
+            continue  # already the repo bind, and it is granted -> stays read-write
+        lines.append(f"mount -t tmpfs tmpfs {q(rw)} || instrument_fail 'tmpfs on granted {rw}'")
+
+    # --- 2b. ProtectSystem=strict: everything else read-only. -----------------------------
+    lines += [
+        "",
+        "# --- ProtectSystem=strict: the whole hierarchy read-only, except the API fs ---",
+        "# THIS IS THE ONE RULE, AND IT IS THE UNIT'S: everything the unit does not grant in",
+        "# ReadWritePaths= is read-only. The ancestors we tmpfs'd above, the repo tree when it",
+        "# is not granted, /tmp, /etc, everything.",
+        "#",
+        "# Deepest-first, so a child is sealed before its parent. Anything that refuses to go",
+        "# read-only is DETACHED instead (strictly more restrictive; can only false-RED). If it",
+        "# will do neither, we do not have the unit's sandbox and we must not pretend we do.",
+        "while IFS= read -r mp; do",
+        '  [ -z "$mp" ] && continue',
+        '  case "$mp" in',
+        "    " + "|".join(f"{p}|{p}/*" for p in API_FILESYSTEMS) + ") continue ;;",
+    ]
+    for rw in sb.rw_paths:
+        lines.append(f"    {rw}|{rw}/*) continue ;;")
+    lines += [
+        "  esac",
+        '  mount -o remount,bind,ro "$mp" 2>/dev/null && continue',
+        '  umount -l "$mp" 2>/dev/null && continue',
+        '  instrument_fail "could not make $mp read-only or detach it — the sandbox is not the'
+        " unit's, so nothing it reports would mean anything\"",
+        "done <<EOF",
+        "$(awk '{print $5}' /proc/self/mountinfo | sed 's/\\\\040/ /g' "
+        "| awk '{ print length, $0 }' | sort -rn | cut -d' ' -f2-)",
+        "EOF",
+    ]
+
+    # --- 3. PrivateTmp / ProtectHome ------------------------------------------------------
+    if sb.private_tmp:
+        lines += [
+            "",
+            "# PrivateTmp=yes — a private, WRITABLE /tmp. (The unit does not set this today;",
+            "# deploy#121 Bug A explains why. If it ever does, a bare mktemp becomes legal and",
+            "# this harness will say so, because it reads the unit rather than a rule.)",
+            "mount -t tmpfs tmpfs /tmp || instrument_fail 'PrivateTmp tmpfs'",
+            "mount -t tmpfs tmpfs /var/tmp || instrument_fail 'PrivateTmp tmpfs (/var/tmp)'",
+        ]
+    if sb.masked_paths:
+        lines += ["", "# ProtectHome=yes — $HOME inaccessible."]
+        for hp in sb.masked_paths:
+            lines.append(
+                f"[ -d {q(hp)} ] && {{ mount -t tmpfs -o ro,mode=0000 tmpfs {q(hp)} "
+                f"|| instrument_fail 'mask {hp}'; }}"
+            )
+
+    # --- 4. Self-check: calibrate the instrument before reading it. ------------------------
+    lines += [
+        "",
+        "# --- SELF-CHECK. Prove the sandbox separates granted from ungranted, BOTH ways. ---",
+        "# A sandbox that refuses every write would pass every negative assertion and look",
+        "# like a perfect gate. A sandbox that allows every write would pass the positive one.",
+        "# Require BOTH, or this is theatre.",
+    ]
+    for rw in sb.rw_paths:
+        lines.append(
+            f"touch {q(rw + '/.harness-selfcheck')} 2>/dev/null "
+            f"|| instrument_fail 'the unit GRANTS {rw} (ReadWritePaths=) but the sandbox will "
+            f"not let us write there — the sandbox is broken, not the script'"
+        )
+        lines.append(f"rm -f {q(rw + '/.harness-selfcheck')}")
+    for denied in sb.denied_probe_paths:
+        lines.append(
+            f"if touch {q(denied + '/.harness-selfcheck')} 2>/dev/null; then "
+            f"rm -f {q(denied + '/.harness-selfcheck')}; "
+            f"instrument_fail 'the unit does NOT grant {denied}, but the sandbox let us write "
+            f"there. It is LAXER than production: a script writing {denied} would pass here and "
+            f"die on the box. Refusing to testify.'; fi"
+        )
+    if sb.masked_paths:
+        lines.append(
+            f"[ -e {q(sb.masked_paths[0] + '/.harness-selfcheck')} ] "
+            f"&& instrument_fail 'ProtectHome mask did not take'"
+        )
+    lines.append(
+        f"[ -x {q(sb.exec_start)} ] || instrument_fail 'ExecStart {sb.exec_start} is not "
+        f"executable inside the sandbox — the repo bind failed'"
+    )
+
+    # --- 5. Run it. -----------------------------------------------------------------------
+    lines += [
+        "",
+        "echo '[harness] sandbox verified: granted paths writable, ungranted paths refused.'",
+        f"# WorkingDirectory={sb.workdir} (systemd uses / when the unit does not set one).",
+        f"cd {q(sb.workdir)} || instrument_fail 'cd {sb.workdir}'",
+        "",
+        "# The entry point's own exit status is DATA, not the harness's verdict. Capture it,",
+        "# report it on a marker line, and let the caller decide. A missing marker means the",
+        "# namespace script itself died -> the caller reads that as rc=2, could-not-find-out.",
+        "exec_rc=0",
+        f"{q(sb.exec_start)} || exec_rc=$?",
+        "",
+        "# What the run LEFT BEHIND, listed from INSIDE the namespace — it is torn down on exit,",
+        "# so this is the caller's only window onto the product. An exit code alone cannot see a",
+        "# write that failed, was swallowed, and quietly corrupted the output; deploy#613 was",
+        "# exactly that, and it is caught by looking at the artifacts and the verdict text, not",
+        "# by looking at $?.",
+        "#",
+        "# The repo tree is deliberately NOT listed: the harness pre-populated it, so its",
+        "# contents are not evidence of anything this run did.",
+    ]
+    for rw in sb.rw_paths:
+        if rw == sb.deploy_root:
+            continue
+        lines.append(f"find {q(rw)} -type f -printf '[harness] artifact %p\\n' 2>/dev/null || true")
+    lines += [
+        'echo "[harness] exec_rc=${exec_rc}"',
+        "exit 0",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+@dataclass
+class Result:
+    rc: int  # 0 clean | 1 finding | 2 could-not-find-out
+    exec_rc: int | None
+    stdout: str
+    stderr: str
+    artifacts: list[str]
+
+    @property
+    def output(self) -> str:
+        return self.stdout + self.stderr
+
+
+def run_unit_under_hardening(
+    unit_path: Path,
+    repo_root: Path,
+    extra_env: dict[str, str] | None = None,
+    timeout: int = 300,
+) -> Result:
+    """Run `unit_path`'s ExecStart under `unit_path`'s own hardening. See module docstring."""
+    backend = None if shutil.which("unshare") is None else sandbox_backend()
+    if backend is None:
+        return Result(
+            2,
+            None,
+            "",
+            "[harness] INSTRUMENT FAILURE: this box will not give us a private mount namespace, "
+            "so the unit's sandbox cannot be built and this check CANNOT RUN.\n"
+            "  Tried: unshare --user --map-root-user --mount (rootless)"
+            + ("" if os.geteuid() == 0 else "; run as root for the second backend")
+            + "\n"
+            "  On Ubuntu 24.04 unprivileged user namespaces may be blocked by AppArmor:\n"
+            "    sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0\n"
+            "  ...or run this as root, which needs no user namespace at all.\n"
+            "It is reporting rc=2 (COULD NOT FIND OUT), not rc=0. A gate that skips green when "
+            "its instrument is missing is the false green this check exists to kill — that is "
+            "the whole of deploy#613/#623, and it applies to this check too.\n",
+            [],
+        )
+
+    unit = parse_unit(unit_path)  # raises Unsupported -> caller maps to rc=2
+    sb = plan(unit)
+
+    # The stubs live INSIDE the repo tree, not in /tmp: /tmp is read-only in the sandbox (and,
+    # under PrivateTmp=yes, a fresh empty tmpfs — the stubs would simply vanish).
+    stub_dir = repo_root / ".harness-stubs"
+    _write_stubs(stub_dir)
+
+    # systemd hands the process Environment= and the contents of EnvironmentFile= as plain
+    # process environment. EnvironmentFile is a CONFIG directive — it constrains nothing — so
+    # the harness supplies its variables directly, exactly as systemd would have.
+    env = {
+        "PATH": f"{sb.deploy_root}/.harness-stubs:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+        # A root service's HOME. It is MASKED by ProtectHome=yes — that is the point.
+        "HOME": "/root",
+        "LANG": "C",
+        **sb.environment,
+        **(extra_env or {}),
+    }
+
+    script = render_namespace_script(sb, repo_root)
+    proc = subprocess.run(
+        # --noprofile --norc: systemd execve()s ExecStart directly. It does not run a shell that
+        # sources /etc/bash.bashrc and ~/.bashrc first — but bash here DID, which (a) printed a
+        # spurious "/root/.bashrc: Permission denied" on every run once ProtectHome masked $HOME,
+        # and (b) let the DEV BOX'S shell config — aliases, exports, a stray PATH — leak into a
+        # run whose entire purpose is to reproduce production exactly. A harness that runs prod
+        # code under someone's dotfiles is not running prod code.
+        [*backend, "bash", "--noprofile", "--norc", "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=timeout,
+    )
+
+    artifacts = [
+        ln.removeprefix("[harness] artifact ")
+        for ln in proc.stdout.splitlines()
+        if ln.startswith("[harness] artifact ")
+    ]
+    marker = [ln for ln in proc.stdout.splitlines() if ln.startswith("[harness] exec_rc=")]
+
+    if proc.returncode == 2 or not marker:
+        # Either the namespace script said so, or it died before it could say anything. Both
+        # are "we could not find out", and neither may be rendered as a pass.
+        return Result(2, None, proc.stdout, proc.stderr, artifacts)
+
+    exec_rc = int(marker[-1].removeprefix("[harness] exec_rc="))
+    return Result(0 if exec_rc == 0 else 1, exec_rc, proc.stdout, proc.stderr, artifacts)
+
+
+# The environment the unit gets from EnvironmentFile=/opt/noorinalabs-deploy/.env on the box.
+# Values are fake; the stubs accept any. BACKUP_PREFIX is `:?`-required by backup.sh (deploy#632).
+HARNESS_ENV = {
+    "B2_KEY_ID": "harness-key-id",
+    "B2_APP_KEY": "harness-app-key",
+    "B2_BUCKET": "harness-bucket",
+    "BACKUP_PREFIX": "stg",
+}
+
+
+def stage_repo(dest: Path, source: Path = REPO_ROOT) -> Path:
+    """A copy of the tree the unit executes.
+
+    A COPY, not the worktree itself. The unit grants /opt/noorinalabs-deploy read-write, so a
+    script under test — or a deliberately broken fixture of one — can legitimately write into
+    the tree it is running from. A harness that let that land in the real checkout would be
+    editing the code it is testing.
+    """
+    dest.mkdir(parents=True, exist_ok=True)
+    for sub in ("scripts", "systemd", "compose"):
+        src = source / sub
+        if src.is_dir():
+            shutil.copytree(src, dest / sub, dirs_exist_ok=True)
+    return dest
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument(
+        "units",
+        nargs="*",
+        type=Path,
+        help="unit files to gate (default: every hardened unit in systemd/)",
+    )
+    args = ap.parse_args(argv)
+
+    units = args.units or hardened_units()
+    if not units:
+        print(
+            "[harness] INSTRUMENT FAILURE: no hardened units found in systemd/. This gate "
+            "found nothing to check, which is not the same as finding nothing wrong.",
+            file=sys.stderr,
+        )
+        return 2
+
+    worst = 0
+    for unit in units:
+        print(f"\n=== {unit} ===", flush=True)
+        with tempfile.TemporaryDirectory() as td:
+            repo = stage_repo(Path(td) / "opt")
+            try:
+                res = run_unit_under_hardening(unit, repo, extra_env=dict(HARNESS_ENV))
+            except Unsupported as exc:
+                print(f"[harness] INSTRUMENT FAILURE: {exc}", file=sys.stderr)
+                worst = max(worst, 2)
+                continue
+        sys.stdout.write(res.stdout)
+        sys.stderr.write(res.stderr)
+        verdict = {0: "PASS", 1: "FAIL", 2: "COULD NOT FIND OUT"}[res.rc]
+        print(f"[harness] {unit.name}: {verdict} (exec_rc={res.exec_rc})")
+        # 2 outranks 1: an instrument we do not trust cannot be allowed to report a finding.
+        worst = 2 if 2 in (worst, res.rc) else max(worst, res.rc)
+
+    return worst
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/unit_hardening.py
+++ b/scripts/tests/unit_hardening.py
@@ -90,6 +90,38 @@ API_FILESYSTEMS = ("/proc", "/sys", "/dev")
 # ProtectHome=yes makes these inaccessible (systemd.exec(5)).
 HOME_PATHS = ("/home", "/root", "/run/user")
 
+COMPOSE_FILE = REPO_ROOT / "compose" / "docker-compose.prod.yml"
+
+
+def scraped_textfile_dir(compose_file: Path = COMPOSE_FILE) -> str:
+    """The directory node-exporter ACTUALLY READS, out of compose. Never re-typed.
+
+    deploy#565 is the bug where the backup gauge was written to `/var/lib/node_exporter` — the
+    PARENT of the collector directory — and so was, in backup.sh's own words, "emitted faithfully
+    and scraped never", for months, while the alert keyed off it could not fire.
+
+    The first version of this harness asserted the gauge with a SUBSTRING match
+    (`"isnad_backup_success.prom" in artifact`). That string is a substring of the WRONG path as
+    well as the right one, so re-injecting deploy#565 verbatim left the gate GREEN — while the
+    harness printed the wrong path in its own artifact listing (deploy#654 review — Nurul Hakim).
+
+    The fix is not to hand-type the full path: that would be one more re-typed constant in a
+    module whose entire thesis is *never re-type the constraint*. `--collector.textfile.directory`
+    in compose is what decides which directory is scraped, so it is what the oracle reads. Change
+    the flag and the assertion moves with it, in the same commit.
+    """
+    flag = "--collector.textfile.directory="
+    for raw in compose_file.read_text().splitlines():
+        if flag in raw:
+            # Split on the flag FIRST, then strip the YAML quoting off the value. Stripping the
+            # line first would eat the flag's own leading `--` along with the list dash.
+            return raw.split(flag, 1)[1].strip().strip("\"',")
+    raise Unsupported(
+        f"no {flag} found in {compose_file}. The harness cannot tell which directory "
+        f"node-exporter actually scrapes, so it CANNOT check that a gauge lands somewhere it "
+        f"will be read — which is deploy#565 exactly. Refusing to guess."
+    )
+
 
 class Unsupported(Exception):
     """A unit directive we cannot faithfully emulate. Refuse to testify — never pass silently.
@@ -171,12 +203,32 @@ class Unit:
         return out
 
     @property
-    def exec_start(self) -> str:
-        line = self.one("ExecStart")
-        if not line:
+    def exec_starts(self) -> list[str]:
+        """EVERY ExecStart=, in order. Not the last one. (deploy#654 review — Nurul Hakim)
+
+        This used to be `one("ExecStart")`, i.e. `vals[-1]` — the LAST command. Both our units
+        are `Type=oneshot`, and systemd.service(5) is explicit that oneshot is exactly the type
+        where **multiple ExecStart= lines are legal and run in sequence**. So a unit like
+
+            ExecStart=/opt/noorinalabs-deploy/scripts/prestep.sh   <- writes /tmp, DIES on the box
+            ExecStart=/opt/noorinalabs-deploy/scripts/backup.sh
+
+        ran only `backup.sh`, reported PASS, and **never executed the command carrying the
+        defect**. Nurul built that unit, put deploy#613's own bug in the first command, and the
+        gate went green.
+
+        That is the worst possible place for a silent skip, and the reason is structural: the
+        DIRECTIVES table catches directives it does not KNOW. `ExecStart` is known — so a second
+        one was not an instrument failure, it was a silently dropped command. The armour did not
+        apply to the one directive that selects WHAT CODE RUNS AT ALL, which defeats this
+        module's own doctrine ("never a silent pass") on the only directive where a silent pass
+        means "we tested nothing".
+        """
+        lines = self.directives.get("ExecStart", [])
+        if not lines:
             raise Unsupported(f"{self.path.name} has no ExecStart=")
         # ExecStart= may carry prefix characters (-, @, +, !) before the binary.
-        return shlex.split(line)[0].lstrip("-@+!")
+        return [shlex.split(line)[0].lstrip("-@+!") for line in lines]
 
     @property
     def environment(self) -> dict[str, str]:
@@ -433,12 +485,21 @@ def sandbox_backend() -> list[str] | None:
 
     None means we could not get a namespace. The caller MUST turn that into rc=2 — never 0.
     """
+    # `unshare` absent entirely is a missing instrument, not a crash. Bereket Tadesse removed the
+    # binary for real in the #654 review; callers (including this module's test suite, at import)
+    # must get a clean None rather than a FileNotFoundError out of the probe.
+    if shutil.which("unshare") is None:
+        return None
+
     candidates = [
         ["unshare", "--user", "--map-root-user", "--mount"],
         *([["unshare", "--mount"]] if os.geteuid() == 0 else []),
     ]
     for argv in candidates:
-        probe = subprocess.run([*argv, "true"], capture_output=True, text=True)
+        try:
+            probe = subprocess.run([*argv, "true"], capture_output=True, text=True)
+        except OSError:
+            continue
         if probe.returncode == 0:
             return argv
     return None
@@ -457,7 +518,7 @@ class Sandbox:
     masked_paths: list[str]  # ProtectHome=yes
     private_tmp: bool
     workdir: str
-    exec_start: str
+    exec_starts: list[str]  # ALL of them, in order — Type=oneshot runs them in sequence
     deploy_root: str
     environment: dict[str, str]
 
@@ -525,11 +586,18 @@ def plan(unit: Unit) -> Sandbox:
     # there. Derived from ExecStart and this repo's layout (scripts/ sits at the root), never
     # from a hard-coded "/opt/noorinalabs-deploy": the self-check below re-verifies by asserting
     # ExecStart is executable inside the sandbox, so a wrong derivation is rc=2, not a lie.
-    exec_start = unit.exec_start
-    deploy_root = str(Path(exec_start).parent.parent)
+    exec_starts = unit.exec_starts
+    roots = {str(Path(e).parent.parent) for e in exec_starts}
+    if len(roots) != 1:
+        raise Unsupported(
+            f"{unit.path.name}: its ExecStart= commands live under different roots "
+            f"({sorted(roots)}). The harness sites ONE tree, so it cannot run them all. Refusing "
+            f"to run a subset — that is the silent skip this whole module exists to prevent."
+        )
+    deploy_root = roots.pop()
     if deploy_root == "/":
         raise Unsupported(
-            f"{unit.path.name}: ExecStart={exec_start} is not <root>/scripts/<script>, so the "
+            f"{unit.path.name}: ExecStart={exec_starts[0]} is not <root>/scripts/<script>, so the "
             f"harness cannot work out where to site the repo."
         )
 
@@ -543,7 +611,7 @@ def plan(unit: Unit) -> Sandbox:
         masked_paths=list(HOME_PATHS) if protect_home == "yes" else [],
         private_tmp=private_tmp,
         workdir=workdir,
-        exec_start=exec_start,
+        exec_starts=exec_starts,
         deploy_root=deploy_root,
         environment=unit.environment,
     )
@@ -706,10 +774,11 @@ def render_namespace_script(sb: Sandbox, repo_root: Path) -> str:
             f"[ -e {q(sb.masked_paths[0] + '/.harness-selfcheck')} ] "
             f"&& instrument_fail 'ProtectHome mask did not take'"
         )
-    lines.append(
-        f"[ -x {q(sb.exec_start)} ] || instrument_fail 'ExecStart {sb.exec_start} is not "
-        f"executable inside the sandbox — the repo bind failed'"
-    )
+    for ex in sb.exec_starts:
+        lines.append(
+            f"[ -x {q(ex)} ] || instrument_fail 'ExecStart {ex} is not executable inside the "
+            f"sandbox — the repo bind failed, or the unit names a script that is not there'"
+        )
 
     # --- 5. Run it. -----------------------------------------------------------------------
     lines += [
@@ -721,8 +790,23 @@ def render_namespace_script(sb: Sandbox, repo_root: Path) -> str:
         "# The entry point's own exit status is DATA, not the harness's verdict. Capture it,",
         "# report it on a marker line, and let the caller decide. A missing marker means the",
         "# namespace script itself died -> the caller reads that as rc=2, could-not-find-out.",
+        "#",
+        "# EVERY ExecStart=, IN ORDER — Type=oneshot runs them in sequence, and stops at the",
+        "# first one that fails (systemd.service(5)). Taking only the LAST one silently skipped",
+        "# any command before it, so a defect in the FIRST ExecStart was never executed and the",
+        "# gate went green over it (deploy#654 review — Nurul Hakim).",
         "exec_rc=0",
-        f"{q(sb.exec_start)} || exec_rc=$?",
+    ]
+    for ex in sb.exec_starts:
+        lines += [
+            "if [ $exec_rc -eq 0 ]; then",
+            f"  echo '[harness] ExecStart: {ex}'",
+            f"  {q(ex)} || exec_rc=$?",
+            "else",
+            f"  echo '[harness] ExecStart NOT REACHED (a previous one failed): {ex}'",
+            "fi",
+        ]
+    lines += [
         "",
         "# What the run LEFT BEHIND, listed from INSIDE the namespace — it is torn down on exit,",
         "# so this is the caller's only window onto the product. An exit code alone cannot see a",


### PR DESCRIPTION
## The problem

`deploy#613` → `#617` → `#623`. Two of the three are **the same bug**: a script under `isnad-backup.service` allocated scratch in `/tmp`, which is **READ-ONLY** there (`ProtectSystem=strict`, `PrivateTmp` deliberately unset per deploy#121 Bug A), and then **reported its own broken instrument as a fact about the subsystem it was meant to check** — *"your B2 key is invalid"* on a good key; *"is the daemon running?"* on a healthy daemon.

Both shipped past a **full green CI and four reviewers**. Not because the tests were weak — **because they were structurally incapable of failing.** CI runners, the rehearsal containers and the dev box all have a writable `/tmp`. Every test we had, *including* the e2e tests that drive the real `backup.sh`, ran where the defect class is unreachable. A suite that cannot express a defect is not a weak instrument; it is not an instrument at all.

## What this adds

**`scripts/tests/unit_hardening.py`** — parses `ProtectSystem=`, `ReadWritePaths=`, `ProtectHome=`, `PrivateTmp=` **out of `systemd/*.service`**, builds a rootless mount namespace from them, and runs the **real `ExecStart`** inside it with `docker`/`rclone`/`zstd`/`systemd-cat` stubbed. Hardened units are **discovered**, never hard-coded — add one tomorrow and it is gated from that moment.

The real `backup.sh` runs end to end in there: B2 preflight, both Postgres dumps, the Neo4j stop/dump/compress/restart cycle, checksums, manifest, upload, retention prune, success metric.

```
[harness] sandbox verified: granted paths writable, ungranted paths refused.
[preflight] verdict=OK
... Stack present in project 'noorinalabs': postgres user-postgres (all running)
... Manifest: complete=true stores=postgres,user-postgres,neo4j
... Emitted success metric: /var/lib/node_exporter/textfile_collector/isnad_backup_success.prom
[harness] artifact /var/lib/node_exporter/textfile_collector/isnad_backup_success.prom
[harness] exec_rc=0
[harness] isnad-backup.service: PASS
```

## The class is NOT "bare mktemp" — and here is the proof

A repo-wide lint banning bare `mktemp` would be sufficient *today*, and that is a **coincidence**. The class is **"writes outside `ReadWritePaths=`"**. Four calibrations, each a fixture copy of a real script with the defect put back:

| # | mutation | harness | the failure it reproduces |
|---|----------|---------|---------------------------|
| 1 | `MUT="$(mktemp)"` | **RED** rc=1 | deploy#613/#623's own spelling |
| 2 | `printf 'x' > /tmp/scratch.txt` | **RED** rc=1 | **NOT mktemp** — no text scan sees this |
| 3 | `printf 'x' > "${HOME}/.rclone.conf"` | **RED** rc=1 | **NOT mktemp, NOT /tmp** — `ProtectHome=yes` |
| 4 | b2_preflight scratch back on `/tmp` | **RED** rc=1 | **deploy#613 itself**, end to end |

```
C1 bare mktemp        rc=1 RED | mktemp: failed to create file via template
                               |   '/tmp/tmp.XXXXXXXXXX': Read-only file system
C2 > /tmp redirect    rc=1 RED | backup.sh: line 59: /tmp/harness-scratch.txt:
                               |   Read-only file system
C3 $HOME write        rc=1 RED | backup.sh: line 59: /root/.harness-rclone.conf:
                               |   Read-only file system
C4 deploy#613 itself  rc=1 RED | [preflight] verdict=PROBE_FAILED   (and NOT KEY_INVALID)
```

**(2) and (3) are the reason this exists.** A harness that only caught `mktemp` would have reimplemented the static pin at 100× the cost and closed nothing.

## Derived from the unit, not restated — tested, both ways

A hand-written "read-only /tmp" job would be a **third place** to encode the same assumption, stale the moment somebody edits `ReadWritePaths=`. "Derived" is a claim, so it is **tested, two-sided** — the *same* mutation under two different units must produce two *different* verdicts:

- `test_a_write_is_refused_or_allowed_according_to_ReadWritePaths` — a write to `/var/lib/harness-extra` **fails** under the real unit and **passes** under a unit that grants that path. Nothing in the harness mentions that path; the only thing that changed is one line in a `.service` file.
- `test_PrivateTmp_yes_makes_a_bare_mktemp_legal_because_production_would` — the identical bare `mktemp` that goes RED above goes **GREEN** under `PrivateTmp=yes`, because on that box it would work. **The harness does not know what `mktemp` is.** A harness with "bare mktemp is bad" wired into it would fail this test.

## A check that cannot run must not testify

`rc=0` clean · `rc=1` **finding** · `rc=2` **COULD NOT FIND OUT** — never green. rc=2 fires for a missing namespace, a **directive the harness cannot emulate**, or a sandbox that **fails its own self-check** (it proves, before every run, that granted paths *are* writable **and** ungranted paths are *not* — a sandbox that refuses everything would pass every negative assertion and look perfect).

An unknown directive is an **instrument failure**, not a silent pass: add `InaccessiblePaths=` or switch to `ProtectSystem=full` and the harness stops and says it no longer knows what production allows, rather than reporting green over an emulation that has drifted.

## The property nobody had written down

Nino raised this in the #624 review: **rclone escapes `ProtectHome=yes` only because `backup.sh` configures it entirely through `RCLONE_CONFIG_ISNAD_*` env vars rather than a config file.** It is load-bearing, invisible, and one refactor from being the next defect. It is now written down *in a test*: the rclone stub **refuses to answer** without those vars, and `test_rclone_is_configured_by_env_not_by_a_file_under_the_masked_HOME` proves the refusal bites.

That test also surfaced something worth a second look: when rclone fails for a **configuration** reason, `b2_preflight` renders it as **`verdict=KEY_INVALID`** — an accusation against a credential, from a refactor that never touched one. deploy#613's shape, one level up. Pinned, not fixed (it is `b2_preflight`'s call, and the classifier cannot tell them apart without parsing rclone's text, which is banned for good reason).

## Honest limits — pinned as tests, not buried in a comment

- **A bare `cd /tmp` is NOT flagged, and that is correct.** Read-only is not inaccessible; `cd /tmp` succeeds on the real box. Only the *write* fails, and that IS caught (calibration 2). A gate that fails on a legal operation gets disabled by the third person it inconveniences.
- **A write the script itself SWALLOWS is not caught.** `mkdir -p /x && printf … > /x/f` — under `set -e`, a failure on the left of `&&` does not abort, so the forbidden write is refused by the kernel and the script sails on. I found this by writing it into my own calibration by accident. The oracle here is exit code + artifacts + verdict text, and a silent swallowed write leaves none of those marks. **This is the seam where the static pin (deploy#626 item 1, @Lucas) still earns its keep** — it reads source text and does not care whether the failure propagates.
- `docker`/`rclone`/`zstd`/`systemd-cat` are **stubs** (no daemon, no network, no B2 in CI). Green means *the script wrote only where the unit grants*, not *the backup works against a real Postgres*. The stub set is asserted by a test so the blind spots stay countable.

## Local⇄CI parity (main#684)

**Mirrored in `.pre-commit-config.yaml` (pre-push).** The sandbox is rootless (`unshare --user --map-root-user --mount`), so a developer gets this gate with **no sudo and no ceremony** — which is the entire point: #613's *second* shipping happened **inside the fix for the first**, because nothing anyone could run locally could express the defect. Now they can.

The calibration half is already carried by the existing `pytest-scripts` pre-push hook (it runs all of `scripts/tests`). CI adds `backup-hardening.yml`, which lifts `kernel.apparmor_restrict_unprivileged_userns` (Ubuntu 24.04 blocks rootless userns by default) — and if that step does nothing, the harness probes its backends, finds none, and exits **2**. The gate does not depend on the setup step succeeding; it depends on the harness being honest when it cannot run, which is itself asserted by a test.

## Verification

```
pre-commit run --all-files ........................ all Passed
pre-commit run --hook-stage pre-push (my files) ... all Passed
  └─ backup-under-unit-hardening (pre-push) ....... Passed
actionlint (shellcheck on PATH) ................... clean
ruff 0.15.11 check + format --check ............... clean
mypy .............................................. clean
pre_commit_ci_sync.py ............................. OK: mirrors all CI-enforced checks
python3 -m pytest scripts/tests -q ................ 471 passed, 3 skipped   (no regressions)
python3 -m pytest .../test_backup_under_unit_hardening.py .. 14 passed
```

The two `promtool` pre-push hooks fail on my box (`docker` is not available in this WSL distro) — pre-existing, path-scoped to `infra/prometheus/`, and **skipped on this push** (no matching files). Not caused by this change and not force-merged past.

Closes #626
Closes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfLUh7qrqfYdfxa2jNKS5f


---

## CI evidence: the rc=2 refusal FIRED, on a real runner

Not a theory. The first push proved it live: `ubuntu-latest` **is** Ubuntu 24.04 with
`kernel.apparmor_restrict_unprivileged_userns=1`, and the `pytest (scripts)` job could not build
the namespace. The harness did **not** skip green — it refused to testify:

```
[harness] INSTRUMENT FAILURE: this box will not give us a private mount namespace,
  so the unit's sandbox cannot be built and this check CANNOT RUN.
  Tried: unshare --user --map-root-user --mount (rootless)
  On Ubuntu 24.04 unprivileged user namespaces may be blocked by AppArmor:
    sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
It is reporting rc=2 (COULD NOT FIND OUT), not rc=0.
```

The job went **RED with the remediation printed**. `cc8f6db` gives `scripts-pytest` the same
one-line lift the dedicated workflow already had. This is the behaviour
`test_the_harness_refuses_to_testify_when_it_cannot_build_the_sandbox` asserts, observed in
production rather than in a fixture — and it is the single property that makes a green tick from
this gate worth anything.

**All 17 checks now green**, including both new ones. On the runner:

```
[harness] isnad-backup.service: PASS (exec_rc=0)
[harness] isnad-backup-failure-marker.service: PASS (exec_rc=0)
14 passed  (all four calibrations RED as required, baseline GREEN)
```
