### PR TITLE
fix(restore-verify): valid histogram Cypher + host self-sync (deploy#684, deploy#685)

### DIFF
--- a/.github/workflows/restore-verify.yml
+++ b/.github/workflows/restore-verify.yml
@@ -184,6 +184,22 @@ jobs:
           script: |
             set -euo pipefail
             cd /opt/noorinalabs-deploy
+
+            # Refresh the on-box checkout to origin/main BEFORE running the script,
+            # exactly as graph-ops.yml / graph-prune-narrators.yml / deploy-data-load.yml
+            # do, so the host runs the current committed restore_verify.sh rather than
+            # whatever was last synced by hand. Its absence was this workflow's FIRST
+            # failure on the real host (deploy#685): `./scripts/restore_verify.sh: No
+            # such file or directory` on a checkout behind main. Guarded even though
+            # `set -e` is on: an unguarded `git fetch` failure would abort with git's
+            # own message and no hint that the danger is the following `reset --hard
+            # origin/main` succeeding against a STALE remote-tracking ref.
+            echo "==> Pulling latest deploy config..."
+            git fetch origin main \
+              || { echo "ERROR: [${{ matrix.env }}] git fetch origin main failed — refusing to run against a stale checkout." >&2; exit 1; }
+            git reset --hard origin/main \
+              || { echo "ERROR: [${{ matrix.env }}] git reset --hard origin/main failed." >&2; exit 1; }
+
             export EXPECT_PREFIX='${{ matrix.env }}'
             ./scripts/restore_verify.sh
         env:

--- a/scripts/restore_verify.sh
+++ b/scripts/restore_verify.sh
@@ -296,10 +296,17 @@ readonly CY_FP_PARTS="MATCH (n:Narrator)
 readonly CY_NODES="MATCH (n) RETURN count(n);"
 readonly CY_RELS="MATCH ()-[r]->() RETURN count(r);"
 # Histograms: a node count can match while the LABELS are wrong.
+# Neo4j 5.x rejects a RETURN that mixes a grouping expression (`l`) with an aggregate
+# (`count(*)`) in the same projection ("Aggregation column contains implicit grouping
+# expressions"). The WITH separates grouping from aggregation before the string is built
+# (deploy#684 — self_test() never exercised these two constants, so this was invalid on
+# every real run and only ever caught by the live comparator dying at exit 2).
 readonly CY_LABEL_HIST="MATCH (n) UNWIND labels(n) AS l
-    RETURN l + '=' + toString(count(*)) AS h ORDER BY h;"
+    WITH l, count(*) AS c
+    RETURN l + '=' + toString(c) AS h ORDER BY h;"
 readonly CY_REL_HIST="MATCH ()-[r]->()
-    RETURN type(r) + '=' + toString(count(r)) AS h ORDER BY h;"
+    WITH type(r) AS t, count(r) AS c
+    RETURN t + '=' + toString(c) AS h ORDER BY h;"
 
 readonly PG_HADITH_COUNT="SELECT count(*) FROM isnad_graph.hadiths;"
 readonly PG_HADITH_MD5="SELECT md5(string_agg(t,'|' ORDER BY t)) FROM (SELECT h::text AS t FROM isnad_graph.hadiths h) s;"

--- a/scripts/restore_verify.sh
+++ b/scripts/restore_verify.sh
@@ -998,6 +998,17 @@ self_test() {
             'NEO4J_USERNAME=neo4j NEO4J_PASSWORD="${NEO4J_AUTH#neo4j/}" exec cypher-shell --format plain "$1"' \
             _ "$q" | tail -n +2 | tr -d ' "\r'
     }
+    # _st_cypher_hist <project> <query> — same flattening as _cypher_hist_raw (multi-row
+    # readings collapse to one line so they compare as scalars). A SEPARATE helper from
+    # _st_cypher because that one strips ALL spaces, which would silently glue
+    # "Hadith=20 Narrator=50" into "Hadith=20Narrator=50" and hide the row boundary.
+    _st_cypher_hist() {
+        local p="$1" q="$2"
+        # shellcheck disable=SC2016
+        _st_dc "$p" exec -T neo4j sh -c \
+            'NEO4J_USERNAME=neo4j NEO4J_PASSWORD="${NEO4J_AUTH#neo4j/}" exec cypher-shell --format plain "$1"' \
+            _ "$q" | tail -n +2 | tr -d '"\r' | tr '\n' ' '
+    }
 
     _st_cleanup() {
         # THE VERDICT. Captured on the first line, before anything here can clobber `$?`,
@@ -1096,6 +1107,37 @@ self_test() {
         rc=1
     fi
 
+    # --- Case 1b: the HISTOGRAM readers are READABLE at all, and MATCH -------
+    # CY_LABEL_HIST / CY_REL_HIST mix a grouping expression with an aggregate in the
+    # same RETURN — invalid on Neo4j 5.x ("Aggregation column contains implicit
+    # grouping expressions"). Nothing above exercises them (calibrate()/self_test()'s
+    # fingerprint cases only ever touch CY_FP / CY_FP_PARTS), so this was invalid on
+    # every real run and only ever caught by the live comparator dying at exit 2
+    # (deploy#684). An INSTRUMENT FAILURE here — an empty reading from a query the
+    # engine refused — must FAIL the case exactly like an empty fingerprint would.
+    local ref_label_hist sub_label_hist ref_rel_hist sub_rel_hist
+    ref_label_hist="$(_st_cypher_hist "$ST_REF_PROJECT" "$CY_LABEL_HIST")" || ref_label_hist=""
+    sub_label_hist="$(_st_cypher_hist "$RV_PROJECT" "$CY_LABEL_HIST")" || sub_label_hist=""
+    log "INFO" "  label histogram (ref): ${ref_label_hist}"
+    log "INFO" "  label histogram (sub): ${sub_label_hist}"
+    if [[ -n "$ref_label_hist" && -n "$sub_label_hist" && "$ref_label_hist" == "$sub_label_hist" ]]; then
+        pass "self-test MATCH: label histogram is READABLE and agrees on identically-seeded stacks (${ref_label_hist})"
+    else
+        fail "self-test MATCH: label histogram is unreadable (invalid Cypher / instrument failure) or disagreed on identical stacks (ref='${ref_label_hist}' sub='${sub_label_hist}')"
+        rc=1
+    fi
+
+    ref_rel_hist="$(_st_cypher_hist "$ST_REF_PROJECT" "$CY_REL_HIST")" || ref_rel_hist=""
+    sub_rel_hist="$(_st_cypher_hist "$RV_PROJECT" "$CY_REL_HIST")" || sub_rel_hist=""
+    log "INFO" "  reltype histogram (ref): ${ref_rel_hist}"
+    log "INFO" "  reltype histogram (sub): ${sub_rel_hist}"
+    if [[ -n "$ref_rel_hist" && -n "$sub_rel_hist" && "$ref_rel_hist" == "$sub_rel_hist" ]]; then
+        pass "self-test MATCH: reltype histogram is READABLE and agrees on identically-seeded stacks (${ref_rel_hist})"
+    else
+        fail "self-test MATCH: reltype histogram is unreadable (invalid Cypher / instrument failure) or disagreed on identical stacks (ref='${ref_rel_hist}' sub='${sub_rel_hist}')"
+        rc=1
+    fi
+
     # --- Case 2: minus one narrator MUST differ ------------------------------
     _st_cypher "$RV_PROJECT" "MATCH (n:Narrator {id:'nar:7'}) DETACH DELETE n;" >/dev/null
     sub_fp="$(_st_cypher "$RV_PROJECT" "$CY_FP")"
@@ -1107,6 +1149,18 @@ self_test() {
         pass "self-test DIFFER: removing ONE narrator changed the fingerprint (ref=${ref_fp} sub=${sub_fp})"
     else
         fail "self-test DIFFER: the fingerprint is INERT or a reading was EMPTY — cannot see a missing narrator (ref=${ref_fp} sub=${sub_fp})"
+        rc=1
+    fi
+
+    # --- Case 2b: the label histogram MUST also see the missing narrator -----
+    # A count/label histogram is coarser than the fingerprint, but it must still be
+    # able to go red: it is the ONLY comparator reading in compare() that a narrator's
+    # own properties never reach (deploy#684).
+    sub_label_hist="$(_st_cypher_hist "$RV_PROJECT" "$CY_LABEL_HIST")" || sub_label_hist=""
+    if st_fp_differs "$ref_label_hist" "$sub_label_hist"; then
+        pass "self-test DIFFER: removing ONE narrator changed the label histogram (ref=${ref_label_hist} sub=${sub_label_hist})"
+    else
+        fail "self-test DIFFER: the label histogram is INERT or a reading was EMPTY — cannot see a missing narrator (ref=${ref_label_hist} sub=${sub_label_hist})"
         rc=1
     fi
 

--- a/scripts/restore_verify.sh
+++ b/scripts/restore_verify.sh
@@ -1171,6 +1171,25 @@ self_test() {
         rc=1
     fi
 
+    # --- Case 2c: the reltype histogram MUST also see a REMOVED RELATIONSHIP -
+    # Case 2b proved the LABEL histogram can go red — but nar:7 (the narrator Case 2
+    # deletes) owns no relationships, so CY_REL_HIST reads identically before and
+    # after that mutation and Case 2b never exercises this reader's DIFFER side. A
+    # histogram proven bidirectional on one axis and MATCH-only on the other is
+    # exactly the gap that erases a class rather than merely under-counting it:
+    # prove the reltype reader separates on a mutation of its OWN class (a
+    # relationship), not a sibling's (feedback_drop_gate_bidirectional_ab,
+    # feedback_silent_zero_is_not_a_measurement).
+    _st_cypher "$RV_PROJECT" \
+        "MATCH (:Narrator {id:'nar:1'})-[e:NARRATED_TO]->(:Narrator {id:'nar:2'}) DELETE e;" >/dev/null
+    sub_rel_hist="$(_st_cypher_hist "$RV_PROJECT" "$CY_REL_HIST")" || sub_rel_hist=""
+    if st_fp_differs "$ref_rel_hist" "$sub_rel_hist"; then
+        pass "self-test DIFFER: removing ONE relationship changed the reltype histogram (ref=${ref_rel_hist} sub=${sub_rel_hist})"
+    else
+        fail "self-test DIFFER: the reltype histogram is INERT or a reading was EMPTY — cannot see a missing relationship (ref=${ref_rel_hist} sub=${sub_rel_hist})"
+        rc=1
+    fi
+
     # --- Case 3: same cardinality, corrupted CONTENT, MUST differ ------------
     # Restore the count, but with a different name. A comparator that only counted would
     # go green here — which is the whole reason the fingerprint sums the text.


### PR DESCRIPTION
Fixes #684, Fixes #685

## What was broken

**#684 — invalid histogram Cypher.** `CY_LABEL_HIST` / `CY_REL_HIST` mixed a grouping
expression with an aggregate in the same `RETURN` — Neo4j 5.x rejects this
("Aggregation column contains implicit grouping expressions"). The first real
`restore-verify.yml` dispatch against the live stg B2 artifact (run 29372897005)
restored the artifact perfectly and content-MATCHED live on node count, relationship
count, and the narrator fingerprint — then died at exit 2 (INSTRUMENT FAILURE) on
exactly this query. The backup was provably restorable; the instrument was broken.

**Why nothing caught it:** `self_test()` — the real-engine calibration gate that
`needs: self-test` puts in front of every real restore-verify run — never exercised
`CY_LABEL_HIST`/`CY_REL_HIST`. Its cases only ever touched `CY_FP`/`CY_FP_PARTS`. A
query-builder unit test proves the STRING, never that the engine ACCEPTS it
(same class as deploy#606/#607).

**#685 — restore-verify.yml doesn't self-sync the host checkout.** The `verify`
job SSHes to the host and runs `cd /opt/noorinalabs-deploy && ./scripts/restore_verify.sh`
without updating the checkout first, so it fails on any host behind main — the
literal first failure this session (`./scripts/restore_verify.sh: No such file or
directory`).

## What this PR does

1. Rewrites both histogram queries with an intermediate `WITH` clause that separates
   grouping from aggregation, preserving the exact `label=count`/`reltype=count`
   output shape the comparator string-compares.
2. Closes the coverage gap: `self_test()` now stands up its two real Neo4j 5.x
   containers and exercises both histogram readers via a new `_st_cypher_hist`
   helper — MATCH on identically-seeded stacks (proves the query is at least
   *readable*) and DIFFER after one narrator is deleted (proves it isn't just
   readable but actually discriminates).
3. Adds the same `git fetch origin main` / `git reset --hard origin/main` self-sync
   block that `graph-prune-narrators.yml` / `graph-flag-over-merged.yml` already use,
   to the top of the `verify` job's SSH script.

## Proof the new test can actually fail (not just pass)

Pushed in two commits on this branch so CI itself is the real-engine proof (no Docker
available to me locally):

- **Commit 1** (this PR's initial push) — the `self_test()` extension ONLY, with the
  two histogram Cypher constants left at their ORIGINAL broken text. This is
  deliberate: the `self-test` job triggered by opening this PR is expected to go RED
  on the new Case 1b/2b histogram checks, with the same
  "Aggregation column contains implicit grouping expressions ... Illegal
  expression(s): l" failure the real host hit. Log will be linked in a follow-up
  comment.
- **Commit 2** (pushed once the RED run is captured) — the `WITH`-clause fix. The
  `self-test` job re-run is expected to go GREEN on the same cases. Log will be
  linked in a follow-up comment.

## Verification

- `bash -n scripts/restore_verify.sh` clean
- `shellcheck scripts/restore_verify.sh` clean
- `actionlint .github/workflows/restore-verify.yml` clean
- Full `scripts/tests` suite: 596 passed, 3 skipped (run both directly and via the
  `pytest-scripts` pre-push hook) — unaffected by either change, confirming the
  existing string-mock tests were never the thing that could have caught #684.

Not touching prod, not self-merging. Requesting review from Lucas Ferreira and
Nurul Hakim (Nurul owns `restore_verify.sh`).
