### PR TITLE
Fix content-manifest postgres-bootstrap race: probe target DB over TCP, not pg_isready (#690)

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -589,9 +589,19 @@ generate_content_manifest() {
         return 1
     fi
 
+    # Readiness gate: query the TARGET DATABASE over TCP — NOT pg_isready (deploy#690).
+    # The postgres image entrypoint runs a TEMPORARY bootstrap server on the unix socket only
+    # (`listen_addresses=''`) to run initdb and CREATE DATABASE "$POSTGRES_DB", then stops it and
+    # starts the real server. `pg_isready` (which hits the socket) reports "ready" DURING that
+    # bootstrap phase — before "$USER_POSTGRES_DB" exists — so pg_restore below then connects and
+    # dies with `FATAL: database "user_service" does not exist`. Observed on the stg host: under
+    # backup-time load pg_isready passed while the DB was still absent; a plain repro didn't hit
+    # the window (calibrated: pg_isready@1.0s vs target-DB-over-TCP@1.3s). A TCP `SELECT 1` against
+    # the target DB is deterministic: the temp bootstrap server refuses TCP, so a TCP connection
+    # succeeds ONLY against the fully-started real server, by which point CREATE DATABASE has run.
     local waited=0
     until docker exec "$CONTENT_MANIFEST_CONTAINER" \
-        pg_isready -U "$USER_POSTGRES_USER" -d "$USER_POSTGRES_DB" >/dev/null 2>&1; do
+        psql -h 127.0.0.1 -U "$USER_POSTGRES_USER" -d "$USER_POSTGRES_DB" -tAc 'SELECT 1' >/dev/null 2>&1; do
         if [[ "$waited" -ge 60 ]]; then
             log "ERROR" "Content manifest: scratch postgres did not become ready within 60s"
             return 1

--- a/scripts/tests/test_content_manifest_readiness.py
+++ b/scripts/tests/test_content_manifest_readiness.py
@@ -1,0 +1,117 @@
+"""Guard: the content-manifest scratch postgres readiness gate must wait for the TARGET
+DATABASE over TCP, not `pg_isready` (deploy#690).
+
+WHY A SOURCE GUARD AND NOT AN EXECUTION TEST. `generate_content_manifest()` restores the
+user-postgres dump into a throwaway `postgres:16-alpine` and reads it back. The image's
+entrypoint runs a TEMPORARY bootstrap server on the unix socket only (`listen_addresses=''`)
+to run initdb and `CREATE DATABASE "$POSTGRES_DB"`, then stops it and starts the real server.
+`pg_isready` hits the socket and reports "ready" DURING that bootstrap phase — before the
+target DB exists — so a `pg_restore -d "$USER_POSTGRES_DB"` that follows dies with
+``FATAL: database "user_service" does not exist``. This is timing/load dependent: it surfaced
+on the real stg host under backup-time CPU load (pg_isready@1.0s vs target-DB-over-TCP@1.3s in
+a calibration probe), NOT in CI, and NOT in a quiescent repro — the exact class of real-host
+race a plain execution test cannot reliably reproduce. And the one end-to-end test that DOES
+run backup.sh under the real hardening asserts ``rc == 0``; because the manifest step is
+fail-safe (it never fails the backup run), that test stays green while the manifest silently
+never gets written. So the durable CI catch is a source guard on the readiness *mechanism*:
+a regression back to `pg_isready` (or to a socket-only probe, or one that omits the target DB)
+must fail here. The definitive proof the fix works is the real-host one recorded on the issue
+(a fresh stg backup logging ``Content manifest: OK``).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+BACKUP_SH = REPO_ROOT / "scripts" / "backup.sh"
+
+
+def _generate_content_manifest_body() -> str:
+    """Return the body of generate_content_manifest(), from its `() {` line to the
+    first line that is a bare `}` in column 0 (the function's closing brace)."""
+    text = BACKUP_SH.read_text()
+    start = re.search(r"^generate_content_manifest\(\)\s*\{", text, re.MULTILINE)
+    assert start, "generate_content_manifest() not found in backup.sh"
+    rest = text[start.end() :]
+    end = re.search(r"^\}", rest, re.MULTILINE)
+    assert end, "could not find the closing brace of generate_content_manifest()"
+    return rest[: end.start()]
+
+
+def _readiness_until_block(body: str) -> str:
+    """The `until docker exec "$CONTENT_MANIFEST_CONTAINER" ...; do ... done` readiness
+    loop that gates pg_restore. Returned as the text from the `until` to its `done`."""
+    m = re.search(
+        r"until\s+docker\s+exec\s+\"\$CONTENT_MANIFEST_CONTAINER\".*?\bdone\b",
+        body,
+        re.DOTALL,
+    )
+    assert m, (
+        'no `until docker exec "$CONTENT_MANIFEST_CONTAINER" ...; do ...; done` '
+        "readiness loop found"
+    )
+    return m.group(0)
+
+
+def test_readiness_gate_exists_before_pg_restore() -> None:
+    body = _generate_content_manifest_body()
+    until_start = body.find("until docker exec")
+    # Anchor on the pg_restore COMMAND (`pg_restore -U ...`), not a prose mention of
+    # "pg_restore" in the readiness comment, which legitimately precedes the loop.
+    restore_at = body.find("pg_restore -U")
+    assert until_start != -1, "no readiness loop in generate_content_manifest()"
+    assert restore_at != -1, "no `pg_restore -U` command in generate_content_manifest()"
+    assert until_start < restore_at, "the readiness gate must precede pg_restore"
+
+
+def test_readiness_gate_does_not_use_pg_isready() -> None:
+    """pg_isready reports ready against the socket-only bootstrap server, before the
+    target DB exists (deploy#690). The readiness gate must not rely on it."""
+    block = _readiness_until_block(_generate_content_manifest_body())
+    assert "pg_isready" not in block, (
+        "content-manifest readiness gate uses pg_isready, which races the postgres "
+        "bootstrap (deploy#690): it reports ready before CREATE DATABASE runs, so "
+        "pg_restore hits 'database does not exist'. Probe the target DB over TCP instead."
+    )
+
+
+def test_readiness_gate_probes_target_db_over_tcp() -> None:
+    """A TCP `SELECT 1` against "$USER_POSTGRES_DB" is deterministic: the temp bootstrap
+    server refuses TCP, so success means the real server is up AND the DB was created."""
+    block = _readiness_until_block(_generate_content_manifest_body())
+    assert "psql" in block, (
+        "readiness gate must probe with psql (a real query), not a liveness ping"
+    )
+    assert "-h 127.0.0.1" in block, (
+        "readiness gate must connect over TCP (-h 127.0.0.1) — only the fully-started "
+        "real server listens on TCP; the bootstrap server is socket-only (deploy#690)"
+    )
+    assert '-d "$USER_POSTGRES_DB"' in block, (
+        "readiness gate must query the TARGET database ($USER_POSTGRES_DB) — that is the "
+        "object whose existence pg_restore depends on (deploy#690)"
+    )
+    assert "SELECT 1" in block, (
+        "readiness gate must issue a real query (SELECT 1) against the target DB"
+    )
+
+
+def test_calibration_the_guard_goes_red_on_the_racy_probe() -> None:
+    """Calibration (feedback: calibrate the mutation before counting it): reconstruct the
+    pre-fix (racy) readiness gate and confirm the guard's core assertion — no `pg_isready` —
+    would REJECT it. A guard that cannot go red on the very defect it names proves nothing.
+    The substitution is anchored to the exact fixed probe text, so it also fails loudly if
+    that text drifts (keeping this calibration honest rather than vacuously green)."""
+    block = _readiness_until_block(_generate_content_manifest_body())
+    racy = re.sub(
+        r"psql -h 127\.0\.0\.1 -U \"\$USER_POSTGRES_USER\" "
+        r"-d \"\$USER_POSTGRES_DB\" -tAc 'SELECT 1'",
+        'pg_isready -U "$USER_POSTGRES_USER" -d "$USER_POSTGRES_DB"',
+        block,
+    )
+    assert racy != block, (
+        "calibration could not construct the racy variant — the fixed probe text drifted"
+    )
+    # The guard's core check is `"pg_isready" not in block`; against the racy variant it trips.
+    assert "pg_isready" in racy, "the reconstructed racy block must contain the forbidden probe"


### PR DESCRIPTION
## Fix content-manifest postgres-bootstrap race (deploy#690)

Closes #690.

### Problem (found rolling out #687/#688 on staging)
The first stg backup with the merged content-manifest code succeeded (dump good, uploaded, `complete=true`) but `generate_content_manifest()` failed:
```
pg_restore: error: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: FATAL:  database "user_service" does not exist
```
`generate_content_manifest()` waited for the throwaway `postgres:16-alpine` with `pg_isready`. The postgres entrypoint runs a **temporary socket-only bootstrap server** (`listen_addresses=''`) to run `initdb` + `CREATE DATABASE "$POSTGRES_DB"`, then stops it and starts the real server. `pg_isready` reports "ready" **during** that bootstrap phase — before the target DB exists — so `pg_restore -d "$USER_POSTGRES_DB"` races it and can hit "database does not exist". Timing/load dependent; only surfaces under real backup-time CPU load, which is why CI and quiescent repros never caught it.

### Calibration (stg host, both probes polled every 0.1s from container start)
```
pg_isready PASSED at 1.0s
  ...at that instant, TCP psql -d user_service SELECT 1: connection refused
TCP psql -d user_service SELECT 1 PASSED at 1.3s
```

### Fix
Gate readiness on a **TCP** `SELECT 1` against the **target DB** instead of `pg_isready`:
```
psql -h 127.0.0.1 -U "$USER_POSTGRES_USER" -d "$USER_POSTGRES_DB" -tAc 'SELECT 1'
```
Deterministic: the temp bootstrap server refuses TCP, so a successful TCP connection means the real server is up **and** `CREATE DATABASE` has already run.

### Tests
`scripts/tests/test_content_manifest_readiness.py` — source guard asserting the readiness gate queries the target DB over TCP and never uses `pg_isready`, with a red-first calibration.
- **Red-first proof:** against the pre-fix probe the guards `test_readiness_gate_does_not_use_pg_isready` and `test_readiness_gate_probes_target_db_over_tcp` FAIL; GREEN after the fix.
- Why a source guard: the one end-to-end test that runs `backup.sh` under real hardening asserts `rc==0`, and the manifest step is fail-safe (never fails the backup), so it stays green while the manifest silently never writes — the "two correct decisions compose a blind spot" class. The definitive proof is the real-host one below.

### Real-host acceptance (post-merge)
Re-run the stg backup → confirm `Content manifest: OK` and the manifest object in B2 → stg `restore-verify` returns rc=0 with content assertions (completes deploy#609 item-3).

Local: shellcheck clean (SC1091 only), ruff 0.15.11 format+lint clean, `test_content_manifest_readiness` + `test_backup_under_unit_hardening` 24 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
