### PR TITLE
feat(backup/restore-verify): user-postgres content manifest (deploy#687)

### DIFF
--- a/.github/workflows/restore-verify.yml
+++ b/.github/workflows/restore-verify.yml
@@ -52,6 +52,10 @@ on:
     paths:
       - "scripts/restore_verify.sh"
       - "scripts/restore.sh"
+      # deploy#687: the count+md5 constants restore_verify.sh's comparator now runs are
+      # defined here, shared with backup.sh — a change to this file alone must still run
+      # the self-test, not only a change to restore_verify.sh itself.
+      - "scripts/user_pg_content_queries.sh"
       - "scripts/tests/test_restore_verify.py"
       - "compose/docker-compose.restore-verify.yml"
       - ".github/workflows/restore-verify.yml"

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -632,8 +632,11 @@ generate_content_manifest() {
         # THE ASSIGNMENT (feedback_errexit_kills_assignment_guard, deploy#563/#584/#591) — the
         # rc check below would be dead code on every failing path.
         rc=0
+        # `-q`: each UPG_CONTENT_<TABLE> query is "SET timezone='UTC'; SELECT ..." — without
+        # -q, psql prints the SET statement's own command tag ahead of the reading, corrupting
+        # the count/md5 split below (found in CI: restore_verify.sh's self-test surfaced it).
         reading="$(docker exec "$CONTENT_MANIFEST_CONTAINER" \
-            psql -U "$USER_POSTGRES_USER" -d "$USER_POSTGRES_DB" -tAc "$query" 2>>"$LOG_FILE")" || rc=$?
+            psql -q -U "$USER_POSTGRES_USER" -d "$USER_POSTGRES_DB" -tAc "$query" 2>>"$LOG_FILE")" || rc=$?
         if [[ "$rc" -ne 0 || -z "$reading" ]]; then
             log "ERROR" "Content manifest: query for table '${table}' failed or returned an empty reading (rc=${rc})"
             return 1

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -346,6 +346,17 @@ cleanup() {
     # per-run subdirectory, not the root above it. Runs FIRST, before the log lines below,
     # because it must not depend on anything this function does afterwards.
     scratch_cleanup_all
+
+    # Sweep the content-manifest scratch container (deploy#687), same reasoning as
+    # scratch_cleanup_all above: the EXIT trap runs on SIGTERM even though a `trap … RETURN`
+    # at the allocation site would not, so this is the only place a killed run's container is
+    # guaranteed to be removed. Tagged with THIS shell's PID ($$, stable across the
+    # generate_content_manifest() call — not $BASHPID), so a concurrent run's own container is
+    # untouchable. `docker rm -f` on a name that never existed, or was already removed, is a
+    # harmless no-op — this line does not depend on CONTENT_MANIFEST_OK or on how far
+    # generate_content_manifest() got before failing.
+    docker rm -f "content-manifest-$$" >/dev/null 2>&1 || true
+
     # Order matters: emit our last log lines BEFORE rm-ing the directory the
     # log file lives in, otherwise tee fails silently with "No such file or
     # directory" and we lose the cleanup confirmation.
@@ -460,6 +471,16 @@ PG_OK=false
 USER_PG_OK=false
 NEO4J_OK=false
 
+# Did the content manifest generate? (deploy#687)
+#
+# Deliberately separate from USER_PG_OK, same shape as RETENTION_OK vs the three dump _OK
+# flags: the ARTIFACT (the dump) and the MANIFEST (a restore-derived attestation of what is
+# IN it) are different facts, and a failure to compute the second must never take down the
+# first. A scratch-container hiccup generating the manifest is not a reason to discard a
+# perfectly good user-postgres dump — "a partial backup beats none" applies here too, one
+# level down: a backup with no content manifest still beats no backup at all.
+CONTENT_MANIFEST_OK=false
+
 # Did THIS RUN leave the graph down? (deploy#617 review — Aisha Idrissi)
 #
 # Deliberately SEPARATE from NEO4J_OK, and the distinction is the whole point:
@@ -518,6 +539,127 @@ dump_postgres() {
     return 0
 }
 
+# ---------------------------------------------------------------------------
+# user-postgres content manifest (deploy#687)
+# ---------------------------------------------------------------------------
+# WHY THIS EXISTS: restore_verify.sh's user-postgres comparators were restored-vs-LIVE,
+# and live legitimately drifts between dump-time and verify-time (a login updates
+# last_login_at, a session is created) — so a perfectly good backup reported MISMATCH,
+# every night, forever. The fix is to compare the restored artifact against an attestation
+# of what THAT ARTIFACT actually contained, not against live's current state.
+#
+# WHY RESTORE-DERIVED, NOT A SECOND LIVE READ: the manifest must be computed from the
+# LITERAL BYTES that went into the dump file, not from a second query against live taken at
+# "approximately the same instant" — the latter is a timing race by construction, the former
+# is not a race at all. So: restore the just-produced dump into a throwaway, disposable
+# postgres:16-alpine container (same bare `docker run --rm` idiom this file already uses for
+# the Neo4j leg's `neo4j-admin`), and query THAT restored copy. See Weronika Zielinska's
+# design note on deploy#687 (owner-approved mechanism, ruling 1) for the full comparison
+# against a held-open `pg_export_snapshot()` coprocess, which this repo's own incident
+# history (command-substitution-eats-your-return-channel, errexit-kills-the-assignment-guard)
+# is the reason NOT to build.
+#
+# The container name is tagged with THIS shell's PID ($$), the same convention scratch.sh
+# uses for its own allocations, so cleanup() can remove it unconditionally and a concurrent
+# run's container is never touched.
+CONTENT_MANIFEST_CONTAINER="content-manifest-$$"
+
+# generate_content_manifest <dump-file> — restores <dump-file> into a throwaway container,
+# queries it, and writes CONTENT_MANIFEST_FILE. Returns 0 on success. On ANY failure it logs
+# the diagnostic and returns 1 WITHOUT writing a manifest file — absence, not a torn file, is
+# the failure mode restore_verify.sh's manifest-fetch is built to recognise (deploy#687 design
+# §2). It must never fail the backup RUN: the raw dump this restores from has already
+# succeeded and is still good, so every call site treats this as best-effort.
+generate_content_manifest() {
+    local dump_file="$1"
+
+    log "INFO" "Generating user-postgres content manifest (restore-derived, deploy#687)..."
+
+    # A previous run's container of the same name (a prior crash mid-generation) must not
+    # make `docker run --name` fail with "name already in use".
+    docker rm -f "$CONTENT_MANIFEST_CONTAINER" >/dev/null 2>&1 || true
+
+    if ! docker run -d --rm --name "$CONTENT_MANIFEST_CONTAINER" \
+        -e POSTGRES_USER="$USER_POSTGRES_USER" \
+        -e POSTGRES_DB="$USER_POSTGRES_DB" \
+        -e POSTGRES_PASSWORD=content_manifest_scratch_only \
+        -v "${dump_file}:/tmp/user-pg.dump:ro" \
+        postgres:16-alpine >>"$LOG_FILE" 2>&1; then
+        log "ERROR" "Content manifest: could not start the scratch postgres container"
+        return 1
+    fi
+
+    local waited=0
+    until docker exec "$CONTENT_MANIFEST_CONTAINER" \
+        pg_isready -U "$USER_POSTGRES_USER" -d "$USER_POSTGRES_DB" >/dev/null 2>&1; do
+        if [[ "$waited" -ge 60 ]]; then
+            log "ERROR" "Content manifest: scratch postgres did not become ready within 60s"
+            return 1
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+
+    # The container's own bootstrap superuser is named identically to the LIVE role
+    # (POSTGRES_USER=$USER_POSTGRES_USER), so the dump's `ALTER ... OWNER TO` statements
+    # resolve against a role that actually exists here — a plain restore, no --no-owner
+    # needed, into a database nothing else can reach or has ever written to.
+    if ! docker exec "$CONTENT_MANIFEST_CONTAINER" \
+        pg_restore -U "$USER_POSTGRES_USER" -d "$USER_POSTGRES_DB" \
+        /tmp/user-pg.dump >>"$LOG_FILE" 2>&1; then
+        log "ERROR" "Content manifest: pg_restore into the scratch container failed"
+        return 1
+    fi
+
+    local queries_lib
+    queries_lib="$(dirname "${BASH_SOURCE[0]}")/user_pg_content_queries.sh"
+    if [[ ! -f "$queries_lib" ]]; then
+        log "ERROR" "Content manifest: missing ${queries_lib} — cannot query the restored copy"
+        return 1
+    fi
+    # shellcheck source=scripts/user_pg_content_queries.sh
+    source "$queries_lib"
+
+    local table query reading rc line count md5 lines=""
+    for table in "${UPG_CONTENT_TABLES[@]}"; do
+        query="$(upg_content_query_for "$table")" || {
+            log "ERROR" "Content manifest: no shared query for table '${table}' — cannot continue"
+            return 1
+        }
+
+        # `|| rc=$?`, never a bare assignment: under `set -euo pipefail` an assignment whose
+        # command substitution exits non-zero IS a failing simple command and errexit fires AT
+        # THE ASSIGNMENT (feedback_errexit_kills_assignment_guard, deploy#563/#584/#591) — the
+        # rc check below would be dead code on every failing path.
+        rc=0
+        reading="$(docker exec "$CONTENT_MANIFEST_CONTAINER" \
+            psql -U "$USER_POSTGRES_USER" -d "$USER_POSTGRES_DB" -tAc "$query" 2>>"$LOG_FILE")" || rc=$?
+        if [[ "$rc" -ne 0 || -z "$reading" ]]; then
+            log "ERROR" "Content manifest: query for table '${table}' failed or returned an empty reading (rc=${rc})"
+            return 1
+        fi
+
+        # "<count>|<md5-or-EMPTY>" — split on the FIRST '|'. string_agg's own separator is
+        # also '|', but it is never visible here: this column is always a 32-hex md5 digest
+        # or the literal EMPTY, never the joined row text.
+        count="${reading%%|*}"
+        md5="${reading#*|}"
+        if [[ -z "$count" || -z "$md5" ]]; then
+            log "ERROR" "Content manifest: could not parse '${reading}' for table '${table}' as count|md5"
+            return 1
+        fi
+
+        line="$(printf 'CONTENT_MANIFEST table=%s count=%s md5=%s' "$table" "$count" "$md5")"
+        lines="${lines}${line}"$'\n'
+        log "INFO" "  ${line}"
+    done
+
+    printf '%s' "$lines" > "$CONTENT_MANIFEST_FILE"
+    sha256sum "$CONTENT_MANIFEST_FILE" | sed "s|${LOCAL_BACKUP_PATH}/||" > "${CONTENT_MANIFEST_FILE}.sha256"
+    log "INFO" "Content manifest written: $(basename "$CONTENT_MANIFEST_FILE")"
+    return 0
+}
+
 PG_DUMP_FILE="${LOCAL_BACKUP_PATH}/isnad-pg-${TIMESTAMP}.dump"
 if dump_postgres postgres "$POSTGRES_USER" "$POSTGRES_DB" "$PG_DUMP_FILE" "PostgreSQL (isnad)"; then
     PG_OK=true
@@ -531,6 +673,27 @@ USER_PG_DUMP_FILE="${LOCAL_BACKUP_PATH}/isnad-userpg-${TIMESTAMP}.dump"
 if dump_postgres user-postgres "$USER_POSTGRES_USER" "$USER_POSTGRES_DB" \
     "$USER_PG_DUMP_FILE" "PostgreSQL (user-service)"; then
     USER_PG_OK=true
+fi
+
+# The content manifest attests to what THIS run's user-postgres dump actually contains, so
+# restore_verify.sh can compare a later restore against it instead of against live (which
+# legitimately drifts between dump-time and verify-time — deploy#687). Only attempted when
+# there is a dump to attest to; on any failure the raw dump is untouched and still good, so
+# this never fails the backup run (see generate_content_manifest's own contract above).
+if $USER_PG_OK; then
+    CONTENT_MANIFEST_FILE="${LOCAL_BACKUP_PATH}/_content_manifest-${TIMESTAMP}.txt"
+    if generate_content_manifest "$USER_PG_DUMP_FILE"; then
+        CONTENT_MANIFEST_OK=true
+    else
+        log "ERROR" "Content manifest generation FAILED — the user-postgres dump is still good"
+        log "ERROR" "  and uploaded, but the restore-verify content check will not be able to"
+        log "ERROR" "  compare a future restore of THIS run against its content (rc=2 there,"
+        log "ERROR" "  not a backup fault)."
+    fi
+    # Always remove the scratch container promptly on the normal path; cleanup()'s EXIT trap
+    # is the backstop for a run that dies mid-generation (deploy#629's reasoning, one object
+    # class over — a container instead of a scratch file).
+    docker rm -f "$CONTENT_MANIFEST_CONTAINER" >/dev/null 2>&1 || true
 fi
 
 # ---------------------------------------------------------------------------
@@ -992,6 +1155,7 @@ log "INFO" "=== Backup summary ==="
 log "INFO" "PostgreSQL (isnad):        $(if $PG_OK; then echo "OK"; else echo "FAILED"; fi)"
 log "INFO" "PostgreSQL (user-service): $(if $USER_PG_OK; then echo "OK"; else echo "FAILED"; fi)"
 log "INFO" "Neo4j:                     $(if $NEO4J_OK; then echo "OK"; else echo "FAILED"; fi)"
+log "INFO" "Content manifest:          $(if $CONTENT_MANIFEST_OK; then echo "OK"; else echo "FAILED (backup artifact unaffected)"; fi)"
 log "INFO" "Retention:                 $(if $RETENTION_OK; then echo "OK"; else echo "FAILED"; fi)"
 log "INFO" "Category:   ${BACKUP_CATEGORY}"
 log "INFO" "Remote:     ${RCLONE_REMOTE}:${B2_BUCKET}/${REMOTE_SUBDIR}/"

--- a/scripts/restore_verify.sh
+++ b/scripts/restore_verify.sh
@@ -1331,6 +1331,11 @@ self_test() {
     CREATE TABLE sessions (id serial PRIMARY KEY, user_id int NOT NULL, created_at timestamptz NOT NULL DEFAULT now());
     CREATE TABLE audit_log (id serial PRIMARY KEY, user_id int, action text NOT NULL, created_at timestamptz NOT NULL DEFAULT now());
     CREATE TABLE alembic_version (version_num varchar(32) PRIMARY KEY);
+    -- The real user_pg schema has MORE tables than the five this manifest attests to
+    -- (user_roles, subscriptions, totp_secrets, verification_tokens, ... — see
+    -- docs/DATASTORES.md). user_roles here mirrors that: the table-set check must
+    -- tolerate a table it has never heard of, not just the five it knows by name.
+    CREATE TABLE user_roles (id serial PRIMARY KEY, name text NOT NULL);
     INSERT INTO users (id, email, last_login_at, updated_at) VALUES
         (1, 'narrator1@example.test', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
         (2, 'narrator2@example.test', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
@@ -1344,10 +1349,12 @@ self_test() {
         (1, 1, 'login', '2026-01-01T00:00:00Z'),
         (2, 2, 'login', '2026-01-01T00:00:00Z');
     INSERT INTO alembic_version (version_num) VALUES ('abc123');
+    INSERT INTO user_roles (id, name) VALUES (1, 'admin');
     SELECT setval('users_id_seq', 2);
     SELECT setval('oauth_accounts_id_seq', 2);
     SELECT setval('sessions_id_seq', 2);
     SELECT setval('audit_log_id_seq', 2);
+    SELECT setval('user_roles_id_seq', 1);
     "
     for p in "$ST_REF_PROJECT" "$RV_PROJECT"; do
         printf '%s\n' "$upg_seed" | _st_dc "$p" exec -T user-postgres \
@@ -1576,6 +1583,25 @@ self_test() {
         fail "self-test MISMATCH: deleting a row from the restored side was NOT caught — the"
         log "ERROR" "        comparator cannot see real loss on the restored side. It must not be"
         log "ERROR" "        used to certify a restore."
+        rc=1
+    fi
+
+    # --- Case 6: table-set check must tolerate a table it does not know about (Weronika review) --
+    # RED-FIRST PROOF (deploy#687): the real user_pg schema has more tables than the five
+    # this manifest attests to — user_roles, seeded above, stands in for that. This case is
+    # DELIBERATELY written with the CURRENT (strict-equality) table-set comparison compare()
+    # uses today, to prove that comparison breaks the moment an extra, non-manifest table
+    # exists — which it always will in production. The very next commit fixes compare() to a
+    # presence check and updates this case to match; only then does it pass.
+    local expected_tables actual_tables
+    expected_tables="$(printf '%s\n' "${UPG_CONTENT_TABLES[@]}" | sort | paste -sd, -)"
+    actual_tables="$(_st_upg "$RV_PROJECT" "SET timezone='UTC'; SELECT string_agg(table_name, ',' ORDER BY table_name) FROM information_schema.tables WHERE table_schema='public';")"
+    if [[ "$expected_tables" == "$actual_tables" ]]; then
+        pass "self-test table-set: matches despite an EXTRA (non-manifest) table present"
+    else
+        fail "self-test table-set: strict equality BROKE on an extra table — expected='${expected_tables}' actual='${actual_tables}'"
+        log "ERROR" "        this is exactly what happens on every REAL restore: the real user_pg"
+        log "ERROR" "        schema always has more tables than the five this manifest attests to"
         rc=1
     fi
 

--- a/scripts/restore_verify.sh
+++ b/scripts/restore_verify.sh
@@ -268,11 +268,20 @@ pg_val() {
 }
 
 # upg_val <live|rv> <sql>  — the user-service store
+#
+# `-q`: the UPG_CONTENT_* queries (deploy#687) are "SET timezone='UTC'; SELECT ..." — a
+# non-SELECT statement ahead of the reading. `-t` (tuples-only) suppresses column headers and
+# the row-count footer for SELECT output; it does NOT suppress the `SET` COMMAND TAG psql
+# prints for the SET statement itself. Without `-q`, MEASURED comes back as "SET\n<row>" —
+# the leading "SET" survives into `${reading%%|*}` (there's no `|` in "SET", so the split
+# lands one line later than intended) and corrupts every count/table-set reading that uses
+# this shape, while md5-only extractions (`${reading#*|}`) happen to still be correct because
+# the LAST `|` in the string is unaffected. Caught by CI's self-test printing the raw value.
 upg_val() {
     local which="$1" sql="$2"
     _run_capture "psql-user(${which})" \
         _dc "$which" exec -T user-postgres \
-        psql -U "$USER_POSTGRES_USER" -d "$USER_POSTGRES_DB" -tAc "$sql" || return $?
+        psql -q -U "$USER_POSTGRES_USER" -d "$USER_POSTGRES_DB" -tAc "$sql" || return $?
 }
 
 # =============================================================================
@@ -1203,8 +1212,10 @@ self_test() {
     # the shell must keep unexpanded.
     _st_upg() {
         local p="$1" q="$2"
+        # `-q`: suppresses the `SET` command tag the UPG_CONTENT_*/MINUS1 queries' leading
+        # `SET timezone='UTC';` would otherwise print ahead of the actual reading — see upg_val().
         _st_dc "$p" exec -T user-postgres \
-            psql -U "$USER_POSTGRES_USER" -d "$USER_POSTGRES_DB" -v ON_ERROR_STOP=1 -tAc "$q"
+            psql -q -U "$USER_POSTGRES_USER" -d "$USER_POSTGRES_DB" -v ON_ERROR_STOP=1 -tAc "$q"
     }
 
     _st_cleanup() {
@@ -1460,19 +1471,16 @@ self_test() {
         "INSERT INTO sessions (id, user_id, created_at) VALUES (2, 2, now());
          UPDATE users SET last_login_at = now(), updated_at = now() WHERE id = 1;" >/dev/null
 
-    local drift_ok=true rv_reading rv_count rv_md5 ref_reread
+    local drift_ok=true rv_reading rv_count rv_md5
     for st_table in "${UPG_CONTENT_TABLES[@]}"; do
         rv_reading="$(_st_upg "$RV_PROJECT" "$(upg_content_query_for "$st_table")")"
         rv_count="${rv_reading%%|*}"
         rv_md5="${rv_reading#*|}"
-        # XXX(deploy#687 red-proof, commit 1/2): comparing against a FRESH read of REF —
-        # exactly the pre-#687 bug — instead of the CAPTURED manifest. This is deliberately
-        # wrong and is fixed in the very next commit; it exists so CI's self-test job proves
-        # this leg can actually fail before the fix commit proves it passes.
-        ref_reread="$(_st_upg "$ST_REF_PROJECT" "$(upg_content_query_for "$st_table")")"
-        if [[ -z "$rv_reading" || -z "$ref_reread" || "$rv_reading" != "$ref_reread" ]]; then
+        if [[ -z "$rv_count" || -z "$rv_md5" \
+            || "$rv_count" != "${CAPTURED_COUNT[$st_table]}" \
+            || "$rv_md5" != "${CAPTURED_MD5[$st_table]}" ]]; then
             drift_ok=false
-            log "ERROR" "  benign-drift MATCH failed for ${st_table}: ref(fresh)=${ref_reread} restored=${rv_reading}"
+            log "ERROR" "  benign-drift MATCH failed for ${st_table}: captured=${CAPTURED_COUNT[$st_table]}|${CAPTURED_MD5[$st_table]} restored=${rv_count}|${rv_md5}"
         fi
     done
     if [[ "$drift_ok" == "true" ]]; then

--- a/scripts/restore_verify.sh
+++ b/scripts/restore_verify.sh
@@ -817,12 +817,40 @@ calibrate() {
     #     user-postgres comparators compare() now runs (users, oauth_accounts, sessions,
     #     audit_log) had no equivalent proof. `alembic_version` deliberately has no MINUS1 leg
     #     — see scripts/user_pg_content_queries.sh's header for why.
-    local upg_table upg_full upg_full_md5 upg_minus1 minus1_query
+    #
+    # ZERO ROWS LIVE IS NOT AN INSTRUMENT FAILURE — IT IS A FACT ABOUT A LOW-ACTIVITY
+    # ENVIRONMENT, AND THIS CALIBRATION MUST NOT REFUSE TO RUN OVER IT. (team-lead review)
+    #
+    # A 0-row table cannot be MINUS1-calibrated here: EMPTY vs EMPTY compare equal, and that is
+    # not this comparator being blind — there is nothing to remove. `audit_log` is legitimately
+    # 0 on stg today, and any user-pg table can be empty on a freshly-provisioned environment.
+    # The first cut of this calibration made that case `instrument_fail` (rc=2), which means
+    # restore_verify.sh would refuse to certify ANY restore on a quiet environment — a strictly
+    # worse operational property than the false-negative this whole design exists to fix.
+    #
+    # So the red-ability proof for a possibly-empty table does not belong here at all: it
+    # belongs in self_test(), on SEEDED data this calibration does not control the row count
+    # of. self_test() seeds every one of these four tables with >=2 rows and asserts each MINUS1
+    # leg differs there — that is where "can this comparator see a missing row" is actually
+    # proven, once, deterministically, against a real engine. This live check is a BONUS: when
+    # the table happens to be populated, prove it here too; when it is not, log why and move on.
+    local upg_table upg_full upg_full_count upg_full_md5 upg_minus1 minus1_query
     for upg_table in users oauth_accounts sessions audit_log; do
         upg_val "$REF" "$(upg_content_query_for "$upg_table")" ||
             instrument_fail "cannot compute the reference ${upg_table} content"
         upg_full="$MEASURED"
+        upg_full_count="${upg_full%%|*}"
         upg_full_md5="${upg_full#*|}"
+
+        if [[ "$upg_full_count" == "0" ]]; then
+            log "INFO" "  ${upg_table}: 0 rows on the reference stack right now — live MINUS1"
+            log "INFO" "    calibration is not possible (EMPTY vs EMPTY compare equal, and there"
+            log "INFO" "    is nothing to remove). This comparator's red-ability is already"
+            log "INFO" "    proven in self_test() on seeded data; THIS run relies on the count"
+            log "INFO" "    comparison, the table-set check, and the manifest's md5=EMPTY match."
+            pass "calibration: ${upg_table} MINUS1 skipped (0 rows live) — proven separately in self-test"
+            continue
+        fi
 
         case "$upg_table" in
             users) minus1_query="$UPG_USERS_MD5_MINUS1" ;;
@@ -838,10 +866,9 @@ calibrate() {
         log "INFO" "  ${upg_table} md5 minus 1 row: ${upg_minus1}"
         if [[ "$upg_full_md5" == "$upg_minus1" ]]; then
             instrument_fail "the ${upg_table} checksum CANNOT SEE A MISSING ROW. It is inert.
-            REFUSING TO TESTIFY. (If ${upg_table} genuinely holds 0 or 1 rows on the reference
-            stack right now, 'minus one row' degenerates to the same EMPTY reading as the full
-            set — that is not a false alarm, it is this calibration correctly refusing to trust
-            a comparator it cannot prove can see a loss on this table today.)"
+            REFUSING TO TESTIFY. (${upg_table} holds ${upg_full_count} row(s) on the reference
+            stack right now, so this is NOT the 0-row degenerate case above — the comparator
+            genuinely cannot detect a loss on populated data.)"
         fi
         pass "calibration: the ${upg_table} checksum DIFFERS when one row is removed — it can go red"
     done
@@ -1307,14 +1334,19 @@ self_test() {
     INSERT INTO users (id, email, last_login_at, updated_at) VALUES
         (1, 'narrator1@example.test', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
         (2, 'narrator2@example.test', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
-    INSERT INTO oauth_accounts (id, user_id, provider) VALUES (1, 1, 'google');
-    INSERT INTO sessions (id, user_id, created_at) VALUES (1, 1, '2026-01-01T00:00:00Z');
+    INSERT INTO oauth_accounts (id, user_id, provider) VALUES
+        (1, 1, 'google'),
+        (2, 2, 'github');
+    INSERT INTO sessions (id, user_id, created_at) VALUES
+        (1, 1, '2026-01-01T00:00:00Z'),
+        (2, 2, '2026-01-01T00:00:00Z');
     INSERT INTO audit_log (id, user_id, action, created_at) VALUES
         (1, 1, 'login', '2026-01-01T00:00:00Z'),
         (2, 2, 'login', '2026-01-01T00:00:00Z');
     INSERT INTO alembic_version (version_num) VALUES ('abc123');
     SELECT setval('users_id_seq', 2);
-    SELECT setval('sessions_id_seq', 1);
+    SELECT setval('oauth_accounts_id_seq', 2);
+    SELECT setval('sessions_id_seq', 2);
     SELECT setval('audit_log_id_seq', 2);
     "
     for p in "$ST_REF_PROJECT" "$RV_PROJECT"; do
@@ -1334,6 +1366,33 @@ self_test() {
         CAPTURED_MD5["$st_table"]="${st_reading#*|}"
     done
     log "INFO" "self-test: captured baseline manifest from ${ST_REF_PROJECT} (pre-mutation)"
+
+    # --- Per-table MINUS1 red-ability, on SEEDED data (team-lead review) --------------------
+    # calibrate()'s live MINUS1 check cannot prove red-ability on a table that happens to be
+    # empty at verify time (EMPTY vs EMPTY compare equal — there is nothing to remove), and
+    # `audit_log` is legitimately 0 on stg today. So THIS is where "can each user-pg comparator
+    # actually see a missing row" gets proven: deterministically, against a real engine, on
+    # data this self-test controls the row count of (every one of the four tables was just
+    # seeded with >=2 rows, specifically so this is never a degenerate case). calibrate()'s
+    # live check becomes a bonus proof when the live table happens to be populated; this is
+    # the one that is never skipped.
+    local minus1_table minus1_query minus1_full minus1_reduced
+    for minus1_table in users oauth_accounts sessions audit_log; do
+        case "$minus1_table" in
+            users) minus1_query="$UPG_USERS_MD5_MINUS1" ;;
+            oauth_accounts) minus1_query="$UPG_OAUTH_ACCOUNTS_MD5_MINUS1" ;;
+            sessions) minus1_query="$UPG_SESSIONS_MD5_MINUS1" ;;
+            audit_log) minus1_query="$UPG_AUDIT_LOG_MD5_MINUS1" ;;
+        esac
+        minus1_full="${CAPTURED_MD5[$minus1_table]}"
+        minus1_reduced="$(_st_upg "$ST_REF_PROJECT" "$minus1_query")"
+        if [[ -n "$minus1_full" && -n "$minus1_reduced" && "$minus1_full" != "$minus1_reduced" ]]; then
+            pass "self-test calibration: ${minus1_table} md5 DIFFERS when one (seeded) row is removed — it can go red"
+        else
+            fail "self-test calibration: ${minus1_table} md5 CANNOT SEE a missing row on seeded data (full=${minus1_full:-<empty>} minus1=${minus1_reduced:-<empty>})"
+            rc=1
+        fi
+    done
 
     local ref_fp sub_fp ref_parts
     ref_fp="$(_st_cypher "$ST_REF_PROJECT" "$CY_FP")"
@@ -1468,7 +1527,7 @@ self_test() {
     # Comparing RV against a FRESH read of REF here would recreate the exact false-negative
     # this design fixes, and this case is what would catch that regression.
     _st_upg "$ST_REF_PROJECT" \
-        "INSERT INTO sessions (id, user_id, created_at) VALUES (2, 2, now());
+        "INSERT INTO sessions (id, user_id, created_at) VALUES (3, 2, now());
          UPDATE users SET last_login_at = now(), updated_at = now() WHERE id = 1;" >/dev/null
 
     local drift_ok=true rv_reading rv_count rv_md5

--- a/scripts/restore_verify.sh
+++ b/scripts/restore_verify.sh
@@ -1001,6 +1001,17 @@ run_restore() {
 declare -gA CM_COUNT=()
 declare -gA CM_MD5=()
 
+# Pre-declared as empty (Weronika review, PR#688): run_restore() assigns these only
+# CONDITIONALLY, inside `if [[ -n "$backup_path_line" ]]`. restore.sh has a real, supported
+# path (its heuristic newest-run fallback when no completeness manifest exists — restore.sh's
+# `elif` branch) that never prints the "Resolved 'latest' to:" / "Manifest attests run" lines,
+# so without this pre-declaration `set -u` turns fetch_content_manifest()'s bare read into an
+# "unbound variable" crash BEFORE its own instrument_fail diagnostic (the one written for
+# exactly that missing-log case) can fire. Same class as self_test()'s ST_REF_PROJECT
+# not-`local` fix (deploy#677). Empty string, so the instrument_fail guard below still trips.
+declare -g CONTENT_MANIFEST_BACKUP_PATH=""
+declare -g CONTENT_MANIFEST_RUN_TS=""
+
 # fetch_content_manifest — pull the B2 object that ATTESTS what the run restore_restore()
 # just restored actually contained, and populate CM_COUNT / CM_MD5.
 #
@@ -1024,18 +1035,38 @@ fetch_content_manifest() {
         run-ts='${CONTENT_MANIFEST_RUN_TS:-<empty>}')"
     fi
 
-    export RCLONE_CONFIG_ISNAD_TYPE="b2"
-    export RCLONE_CONFIG_ISNAD_ACCOUNT="${B2_KEY_ID}"
-    export RCLONE_CONFIG_ISNAD_KEY="${B2_APP_KEY}"
-
-    local remote_path manifest_text rc=0
+    local remote_path local_path manifest_text manifest_source rc=0
+    local_path="${RESTORE_STAGING_DIR}/_content_manifest-${CONTENT_MANIFEST_RUN_TS}.txt"
     remote_path="isnad:${B2_BUCKET}/${BACKUP_PREFIX}/${CONTENT_MANIFEST_BACKUP_PATH}/_content_manifest-${CONTENT_MANIFEST_RUN_TS}.txt"
 
-    # `|| rc=$?`, never a bare assignment — see the header's rules on errexit and assignments.
-    manifest_text="$(rclone cat "$remote_path" 2>&1)" || rc=$?
+    # PREFER the local, already-checksum-verified copy (Lucas review, PR#688). restore.sh —
+    # invoked by run_restore() just above — does an unfiltered `rclone copy` of the ENTIRE
+    # backup-path directory into $RESTORE_STAGING_DIR, which includes _content_manifest-<TS>.txt
+    # and its .sha256 sidecar, and then verify_checksums() globs EVERY *.sha256 in that dir and
+    # verifies it. So by the time we reach here the manifest is already on local disk AND
+    # cryptographically verified, and teardown (which rm -rf's the staging dir) has not run yet.
+    # Reading it locally avoids: a needless second B2 round-trip; a second exposure of
+    # B2_APP_KEY in this process; and — the operative risk — a torn/bit-flipped `rclone cat`
+    # whose corrupted md5 hex would still satisfy the [A-Za-z0-9]+ parse below and silently
+    # substitute a wrong attestation value (a spurious MISMATCH, fail-safe direction, but still
+    # the transient-blip alert-fatigue class this codebase treats as a first-order cost —
+    # deploy#559/#565). Fall back to a direct B2 read ONLY if the local copy is somehow absent,
+    # never the reverse.
+    if [[ -s "$local_path" ]]; then
+        # `|| rc=$?`, never a bare assignment — see the header's rules on errexit and assignments.
+        manifest_text="$(cat "$local_path" 2>&1)" || rc=$?
+        manifest_source="local checksum-verified copy ${local_path}"
+    else
+        export RCLONE_CONFIG_ISNAD_TYPE="b2"
+        export RCLONE_CONFIG_ISNAD_ACCOUNT="${B2_KEY_ID}"
+        export RCLONE_CONFIG_ISNAD_KEY="${B2_APP_KEY}"
+        # `|| rc=$?`, never a bare assignment — see the header's rules on errexit and assignments.
+        manifest_text="$(rclone cat "$remote_path" 2>&1)" || rc=$?
+        manifest_source="B2 fallback ${remote_path} (local copy ${local_path} was absent)"
+    fi
     if [[ "$rc" -ne 0 || -z "$manifest_text" ]]; then
         instrument_fail "content manifest absent for run ${CONTENT_MANIFEST_RUN_TS} — cannot
-        verify user-postgres content. ${remote_path} did not read back (rc=${rc}).
+        verify user-postgres content. Source tried: ${manifest_source} (rc=${rc}).
 
         This is EXPECTED on the very first restore-verify run after deploy#687 merges, before
         any new backup has produced a content manifest — see the design's rollout sequence. It
@@ -1043,7 +1074,7 @@ fetch_content_manifest() {
         user-postgres against LIVE: that fallback is precisely the false-negative this design
         exists to fix (live legitimately drifts between dump-time and verify-time).
 
-        rclone's own words:
+        underlying reader's own words:
         ${manifest_text}"
     fi
 
@@ -1131,15 +1162,31 @@ compare() {
     done
 
     # The table-set check (deploy#687 design §5c / deploy#662): a pg_restore that silently
-    # dropped a table would still MATCH on every table it DID restore — this catches that a
-    # per-table comparison structurally cannot. Compared against UPG_CONTENT_TABLES (the fixed
-    # set the manifest itself declares), not against live: same restored-vs-manifest doctrine
-    # as everything else in this block.
-    local expected_tables
-    expected_tables="$(printf '%s\n' "${UPG_CONTENT_TABLES[@]}" | sort | paste -sd, -)"
-    upg_val rv "SET timezone='UTC'; SELECT string_agg(table_name, ',' ORDER BY table_name) FROM information_schema.tables WHERE table_schema='public';" ||
+    # dropped a table would still MATCH on every table it DID restore — a per-table content
+    # comparison structurally cannot catch a table that is simply GONE. This asserts PRESENCE
+    # (a subset test), NOT set-equality: every table the manifest attests (UPG_CONTENT_TABLES)
+    # must exist in the restored public schema. It deliberately does NOT require the restored
+    # set to contain nothing else — the real user-service schema carries more tables than the
+    # manifest tracks (user_roles, subscriptions, totp_secrets, verification_tokens, … —
+    # docs/DATASTORES.md), so a strict-equality check would MISMATCH on every real restore,
+    # reintroducing the exact false-negative deploy#687 exists to remove (Weronika review,
+    # PR#688). Filtered to BASE TABLE so a restored view/matview can't stand in for a dropped
+    # table. Per-table rows so a drop NAMES the missing table rather than diffing two opaque
+    # comma blobs.
+    local restored_tables upg_table present
+    upg_val rv "SET timezone='UTC'; SELECT string_agg(table_name, ',' ORDER BY table_name) FROM information_schema.tables WHERE table_schema='public' AND table_type='BASE TABLE';" ||
         instrument_fail "cannot read the restored user-postgres table set"
-    row "user-pg table set" "$expected_tables" "$MEASURED" || mismatches=$((mismatches + 1))
+    # Wrap in delimiters so the membership test is exact (',user_roles,' cannot match inside
+    # another name) even though no current table name is a substring of another.
+    restored_tables=",${MEASURED},"
+    for upg_table in "${UPG_CONTENT_TABLES[@]}"; do
+        if [[ "$restored_tables" == *",${upg_table},"* ]]; then
+            present="present"
+        else
+            present="ABSENT"
+        fi
+        row "table present: ${upg_table}" "present" "$present" || mismatches=$((mismatches + 1))
+    done
 
     if [[ "$mismatches" -gt 0 ]]; then
         log "ERROR" "${mismatches} metric(s) MISMATCHED — the restored artifact does NOT reproduce"
@@ -1586,23 +1633,45 @@ self_test() {
         rc=1
     fi
 
-    # --- Case 6: table-set check must tolerate a table it does not know about (Weronika review) --
-    # RED-FIRST PROOF (deploy#687): the real user_pg schema has more tables than the five
-    # this manifest attests to — user_roles, seeded above, stands in for that. This case is
-    # DELIBERATELY written with the CURRENT (strict-equality) table-set comparison compare()
-    # uses today, to prove that comparison breaks the moment an extra, non-manifest table
-    # exists — which it always will in production. The very next commit fixes compare() to a
-    # presence check and updates this case to match; only then does it pass.
-    local expected_tables actual_tables
-    expected_tables="$(printf '%s\n' "${UPG_CONTENT_TABLES[@]}" | sort | paste -sd, -)"
-    actual_tables="$(_st_upg "$RV_PROJECT" "SET timezone='UTC'; SELECT string_agg(table_name, ',' ORDER BY table_name) FROM information_schema.tables WHERE table_schema='public';")"
-    if [[ "$expected_tables" == "$actual_tables" ]]; then
-        pass "self-test table-set: matches despite an EXTRA (non-manifest) table present"
+    # --- Case 6: table-set PRESENCE check — tolerates an unknown table AND catches a dropped one
+    # (Weronika review, PR#688; bidirectional calibration per feedback_drop_gate_bidirectional_ab).
+    # This mirrors compare()'s production table-set logic EXACTLY (subset over UPG_CONTENT_TABLES,
+    # BASE TABLE filter, comma-delimited membership) so the self-test calibrates the real code,
+    # not a parallel reimplementation.
+    #
+    # 6a — TOLERANCE: the real user_pg schema always has MORE tables than the five the manifest
+    # attests to (user_roles, seeded above, stands in for subscriptions/totp_secrets/
+    # verification_tokens/… — docs/DATASTORES.md). The subset check MUST pass despite that extra
+    # table. The strict set-equality this replaced went RED here — proven in the parent commit
+    # (9072350), which is exactly why the fixture seeds user_roles: without a table the manifest
+    # does not know about, neither the bug nor its fix is expressible (main#927).
+    # 6b — RED-ABILITY: tolerance without detection is blindness. Drop a manifest table from the
+    # restored side and require the SAME check to catch it, or "tolerant of extras" degrades to
+    # "blind to drops" — the very failure this check exists to prevent.
+    _st_present_ok() { # _st_present_ok <project> — 0 iff every UPG_CONTENT_TABLES member present
+        local proj="$1" measured wrapped t
+        measured="$(_st_upg "$proj" "SET timezone='UTC'; SELECT string_agg(table_name, ',' ORDER BY table_name) FROM information_schema.tables WHERE table_schema='public' AND table_type='BASE TABLE';")"
+        wrapped=",${measured},"
+        for t in "${UPG_CONTENT_TABLES[@]}"; do
+            [[ "$wrapped" == *",${t},"* ]] || return 1
+        done
+        return 0
+    }
+    if _st_present_ok "$RV_PROJECT"; then
+        pass "self-test table-set: all manifest tables present despite an EXTRA (non-manifest) table"
     else
-        fail "self-test table-set: strict equality BROKE on an extra table — expected='${expected_tables}' actual='${actual_tables}'"
-        log "ERROR" "        this is exactly what happens on every REAL restore: the real user_pg"
-        log "ERROR" "        schema always has more tables than the five this manifest attests to"
+        fail "self-test table-set: subset check FAILED with all manifest tables present plus one extra"
+        log "ERROR" "        the presence check is over-strict — it would red on every real restore"
         rc=1
+    fi
+    # 6b: drop a manifest table on the restored side; the presence check must now go red.
+    _st_upg "$RV_PROJECT" "DROP TABLE audit_log;" >/dev/null
+    if _st_present_ok "$RV_PROJECT"; then
+        fail "self-test table-set: a DROPPED manifest table (audit_log) was NOT caught — the check"
+        log "ERROR" "        is blind, not tolerant; it cannot certify that a restore is complete."
+        rc=1
+    else
+        pass "self-test table-set: DROP of a manifest table (audit_log) correctly caught (red-ability)"
     fi
 
     log "INFO" "=== SELF-TEST: ${PASS_COUNT} passed, ${FAIL_COUNT} failed ==="

--- a/scripts/restore_verify.sh
+++ b/scripts/restore_verify.sh
@@ -142,6 +142,20 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# --- Shared user-postgres content queries (deploy#687) -----------------------
+# The five UPG_CONTENT_<TABLE> count+md5 constants, UPG_CONTENT_TABLES, and the four
+# MINUS1 calibration legs are defined ONCE in scripts/user_pg_content_queries.sh and
+# sourced by BOTH this script and backup.sh, so the SQL that writes the content manifest
+# and the SQL that recomputes it at verify time cannot independently drift. See that
+# file's header for the full reasoning. Sourced here — after argument parsing, before
+# anything else — so both --self-test and the real run get it.
+USER_PG_CONTENT_QUERIES_LIB="${SCRIPT_DIR}/user_pg_content_queries.sh"
+if [[ ! -f "$USER_PG_CONTENT_QUERIES_LIB" ]]; then
+    instrument_fail "missing ${USER_PG_CONTENT_QUERIES_LIB} — cannot query user-postgres content"
+fi
+# shellcheck source=scripts/user_pg_content_queries.sh
+source "$USER_PG_CONTENT_QUERIES_LIB"
+
 # --- Compose plumbing --------------------------------------------------------
 # Every compose call in this file goes through _dc, and every one of them names its
 # PROJECT explicitly. `-f` names the FILE; with no `-p` and no COMPOSE_PROJECT_NAME,
@@ -312,7 +326,13 @@ readonly PG_HADITH_COUNT="SELECT count(*) FROM isnad_graph.hadiths;"
 readonly PG_HADITH_MD5="SELECT md5(string_agg(t,'|' ORDER BY t)) FROM (SELECT h::text AS t FROM isnad_graph.hadiths h) s;"
 readonly PG_HADITH_MD5_MINUS1="SELECT md5(string_agg(t,'|' ORDER BY t)) FROM (SELECT h::text AS t FROM isnad_graph.hadiths h ORDER BY t OFFSET 1) s;"
 
-readonly UPG_USERS_MD5="SELECT md5(string_agg(t,'|' ORDER BY t)) FROM (SELECT u::text AS t FROM users u) s;"
+# The user-postgres count+md5 queries (UPG_CONTENT_*, UPG_CONTENT_TABLES) and their
+# calibration MINUS1 legs are sourced from scripts/user_pg_content_queries.sh — see the
+# "Shared user-postgres content queries" block below main's argument parsing. They replace
+# the single ad hoc UPG_USERS_MD5 this file used to carry: that query compared users
+# restored-vs-LIVE, which is the exact false-negative deploy#687 exists to fix (live
+# legitimately drifts between dump-time and verify-time), and it covered only one of the
+# five user-postgres tables.
 
 # Multi-row readings (histograms) collapse to one line so they compare as scalars.
 cypher_hist() { # cypher_hist <live|rv> <query>
@@ -783,6 +803,40 @@ calibrate() {
     fi
     pass "calibration: the hadiths checksum DIFFERS when one row is removed — it can go red"
 
+    # (4) Same, for EVERY mutable user-postgres table (deploy#687). Before this, calibrate()
+    #     proved only the graph fingerprint and the hadiths checksum could go red — the four
+    #     user-postgres comparators compare() now runs (users, oauth_accounts, sessions,
+    #     audit_log) had no equivalent proof. `alembic_version` deliberately has no MINUS1 leg
+    #     — see scripts/user_pg_content_queries.sh's header for why.
+    local upg_table upg_full upg_full_md5 upg_minus1 minus1_query
+    for upg_table in users oauth_accounts sessions audit_log; do
+        upg_val "$REF" "$(upg_content_query_for "$upg_table")" ||
+            instrument_fail "cannot compute the reference ${upg_table} content"
+        upg_full="$MEASURED"
+        upg_full_md5="${upg_full#*|}"
+
+        case "$upg_table" in
+            users) minus1_query="$UPG_USERS_MD5_MINUS1" ;;
+            oauth_accounts) minus1_query="$UPG_OAUTH_ACCOUNTS_MD5_MINUS1" ;;
+            sessions) minus1_query="$UPG_SESSIONS_MD5_MINUS1" ;;
+            audit_log) minus1_query="$UPG_AUDIT_LOG_MD5_MINUS1" ;;
+        esac
+        upg_val "$REF" "$minus1_query" ||
+            instrument_fail "cannot compute the minus-one ${upg_table} checksum"
+        upg_minus1="$MEASURED"
+
+        log "INFO" "  ${upg_table} md5            : ${upg_full_md5}"
+        log "INFO" "  ${upg_table} md5 minus 1 row: ${upg_minus1}"
+        if [[ "$upg_full_md5" == "$upg_minus1" ]]; then
+            instrument_fail "the ${upg_table} checksum CANNOT SEE A MISSING ROW. It is inert.
+            REFUSING TO TESTIFY. (If ${upg_table} genuinely holds 0 or 1 rows on the reference
+            stack right now, 'minus one row' degenerates to the same EMPTY reading as the full
+            set — that is not a false alarm, it is this calibration correctly refusing to trust
+            a comparator it cannot prove can see a loss on this table today.)"
+        fi
+        pass "calibration: the ${upg_table} checksum DIFFERS when one row is removed — it can go red"
+    done
+
     log "INFO" "=== CALIBRATION PASSED — a MATCH below now means something ==="
 }
 
@@ -829,7 +883,33 @@ run_restore() {
     #                the COMPOSE_PROJECT one. A throwaway run must use the throwaway compose file.
     local rline=""
     rline="$(grep -F 'Resolved Neo4j data volume:' "$out" | tail -1)" || rline=""
+
+    # WHICH RUN'S CONTENT MANIFEST DO WE COMPARE AGAINST? (deploy#687)
+    #
+    # restore.sh already announces exactly this, on two lines, while resolving `latest` and
+    # selecting the manifest-attested dumps for that run:
+    #
+    #     Resolved 'latest' to: <category>/<date>
+    #     Manifest attests run <TIMESTAMP> — selecting that run's dumps
+    #
+    # Read them back from the SAME capture rather than re-deriving BACKUP_PATH/RESTORE_RUN_TS
+    # independently — restore.sh is the only party that actually resolved `latest` and picked
+    # a run, and an independent re-resolution here could disagree with what it chose (the same
+    # discipline this function already applies to the Neo4j volume/project/file handoff below).
+    local backup_path_line="" run_ts_line=""
+    backup_path_line="$(grep -F "Resolved 'latest' to:" "$out" | tail -1)" || backup_path_line=""
+    run_ts_line="$(grep -F 'Manifest attests run' "$out" | tail -1)" || run_ts_line=""
     rm -f "$out"
+
+    if [[ -n "$backup_path_line" ]]; then
+        CONTENT_MANIFEST_BACKUP_PATH="${backup_path_line##*Resolved \'latest\' to: }"
+        CONTENT_MANIFEST_BACKUP_PATH="${CONTENT_MANIFEST_BACKUP_PATH%% *}"
+    fi
+    if [[ -n "$run_ts_line" ]]; then
+        CONTENT_MANIFEST_RUN_TS="${run_ts_line##*Manifest attests run }"
+        CONTENT_MANIFEST_RUN_TS="${CONTENT_MANIFEST_RUN_TS%% *}"
+    fi
+    log "INFO" "restore.sh restored run: backup-path='${CONTENT_MANIFEST_BACKUP_PATH:-<unknown>}' run-ts='${CONTENT_MANIFEST_RUN_TS:-<unknown>}'"
 
     if [[ -z "$rline" ]]; then
         instrument_fail "restore.sh never reported which Neo4j volume it resolved.
@@ -879,6 +959,83 @@ run_restore() {
 }
 
 # =============================================================================
+# Content manifest fetch (deploy#687)
+# =============================================================================
+# populated by fetch_content_manifest(): table -> "count", table -> "md5-or-EMPTY".
+declare -gA CM_COUNT=()
+declare -gA CM_MD5=()
+
+# fetch_content_manifest — pull the B2 object that ATTESTS what the run restore_restore()
+# just restored actually contained, and populate CM_COUNT / CM_MD5.
+#
+# WHY THIS SCRIPT NOW TOUCHES B2 AT ALL: previously restore_verify.sh never read B2 directly
+# — it only shells out to restore.sh, which owns all B2/rclone access. The content manifest
+# is a separate, small object restore.sh does not read, so this is a minimal, LOCAL rclone
+# bootstrap (mirroring restore.sh's own three-line one) rather than a reason to route this
+# through restore.sh — the manifest is verification-only, not a restore input.
+#
+# NEVER FALLS BACK TO LIVE. A missing/unreadable manifest is a THIRD, explicit state — not a
+# false rc=0 pass, not a false rc=1 fail — because restoring the old (pre-deploy#687)
+# restored-vs-live comparison for user-postgres on manifest-less runs would silently
+# reintroduce the exact false-negative this design fixes, with no signal explaining why.
+fetch_content_manifest() {
+    if [[ -z "$CONTENT_MANIFEST_BACKUP_PATH" || -z "$CONTENT_MANIFEST_RUN_TS" ]]; then
+        instrument_fail "could not determine which run's content manifest to fetch — restore.sh
+        never logged its \"Resolved 'latest' to:\" / \"Manifest attests run\" lines (or this
+        script could not read them back). Without both, this script cannot know WHICH object
+        to fetch, and guessing is exactly the independent re-resolution deploy#687's design
+        forbids. (backup-path='${CONTENT_MANIFEST_BACKUP_PATH:-<empty>}'
+        run-ts='${CONTENT_MANIFEST_RUN_TS:-<empty>}')"
+    fi
+
+    export RCLONE_CONFIG_ISNAD_TYPE="b2"
+    export RCLONE_CONFIG_ISNAD_ACCOUNT="${B2_KEY_ID}"
+    export RCLONE_CONFIG_ISNAD_KEY="${B2_APP_KEY}"
+
+    local remote_path manifest_text rc=0
+    remote_path="isnad:${B2_BUCKET}/${BACKUP_PREFIX}/${CONTENT_MANIFEST_BACKUP_PATH}/_content_manifest-${CONTENT_MANIFEST_RUN_TS}.txt"
+
+    # `|| rc=$?`, never a bare assignment — see the header's rules on errexit and assignments.
+    manifest_text="$(rclone cat "$remote_path" 2>&1)" || rc=$?
+    if [[ "$rc" -ne 0 || -z "$manifest_text" ]]; then
+        instrument_fail "content manifest absent for run ${CONTENT_MANIFEST_RUN_TS} — cannot
+        verify user-postgres content. ${remote_path} did not read back (rc=${rc}).
+
+        This is EXPECTED on the very first restore-verify run after deploy#687 merges, before
+        any new backup has produced a content manifest — see the design's rollout sequence. It
+        is NOT a claim that the backup is bad, and this script will NOT fall back to comparing
+        user-postgres against LIVE: that fallback is precisely the false-negative this design
+        exists to fix (live legitimately drifts between dump-time and verify-time).
+
+        rclone's own words:
+        ${manifest_text}"
+    fi
+
+    local line table count md5
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^CONTENT_MANIFEST\ table=([a-z_]+)\ count=([0-9]+)\ md5=([A-Za-z0-9]+)$ ]]; then
+            table="${BASH_REMATCH[1]}"
+            count="${BASH_REMATCH[2]}"
+            md5="${BASH_REMATCH[3]}"
+            CM_COUNT["$table"]="$count"
+            CM_MD5["$table"]="$md5"
+        fi
+    done <<< "$manifest_text"
+
+    local t
+    for t in "${UPG_CONTENT_TABLES[@]}"; do
+        if [[ -z "${CM_MD5[$t]:-}" ]]; then
+            instrument_fail "content manifest for run ${CONTENT_MANIFEST_RUN_TS} has no
+            parseable line for table '${t}'. Either the object is torn, or backup.sh's table
+            set has drifted from this script's UPG_CONTENT_TABLES — refusing to compare
+            against a partial attestation. Raw manifest text follows:
+            ${manifest_text}"
+        fi
+    done
+    pass "content manifest fetched for run ${CONTENT_MANIFEST_RUN_TS}: ${#CM_MD5[@]} table(s) attested"
+}
+
+# =============================================================================
 # The comparison
 # =============================================================================
 row() { # row <label> <reference> <restored>
@@ -916,13 +1073,37 @@ compare() {
     _cmp "pg hadiths"         pg_val      "$PG_HADITH_COUNT"
     _cmp "pg hadiths md5"     pg_val      "$PG_HADITH_MD5"
 
-    # The user-service store is the one nothing else covers (deploy#558-#561).
-    _cmp "users"              upg_val     "SELECT count(*) FROM users;"
-    _cmp "oauth_accounts"     upg_val     "SELECT count(*) FROM oauth_accounts;"
-    _cmp "sessions"           upg_val     "SELECT count(*) FROM sessions;"
-    _cmp "audit_log"          upg_val     "SELECT count(*) FROM audit_log;"
-    _cmp "users md5"          upg_val     "$UPG_USERS_MD5"
-    _cmp "alembic version"    upg_val     "SELECT version_num FROM alembic_version;"
+    # The user-service store (deploy#558-#561) is compared RESTORED-vs-MANIFEST, not
+    # restored-vs-live: live legitimately drifts between dump-time and verify-time (a login,
+    # a new session), and comparing against live's CURRENT state is the proven false-negative
+    # deploy#687 fixes. fetch_content_manifest() has already populated CM_COUNT/CM_MD5 from
+    # the B2 object that attests what THIS run's backup actually contained.
+    _cmp_manifest() { # _cmp_manifest <table>
+        local table="$1" reading count md5
+        upg_val rv "$(upg_content_query_for "$table")" ||
+            instrument_fail "restored reading failed for user-postgres table '${table}'"
+        reading="$MEASURED"
+        count="${reading%%|*}"
+        md5="${reading#*|}"
+        row "${table} count" "${CM_COUNT[$table]}" "$count" || mismatches=$((mismatches + 1))
+        row "${table} md5"   "${CM_MD5[$table]}"   "$md5"   || mismatches=$((mismatches + 1))
+    }
+
+    local upg_table
+    for upg_table in "${UPG_CONTENT_TABLES[@]}"; do
+        _cmp_manifest "$upg_table"
+    done
+
+    # The table-set check (deploy#687 design §5c / deploy#662): a pg_restore that silently
+    # dropped a table would still MATCH on every table it DID restore — this catches that a
+    # per-table comparison structurally cannot. Compared against UPG_CONTENT_TABLES (the fixed
+    # set the manifest itself declares), not against live: same restored-vs-manifest doctrine
+    # as everything else in this block.
+    local expected_tables
+    expected_tables="$(printf '%s\n' "${UPG_CONTENT_TABLES[@]}" | sort | paste -sd, -)"
+    upg_val rv "SET timezone='UTC'; SELECT string_agg(table_name, ',' ORDER BY table_name) FROM information_schema.tables WHERE table_schema='public';" ||
+        instrument_fail "cannot read the restored user-postgres table set"
+    row "user-pg table set" "$expected_tables" "$MEASURED" || mismatches=$((mismatches + 1))
 
     if [[ "$mismatches" -gt 0 ]]; then
         log "ERROR" "${mismatches} metric(s) MISMATCHED — the restored artifact does NOT reproduce"
@@ -1016,6 +1197,15 @@ self_test() {
             'NEO4J_USERNAME=neo4j NEO4J_PASSWORD="${NEO4J_AUTH#neo4j/}" exec cypher-shell --format plain "$1"' \
             _ "$q" | tail -n +2 | tr -d '"\r' | tr '\n' ' '
     }
+    # _st_upg <project> <sql> — the user-postgres equivalent of _st_cypher (deploy#687). No
+    # credential-quoting subtlety here: the scratch compose file's user-postgres password is
+    # a literal (POSTGRES_PASSWORD=restore_verify_scratch_only), not derived from an env var
+    # the shell must keep unexpanded.
+    _st_upg() {
+        local p="$1" q="$2"
+        _st_dc "$p" exec -T user-postgres \
+            psql -U "$USER_POSTGRES_USER" -d "$USER_POSTGRES_DB" -v ON_ERROR_STOP=1 -tAc "$q"
+    }
 
     _st_cleanup() {
         # THE VERDICT. Captured on the first line, before anything here can clobber `$?`,
@@ -1039,25 +1229,30 @@ self_test() {
     for p in "$ST_REF_PROJECT" "$RV_PROJECT"; do
         log "INFO" "self-test: starting ${p}"
         _st_dc "$p" down -v --remove-orphans >/dev/null 2>&1 || true
-        _st_dc "$p" up -d neo4j
+        # user-postgres added for the content-manifest calibration legs (deploy#687) —
+        # neither project needed it before those legs existed.
+        _st_dc "$p" up -d neo4j user-postgres
     done
 
     for p in "$ST_REF_PROJECT" "$RV_PROJECT"; do
-        local waited=0 cid health
-        while :; do
-            # A container that does not exist YET is the normal case on the first pass, so a
-            # failing `ps` here is not an error — but `cid="$(… | head -1)"` under `set -e`
-            # is a CRASH on that path, killing the wait loop before the stack can come up.
-            # start_stack() already guards its identical wait this way and its comment says so;
-            # this is the same fix, the copy that was left behind (deploy#677).
-            cid=""
-            cid="$(_st_dc "$p" ps -q neo4j | head -1)" || cid=""
-            health="none"
-            [[ -n "$cid" ]] && { health="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$cid")" || health="none"; }
-            [[ "$health" == "healthy" ]] && break
-            [[ "$waited" -ge 240 ]] && instrument_fail "self-test: ${p} neo4j never became healthy"
-            sleep 3
-            waited=$((waited + 3))
+        local svc
+        for svc in neo4j user-postgres; do
+            local waited=0 cid health
+            while :; do
+                # A container that does not exist YET is the normal case on the first pass, so a
+                # failing `ps` here is not an error — but `cid="$(… | head -1)"` under `set -e`
+                # is a CRASH on that path, killing the wait loop before the stack can come up.
+                # start_stack() already guards its identical wait this way and its comment says
+                # so; this is the same fix, the copy that was left behind (deploy#677).
+                cid=""
+                cid="$(_st_dc "$p" ps -q "$svc" | head -1)" || cid=""
+                health="none"
+                [[ -n "$cid" ]] && { health="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$cid")" || health="none"; }
+                [[ "$health" == "healthy" ]] && break
+                [[ "$waited" -ge 240 ]] && instrument_fail "self-test: ${p} ${svc} never became healthy"
+                sleep 3
+                waited=$((waited + 3))
+            done
         done
     done
 
@@ -1085,6 +1280,49 @@ self_test() {
         printf '%s\n' "$seed" | _st_dc "$p" exec -T neo4j sh -c \
             'NEO4J_USERNAME=neo4j NEO4J_PASSWORD="${NEO4J_AUTH#neo4j/}" exec cypher-shell' >/dev/null
     done
+
+    # =========================================================================
+    # user-postgres content-manifest calibration (deploy#687)
+    # =========================================================================
+    # A bare postgres:16-alpine has no schema of its own — this creates just enough of one
+    # to exercise every UPG_CONTENT_* query the real comparator runs, seeded IDENTICALLY into
+    # both throwaway stacks (same discipline as the Neo4j seed above).
+    local upg_seed="
+    CREATE TABLE users (id serial PRIMARY KEY, email text NOT NULL, last_login_at timestamptz, updated_at timestamptz);
+    CREATE TABLE oauth_accounts (id serial PRIMARY KEY, user_id int NOT NULL, provider text NOT NULL);
+    CREATE TABLE sessions (id serial PRIMARY KEY, user_id int NOT NULL, created_at timestamptz NOT NULL DEFAULT now());
+    CREATE TABLE audit_log (id serial PRIMARY KEY, user_id int, action text NOT NULL, created_at timestamptz NOT NULL DEFAULT now());
+    CREATE TABLE alembic_version (version_num varchar(32) PRIMARY KEY);
+    INSERT INTO users (id, email, last_login_at, updated_at) VALUES
+        (1, 'narrator1@example.test', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+        (2, 'narrator2@example.test', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+    INSERT INTO oauth_accounts (id, user_id, provider) VALUES (1, 1, 'google');
+    INSERT INTO sessions (id, user_id, created_at) VALUES (1, 1, '2026-01-01T00:00:00Z');
+    INSERT INTO audit_log (id, user_id, action, created_at) VALUES
+        (1, 1, 'login', '2026-01-01T00:00:00Z'),
+        (2, 2, 'login', '2026-01-01T00:00:00Z');
+    INSERT INTO alembic_version (version_num) VALUES ('abc123');
+    SELECT setval('users_id_seq', 2);
+    SELECT setval('sessions_id_seq', 1);
+    SELECT setval('audit_log_id_seq', 2);
+    "
+    for p in "$ST_REF_PROJECT" "$RV_PROJECT"; do
+        printf '%s\n' "$upg_seed" | _st_dc "$p" exec -T user-postgres \
+            psql -U "$USER_POSTGRES_USER" -d "$USER_POSTGRES_DB" -v ON_ERROR_STOP=1 >/dev/null
+    done
+
+    # --- Capture the MANIFEST at seed time, from the REF stack only ----------
+    # This stands in for "the manifest backup.sh wrote from its own restore-derived scratch
+    # container" — computed once, here, before ST_REF_PROJECT is touched again. Everything
+    # that follows compares against THESE captured values, never against a re-read of REF.
+    local st_table st_reading
+    declare -A CAPTURED_COUNT=() CAPTURED_MD5=()
+    for st_table in "${UPG_CONTENT_TABLES[@]}"; do
+        st_reading="$(_st_upg "$ST_REF_PROJECT" "$(upg_content_query_for "$st_table")")"
+        CAPTURED_COUNT["$st_table"]="${st_reading%%|*}"
+        CAPTURED_MD5["$st_table"]="${st_reading#*|}"
+    done
+    log "INFO" "self-test: captured baseline manifest from ${ST_REF_PROJECT} (pre-mutation)"
 
     local ref_fp sub_fp ref_parts
     ref_fp="$(_st_cypher "$ST_REF_PROJECT" "$CY_FP")"
@@ -1210,6 +1448,70 @@ self_test() {
         rc=1
     fi
 
+    # --- Case 4: BENIGN LIVE DRIFT MUST STILL PASS (the actual point of deploy#687) ----------
+    # This is the deliverable. Mutate ST_REF_PROJECT ONLY — reproducing the #687 scenario
+    # exactly: a new session, a login timestamp update — so REF's live content has now moved
+    # AWAY from the manifest captured above. RV_PROJECT (standing in for "the restored
+    # artifact") is left untouched. The comparator must still report MATCH against the
+    # CAPTURED MANIFEST, because that is what deploy#687 changes it to compare against.
+    # Comparing RV against a FRESH read of REF here would recreate the exact false-negative
+    # this design fixes, and this case is what would catch that regression.
+    _st_upg "$ST_REF_PROJECT" \
+        "INSERT INTO sessions (id, user_id, created_at) VALUES (2, 2, now());
+         UPDATE users SET last_login_at = now(), updated_at = now() WHERE id = 1;" >/dev/null
+
+    local drift_ok=true rv_reading rv_count rv_md5 ref_reread
+    for st_table in "${UPG_CONTENT_TABLES[@]}"; do
+        rv_reading="$(_st_upg "$RV_PROJECT" "$(upg_content_query_for "$st_table")")"
+        rv_count="${rv_reading%%|*}"
+        rv_md5="${rv_reading#*|}"
+        # XXX(deploy#687 red-proof, commit 1/2): comparing against a FRESH read of REF —
+        # exactly the pre-#687 bug — instead of the CAPTURED manifest. This is deliberately
+        # wrong and is fixed in the very next commit; it exists so CI's self-test job proves
+        # this leg can actually fail before the fix commit proves it passes.
+        ref_reread="$(_st_upg "$ST_REF_PROJECT" "$(upg_content_query_for "$st_table")")"
+        if [[ -z "$rv_reading" || -z "$ref_reread" || "$rv_reading" != "$ref_reread" ]]; then
+            drift_ok=false
+            log "ERROR" "  benign-drift MATCH failed for ${st_table}: ref(fresh)=${ref_reread} restored=${rv_reading}"
+        fi
+    done
+    if [[ "$drift_ok" == "true" ]]; then
+        pass "self-test MATCH: restored-vs-MANIFEST still agrees after live (REF) drifted post-capture"
+        log "INFO" "        a new session and a login timestamp update on REF did not break the"
+        log "INFO" "        comparison — this is the false-negative deploy#687 exists to fix"
+    else
+        fail "self-test MATCH: restored-vs-manifest comparison broke when only REF drifted — the"
+        log "ERROR" "        comparator is (still) comparing against LIVE, not the manifest"
+        rc=1
+    fi
+
+    # --- Case 5 (mirror of Case 4): REAL LOSS ON THE RESTORED SIDE MUST FAIL -----------------
+    # The other half of the same proof. Mutate RV_PROJECT itself — the side standing in for
+    # "the restored artifact" — and require the SAME comparator to now report MISMATCH against
+    # the SAME captured manifest. Without this leg, Case 4 alone could be satisfied by a
+    # comparator that has simply stopped comparing anything at all.
+    _st_upg "$RV_PROJECT" "DELETE FROM sessions WHERE id = 1;" >/dev/null
+
+    local loss_detected=false
+    for st_table in "${UPG_CONTENT_TABLES[@]}"; do
+        rv_reading="$(_st_upg "$RV_PROJECT" "$(upg_content_query_for "$st_table")")"
+        rv_count="${rv_reading%%|*}"
+        rv_md5="${rv_reading#*|}"
+        if [[ -z "$rv_count" || -z "$rv_md5" \
+            || "$rv_count" != "${CAPTURED_COUNT[$st_table]}" \
+            || "$rv_md5" != "${CAPTURED_MD5[$st_table]}" ]]; then
+            loss_detected=true
+        fi
+    done
+    if [[ "$loss_detected" == "true" ]]; then
+        pass "self-test MISMATCH: deleting a row from the restored side IS caught against the manifest"
+    else
+        fail "self-test MISMATCH: deleting a row from the restored side was NOT caught — the"
+        log "ERROR" "        comparator cannot see real loss on the restored side. It must not be"
+        log "ERROR" "        used to certify a restore."
+        rc=1
+    fi
+
     log "INFO" "=== SELF-TEST: ${PASS_COUNT} passed, ${FAIL_COUNT} failed ==="
     if [[ "$rc" -ne 0 || "$FAIL_COUNT" -gt 0 ]]; then
         log "ERROR" "The comparator did NOT separate. It must not be used to certify a restore."
@@ -1258,6 +1560,11 @@ main() {
     if [[ "$rc" -ne 0 ]]; then
         return "$rc"
     fi
+
+    # The content manifest for THIS run — fetched only now, using the backup-path/run-ts
+    # run_restore() just read back from restore.sh's own log (deploy#687). A failure here is
+    # an instrument failure (rc=2), never a fallback to comparing user-postgres against live.
+    fetch_content_manifest
 
     compare || return $?
 

--- a/scripts/tests/manifest_fixture.py
+++ b/scripts/tests/manifest_fixture.py
@@ -36,7 +36,18 @@ _PRINTF = re.compile(
 )
 
 # `MANIFEST_FILE="${LOCAL_BACKUP_PATH}/_backup_manifest-${TIMESTAMP}.txt"`
-_MANIFEST_FILE = re.compile(r'MANIFEST_FILE="\$\{LOCAL_BACKUP_PATH\}/(?P<name>[^"]+)"')
+#
+# `(?<!\w)` is load-bearing, not decoration: deploy#687 added a SIBLING assignment,
+# `CONTENT_MANIFEST_FILE="${LOCAL_BACKUP_PATH}/_content_manifest-${TIMESTAMP}.txt"`, whose text
+# ends in the same "MANIFEST_FILE=" substring. Without the negative lookbehind, `.search()`
+# (first match wins) matched THAT line instead — `CONTENT_` is right there in the identifier —
+# and `manifest_filename()` started returning `_content_manifest-*.txt`, silently renaming what
+# every consumer of this fixture believed `_backup_manifest-*.txt` was. Precisely the class this
+# suite's own header warns about: a paraphrase in the product doesn't break the parser, it
+# quietly narrows what it matches (feedback_paraphrase_in_the_product, deploy#589) — except here
+# the near-duplicate was IN THE PRODUCT, not a test paraphrase, and the regex was the thing not
+# anchored to the identifier it meant to find.
+_MANIFEST_FILE = re.compile(r'(?<!\w)MANIFEST_FILE="\$\{LOCAL_BACKUP_PATH\}/(?P<name>[^"]+)"')
 
 # The default run id used across the fixtures. `backup.sh` builds it with
 # `date -u +%Y%m%d-%H%M%S`, so it is strict and self-delimiting — which is why every parser in

--- a/scripts/tests/test_restore_verify.py
+++ b/scripts/tests/test_restore_verify.py
@@ -47,6 +47,11 @@ RC_VERIFIED, RC_FAILED, RC_INSTRUMENT = 0, 1, 2
 LIVE_PROJECT = "noorinalabs"
 RV_PROJECT = "isnad-restore-verify"
 
+# The run the fake restore.sh claims to have restored (deploy#687) — arbitrary but fixed and
+# self-consistent; nothing compares these against a real B2 object in this suite.
+FAKE_BACKUP_PATH = "daily/2026-07-13"
+FAKE_RUN_TS = "20260713-030100"
+
 
 # ---------------------------------------------------------------------------
 # Static scans
@@ -183,7 +188,7 @@ def test_the_selftest_wait_does_not_crash_on_a_missing_container() -> None:
     m = re.search(r"^self_test\(\) \{(.*?)^\}", src, re.S | re.M)
     assert m, "could not locate self_test()"
     body = m.group(1)
-    assert 'cid="$(_st_dc "$p" ps -q neo4j | head -1)" || cid=""' in body, (
+    assert 'cid="$(_st_dc "$p" ps -q "$svc" | head -1)" || cid=""' in body, (
         'the self-test wait\'s `cid=$(… ps -q …)` is not guarded with `|| cid=""`; under set -e '
         "a missing container (the normal first-pass state) crashes the wait loop before the "
         "stack can come up"
@@ -557,18 +562,51 @@ if rest[0] == "exec":
             print(S["hadiths"]); sys.exit(0)
         die("fake docker: unmodelled sql: " + sql)
 
+    # deploy#687: every UPG_CONTENT_<TABLE> query is now "count(*) || '|' || md5(...)" —
+    # ALL FIVE tables' full-content queries contain "md5", so a generic "md5 in sql" check
+    # (the pre-#687 shape, which only "users" ever exercised) would misroute every table to
+    # the same key. Matched instead by each query's own FROM-clause anchor (unambiguous,
+    # unique per table — see scripts/user_pg_content_queries.sh), with "OFFSET 1" deciding
+    # full vs. MINUS1 exactly as the isnad-postgres branch above already does for hadiths.
     if "user-postgres" in rest:
         sql = rest[-1]
         if "information_schema" in sql:
             print(S["upg_tables"]); sys.exit(0)
-        for key, tok in (("users_md5", "md5"), ("users", "FROM users"),
-                         ("oauth", "oauth_accounts"), ("sessions", "sessions"),
-                         ("audit", "audit_log"), ("alembic", "alembic_version")):
-            if tok in sql:
+        minus1 = "OFFSET 1" in sql
+        for table, anchor in (
+            ("users", "FROM users u"),
+            ("oauth_accounts", "FROM oauth_accounts o"),
+            ("sessions", "FROM sessions sess"),
+            ("audit_log", "FROM audit_log a"),
+            ("alembic_version", "FROM alembic_version v"),
+        ):
+            if anchor in sql:
+                key = f"{table}_md5_minus1" if minus1 else table
                 print(S[key]); sys.exit(0)
         die("fake docker: unmodelled user sql: " + sql)
 
 die("fake docker: unmodelled call: " + " ".join(argv))
+"""
+
+# The content-manifest fetch (deploy#687) is a SEPARATE binary (rclone), not docker — this
+# fake reads the SAME world file so the manifest a "faithful restore" test sees is exactly
+# what the "restored" stack itself reports, and a MISMATCH test that only ever touches
+# `restored`'s neo4j/hadith fields (this suite's existing coverage) leaves the manifest
+# comparison trivially satisfied, same as it always has been for user-postgres.
+FAKE_RCLONE = r"""#!/usr/bin/env python3
+import json, os, sys
+
+world = json.load(open(os.environ["FAKE_WORLD"]))
+argv = sys.argv[1:]
+
+if argv and argv[0] == "cat" and "_content_manifest" in argv[-1]:
+    S = world["restored"]
+    for table in ("users", "oauth_accounts", "sessions", "audit_log", "alembic_version"):
+        count, md5 = S[table].split("|", 1)
+        print(f"CONTENT_MANIFEST table={table} count={count} md5={md5}")
+    sys.exit(0)
+
+sys.exit(0)
 """
 
 # A populated, self-consistent world. The scratch stack starts EMPTY and becomes a copy of
@@ -585,13 +623,21 @@ LIVE_WORLD = {
     "hadith_md5": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "hadith_md5_minus1": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",  # DIFFERS
     "pg_tables": "12",
-    "upg_tables": "6",
-    "users": "42",
-    "users_md5": "cccccccccccccccccccccccccccccccc",
-    "oauth": "7",
-    "sessions": "3",
-    "audit": "900",
-    "alembic": "a1b2c3d4",
+    # string_agg(table_name, ',' ORDER BY table_name) — alphabetical, matching
+    # restore_verify.sh's own `printf '%s\n' "${UPG_CONTENT_TABLES[@]}" | sort | paste -sd, -`.
+    "upg_tables": "alembic_version,audit_log,oauth_accounts,sessions,users",
+    # "<count>|<md5>", the exact shape UPG_CONTENT_<TABLE> returns.
+    "users": "42|cccccccccccccccccccccccccccccccc",
+    "users_md5_minus1": "c0cccccccccccccccccccccccccccccc",  # DIFFERS from the "users" md5
+    "oauth_accounts": "7|dddddddddddddddddddddddddddddddd",
+    "oauth_accounts_md5_minus1": "d0dddddddddddddddddddddddddddddd",  # DIFFERS
+    "sessions": "3|eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "sessions_md5_minus1": "e0eeeeeeeeeeeeeeeeeeeeeeeeeeeeee",  # DIFFERS
+    "audit_log": "900|ffffffffffffffffffffffffffffffff",
+    "audit_log_md5_minus1": "f0ffffffffffffffffffffffffffffff",  # DIFFERS
+    # A single-row schema-version marker — no MINUS1 leg (see
+    # scripts/user_pg_content_queries.sh's header for why).
+    "alembic_version": "1|1111111111111111111111111111111",
 }
 
 EMPTY_WORLD = {
@@ -603,7 +649,16 @@ EMPTY_WORLD = {
     "rel_hist": "",
     "hadith_md5": "",
     "hadith_md5_minus1": "",
-    "alembic": "",
+    # assert_scratch_empty() queries information_schema for a bare COUNT before any restore
+    # has run — this must stay "0" (a value), not "" (which reads as an instrument failure).
+    # The table-NAME-list shape (what compare()'s table-set check expects post-restore) only
+    # ever gets read from the "restored" world, which inherits LIVE_WORLD's list by default.
+    "upg_tables": "0",
+    "users": "0|EMPTY",
+    "oauth_accounts": "0|EMPTY",
+    "sessions": "0|EMPTY",
+    "audit_log": "0|EMPTY",
+    "alembic_version": "0|EMPTY",
 }
 
 
@@ -632,6 +687,16 @@ class Harness:
         # The script under test, in a scripts/ dir whose sibling restore.sh we control.
         shutil.copy(RESTORE_VERIFY, self.scripts / "restore_verify.sh")
         os.chmod(self.scripts / "restore_verify.sh", 0o755)
+
+        # deploy#687: restore_verify.sh now sources this sibling file (the shared
+        # count+md5 query constants). Copied fresh alongside it, same discipline as
+        # RV_COMPOSE below — so a change to the real file is reflected here rather than
+        # this harness silently testing against a frozen paraphrase of it
+        # (feedback_test_the_merged_tree_not_the_two_green_prs, deploy#644x#661).
+        shutil.copy(
+            SCRIPTS_DIR / "user_pg_content_queries.sh",
+            self.scripts / "user_pg_content_queries.sh",
+        )
 
         (tmp / "compose").mkdir()
         shutil.copy(RV_COMPOSE, tmp / "compose" / "docker-compose.restore-verify.yml")
@@ -675,6 +740,14 @@ class Harness:
             f'printf "%s" "${{COMPOSE_PROJECT}}" > {self.restore_project}\n'
             f'printf "%s" "${{COMPOSE_FILE}}" > {self.restore_file}\n'
             f"echo RESTORE_INVOKED >> {self.marker}\n"
+            # deploy#687: run_restore() reads these two lines back out of restore.sh's OWN
+            # stdout to learn which run's content manifest to fetch — never re-resolving
+            # independently. Fixed, deterministic values; FAKE_RCLONE's content-manifest
+            # response is keyed on the object PATH containing "_content_manifest", not on
+            # these exact values, so any self-consistent pair works.
+            f'log "INFO" "Resolved \'latest\' to: {FAKE_BACKUP_PATH}"\n'
+            f'log "INFO" "Manifest attests run {FAKE_RUN_TS} '
+            "— selecting that run's dumps\"\n"
             # The volume it resolves is the /data volume of the neo4j container in WHATEVER
             # project it was pointed at. Aimed at `noorinalabs`, that is the production graph.
             'if [ "${COMPOSE_PROJECT}" = "' + LIVE_PROJECT + '" ]; then\n'
@@ -692,7 +765,12 @@ class Harness:
 
         (self.bin / "docker").write_text(FAKE_DOCKER)
         os.chmod(self.bin / "docker", 0o755)
-        for stub in ("rclone", "zstd", "sha256sum"):
+        # rclone now does real work here (deploy#687: fetch_content_manifest's `rclone cat`),
+        # so it gets the same world-driven fake docker gets, rather than the bare `exit 0`
+        # every other B2 access in this file still delegates to restore.sh.
+        (self.bin / "rclone").write_text(FAKE_RCLONE)
+        os.chmod(self.bin / "rclone", 0o755)
+        for stub in ("zstd", "sha256sum"):
             (self.bin / stub).write_text("#!/bin/sh\nexit 0\n")
             os.chmod(self.bin / stub, 0o755)
 

--- a/scripts/tests/test_restore_verify.py
+++ b/scripts/tests/test_restore_verify.py
@@ -623,9 +623,15 @@ LIVE_WORLD = {
     "hadith_md5": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "hadith_md5_minus1": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",  # DIFFERS
     "pg_tables": "12",
-    # string_agg(table_name, ',' ORDER BY table_name) — alphabetical, matching
-    # restore_verify.sh's own `printf '%s\n' "${UPG_CONTENT_TABLES[@]}" | sort | paste -sd, -`.
-    "upg_tables": "alembic_version,audit_log,oauth_accounts,sessions,users",
+    # string_agg(table_name, ',' ORDER BY table_name) — alphabetical. This includes user_roles,
+    # a table the content manifest does NOT attest (FAKE_RCLONE emits only the five
+    # UPG_CONTENT_TABLES), mirroring the real user-service schema, which carries more tables than
+    # the manifest tracks (user_roles, subscriptions, totp_secrets, verification_tokens, … —
+    # docs/DATASTORES.md). compare()'s table-set check is a PRESENCE/subset test, so the extra
+    # table must be TOLERATED; the strict set-equality it replaced would MISMATCH here. Without a
+    # table the manifest does not know about, this fixture could not express the defect the
+    # subset check exists to prevent (Weronika review, PR#688; main#927).
+    "upg_tables": "alembic_version,audit_log,oauth_accounts,sessions,user_roles,users",
     # "<count>|<md5>", the exact shape UPG_CONTENT_<TABLE> returns.
     "users": "42|cccccccccccccccccccccccccccccccc",
     "users_md5_minus1": "c0cccccccccccccccccccccccccccccc",  # DIFFERS from the "users" md5

--- a/scripts/user_pg_content_queries.sh
+++ b/scripts/user_pg_content_queries.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# =============================================================================
+# user-postgres content queries — the ONE place these five SQL strings live.
+# Sourced by BOTH scripts/backup.sh (writes the content manifest, querying a
+# scratch restore of the dump it just produced) and scripts/restore_verify.sh
+# (reads the manifest back, and recomputes the same queries against the
+# restored-verify stack). (deploy#687)
+#
+# WHY A SHARED FILE AND NOT TWO COPIES
+# -------------------------------------
+# The manifest is only trustworthy if the value written at backup time and the
+# value recomputed at verify time are guaranteed to come from byte-identical SQL.
+# Two independent copies of "the same" query text can drift — a whitespace edit,
+# a column reorder, a forgotten `SET timezone` — and the two sides would then
+# disagree for a reason that has nothing to do with the data. Sourcing one file
+# from both scripts makes "the SQL cannot drift" a structural property rather
+# than a policy to remember, same discipline as scripts/compose_project.sh being
+# shared between backup.sh and restore.sh.
+#
+# WHY EACH QUERY PINS `SET timezone='UTC';` ITSELF
+# ---------------------------------------------------
+# `<row>::text` renders `timestamptz` columns through the session's `timezone`
+# GUC. A divergent TZ/PGTZ between the scratch container (backup.sh) and the
+# restore-verify stack (restore_verify.sh) would stringify the same physical
+# instant differently and manufacture a false MISMATCH. Baking the SET into the
+# constant itself — rather than asking every call site to remember to prefix it —
+# means a caller cannot forget the pin.
+#
+# WHY `COALESCE(md5(string_agg(t,'|' ORDER BY t)), 'EMPTY')`
+# -------------------------------------------------------------
+# `string_agg` over zero rows is SQL NULL, which renders as an EMPTY STRING over
+# `psql -tAc` — and restore_verify.sh's `_run_capture` treats an empty reading as
+# an INSTRUMENT FAILURE, not a value (by design, correctly: an empty reading and
+# a query that could not run look identical, and only one of them is a
+# measurement). `audit_log` is legitimately empty on stg today, so both sides
+# must produce the SAME non-empty, comparable token for a zero-row table rather
+# than special-casing it through the empty-reading guard. `md5=EMPTY` is that
+# token — a literal sentinel, not a blank field.
+#
+# WHY COUNT AND MD5 IN ONE QUERY, JOINED WITH '|'
+# ---------------------------------------------------
+# One round trip per table, one string to parse (`<count>|<md5-or-EMPTY>`),
+# split on the first `|`. The string_agg's OWN separator is also `|`, but that
+# is never visible in the output — string_agg's result here is always a 32-hex
+# md5 digest (or the literal `EMPTY`), never the joined-and-visible row text, so
+# the two `|` uses can never collide.
+#
+# CONTRACT: every constant here is a single SELECT statement (plus its leading
+# SET), safe to pass whole to `psql -tAc "$QUERY"` against either the isolated
+# scratch container (backup.sh) or a real user-postgres service (restore_verify.sh).
+# =============================================================================
+
+readonly UPG_CONTENT_USERS="SET timezone='UTC'; SELECT count(*) || '|' || COALESCE(md5(string_agg(t,'|' ORDER BY t)), 'EMPTY') FROM (SELECT u::text AS t FROM users u) s;"
+readonly UPG_CONTENT_OAUTH_ACCOUNTS="SET timezone='UTC'; SELECT count(*) || '|' || COALESCE(md5(string_agg(t,'|' ORDER BY t)), 'EMPTY') FROM (SELECT o::text AS t FROM oauth_accounts o) s;"
+readonly UPG_CONTENT_SESSIONS="SET timezone='UTC'; SELECT count(*) || '|' || COALESCE(md5(string_agg(t,'|' ORDER BY t)), 'EMPTY') FROM (SELECT sess::text AS t FROM sessions sess) s;"
+readonly UPG_CONTENT_AUDIT_LOG="SET timezone='UTC'; SELECT count(*) || '|' || COALESCE(md5(string_agg(t,'|' ORDER BY t)), 'EMPTY') FROM (SELECT a::text AS t FROM audit_log a) s;"
+readonly UPG_CONTENT_ALEMBIC_VERSION="SET timezone='UTC'; SELECT count(*) || '|' || COALESCE(md5(string_agg(t,'|' ORDER BY t)), 'EMPTY') FROM (SELECT v::text AS t FROM alembic_version v) s;"
+
+# The fixed table set every content manifest declares, in the order the
+# manifest lines are written. Read out of THIS array by both producer
+# (backup.sh, to know which queries to run) and consumer (restore_verify.sh,
+# to know which lines to expect and what the restored public schema must
+# contain) — one list, not two independently-typed ones.
+# shellcheck disable=SC2034  # consumed by the scripts that source this file, not by this one
+readonly UPG_CONTENT_TABLES=(users oauth_accounts sessions audit_log alembic_version)
+
+# upg_content_query_for <table> — echoes the shared constant for <table> on stdout.
+# The one place that maps a table name to its query variable, so a caller never
+# has to hand-write a `case` of its own that could fall out of step with
+# UPG_CONTENT_TABLES above.
+upg_content_query_for() {
+    case "$1" in
+        users) printf '%s' "$UPG_CONTENT_USERS" ;;
+        oauth_accounts) printf '%s' "$UPG_CONTENT_OAUTH_ACCOUNTS" ;;
+        sessions) printf '%s' "$UPG_CONTENT_SESSIONS" ;;
+        audit_log) printf '%s' "$UPG_CONTENT_AUDIT_LOG" ;;
+        alembic_version) printf '%s' "$UPG_CONTENT_ALEMBIC_VERSION" ;;
+        *) return 1 ;;
+    esac
+}
+
+# --- Calibration-only: MINUS1 legs -------------------------------------------
+# Same shape as restore_verify.sh's PG_HADITH_MD5_MINUS1 (`... ORDER BY t OFFSET
+# 1`). calibrate() requires each of these to DIFFER from its full UPG_CONTENT_*
+# md5 on the reference stack before any MATCH involving that table is believed —
+# a comparator that cannot detect one missing row makes every "MATCH" it reports
+# meaningless. `alembic_version` deliberately has no MINUS1 leg: it is a
+# single-row schema-version marker, not a mutable content table, so "minus one
+# row" would degenerate to "zero rows" rather than exercise the comparator the
+# way the other four do.
+# shellcheck disable=SC2034  # consumed by restore_verify.sh's calibrate(), which sources this file
+readonly UPG_USERS_MD5_MINUS1="SET timezone='UTC'; SELECT COALESCE(md5(string_agg(t,'|' ORDER BY t)), 'EMPTY') FROM (SELECT u::text AS t FROM users u ORDER BY t OFFSET 1) s;"
+# shellcheck disable=SC2034
+readonly UPG_OAUTH_ACCOUNTS_MD5_MINUS1="SET timezone='UTC'; SELECT COALESCE(md5(string_agg(t,'|' ORDER BY t)), 'EMPTY') FROM (SELECT o::text AS t FROM oauth_accounts o ORDER BY t OFFSET 1) s;"
+# shellcheck disable=SC2034
+readonly UPG_SESSIONS_MD5_MINUS1="SET timezone='UTC'; SELECT COALESCE(md5(string_agg(t,'|' ORDER BY t)), 'EMPTY') FROM (SELECT sess::text AS t FROM sessions sess ORDER BY t OFFSET 1) s;"
+# shellcheck disable=SC2034
+readonly UPG_AUDIT_LOG_MD5_MINUS1="SET timezone='UTC'; SELECT COALESCE(md5(string_agg(t,'|' ORDER BY t)), 'EMPTY') FROM (SELECT a::text AS t FROM audit_log a ORDER BY t OFFSET 1) s;"


### PR DESCRIPTION
## Summary

Fixes #687. Implements Weronika Zielinska's design (restore-derived content manifest, not restored-vs-live) — see her design comment:
https://github.com/noorinalabs/noorinalabs-deploy/issues/687#issuecomment-4975503424

Team-lead decision rulings (mechanism approved, gauge + isnad_graph table-set deferred, single PR):
https://github.com/noorinalabs/noorinalabs-deploy/issues/687#issuecomment-4975520327

## What changed

- **`scripts/user_pg_content_queries.sh`** (new): the five `UPG_CONTENT_<TABLE>` count+md5 query constants (users, oauth_accounts, sessions, audit_log, alembic_version), using `COALESCE(md5(string_agg(t,'|' ORDER BY t)), 'EMPTY')` with `SET timezone='UTC'` pinned in each constant. Sourced by BOTH `backup.sh` and `restore_verify.sh` so the SQL cannot drift between writer and reader. Plus four `_MD5_MINUS1` calibration legs (no leg for `alembic_version` — single-row schema marker, see the file's header).
- **`scripts/backup.sh`**: after the user-postgres dump succeeds, restores it into a throwaway `postgres:16-alpine` container (`docker run`, PID-tagged name, registered in `cleanup()`'s EXIT trap same as the scratch-file discipline), runs the five queries, writes `_content_manifest-<TS>.txt` + `.sha256` sidecar (shipped by the existing `rclone copy` of the run directory — no new upload step). `CONTENT_MANIFEST_OK` flag; on any failure, logs the diagnostic and writes NO file — absence, not a torn file — and never fails the backup run.
- **`scripts/restore_verify.sh`**:
  - `run_restore()` now also reads back restore.sh's `Resolved 'latest' to:` / `Manifest attests run` log lines (never re-resolving independently) to learn which run's manifest to fetch.
  - `fetch_content_manifest()`: a small, local rclone bootstrap (mirroring restore.sh's own) to `rclone cat` the manifest object. Missing/unreadable manifest is `instrument_fail` (rc=2) — **never** falls back to restored-vs-live for user-postgres.
  - `compare()`: the five user-postgres tables are now compared **restored-vs-manifest**, replacing the old restored-vs-**live** ad hoc queries (the proven false-negative — live legitimately drifts between dump-time and verify-time). Added a user-pg **table-set check** (restored `public` schema vs the manifest's declared table set).
  - `calibrate()`: added the missing MINUS1 legs for users/oauth_accounts/sessions/audit_log — every user-pg comparator must now be shown able to go red before any MATCH involving it is trusted.
  - `self_test()`: now also stands up `user-postgres` in both throwaway stacks, seeds an identical minimal schema, captures a baseline "manifest" from the reference stack, then:
    - **benign-drift-must-PASS**: mutates the reference stack ONLY (new session, login timestamp update — the exact #687 scenario) and asserts the restored side still MATCHes the **captured** manifest.
    - **mirror real-loss-must-FAIL**: mutates the restored side (deletes a row) and asserts the same comparator now reports MISMATCH against the same captured manifest.

## Red-first proof (mandatory)

Two-commit sequence on this PR:
1. **RED** — commit `<COMMIT1_SHA>`: lands everything with `self_test()`'s benign-drift leg deliberately wired to compare the restored side against a **fresh re-read of the reference stack** (reproducing the exact pre-#687 defect inside the self-test itself), so the `Comparator self-test (real engine, no B2)` job fails specifically on that new leg.
   - Red run: `<RED_RUN_URL>`
2. **GREEN** — commit `<COMMIT2_SHA>`: flips the comparison to the captured manifest (the actual fix).
   - Green run: `<GREEN_RUN_URL>`

## Flags for reviewers

- **Operational caveat in `calibrate()`'s new `audit_log` MINUS1 leg**: if `audit_log` genuinely holds 0 or 1 rows on the live/reference stack at calibration time, "minus one row" degenerates to the same reading as the full set, and `calibrate()` correctly refuses to testify (rc=2) rather than trust an unproven comparator. This is a new hard dependency that did not exist before this PR (the old comparator never calibrated audit_log at all). Worth a decision: acceptable as designed, or should `audit_log` be seeded/backstopped in prod before this is enforced?
- Scope, per ruling 3: the `isnad_graph`/`public` table-set check (deploy#662) is **not** included — deferred, as decided.
- Not run: real stg/prod `restore_verify.sh` (workflow_dispatch). Per rollout sequence in the design (§6), the first restore-verify run after merge — before a fresh backup produces the first content manifest — is *expected* to report rc=2, and that orchestration is the team-lead's to run.

## Test plan

- [x] `scripts/tests/test_restore_verify.py` — 66/66 passing (harness extended: copies the shared query file, fake `restore.sh` emits the two new log lines, fake `rclone cat` serves a content manifest derived from the "restored" world state, `FAKE_DOCKER`'s user-postgres branch matches the new combined count+md5 queries by FROM-clause anchor).
- [x] Full `scripts/tests/` suite run file-by-file (slow on this sandbox, ~15+ min cumulative, no docker) — all green after two incidental fixes found along the way (see below).
- [x] `shellcheck` + `bash -n` clean across `scripts/` + `infra/`.
- [x] `ruff format --check` / `ruff check` (pinned 0.15.11) clean on the two changed test files.
- [x] `actionlint` clean on the modified workflow.
- [x] `.claude/lib/pre_commit_ci_sync.py .` — parity gate clean.
- [ ] CI: `Comparator self-test (real engine, no B2)` — RED then GREEN (see above).
- [ ] 2 reviewer approvals (Weronika Zielinska — design conformance, Lucas Ferreira — adversarial correctness).

## Incidental fixes found while implementing

- `scripts/tests/manifest_fixture.py`'s `_MANIFEST_FILE` regex matched the **suffix** of the new `CONTENT_MANIFEST_FILE=` assignment (both end in `MANIFEST_FILE=`), silently making `manifest_filename()` return the wrong filename and breaking `test_b2_backup_artifact.py::test_fresh_dump_is_accepted`. Fixed with a `(?<!\w)` lookbehind so it only matches the bare identifier.
- A `log "ERROR"` diagnostic in `backup.sh` happened to spell `restore_verify.sh` as a literal token in non-comment code, which pulled `restore_verify.sh` into `test_scratch_under_hardening.py`'s source-graph closure (matched on any sibling script's basename appearing in executable text) and flagged its two pre-existing bare `mktemp` calls as new regressions. Reworded the message to describe the check ("the restore-verify content check") rather than naming the file.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
