### PR TITLE
fix(backup-hardening): close the retention-path scratch blind spot (deploy#675)

### DIFF
--- a/scripts/tests/test_backup_under_unit_hardening.py
+++ b/scripts/tests/test_backup_under_unit_hardening.py
@@ -123,6 +123,19 @@ FALSE_CLAIMS = (
     "Cannot reach Docker Compose",
     "Could not START neo4j",
     "Neo4j is NOT running",
+    # A scratch allocation that failed — reported by compose_project.sh's scratch_failed(). This
+    # is deploy#675, and it is the SEAM between two individually-correct decisions, not a bug in
+    # either. deploy#635 makes a retention (prune_old_backups) scratch failure DELIBERATELY
+    # NON-FATAL: a listing failure must not convert a storage-cost problem into a total backup
+    # outage. deploy#654 asserts the run exits 0 with its success gauge. Compose them and a
+    # scratch_file() regression on the retention path — exactly what deploy#661 routes — logs
+    # this, leaves rc==0 AND the gauge in place, and sails through BOTH halves of the oracle.
+    # docker/rclone are HEALTHY here by construction and BACKUP_DIR is granted, so the ONLY way
+    # this string appears is a scratch write landing somewhere the unit forbids — the #613 class,
+    # on the one path rc-and-gauge structurally cannot see. Adding it is a THIRD observation, NOT
+    # a coupling: retention stays non-fatal (see the calibration below, which asserts rc==0 AND
+    # the gauge survive), we just stop being BLIND to the failure. deploy#675.
+    "no writable scratch file",
 )
 
 
@@ -520,6 +533,76 @@ def test_calibration_deploy613_itself_restored_goes_red(tmp_path: Path) -> None:
     assert "verdict=KEY_INVALID" not in res.output, (
         "THE PREFLIGHT BLAMED THE KEY. The key is fine — the harness's rclone stub is a healthy, "
         f"write-capable key by construction. This is deploy#613's lie, verbatim.\n{res.output}"
+    )
+
+
+@needs_namespace
+def test_calibration_a_retention_path_scratch_failure_goes_red(tmp_path: Path) -> None:
+    """(5) deploy#675: THE SEAM. A scratch failure the gate was BUILT to catch, on the one path
+    it could not see — and neither composing decision is wrong.
+
+    deploy#635 makes a retention (prune_old_backups) scratch failure DELIBERATELY NON-FATAL: a
+    listing failure must not convert a storage-cost problem into a total backup outage. deploy#654
+    (this harness) asserts the run exits 0 with its success gauge. Both are correct in isolation.
+    Compose them and a scratch_file() regression on the retention path — exactly what deploy#661
+    routes — logs "no writable scratch file", sets RETENTION_OK=false, and returns WITHOUT failing
+    the run. The exit code stays 0. The success gauge is still emitted. rc-and-gauge, the entire
+    oracle this harness had, are BOTH still satisfied — so the one gate built specifically to catch
+    a scratch failure under hardening passed straight over one. (Aisha Idrissi, deploy#675.)
+
+    The mutation is that regression, faithfully: a bare scratch that lands in the READ-ONLY /tmp
+    (the #613 class), reported by compose_project.sh's own scratch_failed(), NON-FATAL exactly as
+    deploy#635 mandates. BACKUP_DIR is granted, so the real scratch_file() would SUCCEED here — the
+    defect is precisely routing scratch OFF the library and onto /tmp.
+
+    The fix is a THIRD observation, not a coupling. This test pins BOTH sides of that:
+
+      * retention MUST still not fail the run  -> rc == 0, exec_rc == 0, success gauge present.
+        Coupling the scratch failure to the exit code would "fix" the blind spot by regressing
+        deploy#635 into a total-outage-on-a-listing-failure. That is not the fix.
+      * the failure MUST now be SEEN            -> the FALSE_CLAIMS oracle — the SAME loop the
+        positive control applies to the real run — now finds "no writable scratch file", where
+        before deploy#675 it could not, because the string was not in the tuple.
+    """
+    repo = _stage(tmp_path)
+    # A scratch_file() regression on the retention path: scratch routed to the read-only /tmp
+    # instead of via the library (which uses the granted BACKUP_DIR). Reported by the library's
+    # own scratch_failed(); NON-FATAL, per deploy#635 — the run continues, retention degraded.
+    mutation = (
+        'if ! _HARNESS_RET_SCRATCH="$(mktemp /tmp/retention-XXXXXX 2>/dev/null)"; then\n'
+        "        scratch_failed || true  # deploy#635: a retention scratch failure is NON-FATAL\n"
+        "    fi"
+    )
+    _mutate(repo, "backup.sh", 'local category="$1"', mutation)
+
+    res = _run(repo)
+
+    # (a) deploy#635 is NOT regressed. The retention scratch failure did NOT fail the run: the
+    #     backup artifact is complete and the success gauge is emitted. This is the whole reason
+    #     rc-and-gauge could not see the defect — and the reason the fix must NOT couple them.
+    assert res.rc == 0, (
+        f"THE RETENTION SCRATCH FAILURE FAILED THE RUN. deploy#635 makes it deliberately "
+        f"non-fatal — a listing failure must not become a total backup outage. If this is red, "
+        f"the fix regressed #635 by coupling retention to the exit code.\n{res.output}"
+    )
+    assert res.exec_rc == 0
+    assert_gauge_is_scraped(res, SUCCESS_GAUGE)
+
+    # (b) The mutation actually fired — otherwise this calibration is inert (deploy#574).
+    assert "no writable scratch file" in res.output, (
+        "the injected retention scratch regression did not emit its diagnostic — the mutation is "
+        f"inert and this calibration proves nothing.\n{res.output}"
+    )
+
+    # (c) THE BLIND SPOT, MADE EXPLICIT. rc-and-gauge are both green (asserted above), so the only
+    #     thing standing between this real scratch regression and a PASS is FALSE_CLAIMS. Run the
+    #     positive control's exact oracle and require it to FIRE on this string — where, before
+    #     deploy#675, the string was not in the tuple and the gate went green over the defect.
+    offending = [claim for claim in FALSE_CLAIMS if claim in res.output]
+    assert "no writable scratch file" in offending, (
+        "deploy#675: the retention-path scratch failure is INVISIBLE to the gate. rc==0 and the "
+        "success gauge is present, so the only oracle that can catch it is FALSE_CLAIMS — and it "
+        f"does not. Add 'no writable scratch file' to FALSE_CLAIMS.\nFALSE_CLAIMS={FALSE_CLAIMS}"
     )
 
 

--- a/scripts/tests/unit_hardening.py
+++ b/scripts/tests/unit_hardening.py
@@ -423,7 +423,17 @@ case "${1:-}" in
         # b2_preflight reads the LAST field of each line as a bucket name.
         printf '          -1 2026-01-01 00:00:00        -1 %s\n' "${B2_BUCKET:?}"
         ;;
-    lsf)   ;;  # no pre-existing date dirs -> the retention prune has nothing to purge
+    lsf)
+        # Emit TODAY's date dir — the one the run just uploaded — so retention's HAPPY PATH is
+        # the baseline, not a no-op. An empty listing meant prune_old_backups iterated NOTHING,
+        # so its whole body (date parse, cutoff compare, the scratch a deploy#661-shaped
+        # regression lives on) never ran, and a scratch failure there could not be observed by a
+        # gate whose baseline never exercised it. The date is computed the way backup.sh computes
+        # its own DATE_STAMP (`date -u +%Y-%m-%d`) so the stub and the code cannot disagree at
+        # midnight UTC. Being TODAY, it is newer than any retention cutoff, so it is listed and
+        # parsed but correctly NOT purged — the happy path, and the baseline stays clean.
+        printf '%s/\n' "$(date -u +%Y-%m-%d)"
+        ;;
     copyto|deletefile|copy|purge) ;;
     *) ;;
 esac


### PR DESCRIPTION
## deploy#675 — close the retention-path scratch blind spot

The hardening gate (#654) exists to catch a scratch failure under
`ProtectSystem=strict`. Aisha Idrissi found that it **cannot see one on the
retention path** — and, beautifully, **neither composing decision is wrong**.

### The seam

```
scratch_file() fails under ProtectSystem=strict  (in prune_old_backups)
  -> logs "no writable scratch file"
  -> sets RETENTION_OK=false
  -> and, BY DESIGN (deploy#635), does NOT fail the run
        (failing the run on a listing failure turns a storage-cost problem
         into a TOTAL BACKUP OUTAGE — strictly worse; #635 chose correctly)

the gate (#654) asserts:  rc == 0  AND  success gauge present
  -> BOTH STILL HOLD
  -> *** GATE PASSES ***     "no writable scratch file" was never in FALSE_CLAIMS
```

Two individually-correct decisions compose into a blind spot: the safety
decision (#635) erased the observability the gate (#654) was built to provide.
This is urgent because **#661 is the scratch-class PR**, and this gate is meant
to prove its `scratch_file()` routing works under real hardening.

### The fix — a THIRD observation, not a coupling

1. **`"no writable scratch file"` joins `FALSE_CLAIMS`.** Any scratch
   regression anywhere in `backup.sh` — retention included — now goes RED,
   **without** coupling retention's failure to the run's exit code (which would
   be a #635 regression).
2. **The stub `rclone lsf` now emits today's `%Y-%m-%d/` dir** (computed `date
   -u`, as `backup.sh` computes `DATE_STAMP`), so retention's **happy path** is
   the baseline instead of a no-op. Today's dir is newer than any cutoff:
   listed and parsed, correctly not purged — baseline stays clean.

### Proof (the deliverable)

Identical mutated run — a `scratch_file()` regression injected into
`prune_old_backups` that lands scratch in the read-only `/tmp`, reported by the
library's own `scratch_failed()`, non-fatal per #635:

| | exec_rc / rc | success gauge | `FALSE_CLAIMS` fire | **gate** |
|---|---|---|---|---|
| **before** (unpatched oracle) | 0 / 0 | present | `[]` | **GREEN / PASS** |
| **after** (this PR) | 0 / 0 | present | `['no writable scratch file']` | **RED / FAIL** |

`rc==0` and the gauge survive in BOTH rows — deploy#635 is not regressed; the
RED comes purely from the new observation. Pinned permanently as
`test_calibration_a_retention_path_scratch_failure_goes_red`, which asserts both
halves.

- Baseline gate: **clean** (no ERROR/WARNING lines; 3 dumps complete, 3
  artifacts collected — a run that collects nothing would be BROKEN, not RED).
- Full `scripts/tests`: **502 passed, 3 skipped**. `pre-commit`: clean. `mypy`:
  clean.

### Rebased onto #661 (now merged) and re-validated

The brief anticipated #661 (the scratch-class PR) as in-review; it has since
merged. This branch is rebased onto it and every number above was re-measured
against the **real** #661 world (its new `scripts/scratch.sh`, the
`SCRATCH_PARENT=` unit declarations, `scratch_cleanup_all`). Two facts worth
recording: #661 did **not** route `prune_old_backups`' listing through
`scratch_file()` (retention still uses `rclone lsf … || true`), so this guard is
**forward-looking** — the calibration *injects* the regression, it never
depended on #661 shipping it; and `scratch_failed()`'s diagnostic still emits
`"no writable scratch file"` (now `scratch.sh:340`), so the `FALSE_CLAIMS`
anchor holds. Before=GREEN / after=RED reproduced against #661 verbatim.

### What this gate STILL cannot express

It observes the **diagnostic**, not the **failure**. A retention scratch
failure that is non-fatal (by #635) **and swallowed** — one that emits no
recognized string (`mktemp /tmp/x 2>/dev/null || true` with no
`scratch_failed`) — still leaves `rc==0`, the gauge present, and no false claim:
invisible again. This is the same boundary
`test_the_gate_cannot_see_a_write_the_script_itself_swallows` already documents;
the only true close is a syscall-level EROFS observer (strace/LD_PRELOAD). And
because the guard keys on `scratch_failed()`'s exact wording, if **#661** routes
the retention scratch through a *different* message the guard silently narrows
(the deploy#589 paraphrase class) — worth a confirming glance in #661 review.

Closes #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfLUh7qrqfYdfxa2jNKS5f
