### PR TITLE
fix(restore-verify): calibrator DIFFER cases must not pass on an empty reading (#677)

### DIFF
--- a/scripts/restore_verify.sh
+++ b/scripts/restore_verify.sh
@@ -944,6 +944,26 @@ compare() {
 #   REFUSE (rc=2) when pointed at a property that does not exist  (the n.name trap)
 #
 # It runs on a plain runner: no B2, no VPS, no secrets, nothing live is reachable.
+
+# The DIFFER predicates, extracted so they can be unit-tested with an INJECTED empty reading
+# (the self-test itself needs two real Neo4j stacks; these do not). An empty reading is an
+# INSTRUMENT FAILURE, never a detected difference — so every reading must be non-empty for the
+# case to pass. Without the `-n` guards, `!=` passes on an empty sub and `==` passes on a pair
+# of empty counts, and the calibrator certifies the comparator on nothing (deploy#677).
+# scripts/tests/test_restore_verify.py drives these with empty inputs and requires them to FAIL.
+
+# st_fp_differs <ref_fp> <sub_fp> — 0 (pass) iff both non-empty AND they differ.
+st_fp_differs() {
+    [[ -n "$1" && -n "$2" && "$1" != "$2" ]]
+}
+
+# st_same_count_content_differs <ref_count> <sub_count> <ref_fp> <sub_fp>
+# 0 (pass) iff counts are non-empty AND equal, AND fingerprints are non-empty AND differ:
+# same cardinality, different CONTENT, on real readings.
+st_same_count_content_differs() {
+    [[ -n "$1" && -n "$2" && "$1" == "$2" && -n "$3" && -n "$4" && "$3" != "$4" ]]
+}
+
 self_test() {
     local rc=0
     log "INFO" "=== SELF-TEST: proving the comparator separates (real engines, no B2) ==="
@@ -1007,9 +1027,15 @@ self_test() {
     for p in "$ST_REF_PROJECT" "$RV_PROJECT"; do
         local waited=0 cid health
         while :; do
-            cid="$(_st_dc "$p" ps -q neo4j | head -1)"
+            # A container that does not exist YET is the normal case on the first pass, so a
+            # failing `ps` here is not an error — but `cid="$(… | head -1)"` under `set -e`
+            # is a CRASH on that path, killing the wait loop before the stack can come up.
+            # start_stack() already guards its identical wait this way and its comment says so;
+            # this is the same fix, the copy that was left behind (deploy#677).
+            cid=""
+            cid="$(_st_dc "$p" ps -q neo4j | head -1)" || cid=""
             health="none"
-            [[ -n "$cid" ]] && health="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$cid")"
+            [[ -n "$cid" ]] && { health="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$cid")" || health="none"; }
             [[ "$health" == "healthy" ]] && break
             [[ "$waited" -ge 240 ]] && instrument_fail "self-test: ${p} neo4j never became healthy"
             sleep 3
@@ -1073,10 +1099,14 @@ self_test() {
     # --- Case 2: minus one narrator MUST differ ------------------------------
     _st_cypher "$RV_PROJECT" "MATCH (n:Narrator {id:'nar:7'}) DETACH DELETE n;" >/dev/null
     sub_fp="$(_st_cypher "$RV_PROJECT" "$CY_FP")"
-    if [[ "$ref_fp" != "$sub_fp" ]]; then
+    # `!=` alone PASSES on an empty sub_fp — an empty reading trivially "differs" from a
+    # populated one. That is the "a both-sides-zero is not a match" doctrine violated inside
+    # the calibrator, which is the very thing `needs: self-test` gates the real restore on.
+    # st_fp_differs requires both readings non-empty (deploy#677).
+    if st_fp_differs "$ref_fp" "$sub_fp"; then
         pass "self-test DIFFER: removing ONE narrator changed the fingerprint (ref=${ref_fp} sub=${sub_fp})"
     else
-        fail "self-test DIFFER: the fingerprint is INERT — it cannot see a missing narrator"
+        fail "self-test DIFFER: the fingerprint is INERT or a reading was EMPTY — cannot see a missing narrator (ref=${ref_fp} sub=${sub_fp})"
         rc=1
     fi
 
@@ -1089,11 +1119,14 @@ self_test() {
     ref_count="$(_st_cypher "$ST_REF_PROJECT" "MATCH (n:Narrator) RETURN count(n);")"
     sub_count="$(_st_cypher "$RV_PROJECT" "MATCH (n:Narrator) RETURN count(n);")"
     sub_fp="$(_st_cypher "$RV_PROJECT" "$CY_FP")"
-    if [[ "$ref_count" == "$sub_count" && "$ref_fp" != "$sub_fp" ]]; then
+    # Two empty counts compare EQUAL under `==`, and an empty sub_fp trivially "differs" — so
+    # without the `-n` guards this whole clause PASSES on a pair of empty readings, certifying
+    # the comparator on nothing. st_same_count_content_differs requires every reading non-empty.
+    if st_same_count_content_differs "$ref_count" "$sub_count" "$ref_fp" "$sub_fp"; then
         pass "self-test DIFFER: node COUNT is identical (${ref_count}) yet the fingerprint differs —"
         log "INFO" "        it sees corrupted CONTENT, not just cardinality (ref=${ref_fp} sub=${sub_fp})"
     else
-        fail "self-test DIFFER: a same-count content corruption was NOT detected (count ref=${ref_count} sub=${sub_count}, fp ref=${ref_fp} sub=${sub_fp})"
+        fail "self-test DIFFER: same-count corruption NOT detected or a reading was EMPTY (count ref=${ref_count} sub=${sub_count}, fp ref=${ref_fp} sub=${sub_fp})"
         rc=1
     fi
 
@@ -1153,4 +1186,9 @@ main() {
     return "$RC_VERIFIED"
 }
 
-main "$@"
+# Guard so the file can be SOURCED for unit-testing the extracted predicates (st_fp_differs,
+# st_same_count_content_differs) without running the whole script. When executed directly —
+# which is the only way the workflow ever invokes it — BASH_SOURCE[0] equals $0 and main runs.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/scripts/tests/test_restore_verify.py
+++ b/scripts/tests/test_restore_verify.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import textwrap
@@ -107,6 +108,86 @@ def test_the_scan_can_actually_see_an_unflagged_call(evasion: str) -> None:
 def test_the_scan_does_not_false_positive_on_a_comment() -> None:
     """The other direction: prose about the rule must not fail the build."""
     assert not _unflagged_compose_calls("# every `docker compose` here carries -p")
+
+
+# ---------------------------------------------------------------------------
+# CALIBRATE THE CALIBRATOR (deploy#677)
+# ---------------------------------------------------------------------------
+# The self-test's own DIFFER cases must not pass on an EMPTY reading — that is the
+# "a both-sides-zero is not a match" doctrine, and it was sitting inside the very comparator
+# that `needs: self-test` gates the real restore-verify run on. The predicates were extracted
+# from self_test() precisely so they can be exercised here with an injected empty reading,
+# without the two real Neo4j stacks the full self-test needs. `main` in restore_verify.sh is
+# guarded (`if [[ "${BASH_SOURCE[0]}" == "${0}" ]]`) so the file can be sourced for this.
+def _predicate_rc(func: str, *args: str) -> int:
+    """Source restore_verify.sh and call one of its extracted DIFFER predicates, returning its
+    exit code. Exercises the REAL predicate, not a paraphrase of it."""
+    quoted = " ".join(shlex.quote(a) for a in args)
+    snippet = f"source {shlex.quote(str(RESTORE_VERIFY))}; {func} {quoted}"
+    return subprocess.run(["bash", "-c", snippet], capture_output=True, text=True).returncode
+
+
+@pytest.mark.parametrize(
+    ("ref_fp", "sub_fp", "should_pass"),
+    [
+        ("50/300/450/350", "49/290/440/345", True),  # a genuine difference — the real case
+        ("50/300/450/350", "50/300/450/350", False),  # identical — not a difference
+        ("50/300/450/350", "", False),  # THE BUG: empty sub reading must NOT read as "differs"
+        ("", "49/290/440/345", False),  # empty ref
+        ("", "", False),  # both empty
+    ],
+)
+def test_st_fp_differs_rejects_empty_readings(ref_fp, sub_fp, should_pass) -> None:
+    """Case 2's predicate. Under the old bare `!=`, an empty sub_fp trivially "differed" from a
+    populated ref_fp and the DIFFER case PASSED — certifying the comparator on an instrument
+    failure. It must now FAIL on any empty reading, and still PASS on a genuine difference (so
+    it is a discriminator, not an unconditional refusal). (deploy#677)
+    """
+    rc = _predicate_rc("st_fp_differs", ref_fp, sub_fp)
+    want = "pass" if should_pass else "fail"
+    assert (rc == 0) == should_pass, (
+        f"st_fp_differs({ref_fp!r},{sub_fp!r}) rc={rc}, expected {want}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("ref_count", "sub_count", "ref_fp", "sub_fp", "should_pass"),
+    [
+        ("50", "50", "fpA", "fpB", True),  # same count, different content — the real case
+        ("50", "50", "fpA", "fpA", False),  # same content — no difference
+        ("50", "49", "fpA", "fpB", False),  # different count
+        ("", "", "fpA", "fpB", False),  # THE BUG: two empty counts compare EQUAL under ==
+        ("50", "50", "fpA", "", False),  # empty sub fingerprint
+        ("50", "50", "", "", False),  # both fingerprints empty
+    ],
+)
+def test_st_same_count_content_differs_rejects_empty_readings(
+    ref_count, sub_count, ref_fp, sub_fp, should_pass
+) -> None:
+    """Case 3's predicate. Under the old form, a pair of empty counts compared EQUAL and an
+    empty sub_fp trivially "differed", so the case PASSED on nothing. It must now FAIL unless
+    every reading is non-empty. (deploy#677)
+    """
+    rc = _predicate_rc("st_same_count_content_differs", ref_count, sub_count, ref_fp, sub_fp)
+    assert (rc == 0) == should_pass, (
+        f"st_same_count_content_differs({ref_count!r},{sub_count!r},{ref_fp!r},{sub_fp!r}) "
+        f"rc={rc}, expected {'pass' if should_pass else 'fail'}"
+    )
+
+
+def test_the_selftest_wait_does_not_crash_on_a_missing_container() -> None:
+    """Item 2: the self-test health-wait must not `set -e`-crash when `ps -q` finds no container
+    yet (the normal first-pass state). Static check that the crash-prone bare assignment form is
+    gone from the wait loop — the same shape start_stack() already guards. (deploy#677)"""
+    src = _source()
+    m = re.search(r"^self_test\(\) \{(.*?)^\}", src, re.S | re.M)
+    assert m, "could not locate self_test()"
+    body = m.group(1)
+    assert 'cid="$(_st_dc "$p" ps -q neo4j | head -1)" || cid=""' in body, (
+        'the self-test wait\'s `cid=$(… ps -q …)` is not guarded with `|| cid=""`; under set -e '
+        "a missing container (the normal first-pass state) crashes the wait loop before the "
+        "stack can come up"
+    )
 
 
 def _run_restore_body(text: str) -> str:


### PR DESCRIPTION
Closes #677

Fast-follow tech-debt from Weronika Zielinska's review of #642 — the two "also fix" items that were correctly kept out of #642 (they would have re-staled her hard-won approval on the most dangerous PR of the wave).

Both are in `restore_verify.sh`'s `--self-test`, which is the comparator that `needs: self-test` gates the entire real restore-verify run on.

## 1. The silent-zero doctrine, violated inside the calibrator

The self-test's DIFFER cases 2 and 3 accepted an **empty reading** as a detected difference:

- **Case 2** — `[[ "$ref_fp" != "$sub_fp" ]]` **passes when `sub_fp` is empty** (an empty string trivially differs from a populated one).
- **Case 3** — `[[ "$ref_count" == "$sub_count" && … ]]` **passes when both counts are empty** (two empty strings compare equal under `==`).

Either way the calibrator would certify the comparator as "able to go red" on an **instrument failure** — which is the exact class this whole workflow exists to catch, sitting inside the thing that vouches for it. It is **latent, not live** (the aggregating Cypher always returns a row, and `pipefail`+`set -e` abort a genuine reading failure) — but "a both-sides-empty is not a difference" is absolute, and Case 1 already got it right with `-n`.

**Fix + calibration:** the two predicates are extracted into `st_fp_differs` and `st_same_count_content_differs`, each requiring *every* reading non-empty, and `main` is guarded (`[[ "${BASH_SOURCE[0]}" == "${0}" ]]`) so the file can be sourced. The test **calibrates the calibrator** — it drives the REAL predicates (not a paraphrase) with an injected empty reading and requires them to **FAIL**, and with a genuine difference and requires them to **PASS**:

```
feed empty sub_fp to Case 2's predicate  -> st_fp_differs('50/300/450/350','') -> FAIL  ✓
feed two empty counts to Case 3          -> st_same_count_content_differs('','','fpA','fpB') -> FAIL  ✓
genuine difference                        -> PASS  ✓ (so it discriminates, not just refuses)
```

Reverting either predicate to its old bare form makes those tests go red — verified by mutation (2 tests die per predicate).

## 2. A `set -e` crash in the self-test health-wait

`cid="$(_st_dc "$p" ps -q neo4j | head -1)"` crashes the wait loop under `set -e` when the container does not exist yet — the **normal first-pass state**. This is the identical shape `start_stack()` already guards, with a comment saying exactly why; this is the copy that was left behind. Fixed to `… || cid=""`, and a static test asserts the guarded form is present.

## Verification

- `test_restore_verify.py`: **66 tests** (12 new), all pass
- Full `pytest scripts/tests`: **596 passed, 3 skipped**
- Mutation: reverting each of the three fixes makes its calibration test red
- `--self-test` still runs `main` on direct invocation (the guard only skips `main` when sourced)
- pre-commit `--all-files`, actionlint, shellcheck `-x` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfLUh7qrqfYdfxa2jNKS5f
